### PR TITLE
lib/args: inherit from searchable list instead of array.

### DIFF
--- a/lib/envir/args.fz
+++ b/lib/envir/args.fz
@@ -32,7 +32,7 @@ private args (
   redef r effectMode.val,
 
   _ unit
-  ) : array string all.internalArray unit unit unit, effect r
+  ) : searchablelist all.asList, effect r
 is
 
 


### PR DESCRIPTION
this makes args easier to consume.