### PR TITLE
tests: Change order of options to fz command such that -c is after ma…

### DIFF
--- a/tests/check_simple_example_c.sh
+++ b/tests/check_simple_example_c.sh
@@ -48,10 +48,10 @@ else
     rm -f testbin
 
     # NYI: Use this version to check there are no warnings produced by C compiler:
-    (($1 "$2" -c -o=testbin                && ./testbin) 2>tmp_err0.txt | head -n 100) >tmp_out.txt;
+    (($1 -c "$2" -o=testbin                && ./testbin) 2>tmp_err0.txt | head -n 100) >tmp_out.txt;
 
     # This version dumps stderr output if fz was successful, which essentially ignores C compiler warnings:
-    # (($1 $2 -c -o=testbin 2>tmp_err0.txt && ./testbin  2>tmp_err0.txt | head -n 100) >tmp_out.txt;
+    # (($1 -c $2 -o=testbin 2>tmp_err0.txt && ./testbin  2>tmp_err0.txt | head -n 100) >tmp_out.txt;
 
     cat tmp_err0.txt | sed "s|$CURDIR[\\\/]|--CURDIR--/|g" >tmp_err.txt
     rm -rf tmp_err0.txt

--- a/tests/negative.mk
+++ b/tests/negative.mk
@@ -36,7 +36,7 @@ int:
 	cat err.txt  | grep "should.flag.an.error" | sed "s ^.*//  g"| sort -n | uniq | wc -l | grep ^$(EXPECTED_ERRORS)$$ && echo "test passed." || exit 1
 
 c:
-	($(FUZION) -c $(NAME) -o=testbin && ./testbin) 2>err.txt || echo -n
+	($(FUZION) -c -o=testbin $(NAME) && ./testbin) 2>err.txt || echo -n
 	cat err.txt  | grep "should.flag.an.error" | sed "s ^.*//  g"| sort -n | uniq | wc -l | grep ^$(EXPECTED_ERRORS)$$ && echo "test passed." || exit 1
 
 show:

--- a/tests/positive.mk
+++ b/tests/positive.mk
@@ -34,4 +34,4 @@ int:
 	$(FUZION) $(NAME) 2>err.txt
 
 c:
-	($(FUZION) $(NAME) -c -o=testbin && ./testbin) 2>err.txt
+	($(FUZION) -c -o=testbin $(NAME) && ./testbin) 2>err.txt

--- a/tests/record_simple_example_c.sh
+++ b/tests/record_simple_example_c.sh
@@ -42,7 +42,7 @@ CURDIR=$("$SCRIPTPATH"/_cur_dir.sh)
 if [ -f "$2".skip ]; then
     echo "SKIPPED $2"
 else
-    (($1 "$2" -c -o=testbin && ./testbin) 2>"$2".expected_err_c0 | head -n 100) >"$2".expected_out_c
+    (($1 -c "$2" -o=testbin && ./testbin) 2>"$2".expected_err_c0 | head -n 100) >"$2".expected_out_c
     cat "$2".expected_err_c0 | sed "s|$CURDIR[\\\/]|--CURDIR--/|g" >"$2".expected_err_c
     rm -rf "$2".expected_err_c0 testbin testbin.c
     echo "RECORDED $2"


### PR DESCRIPTION
…in feature

This fixes some of the C backend tests (but not all, need to check what else goes wrong).