### PR TITLE
ast: InlineArray.type() handle incompatible element types as in issue…

### DIFF
--- a/src/dev/flang/ast/InlineArray.java
+++ b/src/dev/flang/ast/InlineArray.java
@@ -111,15 +111,24 @@ public class InlineArray extends ExprWithPos
               t  == null ? null :
               et == null ? null : t.union(et);
           }
-        type_ =
-          t == null              ? null :
-          t == Types.t_UNDEFINED ? null :
-          Types.intern(new Type(pos(),
-                                "array",
-                                new List<>(t),
-                                null,
-                                Types.resolved.f_array,
-                                Type.RefOrVal.LikeUnderlyingFeature));
+        if (t == Types.t_UNDEFINED)
+          {
+            new IncompatibleResultsOnBranches(pos(),
+                                              "Incompatible types in array elements",
+                                              _elements.iterator());
+            type_ = Types.t_ERROR;
+          }
+        if (type_ == null)
+          {
+            type_ =
+              t == null ? Types.t_ERROR :
+              Types.intern(new Type(pos(),
+                                  "array",
+                                  new List<>(t),
+                                  null,
+                                  Types.resolved.f_array,
+                                  Type.RefOrVal.LikeUnderlyingFeature));
+          }
       }
     return type_;
   }


### PR DESCRIPTION
closes #192.
The error message i get with the patch below:
```
...fz:3:8: error 1: Incompatible types in array elements
  b := [f64s.sum, count<f64>]
-------^
Incompatible result types in different branches:
block returns value of type 'f64s.sum' at /home/sam/Downloads/asdf.fz:3:14:
  b := [f64s.sum, count<f64>]
-------------^
block returns value of type 'ex.count<f64>' at /home/sam/Downloads/asdf.fz:3:19:
  b := [f64s.sum, count<f64>]
------------------^

one error.
```