### PR TITLE
acemode: improvements for syntax hightlighting

### DIFF
--- a/src/dev/flang/tools/AceMode.java
+++ b/src/dev/flang/tools/AceMode.java
@@ -192,10 +192,6 @@ public class AceMode extends ANY
 
         const CustomHighlightRules = function CustomHighlightRules()
         {
-          var keywordMapper = this.createKeywordMapper({
-            "keyword": "%s",
-          }, "text", false);
-
           this.$rules = {
             "start": [
               {
@@ -203,8 +199,8 @@ public class AceMode extends ANY
                 regex: /(#|\\/\\/).*$/,
               },
               {
-                regex: "\\\\w+\\\\b",
-                token: keywordMapper
+                token: 'keyword',
+                regex: /\\b(%s)\\b/
               },
               {
                 token: "string.quoted.double",
@@ -218,21 +214,20 @@ public class AceMode extends ANY
                     regex: /\\\\./
                 }, {
                     token: "variable.other",
-                    regex: /\\$[A-Za-z0-9_]+/
+                    regex: /\\$[A-Za-z_]+[A-Za-z0-9_]*/
                 }, {
                     defaultToken: "string.quoted.double"
                 }]
               },
               {
-                token: "numbers",
-                regex: /\\d+(?:[.](\\d)*)?|[.]\\d+/
-              }],
-
-            "static-method": [{
-              token: "support.function",
-              regex: /\\w+/,
-              next: "start"
-            }]
+                token: 'keyword.operator',
+                regex: /:=|=>|->/
+              },
+              {
+                token: 'constant.numeric',
+                regex: /\\b((0(x|b|d|o)[0-9a-fA-F_]*)|(([0-9_]+\\.?[0-9_]*)|(\\.[0-9_]+))((e|E|p|P)(\\+|-)?[0-9_]+)?)\\b/
+              }
+            ]
           };
           this.normalizeRules();
         };


### PR DESCRIPTION
- numeric literals are now coloured
before:
![image](https://user-images.githubusercontent.com/88769212/166656373-cb1bcc00-4375-41ed-9aa7-28b2516d0022.png)
after:
![image](https://user-images.githubusercontent.com/88769212/166656376-16d158be-42a8-491a-aad4-327fd073b0e0.png)
