### PR TITLE
parser: fix spelling issue in antlr grammar

### DIFF
--- a/src/dev/flang/parser/Parser.java
+++ b/src/dev/flang/parser/Parser.java
@@ -3680,7 +3680,7 @@ onetype     : "ref" simpletype
             | simpletype "->" simpletype
             | pTypeList "->" simpletype
             | pTypeList
-            | LPAREN type RPARENT typeTail
+            | LPAREN type RPAREN typeTail
             | simpletype
             ;
 pTypeList   : LPAREN typeList RPAREN


### PR DESCRIPTION
this led to a warning during build