### PR TITLE
util: fix ArrayIndexOutOfBoundsException for empty source files

### DIFF
--- a/src/dev/flang/util/SourceFile.java
+++ b/src/dev/flang/util/SourceFile.java
@@ -807,10 +807,13 @@ public class SourceFile extends ANY
    */
   public int codePointInLine(int pos, int line)
   {
+    if(PRECONDITIONS)
+      require(line > 0);
     int c = 1;
-    for (int i = lineStartPos(line); i < pos; i = i + sizeFromCpAndSize(decodeCodePointAndSize(i))){
-      c++;
-    }
+    for (int i = lineStartPos(line); i < pos; i = i + sizeFromCpAndSize(decodeCodePointAndSize(i)))
+      {
+        c++;
+      }
     return c;
   }
 
@@ -821,7 +824,12 @@ public class SourceFile extends ANY
    */
   public int codePointInLine(int pos)
   {
-    return codePointInLine(pos, lineNum(pos));
+    int line = lineNum(pos);
+    if(line == 0)
+      {
+        return BEGINNING_OF_FILE;
+      }
+    return codePointInLine(pos, line);
   }
 
 


### PR DESCRIPTION
The PR yesterday introduced a minor bug that hit me when running the tests of the language server. Turns out `line` can take the special value 0. Then lineStartPos() crashes with an out of index exception.