### PR TITLE
fuir: ensure matchCaseTags is not empty

### DIFF
--- a/src/dev/flang/fuir/FUIR.java
+++ b/src/dev/flang/fuir/FUIR.java
@@ -1539,6 +1539,8 @@ hw25 is
             result[i] = resultL.get(i);
           }
       }
+    if(POSTCONDITIONS) ensure
+      (result.length > 0);
     return result;
   }
 


### PR DESCRIPTION
this example triggers the post condition:
```
ex =>

  e is

    b is

    l choice<i32,b> := b

    d(c ref e) is
      match c.l
        aa i32 => say aa
        bb b => say bb

    call =>
      d e.this

  e.call
```