### PR TITLE
lib/stdin: refine error codes of `nextByte`

### DIFF
--- a/lib/fuzion/std/in.fz
+++ b/lib/fuzion/std/in.fz
@@ -27,5 +27,11 @@
 # NYI name std.in does not work right now since in is reserved keyword
 public fuzion.stdin is
 
-  # read next byte of stdin, less than zero on error/EOF
+  # read next byte from stdin
+  #
+  # returns:
+  # 0 or greater on success
+  # -1 at end of file
+  # -2 for any other error
+  #
   private nextByte i32 is intrinsic

--- a/src/dev/flang/be/c/Intrinsics.java
+++ b/src/dev/flang/be/c/Intrinsics.java
@@ -98,7 +98,7 @@ public class Intrinsics extends ANY
                  CExpr.exit(1));
     put("fuzion.std.fileio.readFile"   , noFileIo); // NYI
     put("fuzion.std.fileio.getFileSize", noFileIo); // NYI
-    put("fuzion.std.fileio.writeFile"  , noFileIo); // NYI        
+    put("fuzion.std.fileio.writeFile"  , noFileIo); // NYI
     put("fuzion.std.out.flush" ,
         "fuzion.std.err.flush" , (c,cl,outer,in) -> CExpr.call("fflush", new List<>(outOrErr(in))));
     put("fuzion.stdin.nextByte", (c,cl,outer,in) ->
@@ -106,7 +106,14 @@ public class Intrinsics extends ANY
           var cIdent = new CIdent("c");
           return CStmnt.seq(
             CExpr.decl("int", cIdent, CExpr.call("getchar", new List<>())),
-            CExpr.iff(cIdent.eq(new CIdent("EOF")),CExpr.int32const(-1).ret()),
+            CExpr.iff(cIdent.eq(new CIdent("EOF")),
+              CStmnt.seq(
+                // -1 EOF
+                CExpr.iff(CExpr.call("feof", new List<>(CExpr.ident("stdin"))), CExpr.int32const(-1).ret()),
+                // -2 some other error
+                CExpr.int32const(-2).ret()
+              )
+            ),
             cIdent.castTo("fzT_1i32").ret()
           );
         });

--- a/src/dev/flang/be/interpreter/Intrinsics.java
+++ b/src/dev/flang/be/interpreter/Intrinsics.java
@@ -197,8 +197,8 @@ public class Intrinsics extends ANY
               fs.read(byteArr);
               fs.close();
               return Value.EMPTY_VALUE;
-            } 
-          catch (Exception e) 
+            }
+          catch (Exception e)
             {
               return Value.EMPTY_VALUE; // NYI: need to handle an IO error
             }
@@ -216,8 +216,8 @@ public class Intrinsics extends ANY
             {
               long fileLength = Files.size(path);
               return new i64Value(fileLength);
-            } 
-          catch (Exception e) 
+            }
+          catch (Exception e)
             {
               return new i64Value(-1);
             }
@@ -260,7 +260,7 @@ public class Intrinsics extends ANY
             }
             catch (IOException e)
               {
-                return new i32Value(-1);
+                return new i32Value(-2);
               }
         });
     put("fuzion.std.out.flush", (interpreter, innerClazz) ->


### PR DESCRIPTION
return -1 at end of file, -2 for any other error