### PR TITLE
lib/outcome: add and and or

### DIFF
--- a/lib/outcome.fz
+++ b/lib/outcome.fz
@@ -123,6 +123,21 @@ outcome(T type) : choice T error /* ...  NYI: this should be open generic! */ is
     outcome.this ? v T     => v.asString
                  | e error => "--$e--"
 
+  # returns o if outcome is ok, otherwise return the outcome's own
+  # error.
+  and (O type, o outcome O) outcome O is
+    if ok
+      o
+    else
+      outcome.this
+
+  # returns o if outcome is not ok, otherwise return this outcome's value.
+  or (o outcome T) outcome T is
+    if !ok
+      o
+    else
+      outcome.this
+
 
 # outcome with 1 argument provides an short-hand to wrap a value into a
 # outcome


### PR DESCRIPTION
Resolves part of #504. Tests (more or less from Rust docs mentioned in #504):

```
test_outcome_and is
  a outcome u32 := u32 2
  b outcome string := error "late error"

  match (a.and b)
    e error => say e
    s string => say s

  c outcome u32 := error "early error"
  d outcome string := "foo"

  match (c.and d)
    e error => say e
    s string => say s

  e outcome u32 := error "not a 2"
  f outcome string := error "late error"

  match (e.and f)
    e error => say e
    s string => say s

  g outcome u32 := u32 2
  h outcome string := "different result type"

  match (g.and h)
    e error => say e
    s string => say s
```

```
test_outcome_and is
  a outcome u32 := u32 2
  b outcome u32 := error "late error"

  match (a.or b)
    e error => say e
    s u32 => say s

  c outcome u32 := error "early error"
  d outcome u32 := u32 2

  match (c.or d)
    e error => say e
    s u32 => say s

  e outcome u32 := error "not a 2"
  f outcome u32 := error "late error"

  match (e.or f)
    e error => say e
    s u32 => say s

  g outcome u32 := u32 2
  h outcome u32 := u32 100

  match (g.or h)
    e error => say e
    s u32 => say s
```