### PR TITLE
lib: uint fix as string zero

### DIFF
--- a/lib/uint.fz
+++ b/lib/uint.fz
@@ -304,17 +304,20 @@ is
   # this uint as a string, may contain leading zeros
   #
   private asString0 string is
-    if uint.this = zero
-      "0"
+    mrd := uint 1_000_000_000
+    (q, rem) := uint.this.divide_with_remainder mrd
+
+    if q = zero
+      (rem.data.first (u32 0)).asString
     else
-      mrd := uint 1_000_000_000
-      (q, rem) := uint.this.divide_with_remainder mrd
       q.asString0 + (rem.data.first (u32 0)).asString.pad_start 9 "0"
 
 
   redef asString string is
-    ascii_code_zero := codepoints.ascii_digit.first.as_u8
-    strings.fromBytes asString0.utf8.dropWhile(x -> x=ascii_code_zero)
+    if uint.this = zero
+      "0"
+    else
+      asString0
 
 
 uint (val u64) uint is

--- a/tests/int/int_test.fz
+++ b/tests/int/int_test.fz
@@ -50,6 +50,8 @@ int_test is
       if n >= 0
         chck (int m**n = (int m ** int n)) "int: m $m ** n $n"
 
+    chck ("$m" = "{ints.from_i64 m}")  "int:  $m as string"
+
   # test basic uint operations with small numbers
   for m in (u64 0)..5 do
     for n in (u64 0)..5 do
@@ -67,12 +69,14 @@ int_test is
         chck (uint m%n = (uint m % uint n)) "uint: m $m % n $n"
       chck (uint m**n = (uint m ** uint n)) "uint: m $m ** n $n"
 
+    chck ("$m" = "{uint m}") "uint: $m as string"
+
 
   u32_max := u32s.max.as_u64
 
 
-  # test as int/uint string
-  for m in (u32_max - 5)..u32_max do
+  # test int/uint as_string around first overflow
+  for m in (u32_max - 3)..(u32_max + 3) do
     chck ("$m" = "{ints.from_u64 m}")  "int:  $m as string"
     chck ("$m" = "{uint m}") "uint: $m as string"
 


### PR DESCRIPTION
Turns out the `asString` did not work for 0. There it just returned an empty string... :-(
While fixing this I also realized that the code was more complicated than necessary.

I also added tests to test asString around zero and around the first overflow of u32.
