### PR TITLE
Tool: do not fail preconditions if parsePositiveIntArg is given no value

### DIFF
--- a/src/dev/flang/tools/Tool.java
+++ b/src/dev/flang/tools/Tool.java
@@ -316,7 +316,7 @@ public abstract class Tool extends ANY
   protected int parsePositiveIntArg(String a, int defawlt)
   {
     if (PRECONDITIONS) require
-      (a.split("=").length == 2);
+      (a.split("=").length == 1 || a.split("=").length == 2);
 
     int result = defawlt;
     var s = a.split("=");


### PR DESCRIPTION
Fixes #520.