### PR TITLE
ast: formal generics update toString to new-style generics.

### DIFF
--- a/src/dev/flang/ast/FormalGenerics.java
+++ b/src/dev/flang/ast/FormalGenerics.java
@@ -294,7 +294,7 @@ public class FormalGenerics extends ANY
   public String toString()
   {
     return !isOpen() && list.isEmpty() ? ""
-                                       : "<" + list + (isOpen() ? "..." : "") + ">";
+                                       : list + (isOpen() ? "..." : "");
   }
 
 }


### PR DESCRIPTION
Example result:
```
In call to 'tya_field.foo2', no actual generic parameters are given and inference of the generic parameters failed.
Expected generic parameters: 'S, T'
Type inference failed for 2 generic arguments 'S', 'T'
```