### PR TITLE
Lib/comparable sequence

### DIFF
--- a/lib/bool.fz
+++ b/lib/bool.fz
@@ -36,7 +36,7 @@
 # value of type 'bool'.
 #
 #
-bool : choice<FALSE, TRUE> is
+bool : choice<FALSE, TRUE>, hasEquals<bool> is
 
   # not
   prefix ! bool is intrinsic
@@ -59,6 +59,10 @@ bool : choice<FALSE, TRUE> is
   # a == b == c for booleans might not behave as expected
   # ('true <=> false <=> false' evaluates to 'true')
   infix <=> (other bool) => if bool.this other else !other
+
+  # equality check implementation for inherited hasEquals
+  infix = (other bool) bool is
+    bool.this <=> other
 
   # xor
   infix ^   (other bool) => if bool.this (!other) else  other

--- a/lib/comparableSequence.fz
+++ b/lib/comparableSequence.fz
@@ -1,0 +1,43 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion standard library feature comparable_sequence
+#
+#  Author: Michael Lill (michael.lill@tokiwa.software)
+#
+# -----------------------------------------------------------------------
+
+# comparable_sequence -- a Sequence that inherits from hasEquals
+#
+comparable_sequence<A: hasEquals<A>>(from Sequence<A>) : Sequence<A>, hasEquals<comparable_sequence<A>>
+is
+
+  # create a list from this Sequence.
+  #
+  redef asList => from.asList
+
+
+  # equality check implementation for inherited hasEquals
+  infix = (o comparable_sequence<A>) bool is
+    fa := from.asArray
+    oa := o.asArray
+    if fa.count != oa.count
+      false
+    else
+      (0..(from.count - 1)) ∀ (i -> fa[i] = oa[i])


### PR DESCRIPTION
```
ex is
  say ((comparable_sequence [1,2]) = (comparable_sequence [1,2]))    # true
  say ((comparable_sequence [1,2]) = (comparable_sequence [1,3]))    # false
  say ((comparable_sequence [1,2]) = (comparable_sequence [1,2,3]))  # false
  say ((comparable_sequence [1,2,3]) = (comparable_sequence [1,2]))  # false
  say ((comparable_sequence [true]) = (comparable_sequence [false])) # false
  say ((comparable_sequence [true]) = (comparable_sequence [true]))  # true
```