### PR TITLE
ast: isAssignableFrom remove failing check condition

### DIFF
--- a/src/dev/flang/ast/AbstractType.java
+++ b/src/dev/flang/ast/AbstractType.java
@@ -272,9 +272,6 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
   {
     var actlT = expr.type();
 
-    if (CHECKS) check
-      (actlT == Types.intern(actlT));
-
     return isAssignableFromOrContainsError(actlT) &&
       (!expr.isCallToOuterRef() && !(expr instanceof Current) || actlT.isRef() || actlT.isChoice());
   }


### PR DESCRIPTION
when building base.fum the check condition fails in the following cases:
```
Expression : function FEATURE: INVISIBLE  call(LOCAL i32 i) : Object{
  "  ".infix +(box(deref(deref(call.this.#^array2.asString.#fun4.call.#^array2.asString.#fun4).#^array2.asString).slice(call.this.i.infix *(deref(deref(call.this.#^array2.asString.#fun4.call.#^array2.asString.#fun4).#^array2.asString).length1), call.this.i.infix +(1).infix *(deref(deref(call.this.#^array2.asString.#fun4.call.#^array2.asString.#fun4).#^array2.asString).length1))))
}
Type: Function<string, i32>
===
Expression : function FEATURE: INVISIBLE  call(LOCAL i32 i) : Object{
  deref(call.this.#^array3.asString.#fun5.call.#^array3.asString.#fun5).dim_1(call.this.i)
}
Type: Function<string, i32>
===
Expression : function FEATURE: INVISIBLE  call(LOCAL i32 j) : Object{
  deref(deref(call.this.#^array3.asString.dim_1.#fun6.call.#^array3.asString.dim_1.#fun6).#^array3.asString.dim_1).dim_2(deref(call.this.#^array3.asString.dim_1.#fun6.call.#^array3.asString.dim_1.#fun6).i, call.this.j)
}
Type: Function<string, i32>
===
Expression : function FEATURE: INVISIBLE  call(LOCAL Branch<CNode.CTK, CNode.CTV> x) : Object{
  call.this.x.asString
}
Type: Function<string, Branch<CNode.CTK, CNode.CTV>>
===
```
I'm not a 100% sure but it think the check condition is outdated and not correct anymore.
