### PR TITLE
Parser.java: replace # and -- by // in grammar definitions.

### DIFF
--- a/bin/ebnf.sh
+++ b/bin/ebnf.sh
@@ -57,8 +57,6 @@ EBNF_PARSER=$(pcregrep -M "^[a-zA-Z0-9_]+[ ]*:(\n|.)*?( ;)" ./src/dev/flang/pars
 EBNF="grammar Fuzion;${NEW_LINE}${NEW_LINE}"
 # combine parser and lexer
 EBNF="${EBNF}${EBNF_LEXER}${NEW_LINE}${EBNF_PARSER}"
-# remove comments
-EBNF=$(sed 's/ [-#//].*//g' <<< "$EBNF")
 # replace " by '
 EBNF=$(sed 's/"/\x27/g' <<< "$EBNF")
 

--- a/src/dev/flang/parser/Parser.java
+++ b/src/dev/flang/parser/Parser.java
@@ -1521,7 +1521,7 @@ bracketTerm : block
   /**
    * An Expr that ends in white space unless enclosed in { }, [ ], or ( ).
    *
-exprUntilSp : expr         # no white space except enclosed in { }, [ ], or ( ).
+exprUntilSp : expr         // no white space except enclosed in { }, [ ], or ( ).
             ;
 
    */
@@ -1538,8 +1538,8 @@ exprUntilSp : expr         # no white space except enclosed in { }, [ ], or ( ).
    * An expr that does not exceed a single line unless it is enclosed by { } or
    * ( ).
    *
-exprInLine  : expr             # within one line
-            | bracketTerm      # stretching over one or several lines
+exprInLine  : expr             // within one line
+            | bracketTerm      // stretching over one or several lines
             ;
    */
   Expr exprInLine()
@@ -1934,9 +1934,9 @@ simpleterm  : bracketTerm
    * Parse stringTerm
    *
 stringTerm  : STRING
-            # NYI string interpolation
-            # | STRING$ ident stringTerm
-            # | STRING{ block stringTerm
+            // NYI string interpolation
+            // | STRING$ ident stringTerm
+            // | STRING{ block stringTerm
             ;
   */
   Expr stringTerm(Expr leftString)
@@ -2265,8 +2265,8 @@ caseStar    : STAR       caseBlock
   /**
    * Parse caseBlock
    *
-caseBlock   : ARROW          -- if followed by '|'
-            | ARROW block    -- if block does not start with '|'
+caseBlock   : ARROW          // if followed by '|'
+            | ARROW block    // if block does not start with '|'
             ;
    */
   Block caseBlock()


### PR DESCRIPTION
- ebnf.sh don't remove comments in grammar from ebnf file anymore