### PR TITLE
scripts: use /usr/bin/env bash; set -euo pipefail

### DIFF
--- a/bin/ebnf.sh
+++ b/bin/ebnf.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of the Fuzion language implementation.
 #

--- a/bin/fz
+++ b/bin/fz
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of the Fuzion language implementation.
 #
@@ -35,6 +35,8 @@
 #   FUZION_JAVA_STACK_SIZE the stack size parameter passed to the JAVA command
 #   FUZION_JAVA_OPTIONS    options to be passed to the JAVA command (if set, will
 #                          override stack size)
+
+set -euo pipefail
 
 FUZION_CMD=$0
 FUZION_BIN="$(dirname "$(readlink -f "$0")")"

--- a/bin/fzjava
+++ b/bin/fzjava
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of the Fuzion language implementation.
 #
@@ -36,6 +36,8 @@
 #   FUZION_JAVA_STACK_SIZE the stack size parameter passed to the JAVA command
 #   FUZION_JAVA_OPTIONS    options to be passed to the JAVA command (if set, will
 #                          override stack size)
+
+set -euo pipefail
 
 FUZION_CMD=$0
 FUZION_BIN="$(dirname "$(readlink -f "$0")")"

--- a/bin/run_tests.sh
+++ b/bin/run_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of the Fuzion language implementation.
 #
@@ -25,6 +25,7 @@
 #
 # -----------------------------------------------------------------------
 
+set -euo pipefail
 
 # usage: run_tests.sh <build-dir> <target>
 #
@@ -32,6 +33,8 @@
 BUILD_DIR=$1
 TARGET=$2
 TESTS=$(echo "$BUILD_DIR"/tests/*/)
+VERBOSE="${VERBOSE:-""}"
+
 rm -rf "$BUILD_DIR"/run_tests.results
 
 # print collected results up until interruption
@@ -45,11 +48,11 @@ for test in $TESTS; do
     echo -n "_"
     echo "$test: skipped" >>"$BUILD_DIR"/run_tests.results
   else
-    START_TIME=`date +%s%N | cut -b1-13`
+    START_TIME=$(date +%s%N | cut -b1-13)
     make "$TARGET" -e -C >"$test"/out.txt "$test" 2>/dev/null \
         && (echo -n "." && echo "$test: ok"     >>"$BUILD_DIR"/run_tests.results) \
         || (echo -n "#" && echo "$test: failed" >>"$BUILD_DIR"/run_tests.results)
-    END_TIME=`date +%s%N | cut -b1-13`
+    END_TIME=$(date +%s%N | cut -b1-13)
     if test -n "$VERBOSE"; then
       echo -en " time: $((END_TIME-START_TIME))ms"
     fi

--- a/bin/run_tests_parallel.sh
+++ b/bin/run_tests_parallel.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of the Fuzion language implementation.
 #
@@ -25,6 +25,7 @@
 #
 # -----------------------------------------------------------------------
 
+set -euo pipefail
 
 # usage: run_tests_parallel.sh <build-dir> <target>
 #
@@ -60,6 +61,8 @@ renice -n 19 $$ > /dev/null
 BUILD_DIR=$1
 TARGET=$2
 TESTS=$(echo "$BUILD_DIR"/tests/*/)
+VERBOSE="${VERBOSE:-""}"
+
 rm -rf "$BUILD_DIR"/run_tests.results
 
 # print collected results up until interruption

--- a/tests/_cur_dir.sh
+++ b/tests/_cur_dir.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of the Fuzion language implementation.
 #

--- a/tests/check_simple_example.sh
+++ b/tests/check_simple_example.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of the Fuzion language implementation.
 #

--- a/tests/check_simple_example.sh
+++ b/tests/check_simple_example.sh
@@ -26,6 +26,7 @@
 #
 # -----------------------------------------------------------------------
 
+set -euo pipefail
 
 # Run the fuzion example given as an argument $2 and compare the stdout/stderr
 # output to $2.expected_out and $2.expected_err.

--- a/tests/check_simple_example_c.sh
+++ b/tests/check_simple_example_c.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of the Fuzion language implementation.
 #

--- a/tests/check_simple_example_c.sh
+++ b/tests/check_simple_example_c.sh
@@ -26,6 +26,7 @@
 #
 # -----------------------------------------------------------------------
 
+set -euo pipefail
 
 # Run the fuzion example given as an argument $2 using the C backend and compare
 # the stdout/stderr output to $2.expected_out and $2.expected_err.

--- a/tests/record_simple_example.sh
+++ b/tests/record_simple_example.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of the Fuzion language implementation.
 #

--- a/tests/record_simple_example.sh
+++ b/tests/record_simple_example.sh
@@ -26,6 +26,7 @@
 #
 # -----------------------------------------------------------------------
 
+set -euo pipefail
 
 # Run the fuzion example given as an argument $2 and store the stdout/stderr
 # output to $2.expected_out and $2.expected_err.

--- a/tests/record_simple_example_c.sh
+++ b/tests/record_simple_example_c.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of the Fuzion language implementation.
 #

--- a/tests/record_simple_example_c.sh
+++ b/tests/record_simple_example_c.sh
@@ -26,6 +26,7 @@
 #
 # -----------------------------------------------------------------------
 
+set -euo pipefail
 
 # Run the fuzion example given as an argument $2 using the C backend and store
 # the stdout/stderr output to $2.expected_out_c and $2.expected_err_c.


### PR DESCRIPTION
> Running a command through /usr/bin/env has the benefit of looking for whatever the default version of the program is in your current environment.
> 
> This way, you don't have to look for it in a specific place on the system, as those paths may be in different locations on different systems. As long as it's in your path, it will find it.
> 
> One downside is that you will be unable to pass more than one argument (e.g. you will be unable to write /usr/bin/env awk -f) if you wish to support Linux, as [POSIX is vague](https://unix.stackexchange.com/a/399702/6252) on how the line is to be interpreted, and Linux interprets everything after the first space to denote a single argument. You can use /usr/bin/env -S on some versions of env to get around this, but then the script will become even less portable and break on fairly recent systems (e.g. even Ubuntu 16.04 if not later).
> 
> Another downside is that since you aren't calling an explicit executable, it's got the potential for mistakes, and on multiuser systems security problems (if someone managed to get their executable called bash in your path, for example).

https://stackoverflow.com/a/16365367