### PR TITLE
tests: remove FUZION_JAVA_STACK_SIZE, not needed anymore

### DIFF
--- a/tests/loop/Makefile
+++ b/tests/loop/Makefile
@@ -23,6 +23,5 @@
 #
 # -----------------------------------------------------------------------
 
-export FUZION_JAVA_STACK_SIZE = 4m # required since tail recursion is not optimized yet
 NAME = looptest
 include ../positive.mk

--- a/tests/rosettacode_factors_of_an_integer/Makefile
+++ b/tests/rosettacode_factors_of_an_integer/Makefile
@@ -23,6 +23,5 @@
 #
 # -----------------------------------------------------------------------
 
-export FUZION_JAVA_STACK_SIZE = 16m # required since tail recursion is not optimized yet
 NAME = factors
 include ../positive.mk

--- a/tests/rosettacode_man_or_boy/Makefile
+++ b/tests/rosettacode_man_or_boy/Makefile
@@ -23,6 +23,5 @@
 #
 # -----------------------------------------------------------------------
 
-export FUZION_JAVA_STACK_SIZE = 16m # required for manorboy(10)
 NAME = man_or_boy
 include ../positive.mk

--- a/tests/rosettacode_primes/Makefile
+++ b/tests/rosettacode_primes/Makefile
@@ -23,6 +23,5 @@
 #
 # -----------------------------------------------------------------------
 
-export FUZION_JAVA_STACK_SIZE = 16m # required since tail recursion is not optimized yet
 NAME = primes
 include ../positive.mk


### PR DESCRIPTION
I think these are not needed anymore?
Tests are green without these on my machine.