### PR TITLE
lib/float: move from_i64 from float to floats, added comments

### DIFF
--- a/lib/f32.fz
+++ b/lib/f32.fz
@@ -58,10 +58,6 @@ f32(val f32) : float<f32>, f32s is
   redef as_i64 => as_f64.as_i64
 
 
-  redef from_i64(val i64) f32 is
-    val.as_f32
-
-
   as_f64 f64 is intrinsic
 
 
@@ -105,6 +101,9 @@ f32s : floats<f32> is
   redef minPositive f32 is intrinsic
   redef max f32 is intrinsic
   redef epsilon f32 is intrinsic
+
+  redef from_i64(val i64) f32 is
+    val.as_f32
 
   redef squareRoot(val f32) f32 is intrinsic
 

--- a/lib/f64.fz
+++ b/lib/f64.fz
@@ -72,10 +72,6 @@ f64(val f64) : float<f64>, f64s is
     => as_i64_lax
 
 
-  redef from_i64(val i64) f64 is
-    val.as_f64
-
-
   as_f32 f32 is intrinsic
 
 
@@ -120,6 +116,9 @@ f64s : floats<f64> is
   redef minPositive f64 is intrinsic
   redef max f64 is intrinsic
   redef epsilon f64 is intrinsic
+
+  redef from_i64(val i64) f64 is
+    val.as_f64
 
   redef squareRoot(val f64) f64 is intrinsic
 

--- a/lib/float.fz
+++ b/lib/float.fz
@@ -46,9 +46,9 @@ float(redef F float<F>.type) : numeric<F>, floats<F> is
   redef infix **!(other F) bool is true
 
 
+  # convert a float value to i64 dropping any fraction.
+  # the value must be in the range of i64
   as_i64 i64 is abstract
-
-  from_i64(val i64) F is abstract
 
 
   # round floating point number
@@ -116,6 +116,15 @@ floats(F float<F>.type) : numerics<F> is
   minPositive F is abstract
   max F is abstract
   epsilon F is abstract
+
+
+  # conversion
+
+  # convert an i64 value to a floating point value
+  #
+  # if the value cannot be represented exactly, the result is either
+  # the nearest higher or nearest lower value
+  from_i64(val i64) F is abstract
 
 
   squareRoot(val F) F is abstract


### PR DESCRIPTION
from_i64 does not require an instance.
I think it was a mistake to have added it to float instead of floats.