### PR TITLE
Makefile: add target for linting java

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -220,6 +220,14 @@ JAVA_FILES_TOOLS_FZJAVA = \
 JAVA_FILES_MISC_LOGO =\
           $(SRC)/dev/flang/misc/logo/FuzionLogo.java
 
+JAVA_FILES_ALL = $(JAVA_FILES_UTIL) $(JAVA_FILES_UTIL_UNICODE)\
+                 $(JAVA_FILES_AST) $(JAVA_FILES_PARSER) $(JAVA_FILES_IR)\
+                 $(JAVA_FILES_MIR) $(JAVA_FILES_FE) $(JAVA_FILES_AIR)\
+                 $(JAVA_FILES_ME) $(JAVA_FILES_FUIR) $(JAVA_FILES_OPT)\
+                 $(JAVA_FILES_BE_INTERPRETER) $(JAVA_FILES_BE_C)\
+                 $(JAVA_FILES_TOOLS) $(JAVA_FILES_TOOLS_FZJAVA)\
+                 $(JAVA_FILES_MISC_LOGO)
+
 CLASS_FILES_UTIL           = $(CLASSES_DIR)/dev/flang/util/__marker_for_make__
 CLASS_FILES_UTIL_UNICODE   = $(CLASSES_DIR)/dev/flang/util/unicode/__marker_for_make__
 CLASS_FILES_AST            = $(CLASSES_DIR)/dev/flang/ast/__marker_for_make__
@@ -526,3 +534,11 @@ release: clean all
 .PHONY: shellcheck
 shellcheck:
 	shellcheck $(SHELL_SCRIPTS) $(shell find . -iname '*.sh' -not -path "./build/*")
+
+.PHONY: lint/java
+lint/java: $(JARS_JFREE_SVG_JAR)
+	$(JAVAC) -Xlint -cp $(CLASSES_DIR):$(JARS_JFREE_SVG_JAR) -d $(CLASSES_DIR) $(JAVA_FILES_ALL)
+
+.PHONY: lint/javadoc
+lint/javadoc: $(JARS_JFREE_SVG_JAR)
+	$(JAVAC) -Xdoclint -cp $(CLASSES_DIR):$(JARS_JFREE_SVG_JAR) -d $(CLASSES_DIR) $(JAVA_FILES_ALL)


### PR DESCRIPTION
currently yields 91 warnings:
```java
./src/dev/flang/util/SourceFile.java:567: warning: [fallthrough] possible fall-through into case
      case LF:
      ^
./src/dev/flang/util/List.java:137: warning: [unchecked] Possible heap pollution from parameterized vararg type T
  public List(T... i)
                   ^
  where T is a type-variable:
    T extends Object declared in class List
./src/dev/flang/util/List.java:195: warning: [rawtypes] found raw type: Iterator
    Iterator it = iterator();
    ^
  missing type arguments for generic class Iterator<E>
  where E is a type-variable:
    E extends Object declared in interface Iterator
./src/dev/flang/util/List.java:258: warning: [unchecked] Possible heap pollution from parameterized vararg type T
  public void addAll(T... i)
                          ^
  where T is a type-variable:
    T extends Object declared in class List
./src/dev/flang/util/List.java:39: warning: [serial] serializable class List has no definition of serialVersionUID
public class List<T>
       ^
./src/dev/flang/util/MapComparable2Int.java:38: warning: [rawtypes] found raw type: Comparable
public class MapComparable2Int<T extends Comparable> extends Map2Int<T>
                                         ^
  missing type arguments for generic class Comparable<T>
  where T is a type-variable:
    T extends Object declared in interface Comparable
./src/dev/flang/util/Profiler.java:159: warning: [cast] redundant cast to StackTraceElement[]
          StackTraceElement[] s = (StackTraceElement[]) _results_.keySet().toArray(new StackTraceElement[0]);
                                  ^
./src/dev/flang/util/Profiler.java:160: warning: [rawtypes] found raw type: Comparator
          Arrays.sort(s,new Comparator()
                            ^
  missing type arguments for generic class Comparator<T>
  where T is a type-variable:
    T extends Object declared in interface Comparator
./src/dev/flang/util/Profiler.java:160: warning: [unchecked] unchecked method invocation: method sort in class Arrays is applied to given types
          Arrays.sort(s,new Comparator()
                     ^
  required: T[],Comparator<? super T>
  found:    StackTraceElement[],<anonymous Comparator>
  where T is a type-variable:
    T extends Object declared in method <T>sort(T[],Comparator<? super T>)
./src/dev/flang/util/Profiler.java:160: warning: [unchecked] unchecked conversion
          Arrays.sort(s,new Comparator()
                        ^
  required: Comparator<? super T>
  found:    <anonymous Comparator>
  where T is a type-variable:
    T extends Object declared in method <T>sort(T[],Comparator<? super T>)
./src/dev/flang/ast/Feature.java:1399: warning: [fallthrough] possible fall-through into case
      case Field:        // a field
      ^
./src/dev/flang/ast/FormalGenerics.java:273: warning: [rawtypes] found raw type: Iterator
    Iterator it = list.iterator();
    ^
  missing type arguments for generic class Iterator<E>
  where E is a type-variable:
    E extends Object declared in interface Iterator
./src/dev/flang/ast/FormalGenerics.java:322: warning: [serial] serializable class FormalGenerics.AsActuals has no definition of serialVersionUID
  class AsActuals extends List<AbstractType>
  ^
./src/dev/flang/ast/Call.java:820: warning: [rawtypes] found raw type: List
  public void setBlock(List l)
                       ^
  missing type arguments for generic class List<T>
  where T is a type-variable:
    T extends Object declared in class List
./src/dev/flang/ir/IR.java:132: warning: [rawtypes] found raw type: Map2Int
  protected final Map2Int<List<Object>> _codeIds = new Map2Int(CODE_BASE);
                                                       ^
  missing type arguments for generic class Map2Int<T>
  where T is a type-variable:
    T extends Object declared in class Map2Int
./src/dev/flang/ir/IR.java:132: warning: [unchecked] unchecked conversion
  protected final Map2Int<List<Object>> _codeIds = new Map2Int(CODE_BASE);
                                                   ^
  required: Map2Int<List<Object>>
  found:    Map2Int
./src/dev/flang/mir/MIR.java:71: warning: [rawtypes] found raw type: MapComparable2Int
  final Map2Int<AbstractFeature> _featureIds = new MapComparable2Int(FEATURE_BASE);
                                                   ^
  missing type arguments for generic class MapComparable2Int<T>
  where T is a type-variable:
    T extends Comparable declared in class MapComparable2Int
./src/dev/flang/mir/MIR.java:71: warning: [unchecked] unchecked conversion
  final Map2Int<AbstractFeature> _featureIds = new MapComparable2Int(FEATURE_BASE);
                                               ^
  required: Map2Int<AbstractFeature>
  found:    MapComparable2Int
./src/dev/flang/air/Clazz.java:788: warning: [fallthrough] possible fall-through into case
      case After: break;
      ^
./src/dev/flang/fuir/FUIR.java:146: warning: [rawtypes] found raw type: MapComparable2Int
  final Map2Int<Clazz> _clazzIds = new MapComparable2Int(CLAZZ_BASE);
                                       ^
  missing type arguments for generic class MapComparable2Int<T>
  where T is a type-variable:
    T extends Comparable declared in class MapComparable2Int
./src/dev/flang/fuir/FUIR.java:146: warning: [unchecked] unchecked conversion
  final Map2Int<Clazz> _clazzIds = new MapComparable2Int(CLAZZ_BASE);
                                   ^
  required: Map2Int<Clazz>
  found:    MapComparable2Int
./src/dev/flang/fuir/FUIR.java:1153: warning: [cast] redundant cast to Clazz
        tclazz = (Clazz) fld._outer;
                 ^
./src/dev/flang/be/interpreter/JavaInterface.java:63: warning: [rawtypes] found raw type: Class
        Class cl = clazz != null ? Class.forName(clazz) : thiz.getClass();
        ^
  missing type arguments for generic class Class<T>
  where T is a type-variable:
    T extends Object declared in class Class
./src/dev/flang/be/interpreter/JavaInterface.java:99: warning: [rawtypes] found raw type: Class
  static Class forName(String name)
         ^
  missing type arguments for generic class Class<T>
  where T is a type-variable:
    T extends Object declared in class Class
./src/dev/flang/be/interpreter/JavaInterface.java:101: warning: [rawtypes] found raw type: Class
    Class result;
    ^
  missing type arguments for generic class Class<T>
  where T is a type-variable:
    T extends Object declared in class Class
./src/dev/flang/be/interpreter/JavaInterface.java:122: warning: [rawtypes] found raw type: Class
  static Class str2type(String str) {
         ^
  missing type arguments for generic class Class<T>
  where T is a type-variable:
    T extends Object declared in class Class
./src/dev/flang/be/interpreter/JavaInterface.java:167: warning: [rawtypes] found raw type: Class
  static Class[] getPars(String d)
         ^
  missing type arguments for generic class Class<T>
  where T is a type-variable:
    T extends Object declared in class Class
./src/dev/flang/be/interpreter/JavaInterface.java:169: warning: [rawtypes] found raw type: Class
    Class[] result;
    ^
  missing type arguments for generic class Class<T>
  where T is a type-variable:
    T extends Object declared in class Class
./src/dev/flang/be/interpreter/JavaInterface.java:185: warning: [rawtypes] found raw type: Class
    result = new Class[cnt];
                 ^
  missing type arguments for generic class Class<T>
  where T is a type-variable:
    T extends Object declared in class Class
./src/dev/flang/be/interpreter/JavaInterface.java:373: warning: [rawtypes] found raw type: Constructor
    Constructor co = null;
    ^
  missing type arguments for generic class Constructor<T>
  where T is a type-variable:
    T extends Object declared in class Constructor
./src/dev/flang/be/interpreter/JavaInterface.java:380: warning: [rawtypes] found raw type: Class
    Class cl;
    ^
  missing type arguments for generic class Class<T>
  where T is a type-variable:
    T extends Object declared in class Class
./src/dev/flang/be/interpreter/JavaInterface.java:396: warning: [unchecked] unchecked call to getConstructor(Class<?>...) as a member of the raw type Class
            co = cl.getConstructor(p);
                                  ^
  where T is a type-variable:
    T extends Object declared in class Class
./src/dev/flang/be/interpreter/JavaInterface.java:400: warning: [unchecked] unchecked call to getMethod(String,Class<?>...) as a member of the raw type Class
            m = cl.getMethod(name,p);
                            ^
./src/dev/flang/be/c/C.java:328: warning: [unchecked] unchecked cast
        var stackWithArgs = (Stack<CExpr>) stack.clone();
                                                      ^
  required: Stack<CExpr>
  found:    Object
./src/dev/flang/be/c/C.java:356: warning: [unchecked] unchecked cast
            var stk = (Stack<CExpr>) stackWithArgs.clone();
                                                        ^
  required: Stack<CExpr>
  found:    Object
./src/dev/flang/be/c/C.java:387: warning: [static] static variable should be qualified by type name, CNames, instead of by an expression
            var id = tvar.deref().field(_names.CLAZZ_ID);
                                              ^
./src/dev/flang/be/c/C.java:480: warning: [static] static variable should be qualified by type name, CNames, instead of by an expression
                             t.deref().field(_names.CLAZZ_ID).assign(_names.clazzId(rc)),
                                                   ^
./src/dev/flang/be/c/C.java:504: warning: [unchecked] unchecked cast
              ol.add(call(tc, cc0, (Stack<CExpr>) stack.clone(), true));
                                                             ^
  required: Stack<CExpr>
  found:    Object
./src/dev/flang/be/c/C.java:525: warning: [static] static variable should be qualified by type name, CNames, instead of by an expression
          push(stack, cl, _names.OUTER);
                                ^
./src/dev/flang/be/c/C.java:563: warning: [static] static variable should be qualified by type name, CNames, instead of by an expression
          var uniyon    = sub.field(_names.CHOICE_UNION_NAME);
                                          ^
./src/dev/flang/be/c/C.java:565: warning: [static] static variable should be qualified by type name, CNames, instead of by an expression
          var refEntry  = uniyon.field(_names.CHOICE_REF_ENTRY_NAME);
                                             ^
./src/dev/flang/be/c/C.java:568: warning: [static] static variable should be qualified by type name, CNames, instead of by an expression
          var tag       = hasTag ? sub.field(_names.TAG_NAME) : ref.castTo("int64_t");
                                                   ^
./src/dev/flang/be/c/C.java:604: warning: [static] static variable should be qualified by type name, CNames, instead of by an expression
                               _types.hasData(fclazz)   ? uniyon.field(new CIdent(_names.CHOICE_ENTRY_NAME + tags[0]))
                                                                                        ^
./src/dev/flang/be/c/C.java:608: warning: [unchecked] unchecked cast
              sl.add(createCode(cl, (Stack<CExpr>) stack.clone(), _fuir.matchCaseCode(c, i, mc)));
                                                              ^
  required: Stack<CExpr>
  found:    Object
./src/dev/flang/be/c/C.java:620: warning: [static] static variable should be qualified by type name, CNames, instead of by an expression
              var id = refEntry.deref().field(_names.CLAZZ_ID);
                                                    ^
./src/dev/flang/be/c/C.java:635: warning: [static] static variable should be qualified by type name, CNames, instead of by an expression
          var tag     = res.field(_names.TAG_NAME);
                                        ^
./src/dev/flang/be/c/C.java:636: warning: [static] static variable should be qualified by type name, CNames, instead of by an expression
          var uniyon  = res.field(_names.CHOICE_UNION_NAME);
                                        ^
./src/dev/flang/be/c/C.java:638: warning: [static] static variable should be qualified by type name, CNames, instead of by an expression
                                     _fuir.clazzIsChoiceOfOnlyRefs(newcl) ? _names.CHOICE_REF_ENTRY_NAME
                                                                                  ^
./src/dev/flang/be/c/C.java:639: warning: [static] static variable should be qualified by type name, CNames, instead of by an expression
                                                                          : new CIdent(_names.CHOICE_ENTRY_NAME + tagNum));
                                                                                             ^
./src/dev/flang/be/c/C.java:712: warning: [static] static variable should be qualified by type name, CNames, instead of by an expression
                      tmp.deref().field(_names.CLAZZ_ID).assign(_names.clazzId(_fuir.clazz_conststring())),
                                              ^
./src/dev/flang/be/c/C.java:862: warning: [static] static variable should be qualified by type name, CNames, instead of by an expression
        var a = tc == _fuir.clazzUniverse() ? _names.UNIVERSE : pop(stack, tc);
                                                    ^
./src/dev/flang/be/c/C.java:990: warning: [static] static variable should be qualified by type name, CNames, instead of by an expression
    l.add(CStmnt.decl(t + "*", _names.CURRENT, CExpr.call("malloc", new List<>(CExpr.sizeOfType(t)))));
                                     ^
./src/dev/flang/be/c/C.java:991: warning: [static] static variable should be qualified by type name, CNames, instead of by an expression
    l.add(_fuir.clazzIsRef(cl) ? _names.CURRENT.deref().field(_names.CLAZZ_ID).assign(_names.clazzId(cl)) : CStmnt.EMPTY);
                                                                    ^
./src/dev/flang/be/c/C.java:991: warning: [static] static variable should be qualified by type name, CNames, instead of by an expression
    l.add(_fuir.clazzIsRef(cl) ? _names.CURRENT.deref().field(_names.CLAZZ_ID).assign(_names.clazzId(cl)) : CStmnt.EMPTY);
                                       ^
./src/dev/flang/be/c/C.java:993: warning: [static] static variable should be qualified by type name, CNames, instead of by an expression
    var cur = _fuir.clazzIsRef(cl) ? fields(_names.CURRENT, cl)
                                                  ^
./src/dev/flang/be/c/C.java:994: warning: [static] static variable should be qualified by type name, CNames, instead of by an expression
                                   : _names.CURRENT.deref();
                                           ^
./src/dev/flang/be/c/C.java:1052: warning: [static] static variable should be qualified by type name, CNames, instead of by an expression
            l.add(CStmnt.iff(cc.field(_names.TAG_NAME).not(),
                                            ^
./src/dev/flang/be/c/C.java:1071: warning: [static] static variable should be qualified by type name, CNames, instead of by an expression
      _fuir.clazzIsRef(cl) ? _names.CURRENT
                                   ^
./src/dev/flang/be/c/C.java:1072: warning: [static] static variable should be qualified by type name, CNames, instead of by an expression
                           : _names.CURRENT.deref();
                                   ^
./src/dev/flang/be/c/C.java:1089: warning: [static] static variable should be qualified by type name, CNames, instead of by an expression
        outer = _names.UNIVERSE;
                      ^
./src/dev/flang/be/c/C.java:1107: warning: [static] static variable should be qualified by type name, CNames, instead of by an expression
    return _fuir.clazzIsRef(type) ? refOrVal.deref().field(_names.FIELDS_IN_REF_CLAZZ)
                                                                 ^
./src/dev/flang/be/c/C.java:794: warning: [fallthrough] possible fall-through into case
      case Routine  :
      ^
./src/dev/flang/be/c/CTypes.java:274: warning: [static] static variable should be qualified by type name, CNames, instead of by an expression
              els.add(CStmnt.decl("uint32_t", _names.CLAZZ_ID));
                                                    ^
./src/dev/flang/be/c/CTypes.java:275: warning: [static] static variable should be qualified by type name, CNames, instead of by an expression
              els.add(CStmnt.decl(clazz(vcl), _names.FIELDS_IN_REF_CLAZZ));
                                                    ^
./src/dev/flang/be/c/CTypes.java:282: warning: [static] static variable should be qualified by type name, CNames, instead of by an expression
                  els.add(CStmnt.decl(clazzField(ct), _names.TAG_NAME));
                                                            ^
./src/dev/flang/be/c/CTypes.java:290: warning: [static] static variable should be qualified by type name, CNames, instead of by an expression
                      uls.add(CStmnt.decl(clazz(cc), new CIdent(_names.CHOICE_ENTRY_NAME + i)));
                                                                      ^
./src/dev/flang/be/c/CTypes.java:295: warning: [static] static variable should be qualified by type name, CNames, instead of by an expression
                  uls.add(CStmnt.decl(clazz(_fuir.clazzObject()), _names.CHOICE_REF_ENTRY_NAME));
                                                                        ^
./src/dev/flang/be/c/CTypes.java:297: warning: [static] static variable should be qualified by type name, CNames, instead of by an expression
              els.add(CStmnt.unyon(uls, _names.CHOICE_UNION_NAME));
                                              ^
./src/dev/flang/be/c/CTypes.java:310: warning: [static] static variable should be qualified by type name, CNames, instead of by an expression
              l.add(CStmnt.decl("static", _names.struct(cl), _names.UNIVERSE));
                                                                   ^
./src/dev/flang/tools/fzjava/ForClass.java:87: warning: [rawtypes] found raw type: Class
  Class _class;
  ^
  missing type arguments for generic class Class<T>
  where T is a type-variable:
    T extends Object declared in class Class
./src/dev/flang/tools/fzjava/ForClass.java:124: warning: [rawtypes] found raw type: Constructor
  List<Constructor> _generateC = new List<>();
       ^
  missing type arguments for generic class Constructor<T>
  where T is a type-variable:
    T extends Object declared in class Constructor
./src/dev/flang/tools/fzjava/ForClass.java:132: warning: [rawtypes] found raw type: Constructor
  TreeMap<Integer, Constructor> _overloadedC = new TreeMap<>();
                   ^
  missing type arguments for generic class Constructor<T>
  where T is a type-variable:
    T extends Object declared in class Constructor
./src/dev/flang/tools/fzjava/ForClass.java:145: warning: [rawtypes] found raw type: Class
  ForClass(Class c, ForClass sc)
           ^
  missing type arguments for generic class Class<T>
  where T is a type-variable:
    T extends Object declared in class Class
warning: [rawtypes] found raw type: Constructor
  missing type arguments for generic class Constructor<T>
  where T is a type-variable:
    T extends Object declared in class Constructor
./src/dev/flang/tools/fzjava/ForClass.java:212: warning: [rawtypes] found raw type: Constructor
  void findConstructor(Constructor co)
                       ^
  missing type arguments for generic class Constructor<T>
  where T is a type-variable:
    T extends Object declared in class Constructor
warning: [rawtypes] found raw type: Constructor
  missing type arguments for generic class Constructor<T>
  where T is a type-variable:
    T extends Object declared in class Constructor
warning: [rawtypes] found raw type: Constructor
  missing type arguments for generic class Constructor<T>
  where T is a type-variable:
    T extends Object declared in class Constructor
./src/dev/flang/tools/fzjava/ForClass.java:508: warning: [rawtypes] found raw type: Constructor
  void processConstructor(Constructor co,
                          ^
  missing type arguments for generic class Constructor<T>
  where T is a type-variable:
    T extends Object declared in class Constructor
./src/dev/flang/tools/fzjava/ForClass.java:567: warning: [rawtypes] found raw type: Constructor
  void shortHand(Constructor co,
                 ^
  missing type arguments for generic class Constructor<T>
  where T is a type-variable:
    T extends Object declared in class Constructor
./src/dev/flang/tools/fzjava/ForClass.java:595: warning: [rawtypes] found raw type: Class
  boolean preferredResult(Class r1, Class r2)
                          ^
  missing type arguments for generic class Class<T>
  where T is a type-variable:
    T extends Object declared in class Class
./src/dev/flang/tools/fzjava/ForClass.java:595: warning: [rawtypes] found raw type: Class
  boolean preferredResult(Class r1, Class r2)
                                    ^
  missing type arguments for generic class Class<T>
  where T is a type-variable:
    T extends Object declared in class Class
./src/dev/flang/tools/fzjava/ForClass.java:597: warning: [unchecked] unchecked call to isAssignableFrom(Class<?>) as a member of the raw type Class
    return r2.isAssignableFrom(r1);
                              ^
./src/dev/flang/tools/fzjava/ForClass.java:688: warning: [rawtypes] found raw type: Constructor
  boolean preferred(Constructor c1, Constructor c2)
                    ^
  missing type arguments for generic class Constructor<T>
  where T is a type-variable:
    T extends Object declared in class Constructor
./src/dev/flang/tools/fzjava/ForClass.java:688: warning: [rawtypes] found raw type: Constructor
  boolean preferred(Constructor c1, Constructor c2)
                                    ^
  missing type arguments for generic class Constructor<T>
  where T is a type-variable:
    T extends Object declared in class Constructor
./src/dev/flang/tools/fzjava/ForClass.java:757: warning: [rawtypes] found raw type: Class
  String signature(Parameter[] pa, Class returnType)
                                   ^
  missing type arguments for generic class Class<T>
  where T is a type-variable:
    T extends Object declared in class Class
./src/dev/flang/tools/fzjava/ForClass.java:789: warning: [rawtypes] found raw type: Class
  String signature(Class t)
                   ^
  missing type arguments for generic class Class<T>
  where T is a type-variable:
    T extends Object declared in class Class
./src/dev/flang/tools/fzjava/ForClass.java:890: warning: [rawtypes] found raw type: Class
  String resultType(Class rt, java.lang.reflect.Executable me)
                    ^
  missing type arguments for generic class Class<T>
  where T is a type-variable:
    T extends Object declared in class Class
./src/dev/flang/tools/fzjava/ForClass.java:914: warning: [rawtypes] found raw type: Class
  String plainResultType(Class t)
                         ^
  missing type arguments for generic class Class<T>
  where T is a type-variable:
    T extends Object declared in class Class
./src/dev/flang/tools/fzjava/ForClass.java:952: warning: [rawtypes] found raw type: Class
  String typeName(Class t)
                  ^
  missing type arguments for generic class Class<T>
  where T is a type-variable:
    T extends Object declared in class Class
./src/dev/flang/tools/fzjava/FZJava.java:367: warning: [rawtypes] found raw type: Class
  ForClass forClass(Class c)
                    ^
  missing type arguments for generic class Class<T>
  where T is a type-variable:
    T extends Object declared in class Class
./src/dev/flang/tools/fzjava/FZJava.java:398: warning: [rawtypes] found raw type: Class
  void processClass(Class c)
                    ^
  missing type arguments for generic class Class<T>
  where T is a type-variable:
    T extends Object declared in class Class
91 warnings
```