### PR TITLE
util: SourceFile.codePointInLine erroneously returned byte-Index

### DIFF
--- a/src/dev/flang/util/SourceFile.java
+++ b/src/dev/flang/util/SourceFile.java
@@ -807,7 +807,11 @@ public class SourceFile extends ANY
    */
   public int codePointInLine(int pos, int line)
   {
-    return pos - lineStartPos(line) + 1;
+    int c = 1;
+    for (int i = lineStartPos(line); i < pos; i = i + sizeFromCpAndSize(decodeCodePointAndSize(i))){
+      c++;
+    }
+    return c;
   }
 
 

--- a/src/dev/flang/util/SourcePosition.java
+++ b/src/dev/flang/util/SourcePosition.java
@@ -107,7 +107,7 @@ public class SourcePosition extends ANY implements Comparable<SourcePosition>, H
    *
    * @param l the line number, starting at 1
    *
-   * @param c the colun, starting at 1.
+   * @param c the column, starting at 1.
    */
   public SourcePosition(SourceFile sourceFile, int l, int c)
   {


### PR DESCRIPTION
@fridis: This fix may have some performance implications since `codePointInLine()` is called in the Lexer quite often. 
Put differently, I'm open to suggestions to fix this bug in a better way.
