### PR TITLE
lib/codepoints: added definitions for latin alphabet and arabic numeral

### DIFF
--- a/lib/codepoints.fz
+++ b/lib/codepoints.fz
@@ -47,7 +47,7 @@ codepoints is
 
   # a-z and A-Z
   # https://en.wikipedia.org/wiki/ISO_basic_Latin_alphabet
-  latin_alphabet => A_to_Z.concatSequences a_to_z
+  latin_alphabet => A_to_Z.concatSequences a_to_z # NYI It would be better to use union of those two sets
 
   # range of values encoded in one byte
   #

--- a/lib/codepoints.fz
+++ b/lib/codepoints.fz
@@ -36,6 +36,18 @@ codepoints is
   #
   ascii => u32 0 .. 0x7f
 
+  # 0 to 9
+  arabic_numeral => (u32 0x30 .. 0x39).mapSequence<codepoint> (x -> codepoint x)
+
+  # A to Z (uppercase only)
+  A_to_Z => (u32 0x41 .. 0x5A).mapSequence<codepoint> (x -> codepoint x)
+
+  # a to z (lowercase only)
+  a_to_z => (u32 0x61 .. 0x7A).mapSequence<codepoint> (x -> codepoint x)
+
+  # a-z and A-Z
+  # https://en.wikipedia.org/wiki/ISO_basic_Latin_alphabet
+  latin_alphabet => A_to_Z.concatSequences a_to_z
 
   # range of values encoded in one byte
   #

--- a/lib/codepoints.fz
+++ b/lib/codepoints.fz
@@ -37,13 +37,13 @@ codepoints is
   ascii => u32 0 .. 0x7f
 
   # 0 to 9
-  arabic_numeral => (u32 0x30 .. 0x39).mapSequence<codepoint> (x -> codepoint x)
+  ascii_digit => u32 0x30 .. 0x39
 
   # A to Z (uppercase only)
-  A_to_Z => (u32 0x41 .. 0x5A).mapSequence<codepoint> (x -> codepoint x)
+  A_to_Z => u32 0x41 .. 0x5A
 
   # a to z (lowercase only)
-  a_to_z => (u32 0x61 .. 0x7A).mapSequence<codepoint> (x -> codepoint x)
+  a_to_z => u32 0x61 .. 0x7A
 
   # a-z and A-Z
   # https://en.wikipedia.org/wiki/ISO_basic_Latin_alphabet


### PR DESCRIPTION
I'm unsure if this is a good way to do it.
I mapped the u32 sequence to a codepoint sequence because this seemed more useful to me?
Maybe it also makes sense to make it lazy via list?
