### PR TITLE
lib/float: fix ceiling function

### DIFF
--- a/lib/float.fz
+++ b/lib/float.fz
@@ -78,7 +78,7 @@ float(redef F (float F).type) : numeric F, floats F is
 
   # ceiling: the smallest integer greater or equal to this
   ceil F is
-    if fract < zero
+    if fract <= zero
       thiz - fract
     else
       thiz - fract + one


### PR DESCRIPTION
The previous implementation returned the least integer greater than x. The commonly accepted definition is to return the least integer greater than or equal to x.

Fixes #469.