### PR TITLE
lib/thread: relax return type of code passed to spawn

### DIFF
--- a/lib/concur/thread.fz
+++ b/lib/concur/thread.fz
@@ -37,7 +37,7 @@ is
 
   # spawn a new thread
   #
-  spawn(code ()->unit) =>
+  spawn(code ()->Object) =>
     p.spawn code
     _ := thread p mode
 
@@ -56,7 +56,7 @@ threadProvider ref is
 
   # spawn a new thread using given code
   #
-  spawn(code ()->unit) unit is abstract
+  spawn(code ()->Object) unit is abstract
 
 
 # type related to thread declaring features not requiring an instance of thread
@@ -74,4 +74,4 @@ defaultThread : threadProvider is
 
   # spawn a new thread using given code
   #
-  spawn(code ()->unit) => fuzion.sys.thread.spawn code
+  spawn(code ()->Object) => fuzion.sys.thread.spawn code

--- a/lib/fuzion/sys/thread.fz
+++ b/lib/fuzion/sys/thread.fz
@@ -30,11 +30,11 @@ private thread is
 
   # intrinsic to spawn a new thread
   #
-  private spawn(code ()->unit) =>
-    doCall ref : Function<unit> is
+  private spawn(code ()->Object) =>
+    doCall ref : Function<Object> is
       call =>
         code()
 
     spawn0 doCall
 
-  private spawn0<T: Function<unit>>(code T) unit is intrinsic
+  private spawn0<T: Function<Object>>(code T) unit is intrinsic


### PR DESCRIPTION
I think this change might make thread spawning more convenient.
@fridis Is there any downside to allowing the code passed to a thread returning not just unit but anything?