### PR TITLE
ast: call.splitOffTypeArgs, add only none null types to generics list.

### DIFF
--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -842,8 +842,8 @@ public class Call extends AbstractCall
             if (t != null)
               {
                 t.visit(Feature.findGenerics, outer);
+                g.add(t);
               }
-            g.add(t);
             ai.set(null);  // make sure visit() no longer visits this
             if (ts.get(ti).kind() != AbstractFeature.Kind.OpenTypeParameter)
               {


### PR DESCRIPTION
this fixes a null pointer exception for the following - broken - code:
```
# a container node
# consists of a bitmap of filled spaces and an array of child nodes
private CNode<CTK: hasHash<CTK>,CTV>(bmp u32, array array<Branch<CTK,CTV>>) is

# the ctrie
# NYI marking ctrie as ref see issue https://github.com/tokiwa-software/fuzion/issues/304
private CTrie<CTK: hasHash<CTK>, CTV>(root choice<INode<CTK,CTV>, RDCSS_Descriptor>, read_only bool) ref : map<CTK, CTV>
is

  # compress a container node
  private compress(cn CNode<CTK,CTV>, lev u32, gen i32) =>
    narr := cn.array.map<Branch<CTK,CTV>> (n -> match n
                                                  m INode =>
                                                    match m.GCAS_READ(CTrie.this).data
                                                      // resurrect
                                                      tn TNode<CTK,CTV> => tn.sn
                                                      * => m
                                                  sn SNode => sn
                                    )
    contract (CNode CTK CTV> cn.bmp narr) lev gen
#------------------>       <-------------------------- the issue, missing < triggers the issue
```