### PR TITLE
AST: Make 'result' visible in post-condition of routine using '=>', f…

### DIFF
--- a/src/dev/flang/ast/Feature.java
+++ b/src/dev/flang/ast/Feature.java
@@ -903,14 +903,15 @@ public class Feature extends AbstractFeature implements Stmnt
 
   /**
    * Check if the result variable should be internal, i.e., have a name that is
-   * not accessible by source code.  This is true for routines defined usings
-   * '=>" (RoutineDef) and also for internally used routines created for loops.
+   * not accessible by source code.  This is true for routines defined using
+   * '=>" (RoutineDef) that are internally generated, e.g. for loops.
    * In these cases, the result variable of the enclosing outer feature can be
    * accessed without qualification.
    */
   public boolean resultInternal()
   {
-    return _impl.kind_ == Impl.Kind.RoutineDef; // NYI: should be true if result is not used
+    return _impl.kind_ == Impl.Kind.RoutineDef &&
+      _featureName.baseName().startsWith(FuzionConstants.INTERNAL_NAME_PREFIX);
   }
 
 
@@ -1033,9 +1034,9 @@ public class Feature extends AbstractFeature implements Stmnt
         if (CHECKS) check
           (c == nc); // NYI: This will fail when doing funny stuff like inherit from bool.infix &&, need to check and handle explicitly
       }
-    _contract.visit(v, this);
     _impl.visit(v, this);
     _returnType.visit(v, this);
+    _contract.visit(v, this);
   }
 
 


### PR DESCRIPTION
…ix#45

Also had to change the order when visiting features: contract is visited after
the implementation since the implementation determines the type of the result,
which is then used in the post condition.

'result' is now also visible in pre-condition and in the implementation, but
reading it will result in reading an uninitialized field.