### PR TITLE
lib/mutate: add small convenience feature `copy`

### DIFF
--- a/lib/mutate.fz
+++ b/lib/mutate.fz
@@ -98,6 +98,12 @@ is
       put (f get)
 
 
+    # creates a copy of the mutable field
+    #
+    copy new T is
+      mut get
+
+
   # install default instance of mutate
   #
   type.installDefault =>


### PR DESCRIPTION
Instead of writing
`copy := mut my_mut.get`
we can now write
`copy := my_mut.copy`