### PR TITLE
ast: error on loss of precision for floating point numbers

### DIFF
--- a/src/dev/flang/ast/AstErrors.java
+++ b/src/dev/flang/ast/AstErrors.java
@@ -1352,6 +1352,13 @@ public class AstErrors extends ANY
           "Incompatible result types in different branches:\n" +
           typesMsg);
   }
+
+  static void lossOfPrecision(SourcePosition pos, String _originalString, int _base, AbstractType type_)
+  {
+    error(pos,
+      "Loss of precision for: " + _originalString,
+      "Expected number given in base " + _base + " to fit into " + type_ + " without loss of precision.");
+  }
 }
 
 /* end of file */

--- a/src/dev/flang/ast/NumLiteral.java
+++ b/src/dev/flang/ast/NumLiteral.java
@@ -556,7 +556,12 @@ public class NumLiteral extends Constant
     else if (sh < 0)
       {
         var roundingBit = B1.shiftLeft(-sh-1);
-        return v.add(roundingBit).shiftRight(-sh);
+        var result = v.add(roundingBit).shiftRight(-sh);
+        if (_exponent5 == 0 && !result.shiftLeft(-sh).equals(v))
+          {
+            AstErrors.lossOfPrecision(pos(), _originalString, _base, type_);
+          }
+        return result;
       }
     else
       {


### PR DESCRIPTION
- only when float is given in a base which is a multiple of 2
Example output:
```
/home/not_synced/openvscode-server-fuzion/vscode-fuzion/fuzion-lsp-server/fuzion/asdf7.fz:111:35: error 1: Loss of precision for: -0x0.1P-146
  say "{(f32 -0x0.2P-146) == (f32 -0x0.1P-146)}"
----------------------------------^
Expected number given in base 16 to fit into f32 without loss of precision.
```