### PR TITLE
fix compilation "Redefinition must be declared..."

### DIFF
--- a/lib/int.fz
+++ b/lib/int.fz
@@ -182,11 +182,6 @@ is
     (b1.zip b2 ((a,b) -> a = b)) ∀ (x->x)
 
 
-  # are these natural numbers different?
-  infix != (other nat) bool is
-    !(thiz == other)
-
-
   # less or equal
   infix <= (other nat) =>
       (b1, b2) := equalize other
@@ -376,9 +371,6 @@ is
   # are these two ints equal?
   infix == (other int) bool is
     ns = other.ns & n = other.n
-
-  infix != (other int) bool is
-    !(thiz == other)
 
   orderedThis int is int ns n
 


### PR DESCRIPTION
"...using modifier 'redef'"
the underlying reason for this error is that in numeric `infix !=` is no longer abstract