### PR TITLE
lib: sequence add feature `indexed`

### DIFF
--- a/lib/Sequence.fz
+++ b/lib/Sequence.fz
@@ -342,6 +342,13 @@ Sequence(T type) ref is
       c Cons => c.head
 
 
+  # adds the corresponding index to
+  # every element in the sequence
+  #
+  indexed list (tuple i32 T) is
+    zip (0..) (a,b -> (b, a))
+
+
 # Sequences -- unit type defining features related to Sequence but not requiring
 # an instance
 #


### PR DESCRIPTION
example:

```
ex =>
  say (["one","two", "three"]
    .indexed
    .mapSequence (x ->
      (idx, str) := x
      "$idx $str"
    ))
```

result:
`[0 one,1 two,2 three]`