### PR TITLE
fe: error if main_feature.fz does not exist

### DIFF
--- a/src/dev/flang/fe/FrontEndOptions.java
+++ b/src/dev/flang/fe/FrontEndOptions.java
@@ -133,6 +133,10 @@ public class FrontEndOptions extends FuzionOptions
                     inputFile = p;
                     main = null;
                   }
+                else
+                  {
+                    Errors.fatal("file does not exist: " + p, "");
+                  }
               }
           }
       }


### PR DESCRIPTION
- if main feature ends with (fz, fu, ...) assume it must be a file and error if it does not exist
- this is in contrast to previous behaviour where the current dir was then searched for a feature with given name