### PR TITLE
interrupting test run leads to printing of intermediate results.

### DIFF
--- a/bin/run_tests.sh
+++ b/bin/run_tests.sh
@@ -33,6 +33,10 @@ BUILD_DIR=$1
 TARGET=$2
 TESTS=$(echo "$BUILD_DIR"/tests/*/)
 rm -rf "$BUILD_DIR"/run_tests.results
+
+# print collected results up until interruption
+trap "echo """"; cat ""$BUILD_DIR""/run_tests.results; exit 130;" INT
+
 for test in $TESTS; do
   if test -n "$VERBOSE"; then
     echo -en "\nrun $test: "

--- a/bin/run_tests_parallel.sh
+++ b/bin/run_tests_parallel.sh
@@ -62,6 +62,9 @@ TARGET=$2
 TESTS=$(echo "$BUILD_DIR"/tests/*/)
 rm -rf "$BUILD_DIR"/run_tests.results
 
+# print collected results up until interruption
+trap "echo """"; cat ""$BUILD_DIR""/run_tests.results; exit 130;" INT
+
 N=$(nproc --all || echo 1)
 open_sem "$N"
 


### PR DESCRIPTION
example:
```
sam@debian /home/not_synced/fuzion (main)130$ make run_tests
testing interpreter: ...^C
./build/tests/abstractfeatures_negative/: ok
./build/tests/argumentcount_negative/: ok
./build/tests/assignment_negative/: ok
make: [Makefile:415: run_tests_int] Error 130 (ignored)
```