### PR TITLE
fe: Eliminate special handling for type parameter Object as constrain…

### DIFF
--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -1361,7 +1361,7 @@ public class Call extends AbstractCall
             throw new Error("NYI (see #283): Calling open type parameter");
           }
         var tptype = t.resolve(res, tt.featureOfType());
-        if (!tptype.isGenericArgument() && tptype.compareTo(Types.resolved.t_object) != 0)
+        if (!tptype.isGenericArgument())
           {
             tptype = tptype.featureOfType().typeFeature(res).thisType();
           }


### PR DESCRIPTION
…t, fix #519

Not sure why this special handling was there, but it results in the result type of a type parameter being 'Object' (which is a ref), and not 'Object.#type', which is a value type.