### PR TITLE
ast: Fix precondition when boxing a value

### DIFF
--- a/src/dev/flang/ast/Box.java
+++ b/src/dev/flang/ast/Box.java
@@ -72,16 +72,13 @@ public class Box extends Expr
    *
    * @param value the value instance
    *
-   * @param s Stmnt that is the target of the boxed value
-   *
-   * @param arg in case s is Call, this is the index of the actual argument
-   * that is the target of the boxed value
+   * @param frmlT formal type the Expr should result in
    */
   public Box(Expr value, AbstractType frmlT)
   {
     if (PRECONDITIONS) require
       (value != null,
-       !value.type().isRef() || value.isCallToOuterRef());
+       frmlT.isGenericArgument() || !value.type().isRef() || value.isCallToOuterRef());
 
     this._value = value;
     var t = value.type();


### PR DESCRIPTION
- in the special case the formaltype of the expression is a generic argument
- closes #194 
with fix below example in #194 results in:
```
/home/sam/Downloads/asdf.fz:16:19: error 1: Incompatible types in assignment
    b.map<T>(m -> m)
------------------^
assignment to field : 'ex.a.#fun0.call.result'
expected formal type: 'ex.a.T'
actual type found   : 'Monoid<ex.a.T>'
assignable to       : 'Monoid<ex.a.T>'
for value assigned  : '{
  box(call.this.m)
}'
To solve this, you could change the type of the target 'ex.a.#fun0.call.result' to 'Monoid<ex.a.T>' or convert the type of the assigned value to 'ex.a.T'.

one error.
```