### PR TITLE
lib: uint.asString improved performance

### DIFF
--- a/lib/int.fz
+++ b/lib/int.fz
@@ -159,7 +159,7 @@ is
           minus => other.n <= n
 
   redef asString string is
-    int.this.asString 10
+    s.asString + n.asString
 
 
 int (val i64) int is
@@ -202,6 +202,6 @@ sign : choice plus minus, hasEquals sign is
 
   redef asString string is
     match sign.this
-      plus => "+"
+      plus => ""
       minus => "-"
 

--- a/lib/string.fz
+++ b/lib/string.fz
@@ -493,6 +493,19 @@ string ref : hasHash string, ordered string, strings is
   infix ∉ (s Set string) => string.this.notElementOf s
 
 
+  # return string of at least length l by
+  # padding s to start of string
+  #
+  pad_start(l i32, s string) string
+  pre s.codepointLength = 1
+  is
+    missing := l - codepointLength
+    if missing <= 0
+      string.this
+    else
+      (s * missing) + string.this
+
+
 # strings -- unit type defining features related to string but not
 # requiring an instance
 #

--- a/lib/uint.fz
+++ b/lib/uint.fz
@@ -301,8 +301,20 @@ is
     as_u32.as_i32
 
 
+  # this uint as a string, may contain leading zeros
+  #
+  private asString0 string is
+    if uint.this = zero
+      "0"
+    else
+      mrd := uint 1_000_000_000
+      (q, rem) := uint.this.divide_with_remainder mrd
+      q.asString0 + (rem.data.first (u32 0)).asString.pad_start 9 "0"
+
+
   redef asString string is
-    uint.this.asString 10
+    ascii_code_zero := codepoints.ascii_digit.first.as_u8
+    strings.fromBytes asString0.utf8.dropWhile(x -> x=ascii_code_zero)
 
 
 uint (val u64) uint is


### PR DESCRIPTION
Simple measurements suggest that for large numbers this make asString roughly 10 times faster:

```
ex is
  a := (int 3)**(int 247)
  say (bench (() -> say a) 10000)
```
