### PR TITLE
ast: type change visibility of name() to public

### DIFF
--- a/src/dev/flang/ast/AbstractType.java
+++ b/src/dev/flang/ast/AbstractType.java
@@ -910,7 +910,7 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
     return result;
   }
 
-  String name()
+  public String name()
   {
     return isGenericArgument() ? genericArgument().name() : featureOfType().featureName().baseName();
   }

--- a/src/dev/flang/ast/Type.java
+++ b/src/dev/flang/ast/Type.java
@@ -103,7 +103,7 @@ public class Type extends AbstractType
    * artificial type, this is one of Types.INTERNAL_NAMES (e.g., '--ADDRESS--).
    */
   public final String name;
-  String name()
+  public String name()
   {
     return name;
   }


### PR DESCRIPTION
This is used by both the fuziondoc and the language server.