### PR TITLE
be/interpreter: implement fuzion.std.args.* intrinsics

### DIFF
--- a/lib/fuzion/std/args.fz
+++ b/lib/fuzion/std/args.fz
@@ -31,7 +31,10 @@ private args =>
   count i32 is intrinsic
 
   # intrinsic to get i-th argument as a string
-  get(i i32) string is intrinsic
+  get(i i32) string
+    pre
+      i < count
+    is intrinsic
 
   # return the arguments in an array
   array string count (i -> get i)

--- a/src/dev/flang/be/interpreter/Intrinsics.java
+++ b/src/dev/flang/be/interpreter/Intrinsics.java
@@ -159,7 +159,7 @@ public class Intrinsics extends ANY
   static
   {
     put("Type.name"            , (interpreter, innerClazz) -> args -> Interpreter.value(innerClazz._outer.typeName()));
-    put("fuzion.std.args.count", (interpreter, innerClazz) -> args -> new i32Value(1)); /* NYI: args after cmd name not supported yet */
+    put("fuzion.std.args.count", (interpreter, innerClazz) -> args -> new i32Value(Interpreter._options_.getBackendArgs().size() + 1));
     put("fuzion.std.args.get"  , (interpreter, innerClazz) -> args ->
         {
           var i = args.get(1).i32Value();
@@ -170,7 +170,7 @@ public class Intrinsics extends ANY
             }
           else
             {
-              return  Interpreter.value("argument#"+i); // NYI: args after cmd name not supported yet
+              return  Interpreter.value(Interpreter._options_.getBackendArgs().get(i - 1));
             }
         });
     put("fuzion.std.out.write", (interpreter, innerClazz) ->

--- a/src/dev/flang/util/FuzionOptions.java
+++ b/src/dev/flang/util/FuzionOptions.java
@@ -26,6 +26,8 @@ Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
 
 package dev.flang.util;
 
+import java.util.ArrayList;
+
 
 /**
  * FrontEndOptions specify the configuration of the front end
@@ -62,6 +64,15 @@ public class FuzionOptions extends ANY
    * not allowed if run in a web playground.
    */
   final boolean _enableUnsafeIntrinsics;
+
+
+  /*
+   * Array that can be set to pass arbitrary arguments to the backend. Currently used
+   * for passing arguments given to the interpreter to the fuzion.std.args intrinsics.
+   */
+  private ArrayList<String> _backendArgs;
+  public void setBackendArgs(ArrayList<String> args) { _backendArgs = args; }
+  public ArrayList<String> getBackendArgs() { return _backendArgs; }
 
 
   private boolean _tailRecursionInsteadOfLoops; // NYI: move to FrontendOptions


### PR DESCRIPTION
Make the `envir.args` effect work with the interpreter backend. Arguments can be passed as follows:

```
fz feature.fz -- arg1 arg2 arg3...
```

Fixes #468.