### PR TITLE
lib/array[n]: change asString to improve readability

### DIFF
--- a/lib/array2.fz
+++ b/lib/array2.fz
@@ -72,13 +72,13 @@ is
   # and ']'.  Arrays in inner dimensions are grouped using '[' and ']'.
   #
   redef asString =>
-    "[{for
-         s := "", s + c + (slice i*length1 (i+1)*length1)
-         i in indices0
-         c := "", ","
-       else
-         s
-      }]"
+    line_sep := strings.line_separator
+    ("["
+      + line_sep
+      + indices0
+          .map(i -> "  " + (slice i*length1 (i+1)*length1))
+          .fold(strings.concat("," + line_sep))
+      + line_sep + "]")
 
 
   # get a list of tuples indices and elements in this array

--- a/lib/array3.fz
+++ b/lib/array3.fz
@@ -75,23 +75,25 @@ is
   # and ']'.  Arrays in inner dimensions are grouped using '[' and ']'.
   #
   redef asString =>
-    "[{for
-         s := "", s + c + u
-         i0 in indices0
-         c := "", ","
-         u := "[{for
-                   s2 := "", s2 + c2 + (slice from to)
-                   i1 in indices1
-                   c2 := "", ","
-                   from := ((i0 * length1 + i1) * length2)
-                   to := from + length2
-                 else
-                   s2
-                }]"
-       else
-         s
-      }]"
+    line_sep := strings.line_separator
 
+    dim_1(i i32) =>
+      ("  [" + line_sep
+        + indices1
+            .map(j -> dim_2 i j)
+            .fold strings.concat("," + line_sep)
+        + line_sep + "  ]")
+
+    dim_2(i i32, j i32) =>
+      from := (i * length1 + j) * length2
+      to := from + length2
+      "    " + slice from to
+
+    ("[" + line_sep
+      + indices0
+          .map(i -> dim_1 i)
+          .fold strings.concat("," + line_sep)
+      + line_sep + "]")
 
 
   # get a list of tuples indices and elements in this array

--- a/lib/string.fz
+++ b/lib/string.fz
@@ -593,3 +593,7 @@ strings is
   zChar     => "z".utf8.asStream.next
   capAChar  => "A".utf8.asStream.next
   capZChar  => "Z".utf8.asStream.next
+
+
+  # a line break
+  line_separator => fromBytes [u8 10]


### PR DESCRIPTION
```
ex =>
  cnt := mut 0
  get => cnt <- cnt.get + 1; cnt.get
  say (array2 3 2 ((_,_) -> get))
  say "=="
  say (array3 6 3 2 ((_,_,_) -> get))
```
output:
```
[
  [1,2],
  [3,4],
  [5,6]
]
==
[
  [
    [7,8],
    [9,10],
    [11,12]
  ],
  [
    [13,14],
    [15,16],
    [17,18]
  ],
  [
    [19,20],
    [21,22],
    [23,24]
  ],
  [
    [25,26],
    [27,28],
    [29,30]
  ],
  [
    [31,32],
    [33,34],
    [35,36]
  ],
  [
    [37,38],
    [39,40],
    [41,42]
  ]
]
```