### PR TITLE
parser: fix precondition failure in this example:

### DIFF
--- a/src/dev/flang/parser/Parser.java
+++ b/src/dev/flang/parser/Parser.java
@@ -2336,7 +2336,16 @@ fun         : "fun" function
       }
     else
       {
-        result = new Function(pos, call(null));
+        var c = call(null);
+        if (c.actuals().size() == 0)
+          {
+            result = new Function(pos, c);
+          }
+        else
+          {
+            syntaxError(c.pos().bytePos(), "call without actual arguments", "fun");
+            result = c;
+          }
       }
     return result;
   }


### PR DESCRIPTION
```
fun adf old
```