### PR TITLE
fzjava: fix generation of fuzion features for java modules ()

### DIFF
--- a/src/dev/flang/tools/fzjava/ForClass.java
+++ b/src/dev/flang/tools/fzjava/ForClass.java
@@ -720,7 +720,7 @@ class ForClass extends ANY
         if (t.isArray())
           {
             var et = plainResultType(t.getComponentType());
-            mt = (et == null) ? null : "List<" + et + ">";
+            mt = (et == null) ? null : "Sequence<" + et + ">";
           }
         else if (t == String.class)
           {


### PR DESCRIPTION
- was broken since and because of renaming List to Sequence
- error was: Type 'List' was not found, no corresponding feature nor formal generic argument exists