### PR TITLE
error in lib/ctrie.fz hotfix

### DIFF
--- a/lib/ctrie.fz
+++ b/lib/ctrie.fz
@@ -327,7 +327,7 @@ is
                                                       * => m
                                                   sn SNode => sn
                                     )
-    contract (CNode<CTK,CTV> cn.bmp narr) lev gen
+    contract (CNode CTK CTV cn.bmp narr) lev gen
 
 
   # contract a container node


### PR DESCRIPTION
This error occurred while doing a make: 

/home/wael/fuzion-code/fuzion/build/bin/../lib/ctrie.fz:330:30: error 1: Syntax error: expected right parenthesis ')', found identifier 'cn'
    contract (CNode<CTK,CTV> cn.bmp narr) lev gen
-----------------------------^
While parsing: pTypeList, parse stack: onetype, type, actual, actualSpace, actualsList, actualArgs, call, callOrFeatOrThis, term, opTail, opExpr, expr, exprInLine, stmnt, stmnts, block, implRout, routOrField, feature, stmnt, stmnts, block, implRout, routOrField, feature, stmnt, stmnts, unit

one error.
make: *** [Makefile:274: build/modules/base.fum] Error 1

After deleting the " < , > " the make is working again.