### PR TITLE
.gitattributes checkout text files with LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,5 @@
+* text eol=lf
+
 # Change language for files ending in .fz to Fuzion
 #
 # NYI: This should happen automatically if Fuzion support was added to


### PR DESCRIPTION
 .gitattributes added rule to checkout text files with LF as newline separator
