### PR TITLE
ebnf.sh: move parser before lexer rules

### DIFF
--- a/bin/ebnf.sh
+++ b/bin/ebnf.sh
@@ -50,13 +50,13 @@ SCRIPTPATH="$(dirname "$(readlink -f "$0")")"
 cd "$SCRIPTPATH"/..
 
 #
-EBNF_LEXER=$(pcregrep -M "^[a-zA-Z0-9_]+[ ]*:(\n|.)*?( ;)" ./src/dev/flang/parser/Lexer.java)
-EBNF_PARSER=$(pcregrep -M "^[a-zA-Z0-9_]+[ ]*:(\n|.)*?( ;)" ./src/dev/flang/parser/Parser.java)
+EBNF_LEXER=$(pcregrep -M "^(fragment[ ])*[a-zA-Z0-9_]+[ ]*:(\n|.)*?( ;)" ./src/dev/flang/parser/Lexer.java)
+EBNF_PARSER=$(pcregrep -M "^(fragment[ ])*[a-zA-Z0-9_]+[ ]*:(\n|.)*?( ;)" ./src/dev/flang/parser/Parser.java)
 
 # header
-EBNF="grammar Fuzion;${NEW_LINE}${NEW_LINE}"
+EBNF_HEADER="grammar Fuzion;${NEW_LINE}${NEW_LINE}"
 # combine parser and lexer
-EBNF="${EBNF}${EBNF_LEXER}${NEW_LINE}${EBNF_PARSER}"
+EBNF="${EBNF_HEADER}${EBNF_PARSER}${NEW_LINE}${EBNF_LEXER}"
 # replace " by '
 EBNF=$(sed 's/"/\x27/g' <<< "$EBNF")
 

--- a/bin/ebnf.sh
+++ b/bin/ebnf.sh
@@ -49,9 +49,9 @@ NEW_LINE=$'\n'
 SCRIPTPATH="$(dirname "$(readlink -f "$0")")"
 cd "$SCRIPTPATH"/..
 
-#
-EBNF_LEXER=$(pcregrep -M "^(fragment[ ])*[a-zA-Z0-9_]+[ ]*:(\n|.)*?( ;)" ./src/dev/flang/parser/Lexer.java)
-EBNF_PARSER=$(pcregrep -M "^(fragment[ ])*[a-zA-Z0-9_]+[ ]*:(\n|.)*?( ;)" ./src/dev/flang/parser/Parser.java)
+RULE_MATCHER="^(fragment\n)*[a-zA-Z0-9_]+[ ]*:(\n|.)*?( ;)"
+EBNF_LEXER=$(pcregrep -M "$RULE_MATCHER" ./src/dev/flang/parser/Lexer.java)
+EBNF_PARSER=$(pcregrep -M "$RULE_MATCHER" ./src/dev/flang/parser/Parser.java)
 
 # header
 EBNF_HEADER="grammar Fuzion;${NEW_LINE}${NEW_LINE}"

--- a/src/dev/flang/parser/Lexer.java
+++ b/src/dev/flang/parser/Lexer.java
@@ -1187,11 +1187,11 @@ NUM_LITERAL : [0-9]+
    *
 LITERAL     : DIGITS_W_DOT EXPONENT
             ;
-EXPONENT    : "E" PLUSMINUS DIGITS
+fragment EXPONENT    : "E" PLUSMINUS DIGITS
             | "P" PLUSMINUS DIGITS
             |
             ;
-PLUSMINUS   : "+"
+fragment PLUSMINUS   : "+"
             | "-"
             |
             ;
@@ -1454,17 +1454,17 @@ DIGITS_W_DOT: DIGITS
             | "0" "d" DEC_DIGIT_ DEC_DIGITS_ DEC_TAIL
             | "0" "x" HEX_DIGIT_ HEX_DIGITS_ HEX_TAIL
             ;
-UNDERSCORE  : "_"
+fragment UNDERSCORE  : "_"
             |
             ;
 BIN_DIGIT   : "0" | "1"
             ;
 BIN_DIGIT_  : UNDERSCORE BIN_DIGIT
             ;
-BIN_DIGITS_ : BIN_DIGIT_ BIN_DIGITS_
+fragment BIN_DIGITS_ : BIN_DIGIT_ BIN_DIGITS_
             |
             ;
-BIN_DIGITS  : BIN_DIGIT BIN_DIGITS
+fragment BIN_DIGITS  : BIN_DIGIT BIN_DIGITS
             |
             ;
 BIN_TAIL    : "." BIN_DIGITS
@@ -1473,10 +1473,10 @@ OCT_DIGIT   : "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7"
             ;
 OCT_DIGIT_  : UNDERSCORE OCT_DIGIT
             ;
-OCT_DIGITS_ : OCT_DIGIT_ OCT_DIGITS_
+fragment OCT_DIGITS_ : OCT_DIGIT_ OCT_DIGITS_
             |
             ;
-OCT_DIGITS  : OCT_DIGIT OCT_DIGITS
+fragment OCT_DIGITS  : OCT_DIGIT OCT_DIGITS
             |
             ;
 OCT_TAIL    : "." OCT_DIGITS
@@ -1485,10 +1485,10 @@ DEC_DIGIT   : "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9"
             ;
 DEC_DIGIT_  : UNDERSCORE DEC_DIGIT
             ;
-DEC_DIGITS_ : DEC_DIGIT_ DEC_DIGITS_
+fragment DEC_DIGITS_ : DEC_DIGIT_ DEC_DIGITS_
             |
             ;
-DEC_DIGITS  : DEC_DIGIT DEC_DIGITS
+fragment DEC_DIGITS  : DEC_DIGIT DEC_DIGITS
             |
             ;
 DEC_TAIL    : "." DEC_DIGITS
@@ -1499,10 +1499,10 @@ HEX_DIGIT   : "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9"
             ;
 HEX_DIGIT_  : UNDERSCORE HEX_DIGIT
             ;
-HEX_DIGITS_ : HEX_DIGIT_ HEX_DIGITS_
+fragment HEX_DIGITS_ : HEX_DIGIT_ HEX_DIGITS_
             |
             ;
-HEX_DIGITS  : HEX_DIGIT HEX_DIGITS
+fragment HEX_DIGITS  : HEX_DIGIT HEX_DIGITS
             |
             ;
 HEX_TAIL    : "." HEX_DIGITS
@@ -1873,6 +1873,15 @@ HEX_TAIL    : "." HEX_DIGITS
    * Match the current token with the given operator, i.e, check that current()
    * is Token.t_op and the operator is op.  If so, advance to the next token
    * using next(). Otherwise, cause a syntax error.
+   *
+COLON       : ":"
+            ;
+
+ARROW       : "=>"
+            ;
+
+PIPE        : "|"
+            ;
    *
    * @param op the operator we want to see
    *
@@ -2571,6 +2580,11 @@ HEX_TAIL    : "." HEX_DIGITS
 
   /**
    * Parse singe-char t_op.
+   *
+STAR        : "*"
+            ;
+QUESTION    : "?"
+            ;
    *
    * @param op the single-char operator
    *

--- a/src/dev/flang/parser/Lexer.java
+++ b/src/dev/flang/parser/Lexer.java
@@ -1187,11 +1187,13 @@ NUM_LITERAL : [0-9]+
    *
 LITERAL     : DIGITS_W_DOT EXPONENT
             ;
-fragment EXPONENT    : "E" PLUSMINUS DIGITS
+fragment
+EXPONENT    : "E" PLUSMINUS DIGITS
             | "P" PLUSMINUS DIGITS
             |
             ;
-fragment PLUSMINUS   : "+"
+fragment
+PLUSMINUS   : "+"
             | "-"
             |
             ;
@@ -1454,17 +1456,20 @@ DIGITS_W_DOT: DIGITS
             | "0" "d" DEC_DIGIT_ DEC_DIGITS_ DEC_TAIL
             | "0" "x" HEX_DIGIT_ HEX_DIGITS_ HEX_TAIL
             ;
-fragment UNDERSCORE  : "_"
+fragment
+UNDERSCORE  : "_"
             |
             ;
 BIN_DIGIT   : "0" | "1"
             ;
 BIN_DIGIT_  : UNDERSCORE BIN_DIGIT
             ;
-fragment BIN_DIGITS_ : BIN_DIGIT_ BIN_DIGITS_
+fragment
+BIN_DIGITS_ : BIN_DIGIT_ BIN_DIGITS_
             |
             ;
-fragment BIN_DIGITS  : BIN_DIGIT BIN_DIGITS
+fragment
+BIN_DIGITS  : BIN_DIGIT BIN_DIGITS
             |
             ;
 BIN_TAIL    : "." BIN_DIGITS
@@ -1473,10 +1478,12 @@ OCT_DIGIT   : "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7"
             ;
 OCT_DIGIT_  : UNDERSCORE OCT_DIGIT
             ;
-fragment OCT_DIGITS_ : OCT_DIGIT_ OCT_DIGITS_
+fragment
+OCT_DIGITS_ : OCT_DIGIT_ OCT_DIGITS_
             |
             ;
-fragment OCT_DIGITS  : OCT_DIGIT OCT_DIGITS
+fragment
+OCT_DIGITS  : OCT_DIGIT OCT_DIGITS
             |
             ;
 OCT_TAIL    : "." OCT_DIGITS
@@ -1485,10 +1492,12 @@ DEC_DIGIT   : "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9"
             ;
 DEC_DIGIT_  : UNDERSCORE DEC_DIGIT
             ;
-fragment DEC_DIGITS_ : DEC_DIGIT_ DEC_DIGITS_
+fragment
+DEC_DIGITS_ : DEC_DIGIT_ DEC_DIGITS_
             |
             ;
-fragment DEC_DIGITS  : DEC_DIGIT DEC_DIGITS
+fragment
+DEC_DIGITS  : DEC_DIGIT DEC_DIGITS
             |
             ;
 DEC_TAIL    : "." DEC_DIGITS
@@ -1499,10 +1508,12 @@ HEX_DIGIT   : "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9"
             ;
 HEX_DIGIT_  : UNDERSCORE HEX_DIGIT
             ;
-fragment HEX_DIGITS_ : HEX_DIGIT_ HEX_DIGITS_
+fragment
+HEX_DIGITS_ : HEX_DIGIT_ HEX_DIGITS_
             |
             ;
-fragment HEX_DIGITS  : HEX_DIGIT HEX_DIGITS
+fragment
+HEX_DIGITS  : HEX_DIGIT HEX_DIGITS
             |
             ;
 HEX_TAIL    : "." HEX_DIGITS


### PR DESCRIPTION
- add some missing lexer grammar rules
- fix antlr warnings: `non-fragment lexer rule ... can match the empty string`