### PR TITLE
int: remove postcondition, result of choice must not be null (anymore)

### DIFF
--- a/src/dev/flang/be/interpreter/Interpreter.java
+++ b/src/dev/flang/be/interpreter/Interpreter.java
@@ -1326,8 +1326,7 @@ public class Interpreter extends ANY
       }
 
     if (POSTCONDITIONS) ensure
-      (   thiz.isChoice()                         // null is used e.g. in Option<T>: choice<T,Null>.
-       || result != null                          // otherwise, there must not be any null
+      (   result != null                          // otherwise, there must not be any null
        || allowUninitializedRefField              // unless we explicitly allowed uninitialized data
       );
 

--- a/src/dev/flang/be/interpreter/Interpreter.java
+++ b/src/dev/flang/be/interpreter/Interpreter.java
@@ -1326,7 +1326,7 @@ public class Interpreter extends ANY
       }
 
     if (POSTCONDITIONS) ensure
-      (   result != null                          // otherwise, there must not be any null
+      (   result != null                          // there must not be any null
        || allowUninitializedRefField              // unless we explicitly allowed uninitialized data
       );
 


### PR DESCRIPTION
I think it is not the case (anymore) that result might be null in case getField() is used on choice type.