### PR TITLE
adding error handling to the fileio.move/rename feature

### DIFF
--- a/lib/fuzion/std/fileio.fz
+++ b/lib/fuzion/std/fileio.fz
@@ -142,7 +142,7 @@ public fileio is
     if move arr0.internalArray.data arr0.length arr1.internalArray.data arr1.length
       unit
     else
-      error "an error occured while performing the following move operation: \"$old_path\" --> \"$new_path\""
+      error "an error occurred while performing the following move operation: \"$old_path\" --> \"$new_path\""
 
   # intrinsic that returns TRUE in case the move was successful and FALSE in case not
   #

--- a/lib/fuzion/std/fileio.fz
+++ b/lib/fuzion/std/fileio.fz
@@ -130,16 +130,19 @@ public fileio is
 
   # moves file/dir from an old path to a the new path
   # can rename the file/dir as well by changing the name of the old file/dir to a new name in the new_path
-  # returns TRUE in case of success and FALSE in case of failure
+  # returns a unit type as outcome in case of success and error in case of failure
   #
   public move(
               # the old (relative or absolute) file name, using platform specific path separators
               old_path string,
               # the new (relative or absolute) file name, using platform specific path separators
-              new_path string) =>
+              new_path string) outcome unit is
     arr0 := old_path.utf8.asArray
     arr1 := new_path.utf8.asArray
-    move arr0.internalArray.data arr0.length arr1.internalArray.data arr1.length
+    if move arr0.internalArray.data arr0.length arr1.internalArray.data arr1.length
+      unit
+    else
+      error "an error occured while performing the following move operation: \"$old_path\" --> \"$new_path\""
 
   # intrinsic that returns TRUE in case the move was successful and FALSE in case not
   #

--- a/src/dev/flang/be/interpreter/Intrinsics.java
+++ b/src/dev/flang/be/interpreter/Intrinsics.java
@@ -298,7 +298,7 @@ public class Intrinsics extends ANY
             }
           catch (Exception e)
             {
-              return new boolValue(false); // NYI : need to handle an IO error
+              return new boolValue(false);
             }
         });
     put("fuzion.std.fileio.create_dir", (interpreter, innerClazz) -> args ->


### PR DESCRIPTION
fuzion.std.fileio.move now returns an outcome unit in case of success and error in case of failure