### PR TITLE
lib/list: take n, avoid creating tail

### DIFF
--- a/lib/list.fz
+++ b/lib/list.fz
@@ -196,7 +196,7 @@ list(A type) : choice<nil, Cons<A, list<A>>>, Sequence<A> is
         c Cons =>
           ref : Cons<A, list<A>>   # NYI: indentation syntax for anonymous not supported
             redef head => c.head
-            redef tail => c.tail.take n-1
+            redef tail => if n = 1 then nil else c.tail.take n-1
 
 
   # reverse the order of the elements in this list


### PR DESCRIPTION
This avoids creating the tail of the list after the last taken element.