### PR TITLE
fzjava: do not generate duplicate features

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -644,9 +644,6 @@ $(MOD_JAVA_XML_CRYPTO_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE) $(MOD_
 	rm -rf $(@D)
 	mkdir -p $(@D)
 	/bin/bash -c "$(BUILD_DIR)/bin/fzjava java.xml.crypto -to=$(@D) -modules=java.xml,java.base -verbose=0"
-# NYI: Still creates duplicate features for some reason.
-	rm -f $(BUILD_DIR)/modules/java.xml.crypto/Java/javax/xml_pkg.fz
-	rm -f $(BUILD_DIR)/modules/java.xml.crypto/Java/org_pkg.fz
 	touch $@
 $(MOD_JDK_ACCESSIBILITY_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE) $(MOD_JAVA_DESKTOP)
 	rm -rf $(@D)
@@ -812,10 +809,6 @@ $(MOD_JDK_XML_DOM_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE) $(MOD_JAVA
 	rm -rf $(@D)
 	mkdir -p $(@D)
 	/bin/bash -c "$(BUILD_DIR)/bin/fzjava jdk.xml.dom -to=$(@D) -modules=java.base,java.xml -verbose=0"
-# NYI: Still creates duplicate features for some reason.
-	rm -f $(BUILD_DIR)/modules/jdk.xml.dom/Java/org_pkg.fz
-	rm -f $(BUILD_DIR)/modules/jdk.xml.dom/Java/org/w3c_pkg.fz
-	rm -f $(BUILD_DIR)/modules/jdk.xml.dom/Java/org/w3c/dom_pkg.fz
 	touch $@
 $(MOD_JDK_ZIPFS_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE)
 	rm -rf $(@D)

--- a/Makefile
+++ b/Makefile
@@ -549,10 +549,6 @@ $(MOD_JAVA_DESKTOP_FZ_FILES): $(BUILD_DIR)/bin/fzjava
 	mv $(BUILD_DIR)/modules/java.desktop/Java/sun/swing_pkg.fz $(BUILD_DIR)/modules/java.desktop/sun_swing_pkg.fz
 	mv $(BUILD_DIR)/modules/java.desktop/Java/sun/print_pkg.fz $(BUILD_DIR)/modules/java.desktop/sun_print_pkg.fz
 	mv $(BUILD_DIR)/modules/java.desktop/Java/sun/*.fz $(BUILD_DIR)/modules/java.desktop/
-# NYI: cleanup: see #463: manually delete redundant features
-# Is it necessary to remove awt_pkg.fz here? It is not getting generated, but
-# this is not due to my changes.
-	rm -f $(BUILD_DIR)/modules/java.desktop/Java/java/awt_pkg.fz
 	touch $@
 
 $(MOD_JAVA_COMPILER_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE)

--- a/Makefile
+++ b/Makefile
@@ -315,12 +315,6 @@ $(MOD_JAVA_XML_FZ_FILES): $(BUILD_DIR)/bin/fzjava
 	mkdir -p $(@D)
 # wrapping in /bin/bash -c "..." is a workaround for building on windows, bash (mingw)
 	/bin/bash -c "$(BUILD_DIR)/bin/fzjava java.xml -to=$(@D) -modules=java.base -verbose=0"
-# NYI: cleanup: see #463: manually delete redundant features
-	rm -f $(BUILD_DIR)/modules/java.xml/Java_pkg.fz
-	rm -f $(BUILD_DIR)/modules/java.xml/Java/jdk_pkg.fz
-	rm -f $(BUILD_DIR)/modules/java.xml/Java/javax_pkg.fz
-	rm -f $(BUILD_DIR)/modules/java.xml/Java/com_pkg.fz
-	rm -f $(BUILD_DIR)/modules/java.xml/Java/com/sun_pkg.fz
 	touch $@
 
 $(MOD_JAVA_DATATRANSFER_FZ_FILES): $(BUILD_DIR)/bin/fzjava
@@ -328,10 +322,6 @@ $(MOD_JAVA_DATATRANSFER_FZ_FILES): $(BUILD_DIR)/bin/fzjava
 	mkdir -p $(@D)
 # wrapping in /bin/bash -c "..." is a workaround for building on windows, bash (mingw)
 	/bin/bash -c "$(BUILD_DIR)/bin/fzjava java.datatransfer -to=$(@D) -modules=java.base,java.xml -verbose=0"
-# NYI: cleanup: see #463: manually delete redundant features
-	rm -f $(BUILD_DIR)/modules/java.datatransfer/Java_pkg.fz
-	rm -f $(BUILD_DIR)/modules/java.datatransfer/Java/java_pkg.fz
-	rm -f $(BUILD_DIR)/modules/java.datatransfer/Java/sun_pkg.fz
 # NYI: cleanup: see #462: manually move these features to the main directory
 # since otherwise they would not be found automatically.
 	mv $(BUILD_DIR)/modules/java.datatransfer/Java/sun/datatransfer_pkg.fz $(BUILD_DIR)/modules/java.datatransfer/
@@ -352,12 +342,8 @@ $(MOD_JAVA_DESKTOP_FZ_FILES): $(BUILD_DIR)/bin/fzjava
 	mv $(BUILD_DIR)/modules/java.desktop/Java/sun/print_pkg.fz $(BUILD_DIR)/modules/java.desktop/sun_print_pkg.fz
 	mv $(BUILD_DIR)/modules/java.desktop/Java/sun/*.fz $(BUILD_DIR)/modules/java.desktop/
 # NYI: cleanup: see #463: manually delete redundant features
-	rm -f $(BUILD_DIR)/modules/java.desktop/Java_pkg.fz
-	rm -f $(BUILD_DIR)/modules/java.desktop/Java/javax_pkg.fz
-	rm -f $(BUILD_DIR)/modules/java.desktop/Java/com_pkg.fz
-	rm -f $(BUILD_DIR)/modules/java.desktop/Java/sun_pkg.fz
-	rm -f $(BUILD_DIR)/modules/java.desktop/Java/com/sun_pkg.fz
-	rm -f $(BUILD_DIR)/modules/java.desktop/Java/java_pkg.fz
+# Is it necessary to remove awt_pkg.fz here? It is not getting generated, but
+# this is not due to my changes.
 	rm -f $(BUILD_DIR)/modules/java.desktop/Java/java/awt_pkg.fz
 	touch $@
 

--- a/Makefile
+++ b/Makefile
@@ -314,7 +314,7 @@ $(MOD_JAVA_XML_FZ_FILES): $(BUILD_DIR)/bin/fzjava
 	rm -rf $(@D)
 	mkdir -p $(@D)
 # wrapping in /bin/bash -c "..." is a workaround for building on windows, bash (mingw)
-	/bin/bash -c "$(BUILD_DIR)/bin/fzjava java.xml -to=$(@D) -verbose=0"
+	/bin/bash -c "$(BUILD_DIR)/bin/fzjava java.xml -to=$(@D) -modules=java.base -verbose=0"
 # NYI: cleanup: see #463: manually delete redundant features
 	rm -f $(BUILD_DIR)/modules/java.xml/Java_pkg.fz
 	rm -f $(BUILD_DIR)/modules/java.xml/Java/jdk_pkg.fz
@@ -327,7 +327,7 @@ $(MOD_JAVA_DATATRANSFER_FZ_FILES): $(BUILD_DIR)/bin/fzjava
 	rm -rf $(@D)
 	mkdir -p $(@D)
 # wrapping in /bin/bash -c "..." is a workaround for building on windows, bash (mingw)
-	/bin/bash -c "$(BUILD_DIR)/bin/fzjava java.datatransfer -to=$(@D) -verbose=0"
+	/bin/bash -c "$(BUILD_DIR)/bin/fzjava java.datatransfer -to=$(@D) -modules=java.base,java.xml -verbose=0"
 # NYI: cleanup: see #463: manually delete redundant features
 	rm -f $(BUILD_DIR)/modules/java.datatransfer/Java_pkg.fz
 	rm -f $(BUILD_DIR)/modules/java.datatransfer/Java/java_pkg.fz
@@ -342,7 +342,7 @@ $(MOD_JAVA_DESKTOP_FZ_FILES): $(BUILD_DIR)/bin/fzjava
 	rm -rf $(@D)
 	mkdir -p $(@D)
 # wrapping in /bin/bash -c "..." is a workaround for building on windows, bash (mingw)
-	/bin/bash -c "$(BUILD_DIR)/bin/fzjava java.desktop -to=$(@D) -verbose=0"
+	/bin/bash -c "$(BUILD_DIR)/bin/fzjava java.desktop -to=$(@D) -modules=java.base,java.xml,java.datatransfer -verbose=0"
 # NYI: cleanup: see #462: manually move these features to the main directory
 # since otherwise they would not be found automatically.
 	mv $(BUILD_DIR)/modules/java.desktop/Java/com/sun/*.fz $(BUILD_DIR)/modules/java.desktop/

--- a/Makefile
+++ b/Makefile
@@ -276,21 +276,15 @@ FUZION_JAVA_MODULES = \
 					$(MOD_JAVA_NET_HTTP) \
 					$(MOD_JAVA_PREFS) \
 					$(MOD_JAVA_RMI) \
-					$(MOD_JAVA_SCRIPTING)
-# NYI: Depends on java.xml.crypto, which causes problems (see NYI below).
-#					$(MOD_JAVA_SE) \
-# this comment is necessary for otherwise, the lines below are commented too.
-FUZION_JAVA_MODULES += \
+					$(MOD_JAVA_SCRIPTING) \
+					$(MOD_JAVA_SE) \
 					$(MOD_JAVA_SECURITY_JGSS) \
 					$(MOD_JAVA_SECURITY_SASL) \
 					$(MOD_JAVA_SMARTCARDIO) \
 					$(MOD_JAVA_SQL) \
 					$(MOD_JAVA_SQL_ROWSET) \
-					$(MOD_JAVA_TRANSACTION_XA)
-# NYI: Still creates duplicate features for some reason.
-#					$(MOD_JAVA_XML_CRYPTO) \
-# this comment is necessary for otherwise, the lines below are commented too.
-FUZION_JAVA_MODULES += \
+					$(MOD_JAVA_TRANSACTION_XA) \
+					$(MOD_JAVA_XML_CRYPTO) \
 					$(MOD_JDK_ACCESSIBILITY) \
 					$(MOD_JDK_ATTACH) \
 					$(MOD_JDK_CHARSETS) \
@@ -322,11 +316,8 @@ FUZION_JAVA_MODULES += \
 					$(MOD_JDK_NIO_MAPMODE) \
 					$(MOD_JDK_SCTP) \
 					$(MOD_JDK_SECURITY_AUTH) \
-					$(MOD_JDK_SECURITY_JGSS)
-# NYI: Still creates duplicate features for some reason.
-#					$(MOD_JDK_XML_DOM) \
-# this comment is necessary for otherwise, the lines below are commented too.
-FUZION_JAVA_MODULES += \
+					$(MOD_JDK_SECURITY_JGSS) \
+					$(MOD_JDK_XML_DOM) \
 					$(MOD_JDK_ZIPFS)
 
 FUZION_FILES = \
@@ -653,6 +644,9 @@ $(MOD_JAVA_XML_CRYPTO_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE) $(MOD_
 	rm -rf $(@D)
 	mkdir -p $(@D)
 	/bin/bash -c "$(BUILD_DIR)/bin/fzjava java.xml.crypto -to=$(@D) -modules=java.xml,java.base -verbose=0"
+# NYI: Still creates duplicate features for some reason.
+	rm -f $(BUILD_DIR)/modules/java.xml.crypto/Java/javax/xml_pkg.fz
+	rm -f $(BUILD_DIR)/modules/java.xml.crypto/Java/org_pkg.fz
 	touch $@
 $(MOD_JDK_ACCESSIBILITY_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE) $(MOD_JAVA_DESKTOP)
 	rm -rf $(@D)
@@ -818,6 +812,10 @@ $(MOD_JDK_XML_DOM_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE) $(MOD_JAVA
 	rm -rf $(@D)
 	mkdir -p $(@D)
 	/bin/bash -c "$(BUILD_DIR)/bin/fzjava jdk.xml.dom -to=$(@D) -modules=java.base,java.xml -verbose=0"
+# NYI: Still creates duplicate features for some reason.
+	rm -f $(BUILD_DIR)/modules/jdk.xml.dom/Java/org_pkg.fz
+	rm -f $(BUILD_DIR)/modules/jdk.xml.dom/Java/org/w3c_pkg.fz
+	rm -f $(BUILD_DIR)/modules/jdk.xml.dom/Java/org/w3c/dom_pkg.fz
 	touch $@
 $(MOD_JDK_ZIPFS_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE)
 	rm -rf $(@D)

--- a/Makefile
+++ b/Makefile
@@ -97,6 +97,162 @@ MOD_JAVA_BASE_FZ_FILES         = $(MOD_JAVA_BASE_DIR)/__marker_for_make__
 MOD_JAVA_XML_FZ_FILES          = $(MOD_JAVA_XML_DIR)/__marker_for_make__
 MOD_JAVA_DATATRANSFER_FZ_FILES = $(MOD_JAVA_DATATRANSFER_DIR)/__marker_for_make__
 MOD_JAVA_DESKTOP_FZ_FILES      = $(MOD_JAVA_DESKTOP_DIR)/__marker_for_make__
+MOD_JAVA_COMPILER_DIR = $(BUILD_DIR)/modules/java.compiler
+MOD_JAVA_INSTRUMENT_DIR = $(BUILD_DIR)/modules/java.instrument
+MOD_JAVA_LOGGING_DIR = $(BUILD_DIR)/modules/java.logging
+MOD_JAVA_MANAGEMENT_DIR = $(BUILD_DIR)/modules/java.management
+MOD_JAVA_MANAGEMENT_RMI_DIR = $(BUILD_DIR)/modules/java.management.rmi
+MOD_JAVA_NAMING_DIR = $(BUILD_DIR)/modules/java.naming
+MOD_JAVA_NET_HTTP_DIR = $(BUILD_DIR)/modules/java.net.http
+MOD_JAVA_PREFS_DIR = $(BUILD_DIR)/modules/java.prefs
+MOD_JAVA_RMI_DIR = $(BUILD_DIR)/modules/java.rmi
+MOD_JAVA_SCRIPTING_DIR = $(BUILD_DIR)/modules/java.scripting
+MOD_JAVA_SE_DIR = $(BUILD_DIR)/modules/java.se
+MOD_JAVA_SECURITY_JGSS_DIR = $(BUILD_DIR)/modules/java.security.jgss
+MOD_JAVA_SECURITY_SASL_DIR = $(BUILD_DIR)/modules/java.security.sasl
+MOD_JAVA_SMARTCARDIO_DIR = $(BUILD_DIR)/modules/java.smartcardio
+MOD_JAVA_SQL_DIR = $(BUILD_DIR)/modules/java.sql
+MOD_JAVA_SQL_ROWSET_DIR = $(BUILD_DIR)/modules/java.sql.rowset
+MOD_JAVA_TRANSACTION_XA_DIR = $(BUILD_DIR)/modules/java.transaction.xa
+MOD_JAVA_XML_CRYPTO_DIR = $(BUILD_DIR)/modules/java.xml.crypto
+MOD_JDK_ACCESSIBILITY_DIR = $(BUILD_DIR)/modules/jdk.accessibility
+MOD_JDK_ATTACH_DIR = $(BUILD_DIR)/modules/jdk.attach
+MOD_JDK_CHARSETS_DIR = $(BUILD_DIR)/modules/jdk.charsets
+MOD_JDK_COMPILER_DIR = $(BUILD_DIR)/modules/jdk.compiler
+MOD_JDK_CRYPTO_CRYPTOKI_DIR = $(BUILD_DIR)/modules/jdk.crypto.cryptoki
+MOD_JDK_CRYPTO_EC_DIR = $(BUILD_DIR)/modules/jdk.crypto.ec
+MOD_JDK_DYNALINK_DIR = $(BUILD_DIR)/modules/jdk.dynalink
+MOD_JDK_EDITPAD_DIR = $(BUILD_DIR)/modules/jdk.editpad
+MOD_JDK_HTTPSERVER_DIR = $(BUILD_DIR)/modules/jdk.httpserver
+MOD_JDK_JARTOOL_DIR = $(BUILD_DIR)/modules/jdk.jartool
+MOD_JDK_JAVADOC_DIR = $(BUILD_DIR)/modules/jdk.javadoc
+MOD_JDK_JCONSOLE_DIR = $(BUILD_DIR)/modules/jdk.jconsole
+MOD_JDK_JDEPS_DIR = $(BUILD_DIR)/modules/jdk.jdeps
+MOD_JDK_JDI_DIR = $(BUILD_DIR)/modules/jdk.jdi
+MOD_JDK_JDWP_AGENT_DIR = $(BUILD_DIR)/modules/jdk.jdwp.agent
+MOD_JDK_JFR_DIR = $(BUILD_DIR)/modules/jdk.jfr
+MOD_JDK_JLINK_DIR = $(BUILD_DIR)/modules/jdk.jlink
+MOD_JDK_JPACKAGE_DIR = $(BUILD_DIR)/modules/jdk.jpackage
+MOD_JDK_JSHELL_DIR = $(BUILD_DIR)/modules/jdk.jshell
+MOD_JDK_JSOBJECT_DIR = $(BUILD_DIR)/modules/jdk.jsobject
+MOD_JDK_JSTATD_DIR = $(BUILD_DIR)/modules/jdk.jstatd
+MOD_JDK_LOCALEDATA_DIR = $(BUILD_DIR)/modules/jdk.localedata
+MOD_JDK_MANAGEMENT_DIR = $(BUILD_DIR)/modules/jdk.management
+MOD_JDK_MANAGEMENT_AGENT_DIR = $(BUILD_DIR)/modules/jdk.management.agent
+MOD_JDK_MANAGEMENT_JFR_DIR = $(BUILD_DIR)/modules/jdk.management.jfr
+MOD_JDK_NAMING_DNS_DIR = $(BUILD_DIR)/modules/jdk.naming.dns
+MOD_JDK_NAMING_RMI_DIR = $(BUILD_DIR)/modules/jdk.naming.rmi
+MOD_JDK_NET_DIR = $(BUILD_DIR)/modules/jdk.net
+MOD_JDK_NIO_MAPMODE_DIR = $(BUILD_DIR)/modules/jdk.nio.mapmode
+MOD_JDK_SCTP_DIR = $(BUILD_DIR)/modules/jdk.sctp
+MOD_JDK_SECURITY_AUTH_DIR = $(BUILD_DIR)/modules/jdk.security.auth
+MOD_JDK_SECURITY_JGSS_DIR = $(BUILD_DIR)/modules/jdk.security.jgss
+MOD_JDK_XML_DOM_DIR = $(BUILD_DIR)/modules/jdk.xml.dom
+MOD_JDK_ZIPFS_DIR = $(BUILD_DIR)/modules/jdk.zipfs
+MOD_JAVA_COMPILER = $(MOD_JAVA_COMPILER_DIR).fum
+MOD_JAVA_INSTRUMENT = $(MOD_JAVA_INSTRUMENT_DIR).fum
+MOD_JAVA_LOGGING = $(MOD_JAVA_LOGGING_DIR).fum
+MOD_JAVA_MANAGEMENT = $(MOD_JAVA_MANAGEMENT_DIR).fum
+MOD_JAVA_MANAGEMENT_RMI = $(MOD_JAVA_MANAGEMENT_RMI_DIR).fum
+MOD_JAVA_NAMING = $(MOD_JAVA_NAMING_DIR).fum
+MOD_JAVA_NET_HTTP = $(MOD_JAVA_NET_HTTP_DIR).fum
+MOD_JAVA_PREFS = $(MOD_JAVA_PREFS_DIR).fum
+MOD_JAVA_RMI = $(MOD_JAVA_RMI_DIR).fum
+MOD_JAVA_SCRIPTING = $(MOD_JAVA_SCRIPTING_DIR).fum
+MOD_JAVA_SE = $(MOD_JAVA_SE_DIR).fum
+MOD_JAVA_SECURITY_JGSS = $(MOD_JAVA_SECURITY_JGSS_DIR).fum
+MOD_JAVA_SECURITY_SASL = $(MOD_JAVA_SECURITY_SASL_DIR).fum
+MOD_JAVA_SMARTCARDIO = $(MOD_JAVA_SMARTCARDIO_DIR).fum
+MOD_JAVA_SQL = $(MOD_JAVA_SQL_DIR).fum
+MOD_JAVA_SQL_ROWSET = $(MOD_JAVA_SQL_ROWSET_DIR).fum
+MOD_JAVA_TRANSACTION_XA = $(MOD_JAVA_TRANSACTION_XA_DIR).fum
+MOD_JAVA_XML_CRYPTO = $(MOD_JAVA_XML_CRYPTO_DIR).fum
+MOD_JDK_ACCESSIBILITY = $(MOD_JDK_ACCESSIBILITY_DIR).fum
+MOD_JDK_ATTACH = $(MOD_JDK_ATTACH_DIR).fum
+MOD_JDK_CHARSETS = $(MOD_JDK_CHARSETS_DIR).fum
+MOD_JDK_COMPILER = $(MOD_JDK_COMPILER_DIR).fum
+MOD_JDK_CRYPTO_CRYPTOKI = $(MOD_JDK_CRYPTO_CRYPTOKI_DIR).fum
+MOD_JDK_CRYPTO_EC = $(MOD_JDK_CRYPTO_EC_DIR).fum
+MOD_JDK_DYNALINK = $(MOD_JDK_DYNALINK_DIR).fum
+MOD_JDK_EDITPAD = $(MOD_JDK_EDITPAD_DIR).fum
+MOD_JDK_HTTPSERVER = $(MOD_JDK_HTTPSERVER_DIR).fum
+MOD_JDK_JARTOOL = $(MOD_JDK_JARTOOL_DIR).fum
+MOD_JDK_JAVADOC = $(MOD_JDK_JAVADOC_DIR).fum
+MOD_JDK_JCONSOLE = $(MOD_JDK_JCONSOLE_DIR).fum
+MOD_JDK_JDEPS = $(MOD_JDK_JDEPS_DIR).fum
+MOD_JDK_JDI = $(MOD_JDK_JDI_DIR).fum
+MOD_JDK_JDWP_AGENT = $(MOD_JDK_JDWP_AGENT_DIR).fum
+MOD_JDK_JFR = $(MOD_JDK_JFR_DIR).fum
+MOD_JDK_JLINK = $(MOD_JDK_JLINK_DIR).fum
+MOD_JDK_JPACKAGE = $(MOD_JDK_JPACKAGE_DIR).fum
+MOD_JDK_JSHELL = $(MOD_JDK_JSHELL_DIR).fum
+MOD_JDK_JSOBJECT = $(MOD_JDK_JSOBJECT_DIR).fum
+MOD_JDK_JSTATD = $(MOD_JDK_JSTATD_DIR).fum
+MOD_JDK_LOCALEDATA = $(MOD_JDK_LOCALEDATA_DIR).fum
+MOD_JDK_MANAGEMENT = $(MOD_JDK_MANAGEMENT_DIR).fum
+MOD_JDK_MANAGEMENT_AGENT = $(MOD_JDK_MANAGEMENT_AGENT_DIR).fum
+MOD_JDK_MANAGEMENT_JFR = $(MOD_JDK_MANAGEMENT_JFR_DIR).fum
+MOD_JDK_NAMING_DNS = $(MOD_JDK_NAMING_DNS_DIR).fum
+MOD_JDK_NAMING_RMI = $(MOD_JDK_NAMING_RMI_DIR).fum
+MOD_JDK_NET = $(MOD_JDK_NET_DIR).fum
+MOD_JDK_NIO_MAPMODE = $(MOD_JDK_NIO_MAPMODE_DIR).fum
+MOD_JDK_SCTP = $(MOD_JDK_SCTP_DIR).fum
+MOD_JDK_SECURITY_AUTH = $(MOD_JDK_SECURITY_AUTH_DIR).fum
+MOD_JDK_SECURITY_JGSS = $(MOD_JDK_SECURITY_JGSS_DIR).fum
+MOD_JDK_XML_DOM = $(MOD_JDK_XML_DOM_DIR).fum
+MOD_JDK_ZIPFS = $(MOD_JDK_ZIPFS_DIR).fum
+MOD_JAVA_COMPILER_FZ_FILES = $(MOD_JAVA_COMPILER_DIR)/__marker_for_make__
+MOD_JAVA_INSTRUMENT_FZ_FILES = $(MOD_JAVA_INSTRUMENT_DIR)/__marker_for_make__
+MOD_JAVA_LOGGING_FZ_FILES = $(MOD_JAVA_LOGGING_DIR)/__marker_for_make__
+MOD_JAVA_MANAGEMENT_FZ_FILES = $(MOD_JAVA_MANAGEMENT_DIR)/__marker_for_make__
+MOD_JAVA_MANAGEMENT_RMI_FZ_FILES = $(MOD_JAVA_MANAGEMENT_RMI_DIR)/__marker_for_make__
+MOD_JAVA_NAMING_FZ_FILES = $(MOD_JAVA_NAMING_DIR)/__marker_for_make__
+MOD_JAVA_NET_HTTP_FZ_FILES = $(MOD_JAVA_NET_HTTP_DIR)/__marker_for_make__
+MOD_JAVA_PREFS_FZ_FILES = $(MOD_JAVA_PREFS_DIR)/__marker_for_make__
+MOD_JAVA_RMI_FZ_FILES = $(MOD_JAVA_RMI_DIR)/__marker_for_make__
+MOD_JAVA_SCRIPTING_FZ_FILES = $(MOD_JAVA_SCRIPTING_DIR)/__marker_for_make__
+MOD_JAVA_SE_FZ_FILES = $(MOD_JAVA_SE_DIR)/__marker_for_make__
+MOD_JAVA_SECURITY_JGSS_FZ_FILES = $(MOD_JAVA_SECURITY_JGSS_DIR)/__marker_for_make__
+MOD_JAVA_SECURITY_SASL_FZ_FILES = $(MOD_JAVA_SECURITY_SASL_DIR)/__marker_for_make__
+MOD_JAVA_SMARTCARDIO_FZ_FILES = $(MOD_JAVA_SMARTCARDIO_DIR)/__marker_for_make__
+MOD_JAVA_SQL_FZ_FILES = $(MOD_JAVA_SQL_DIR)/__marker_for_make__
+MOD_JAVA_SQL_ROWSET_FZ_FILES = $(MOD_JAVA_SQL_ROWSET_DIR)/__marker_for_make__
+MOD_JAVA_TRANSACTION_XA_FZ_FILES = $(MOD_JAVA_TRANSACTION_XA_DIR)/__marker_for_make__
+MOD_JAVA_XML_CRYPTO_FZ_FILES = $(MOD_JAVA_XML_CRYPTO_DIR)/__marker_for_make__
+MOD_JDK_ACCESSIBILITY_FZ_FILES = $(MOD_JDK_ACCESSIBILITY_DIR)/__marker_for_make__
+MOD_JDK_ATTACH_FZ_FILES = $(MOD_JDK_ATTACH_DIR)/__marker_for_make__
+MOD_JDK_CHARSETS_FZ_FILES = $(MOD_JDK_CHARSETS_DIR)/__marker_for_make__
+MOD_JDK_COMPILER_FZ_FILES = $(MOD_JDK_COMPILER_DIR)/__marker_for_make__
+MOD_JDK_CRYPTO_CRYPTOKI_FZ_FILES = $(MOD_JDK_CRYPTO_CRYPTOKI_DIR)/__marker_for_make__
+MOD_JDK_CRYPTO_EC_FZ_FILES = $(MOD_JDK_CRYPTO_EC_DIR)/__marker_for_make__
+MOD_JDK_DYNALINK_FZ_FILES = $(MOD_JDK_DYNALINK_DIR)/__marker_for_make__
+MOD_JDK_EDITPAD_FZ_FILES = $(MOD_JDK_EDITPAD_DIR)/__marker_for_make__
+MOD_JDK_HTTPSERVER_FZ_FILES = $(MOD_JDK_HTTPSERVER_DIR)/__marker_for_make__
+MOD_JDK_JARTOOL_FZ_FILES = $(MOD_JDK_JARTOOL_DIR)/__marker_for_make__
+MOD_JDK_JAVADOC_FZ_FILES = $(MOD_JDK_JAVADOC_DIR)/__marker_for_make__
+MOD_JDK_JCONSOLE_FZ_FILES = $(MOD_JDK_JCONSOLE_DIR)/__marker_for_make__
+MOD_JDK_JDEPS_FZ_FILES = $(MOD_JDK_JDEPS_DIR)/__marker_for_make__
+MOD_JDK_JDI_FZ_FILES = $(MOD_JDK_JDI_DIR)/__marker_for_make__
+MOD_JDK_JDWP_AGENT_FZ_FILES = $(MOD_JDK_JDWP_AGENT_DIR)/__marker_for_make__
+MOD_JDK_JFR_FZ_FILES = $(MOD_JDK_JFR_DIR)/__marker_for_make__
+MOD_JDK_JLINK_FZ_FILES = $(MOD_JDK_JLINK_DIR)/__marker_for_make__
+MOD_JDK_JPACKAGE_FZ_FILES = $(MOD_JDK_JPACKAGE_DIR)/__marker_for_make__
+MOD_JDK_JSHELL_FZ_FILES = $(MOD_JDK_JSHELL_DIR)/__marker_for_make__
+MOD_JDK_JSOBJECT_FZ_FILES = $(MOD_JDK_JSOBJECT_DIR)/__marker_for_make__
+MOD_JDK_JSTATD_FZ_FILES = $(MOD_JDK_JSTATD_DIR)/__marker_for_make__
+MOD_JDK_LOCALEDATA_FZ_FILES = $(MOD_JDK_LOCALEDATA_DIR)/__marker_for_make__
+MOD_JDK_MANAGEMENT_FZ_FILES = $(MOD_JDK_MANAGEMENT_DIR)/__marker_for_make__
+MOD_JDK_MANAGEMENT_AGENT_FZ_FILES = $(MOD_JDK_MANAGEMENT_AGENT_DIR)/__marker_for_make__
+MOD_JDK_MANAGEMENT_JFR_FZ_FILES = $(MOD_JDK_MANAGEMENT_JFR_DIR)/__marker_for_make__
+MOD_JDK_NAMING_DNS_FZ_FILES = $(MOD_JDK_NAMING_DNS_DIR)/__marker_for_make__
+MOD_JDK_NAMING_RMI_FZ_FILES = $(MOD_JDK_NAMING_RMI_DIR)/__marker_for_make__
+MOD_JDK_NET_FZ_FILES = $(MOD_JDK_NET_DIR)/__marker_for_make__
+MOD_JDK_NIO_MAPMODE_FZ_FILES = $(MOD_JDK_NIO_MAPMODE_DIR)/__marker_for_make__
+MOD_JDK_SCTP_FZ_FILES = $(MOD_JDK_SCTP_DIR)/__marker_for_make__
+MOD_JDK_SECURITY_AUTH_FZ_FILES = $(MOD_JDK_SECURITY_AUTH_DIR)/__marker_for_make__
+MOD_JDK_SECURITY_JGSS_FZ_FILES = $(MOD_JDK_SECURITY_JGSS_DIR)/__marker_for_make__
+MOD_JDK_XML_DOM_FZ_FILES = $(MOD_JDK_XML_DOM_DIR)/__marker_for_make__
+MOD_JDK_ZIPFS_FZ_FILES = $(MOD_JDK_ZIPFS_DIR)/__marker_for_make__
 
 VERSION = $(shell cat $(FZ_SRC)/version.txt)
 
@@ -110,7 +266,68 @@ FUZION_JAVA_MODULES = \
 					$(MOD_JAVA_BASE) \
 					$(MOD_JAVA_XML) \
 					$(MOD_JAVA_DATATRANSFER) \
-					$(MOD_JAVA_DESKTOP)
+					$(MOD_JAVA_DESKTOP) \
+					$(MOD_JAVA_COMPILER) \
+					$(MOD_JAVA_INSTRUMENT) \
+					$(MOD_JAVA_LOGGING) \
+					$(MOD_JAVA_MANAGEMENT) \
+					$(MOD_JAVA_MANAGEMENT_RMI) \
+					$(MOD_JAVA_NAMING) \
+					$(MOD_JAVA_NET_HTTP) \
+					$(MOD_JAVA_PREFS) \
+					$(MOD_JAVA_RMI) \
+					$(MOD_JAVA_SCRIPTING)
+# NYI: Depends on java.xml.crypto, which causes problems (see NYI below).
+#					$(MOD_JAVA_SE) \
+# this comment is necessary for otherwise, the lines below are commented too.
+FUZION_JAVA_MODULES += \
+					$(MOD_JAVA_SECURITY_JGSS) \
+					$(MOD_JAVA_SECURITY_SASL) \
+					$(MOD_JAVA_SMARTCARDIO) \
+					$(MOD_JAVA_SQL) \
+					$(MOD_JAVA_SQL_ROWSET) \
+					$(MOD_JAVA_TRANSACTION_XA)
+# NYI: Still creates duplicate features for some reason.
+#					$(MOD_JAVA_XML_CRYPTO) \
+# this comment is necessary for otherwise, the lines below are commented too.
+FUZION_JAVA_MODULES += \
+					$(MOD_JDK_ACCESSIBILITY) \
+					$(MOD_JDK_ATTACH) \
+					$(MOD_JDK_CHARSETS) \
+					$(MOD_JDK_COMPILER) \
+					$(MOD_JDK_CRYPTO_CRYPTOKI) \
+					$(MOD_JDK_CRYPTO_EC) \
+					$(MOD_JDK_DYNALINK) \
+					$(MOD_JDK_EDITPAD) \
+					$(MOD_JDK_HTTPSERVER) \
+					$(MOD_JDK_JARTOOL) \
+					$(MOD_JDK_JAVADOC) \
+					$(MOD_JDK_JCONSOLE) \
+					$(MOD_JDK_JDEPS) \
+					$(MOD_JDK_JDI) \
+					$(MOD_JDK_JDWP_AGENT) \
+					$(MOD_JDK_JFR) \
+					$(MOD_JDK_JLINK) \
+					$(MOD_JDK_JPACKAGE) \
+					$(MOD_JDK_JSHELL) \
+					$(MOD_JDK_JSOBJECT) \
+					$(MOD_JDK_JSTATD) \
+					$(MOD_JDK_LOCALEDATA) \
+					$(MOD_JDK_MANAGEMENT) \
+					$(MOD_JDK_MANAGEMENT_AGENT) \
+					$(MOD_JDK_MANAGEMENT_JFR) \
+					$(MOD_JDK_NAMING_DNS) \
+					$(MOD_JDK_NAMING_RMI) \
+					$(MOD_JDK_NET) \
+					$(MOD_JDK_NIO_MAPMODE) \
+					$(MOD_JDK_SCTP) \
+					$(MOD_JDK_SECURITY_AUTH) \
+					$(MOD_JDK_SECURITY_JGSS)
+# NYI: Still creates duplicate features for some reason.
+#					$(MOD_JDK_XML_DOM) \
+# this comment is necessary for otherwise, the lines below are commented too.
+FUZION_JAVA_MODULES += \
+					$(MOD_JDK_ZIPFS)
 
 FUZION_FILES = \
 			 $(BUILD_DIR)/tests \
@@ -347,6 +564,267 @@ $(MOD_JAVA_DESKTOP_FZ_FILES): $(BUILD_DIR)/bin/fzjava
 	rm -f $(BUILD_DIR)/modules/java.desktop/Java/java/awt_pkg.fz
 	touch $@
 
+$(MOD_JAVA_COMPILER_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE)
+	rm -rf $(@D)
+	mkdir -p $(@D)
+	/bin/bash -c "$(BUILD_DIR)/bin/fzjava java.compiler -to=$(@D) -modules=java.base -verbose=0"
+	touch $@
+$(MOD_JAVA_INSTRUMENT_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE)
+	rm -rf $(@D)
+	mkdir -p $(@D)
+	/bin/bash -c "$(BUILD_DIR)/bin/fzjava java.instrument -to=$(@D) -modules=java.base -verbose=0"
+	touch $@
+$(MOD_JAVA_LOGGING_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE)
+	rm -rf $(@D)
+	mkdir -p $(@D)
+	/bin/bash -c "$(BUILD_DIR)/bin/fzjava java.logging -to=$(@D) -modules=java.base -verbose=0"
+	touch $@
+$(MOD_JAVA_MANAGEMENT_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE)
+	rm -rf $(@D)
+	mkdir -p $(@D)
+	/bin/bash -c "$(BUILD_DIR)/bin/fzjava java.management -to=$(@D) -modules=java.base -verbose=0"
+	touch $@
+$(MOD_JAVA_MANAGEMENT_RMI_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE) $(MOD_JAVA_MANAGEMENT) $(MOD_JAVA_RMI)
+	rm -rf $(@D)
+	mkdir -p $(@D)
+	/bin/bash -c "$(BUILD_DIR)/bin/fzjava java.management.rmi -to=$(@D) -modules=java.base,java.management,java.rmi -verbose=0"
+	touch $@
+$(MOD_JAVA_NAMING_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE)
+	rm -rf $(@D)
+	mkdir -p $(@D)
+	/bin/bash -c "$(BUILD_DIR)/bin/fzjava java.naming -to=$(@D) -modules=java.base -verbose=0"
+	touch $@
+$(MOD_JAVA_NET_HTTP_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE)
+	rm -rf $(@D)
+	mkdir -p $(@D)
+	/bin/bash -c "$(BUILD_DIR)/bin/fzjava java.net.http -to=$(@D) -modules=java.base -verbose=0"
+	touch $@
+$(MOD_JAVA_PREFS_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE)
+	rm -rf $(@D)
+	mkdir -p $(@D)
+	/bin/bash -c "$(BUILD_DIR)/bin/fzjava java.prefs -to=$(@D) -modules=java.base -verbose=0"
+	touch $@
+$(MOD_JAVA_RMI_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE)
+	rm -rf $(@D)
+	mkdir -p $(@D)
+	/bin/bash -c "$(BUILD_DIR)/bin/fzjava java.rmi -to=$(@D) -modules=java.base -verbose=0"
+	touch $@
+$(MOD_JAVA_SCRIPTING_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE)
+	rm -rf $(@D)
+	mkdir -p $(@D)
+	/bin/bash -c "$(BUILD_DIR)/bin/fzjava java.scripting -to=$(@D) -modules=java.base -verbose=0"
+	touch $@
+$(MOD_JAVA_SE_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE) $(MOD_JAVA_SQL_ROWSET) $(MOD_JAVA_XML_CRYPTO) $(MOD_JAVA_MANAGEMENT_RMI) $(MOD_JAVA_SECURITY_JGSS) $(MOD_JAVA_SECURITY_SASL) $(MOD_JAVA_SCRIPTING) $(MOD_JAVA_DESKTOP) $(MOD_JAVA_COMPILER) $(MOD_JAVA_INSTRUMENT) $(MOD_JAVA_NET_HTTP) $(MOD_JAVA_PREFS)
+	rm -rf $(@D)
+	mkdir -p $(@D)
+	/bin/bash -c "$(BUILD_DIR)/bin/fzjava java.se -to=$(@D) -modules=java.base,java.naming,java.transaction.xa,java.logging,java.scripting,java.xml,java.datatransfer,java.prefs,java.sql,java.desktop,java.compiler,java.instrument,java.rmi,java.management,java.net.http,java.sql.rowset,java.xml.crypto,java.management.rmi,java.security.jgss,java.security.sasl -verbose=0"
+	touch $@
+$(MOD_JAVA_SECURITY_JGSS_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE)
+	rm -rf $(@D)
+	mkdir -p $(@D)
+	/bin/bash -c "$(BUILD_DIR)/bin/fzjava java.security.jgss -to=$(@D) -modules=java.base -verbose=0"
+	touch $@
+$(MOD_JAVA_SECURITY_SASL_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE)
+	rm -rf $(@D)
+	mkdir -p $(@D)
+	/bin/bash -c "$(BUILD_DIR)/bin/fzjava java.security.sasl -to=$(@D) -modules=java.base -verbose=0"
+	touch $@
+$(MOD_JAVA_SMARTCARDIO_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE)
+	rm -rf $(@D)
+	mkdir -p $(@D)
+	/bin/bash -c "$(BUILD_DIR)/bin/fzjava java.smartcardio -to=$(@D) -modules=java.base -verbose=0"
+	touch $@
+$(MOD_JAVA_SQL_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE) $(MOD_JAVA_LOGGING) $(MOD_JAVA_XML) $(MOD_JAVA_TRANSACTION_XA)
+	rm -rf $(@D)
+	mkdir -p $(@D)
+	/bin/bash -c "$(BUILD_DIR)/bin/fzjava java.sql -to=$(@D) -modules=java.base,java.logging,java.xml,java.transaction.xa -verbose=0"
+	touch $@
+$(MOD_JAVA_SQL_ROWSET_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE) $(MOD_JAVA_SQL) $(MOD_JAVA_NAMING) $(MOD_JAVA_LOGGING) $(MOD_JAVA_XML) $(MOD_JAVA_TRANSACTION_XA)
+	rm -rf $(@D)
+	mkdir -p $(@D)
+	/bin/bash -c "$(BUILD_DIR)/bin/fzjava java.sql.rowset -to=$(@D) -modules=java.base,java.logging,java.xml,java.transaction.xa,java.sql,java.naming -verbose=0"
+	touch $@
+$(MOD_JAVA_TRANSACTION_XA_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE)
+	rm -rf $(@D)
+	mkdir -p $(@D)
+	/bin/bash -c "$(BUILD_DIR)/bin/fzjava java.transaction.xa -to=$(@D) -modules=java.base -verbose=0"
+	touch $@
+$(MOD_JAVA_XML_CRYPTO_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE) $(MOD_JAVA_XML)
+	rm -rf $(@D)
+	mkdir -p $(@D)
+	/bin/bash -c "$(BUILD_DIR)/bin/fzjava java.xml.crypto -to=$(@D) -modules=java.xml,java.base -verbose=0"
+	touch $@
+$(MOD_JDK_ACCESSIBILITY_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE) $(MOD_JAVA_DESKTOP)
+	rm -rf $(@D)
+	mkdir -p $(@D)
+	/bin/bash -c "$(BUILD_DIR)/bin/fzjava jdk.accessibility -to=$(@D) -modules=java.base,java.xml,java.datatransfer,java.desktop -verbose=0"
+	touch $@
+$(MOD_JDK_ATTACH_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE)
+	rm -rf $(@D)
+	mkdir -p $(@D)
+	/bin/bash -c "$(BUILD_DIR)/bin/fzjava jdk.attach -to=$(@D) -modules=java.base -verbose=0"
+	touch $@
+$(MOD_JDK_CHARSETS_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE)
+	rm -rf $(@D)
+	mkdir -p $(@D)
+	/bin/bash -c "$(BUILD_DIR)/bin/fzjava jdk.charsets -to=$(@D) -modules=java.base -verbose=0"
+	touch $@
+$(MOD_JDK_COMPILER_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE) $(MOD_JAVA_COMPILER)
+	rm -rf $(@D)
+	mkdir -p $(@D)
+	/bin/bash -c "$(BUILD_DIR)/bin/fzjava jdk.compiler -to=$(@D) -modules=java.base,java.compiler -verbose=0"
+	touch $@
+$(MOD_JDK_CRYPTO_CRYPTOKI_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE)
+	rm -rf $(@D)
+	mkdir -p $(@D)
+	/bin/bash -c "$(BUILD_DIR)/bin/fzjava jdk.crypto.cryptoki -to=$(@D) -modules=java.base -verbose=0"
+	touch $@
+$(MOD_JDK_CRYPTO_EC_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE)
+	rm -rf $(@D)
+	mkdir -p $(@D)
+	/bin/bash -c "$(BUILD_DIR)/bin/fzjava jdk.crypto.ec -to=$(@D) -modules=java.base -verbose=0"
+	touch $@
+$(MOD_JDK_DYNALINK_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE)
+	rm -rf $(@D)
+	mkdir -p $(@D)
+	/bin/bash -c "$(BUILD_DIR)/bin/fzjava jdk.dynalink -to=$(@D) -modules=java.base -verbose=0"
+	touch $@
+$(MOD_JDK_EDITPAD_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE)
+	rm -rf $(@D)
+	mkdir -p $(@D)
+	/bin/bash -c "$(BUILD_DIR)/bin/fzjava jdk.editpad -to=$(@D) -modules=java.base -verbose=0"
+	touch $@
+$(MOD_JDK_HTTPSERVER_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE)
+	rm -rf $(@D)
+	mkdir -p $(@D)
+	/bin/bash -c "$(BUILD_DIR)/bin/fzjava jdk.httpserver -to=$(@D) -modules=java.base -verbose=0"
+	touch $@
+$(MOD_JDK_JARTOOL_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE)
+	rm -rf $(@D)
+	mkdir -p $(@D)
+	/bin/bash -c "$(BUILD_DIR)/bin/fzjava jdk.jartool -to=$(@D) -modules=java.base -verbose=0"
+	touch $@
+$(MOD_JDK_JAVADOC_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE) $(MOD_JDK_COMPILER)
+	rm -rf $(@D)
+	mkdir -p $(@D)
+	/bin/bash -c "$(BUILD_DIR)/bin/fzjava jdk.javadoc -to=$(@D) -modules=java.base,java.compiler,jdk.compiler -verbose=0"
+	touch $@
+$(MOD_JDK_JCONSOLE_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE) $(MOD_JAVA_DESKTOP) $(MOD_JAVA_MANAGEMENT)
+	rm -rf $(@D)
+	mkdir -p $(@D)
+	/bin/bash -c "$(BUILD_DIR)/bin/fzjava jdk.jconsole -to=$(@D) -modules=java.base,java.xml,java.datatransfer,java.desktop,java.management -verbose=0"
+	touch $@
+$(MOD_JDK_JDEPS_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE)
+	rm -rf $(@D)
+	mkdir -p $(@D)
+	/bin/bash -c "$(BUILD_DIR)/bin/fzjava jdk.jdeps -to=$(@D) -modules=java.base -verbose=0"
+	touch $@
+$(MOD_JDK_JDI_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE)
+	rm -rf $(@D)
+	mkdir -p $(@D)
+	/bin/bash -c "$(BUILD_DIR)/bin/fzjava jdk.jdi -to=$(@D) -modules=java.base -verbose=0"
+	touch $@
+$(MOD_JDK_JDWP_AGENT_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE)
+	rm -rf $(@D)
+	mkdir -p $(@D)
+	/bin/bash -c "$(BUILD_DIR)/bin/fzjava jdk.jdwp.agent -to=$(@D) -modules=java.base -verbose=0"
+	touch $@
+$(MOD_JDK_JFR_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE)
+	rm -rf $(@D)
+	mkdir -p $(@D)
+	/bin/bash -c "$(BUILD_DIR)/bin/fzjava jdk.jfr -to=$(@D) -modules=java.base -verbose=0"
+	touch $@
+$(MOD_JDK_JLINK_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE)
+	rm -rf $(@D)
+	mkdir -p $(@D)
+	/bin/bash -c "$(BUILD_DIR)/bin/fzjava jdk.jlink -to=$(@D) -modules=java.base -verbose=0"
+	touch $@
+$(MOD_JDK_JPACKAGE_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE)
+	rm -rf $(@D)
+	mkdir -p $(@D)
+	/bin/bash -c "$(BUILD_DIR)/bin/fzjava jdk.jpackage -to=$(@D) -modules=java.base -verbose=0"
+	touch $@
+$(MOD_JDK_JSHELL_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE) $(MOD_JAVA_COMPILER) $(MOD_JAVA_PREFS) $(MOD_JDK_JDI)
+	rm -rf $(@D)
+	mkdir -p $(@D)
+	/bin/bash -c "$(BUILD_DIR)/bin/fzjava jdk.jshell -to=$(@D) -modules=java.base,java.compiler,java.prefs,jdk.jdi -verbose=0"
+	touch $@
+$(MOD_JDK_JSOBJECT_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE)
+	rm -rf $(@D)
+	mkdir -p $(@D)
+	/bin/bash -c "$(BUILD_DIR)/bin/fzjava jdk.jsobject -to=$(@D) -modules=java.base -verbose=0"
+	touch $@
+$(MOD_JDK_JSTATD_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE)
+	rm -rf $(@D)
+	mkdir -p $(@D)
+	/bin/bash -c "$(BUILD_DIR)/bin/fzjava jdk.jstatd -to=$(@D) -modules=java.base -verbose=0"
+	touch $@
+$(MOD_JDK_LOCALEDATA_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE)
+	rm -rf $(@D)
+	mkdir -p $(@D)
+	/bin/bash -c "$(BUILD_DIR)/bin/fzjava jdk.localedata -to=$(@D) -modules=java.base -verbose=0"
+	touch $@
+$(MOD_JDK_MANAGEMENT_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE) $(MOD_JAVA_MANAGEMENT)
+	rm -rf $(@D)
+	mkdir -p $(@D)
+	/bin/bash -c "$(BUILD_DIR)/bin/fzjava jdk.management -to=$(@D) -modules=java.base,java.management -verbose=0"
+	touch $@
+$(MOD_JDK_MANAGEMENT_AGENT_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE)
+	rm -rf $(@D)
+	mkdir -p $(@D)
+	/bin/bash -c "$(BUILD_DIR)/bin/fzjava jdk.management.agent -to=$(@D) -modules=java.base -verbose=0"
+	touch $@
+$(MOD_JDK_MANAGEMENT_JFR_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE) $(MOD_JAVA_MANAGEMENT) $(MOD_JDK_JFR)
+	rm -rf $(@D)
+	mkdir -p $(@D)
+	/bin/bash -c "$(BUILD_DIR)/bin/fzjava jdk.management.jfr -to=$(@D) -modules=java.base,java.management,jdk.jfr -verbose=0"
+	touch $@
+$(MOD_JDK_NAMING_DNS_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE)
+	rm -rf $(@D)
+	mkdir -p $(@D)
+	/bin/bash -c "$(BUILD_DIR)/bin/fzjava jdk.naming.dns -to=$(@D) -modules=java.base -verbose=0"
+	touch $@
+$(MOD_JDK_NAMING_RMI_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE)
+	rm -rf $(@D)
+	mkdir -p $(@D)
+	/bin/bash -c "$(BUILD_DIR)/bin/fzjava jdk.naming.rmi -to=$(@D) -modules=java.base -verbose=0"
+	touch $@
+$(MOD_JDK_NET_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE)
+	rm -rf $(@D)
+	mkdir -p $(@D)
+	/bin/bash -c "$(BUILD_DIR)/bin/fzjava jdk.net -to=$(@D) -modules=java.base -verbose=0"
+	touch $@
+$(MOD_JDK_NIO_MAPMODE_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE)
+	rm -rf $(@D)
+	mkdir -p $(@D)
+	/bin/bash -c "$(BUILD_DIR)/bin/fzjava jdk.nio.mapmode -to=$(@D) -modules=java.base -verbose=0"
+	touch $@
+$(MOD_JDK_SCTP_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE)
+	rm -rf $(@D)
+	mkdir -p $(@D)
+	/bin/bash -c "$(BUILD_DIR)/bin/fzjava jdk.sctp -to=$(@D) -modules=java.base -verbose=0"
+	touch $@
+$(MOD_JDK_SECURITY_AUTH_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE) $(MOD_JAVA_NAMING)
+	rm -rf $(@D)
+	mkdir -p $(@D)
+	/bin/bash -c "$(BUILD_DIR)/bin/fzjava jdk.security.auth -to=$(@D) -modules=java.base,java.naming -verbose=0"
+	touch $@
+$(MOD_JDK_SECURITY_JGSS_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE) $(MOD_JAVA_SECURITY_JGSS)
+	rm -rf $(@D)
+	mkdir -p $(@D)
+	/bin/bash -c "$(BUILD_DIR)/bin/fzjava jdk.security.jgss -to=$(@D) -modules=java.base,java.security.jgss -verbose=0"
+	touch $@
+$(MOD_JDK_XML_DOM_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE) $(MOD_JAVA_XML)
+	rm -rf $(@D)
+	mkdir -p $(@D)
+	/bin/bash -c "$(BUILD_DIR)/bin/fzjava jdk.xml.dom -to=$(@D) -modules=java.base,java.xml -verbose=0"
+	touch $@
+$(MOD_JDK_ZIPFS_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE)
+	rm -rf $(@D)
+	mkdir -p $(@D)
+	/bin/bash -c "$(BUILD_DIR)/bin/fzjava jdk.zipfs -to=$(@D) -modules=java.base -verbose=0"
+	touch $@
+
 $(MOD_JAVA_BASE): $(MOD_JAVA_BASE_FZ_FILES)
 	$(BUILD_DIR)/bin/fz -sourceDirs=$(^D) -saveLib=$@
 
@@ -358,6 +836,111 @@ $(MOD_JAVA_DATATRANSFER): $(MOD_JAVA_BASE) $(MOD_JAVA_XML) $(MOD_JAVA_DATATRANSF
 
 $(MOD_JAVA_DESKTOP): $(MOD_JAVA_BASE) $(MOD_JAVA_XML) $(MOD_JAVA_DATATRANSFER) $(MOD_JAVA_DESKTOP_FZ_FILES)
 	$(BUILD_DIR)/bin/fz -sourceDirs=$(MOD_JAVA_DESKTOP_DIR) -modules=java.base,java.xml,java.datatransfer -saveLib=$@
+
+$(MOD_JAVA_COMPILER): $(MOD_JAVA_BASE) $(MOD_JAVA_COMPILER_FZ_FILES)
+	$(BUILD_DIR)/bin/fz -sourceDirs=$(MOD_JAVA_COMPILER_DIR) -modules=java.base -saveLib=$@
+$(MOD_JAVA_INSTRUMENT): $(MOD_JAVA_BASE) $(MOD_JAVA_INSTRUMENT_FZ_FILES)
+	$(BUILD_DIR)/bin/fz -sourceDirs=$(MOD_JAVA_INSTRUMENT_DIR) -modules=java.base -saveLib=$@
+$(MOD_JAVA_LOGGING): $(MOD_JAVA_BASE) $(MOD_JAVA_LOGGING_FZ_FILES)
+	$(BUILD_DIR)/bin/fz -sourceDirs=$(MOD_JAVA_LOGGING_DIR) -modules=java.base -saveLib=$@
+$(MOD_JAVA_MANAGEMENT): $(MOD_JAVA_BASE) $(MOD_JAVA_MANAGEMENT_FZ_FILES)
+	$(BUILD_DIR)/bin/fz -sourceDirs=$(MOD_JAVA_MANAGEMENT_DIR) -modules=java.base -saveLib=$@
+$(MOD_JAVA_MANAGEMENT_RMI): $(MOD_JAVA_BASE) $(MOD_JAVA_MANAGEMENT) $(MOD_JAVA_RMI) $(MOD_JAVA_MANAGEMENT_RMI_FZ_FILES)
+	$(BUILD_DIR)/bin/fz -sourceDirs=$(MOD_JAVA_MANAGEMENT_RMI_DIR) -modules=java.base,java.management,java.rmi -saveLib=$@
+$(MOD_JAVA_NAMING): $(MOD_JAVA_BASE) $(MOD_JAVA_NAMING_FZ_FILES)
+	$(BUILD_DIR)/bin/fz -sourceDirs=$(MOD_JAVA_NAMING_DIR) -modules=java.base -saveLib=$@
+$(MOD_JAVA_NET_HTTP): $(MOD_JAVA_BASE) $(MOD_JAVA_NET_HTTP_FZ_FILES)
+	$(BUILD_DIR)/bin/fz -sourceDirs=$(MOD_JAVA_NET_HTTP_DIR) -modules=java.base -saveLib=$@
+$(MOD_JAVA_PREFS): $(MOD_JAVA_BASE) $(MOD_JAVA_PREFS_FZ_FILES)
+	$(BUILD_DIR)/bin/fz -sourceDirs=$(MOD_JAVA_PREFS_DIR) -modules=java.base -saveLib=$@
+$(MOD_JAVA_RMI): $(MOD_JAVA_BASE) $(MOD_JAVA_RMI_FZ_FILES)
+	$(BUILD_DIR)/bin/fz -sourceDirs=$(MOD_JAVA_RMI_DIR) -modules=java.base -saveLib=$@
+$(MOD_JAVA_SCRIPTING): $(MOD_JAVA_BASE) $(MOD_JAVA_SCRIPTING_FZ_FILES)
+	$(BUILD_DIR)/bin/fz -sourceDirs=$(MOD_JAVA_SCRIPTING_DIR) -modules=java.base -saveLib=$@
+$(MOD_JAVA_SE): $(MOD_JAVA_BASE) $(MOD_JAVA_SQL_ROWSET) $(MOD_JAVA_XML_CRYPTO) $(MOD_JAVA_MANAGEMENT_RMI) $(MOD_JAVA_SECURITY_JGSS) $(MOD_JAVA_SECURITY_SASL) $(MOD_JAVA_SCRIPTING) $(MOD_JAVA_DESKTOP) $(MOD_JAVA_COMPILER) $(MOD_JAVA_INSTRUMENT) $(MOD_JAVA_NET_HTTP) $(MOD_JAVA_PREFS) $(MOD_JAVA_SE_FZ_FILES)
+	$(BUILD_DIR)/bin/fz -sourceDirs=$(MOD_JAVA_SE_DIR) -modules=java.base,java.naming,java.transaction.xa,java.logging,java.scripting,java.xml,java.datatransfer,java.prefs,java.sql,java.desktop,java.compiler,java.instrument,java.rmi,java.management,java.net.http,java.sql.rowset,java.xml.crypto,java.management.rmi,java.security.jgss,java.security.sasl -saveLib=$@
+$(MOD_JAVA_SECURITY_JGSS): $(MOD_JAVA_BASE) $(MOD_JAVA_SECURITY_JGSS_FZ_FILES)
+	$(BUILD_DIR)/bin/fz -sourceDirs=$(MOD_JAVA_SECURITY_JGSS_DIR) -modules=java.base -saveLib=$@
+$(MOD_JAVA_SECURITY_SASL): $(MOD_JAVA_BASE) $(MOD_JAVA_SECURITY_SASL_FZ_FILES)
+	$(BUILD_DIR)/bin/fz -sourceDirs=$(MOD_JAVA_SECURITY_SASL_DIR) -modules=java.base -saveLib=$@
+$(MOD_JAVA_SMARTCARDIO): $(MOD_JAVA_BASE) $(MOD_JAVA_SMARTCARDIO_FZ_FILES)
+	$(BUILD_DIR)/bin/fz -sourceDirs=$(MOD_JAVA_SMARTCARDIO_DIR) -modules=java.base -saveLib=$@
+$(MOD_JAVA_SQL): $(MOD_JAVA_BASE) $(MOD_JAVA_LOGGING) $(MOD_JAVA_XML) $(MOD_JAVA_TRANSACTION_XA) $(MOD_JAVA_SQL_FZ_FILES)
+	$(BUILD_DIR)/bin/fz -sourceDirs=$(MOD_JAVA_SQL_DIR) -modules=java.base,java.logging,java.xml,java.transaction.xa -saveLib=$@
+$(MOD_JAVA_SQL_ROWSET): $(MOD_JAVA_BASE) $(MOD_JAVA_SQL) $(MOD_JAVA_NAMING) $(MOD_JAVA_LOGGING) $(MOD_JAVA_XML) $(MOD_JAVA_TRANSACTION_XA) $(MOD_JAVA_SQL_ROWSET_FZ_FILES)
+	$(BUILD_DIR)/bin/fz -sourceDirs=$(MOD_JAVA_SQL_ROWSET_DIR) -modules=java.base,java.sql,java.naming,java.logging,java.xml,java.transaction.xa -saveLib=$@
+$(MOD_JAVA_TRANSACTION_XA): $(MOD_JAVA_BASE) $(MOD_JAVA_TRANSACTION_XA_FZ_FILES)
+	$(BUILD_DIR)/bin/fz -sourceDirs=$(MOD_JAVA_TRANSACTION_XA_DIR) -modules=java.base -saveLib=$@
+$(MOD_JAVA_XML_CRYPTO): $(MOD_JAVA_BASE) $(MOD_JAVA_XML) $(MOD_JAVA_XML_CRYPTO_FZ_FILES)
+	$(BUILD_DIR)/bin/fz -sourceDirs=$(MOD_JAVA_XML_CRYPTO_DIR) -modules=java.base,java.xml -saveLib=$@
+$(MOD_JDK_ACCESSIBILITY): $(MOD_JAVA_BASE) $(MOD_JAVA_DESKTOP) $(MOD_JDK_ACCESSIBILITY_FZ_FILES)
+	$(BUILD_DIR)/bin/fz -sourceDirs=$(MOD_JDK_ACCESSIBILITY_DIR) -modules=java.base,java.xml,java.datatransfer,java.desktop -saveLib=$@
+$(MOD_JDK_ATTACH): $(MOD_JAVA_BASE) $(MOD_JDK_ATTACH_FZ_FILES)
+	$(BUILD_DIR)/bin/fz -sourceDirs=$(MOD_JDK_ATTACH_DIR) -modules=java.base -saveLib=$@
+$(MOD_JDK_CHARSETS): $(MOD_JAVA_BASE) $(MOD_JDK_CHARSETS_FZ_FILES)
+	$(BUILD_DIR)/bin/fz -sourceDirs=$(MOD_JDK_CHARSETS_DIR) -modules=java.base -saveLib=$@
+$(MOD_JDK_COMPILER): $(MOD_JAVA_BASE) $(MOD_JAVA_COMPILER) $(MOD_JDK_COMPILER_FZ_FILES)
+	$(BUILD_DIR)/bin/fz -sourceDirs=$(MOD_JDK_COMPILER_DIR) -modules=java.base,java.compiler -saveLib=$@
+$(MOD_JDK_CRYPTO_CRYPTOKI): $(MOD_JAVA_BASE) $(MOD_JDK_CRYPTO_CRYPTOKI_FZ_FILES)
+	$(BUILD_DIR)/bin/fz -sourceDirs=$(MOD_JDK_CRYPTO_CRYPTOKI_DIR) -modules=java.base -saveLib=$@
+$(MOD_JDK_CRYPTO_EC): $(MOD_JAVA_BASE) $(MOD_JDK_CRYPTO_EC_FZ_FILES)
+	$(BUILD_DIR)/bin/fz -sourceDirs=$(MOD_JDK_CRYPTO_EC_DIR) -modules=java.base -saveLib=$@
+$(MOD_JDK_DYNALINK): $(MOD_JAVA_BASE) $(MOD_JDK_DYNALINK_FZ_FILES)
+	$(BUILD_DIR)/bin/fz -sourceDirs=$(MOD_JDK_DYNALINK_DIR) -modules=java.base -saveLib=$@
+$(MOD_JDK_EDITPAD): $(MOD_JAVA_BASE) $(MOD_JDK_EDITPAD_FZ_FILES)
+	$(BUILD_DIR)/bin/fz -sourceDirs=$(MOD_JDK_EDITPAD_DIR) -modules=java.base -saveLib=$@
+$(MOD_JDK_HTTPSERVER): $(MOD_JAVA_BASE) $(MOD_JDK_HTTPSERVER_FZ_FILES)
+	$(BUILD_DIR)/bin/fz -sourceDirs=$(MOD_JDK_HTTPSERVER_DIR) -modules=java.base -saveLib=$@
+$(MOD_JDK_JARTOOL): $(MOD_JAVA_BASE) $(MOD_JDK_JARTOOL_FZ_FILES)
+	$(BUILD_DIR)/bin/fz -sourceDirs=$(MOD_JDK_JARTOOL_DIR) -modules=java.base -saveLib=$@
+$(MOD_JDK_JAVADOC): $(MOD_JAVA_BASE) $(MOD_JDK_COMPILER) $(MOD_JDK_JAVADOC_FZ_FILES)
+	$(BUILD_DIR)/bin/fz -sourceDirs=$(MOD_JDK_JAVADOC_DIR) -modules=java.base,java.compiler,jdk.compiler -saveLib=$@
+$(MOD_JDK_JCONSOLE): $(MOD_JAVA_BASE) $(MOD_JAVA_DESKTOP) $(MOD_JAVA_MANAGEMENT) $(MOD_JDK_JCONSOLE_FZ_FILES)
+	$(BUILD_DIR)/bin/fz -sourceDirs=$(MOD_JDK_JCONSOLE_DIR) -modules=java.base,java.xml,java.datatransfer,java.desktop,java.management -saveLib=$@
+$(MOD_JDK_JDEPS): $(MOD_JAVA_BASE) $(MOD_JDK_JDEPS_FZ_FILES)
+	$(BUILD_DIR)/bin/fz -sourceDirs=$(MOD_JDK_JDEPS_DIR) -modules=java.base -saveLib=$@
+$(MOD_JDK_JDI): $(MOD_JAVA_BASE) $(MOD_JDK_JDI_FZ_FILES)
+	$(BUILD_DIR)/bin/fz -sourceDirs=$(MOD_JDK_JDI_DIR) -modules=java.base -saveLib=$@
+$(MOD_JDK_JDWP_AGENT): $(MOD_JAVA_BASE) $(MOD_JDK_JDWP_AGENT_FZ_FILES)
+	$(BUILD_DIR)/bin/fz -sourceDirs=$(MOD_JDK_JDWP_AGENT_DIR) -modules=java.base -saveLib=$@
+$(MOD_JDK_JFR): $(MOD_JAVA_BASE) $(MOD_JDK_JFR_FZ_FILES)
+	$(BUILD_DIR)/bin/fz -sourceDirs=$(MOD_JDK_JFR_DIR) -modules=java.base -saveLib=$@
+$(MOD_JDK_JLINK): $(MOD_JAVA_BASE) $(MOD_JDK_JLINK_FZ_FILES)
+	$(BUILD_DIR)/bin/fz -sourceDirs=$(MOD_JDK_JLINK_DIR) -modules=java.base -saveLib=$@
+$(MOD_JDK_JPACKAGE): $(MOD_JAVA_BASE) $(MOD_JDK_JPACKAGE_FZ_FILES)
+	$(BUILD_DIR)/bin/fz -sourceDirs=$(MOD_JDK_JPACKAGE_DIR) -modules=java.base -saveLib=$@
+$(MOD_JDK_JSHELL): $(MOD_JAVA_BASE) $(MOD_JAVA_COMPILER) $(MOD_JAVA_PREFS) $(MOD_JDK_JDI) $(MOD_JDK_JSHELL_FZ_FILES)
+	$(BUILD_DIR)/bin/fz -sourceDirs=$(MOD_JDK_JSHELL_DIR) -modules=java.base,java.compiler,java.prefs,jdk.jdi -saveLib=$@
+$(MOD_JDK_JSOBJECT): $(MOD_JAVA_BASE) $(MOD_JDK_JSOBJECT_FZ_FILES)
+	$(BUILD_DIR)/bin/fz -sourceDirs=$(MOD_JDK_JSOBJECT_DIR) -modules=java.base -saveLib=$@
+$(MOD_JDK_JSTATD): $(MOD_JAVA_BASE) $(MOD_JDK_JSTATD_FZ_FILES)
+	$(BUILD_DIR)/bin/fz -sourceDirs=$(MOD_JDK_JSTATD_DIR) -modules=java.base -saveLib=$@
+$(MOD_JDK_LOCALEDATA): $(MOD_JAVA_BASE) $(MOD_JDK_LOCALEDATA_FZ_FILES)
+	$(BUILD_DIR)/bin/fz -sourceDirs=$(MOD_JDK_LOCALEDATA_DIR) -modules=java.base -saveLib=$@
+$(MOD_JDK_MANAGEMENT): $(MOD_JAVA_BASE) $(MOD_JAVA_MANAGEMENT) $(MOD_JDK_MANAGEMENT_FZ_FILES)
+	$(BUILD_DIR)/bin/fz -sourceDirs=$(MOD_JDK_MANAGEMENT_DIR) -modules=java.base,java.management -saveLib=$@
+$(MOD_JDK_MANAGEMENT_AGENT): $(MOD_JAVA_BASE) $(MOD_JDK_MANAGEMENT_AGENT_FZ_FILES)
+	$(BUILD_DIR)/bin/fz -sourceDirs=$(MOD_JDK_MANAGEMENT_AGENT_DIR) -modules=java.base -saveLib=$@
+$(MOD_JDK_MANAGEMENT_JFR): $(MOD_JAVA_BASE) $(MOD_JAVA_MANAGEMENT) $(MOD_JDK_JFR) $(MOD_JDK_MANAGEMENT_JFR_FZ_FILES)
+	$(BUILD_DIR)/bin/fz -sourceDirs=$(MOD_JDK_MANAGEMENT_JFR_DIR) -modules=java.base,java.management,jdk.jfr -saveLib=$@
+$(MOD_JDK_NAMING_DNS): $(MOD_JAVA_BASE) $(MOD_JDK_NAMING_DNS_FZ_FILES)
+	$(BUILD_DIR)/bin/fz -sourceDirs=$(MOD_JDK_NAMING_DNS_DIR) -modules=java.base -saveLib=$@
+$(MOD_JDK_NAMING_RMI): $(MOD_JAVA_BASE) $(MOD_JDK_NAMING_RMI_FZ_FILES)
+	$(BUILD_DIR)/bin/fz -sourceDirs=$(MOD_JDK_NAMING_RMI_DIR) -modules=java.base -saveLib=$@
+$(MOD_JDK_NET): $(MOD_JAVA_BASE) $(MOD_JDK_NET_FZ_FILES)
+	$(BUILD_DIR)/bin/fz -sourceDirs=$(MOD_JDK_NET_DIR) -modules=java.base -saveLib=$@
+$(MOD_JDK_NIO_MAPMODE): $(MOD_JAVA_BASE) $(MOD_JDK_NIO_MAPMODE_FZ_FILES)
+	$(BUILD_DIR)/bin/fz -sourceDirs=$(MOD_JDK_NIO_MAPMODE_DIR) -modules=java.base -saveLib=$@
+$(MOD_JDK_SCTP): $(MOD_JAVA_BASE) $(MOD_JDK_SCTP_FZ_FILES)
+	$(BUILD_DIR)/bin/fz -sourceDirs=$(MOD_JDK_SCTP_DIR) -modules=java.base -saveLib=$@
+$(MOD_JDK_SECURITY_AUTH): $(MOD_JAVA_BASE) $(MOD_JAVA_NAMING) $(MOD_JDK_SECURITY_AUTH_FZ_FILES)
+	$(BUILD_DIR)/bin/fz -sourceDirs=$(MOD_JDK_SECURITY_AUTH_DIR) -modules=java.base,java.naming -saveLib=$@
+$(MOD_JDK_SECURITY_JGSS): $(MOD_JAVA_BASE) $(MOD_JAVA_SECURITY_JGSS) $(MOD_JDK_SECURITY_JGSS_FZ_FILES)
+	$(BUILD_DIR)/bin/fz -sourceDirs=$(MOD_JDK_SECURITY_JGSS_DIR) -modules=java.base,java.security.jgss -saveLib=$@
+$(MOD_JDK_XML_DOM): $(MOD_JAVA_BASE) $(MOD_JAVA_XML) $(MOD_JDK_XML_DOM_FZ_FILES)
+	$(BUILD_DIR)/bin/fz -sourceDirs=$(MOD_JDK_XML_DOM_DIR) -modules=java.base,java.xml -saveLib=$@
+$(MOD_JDK_ZIPFS): $(MOD_JAVA_BASE) $(MOD_JDK_ZIPFS_FZ_FILES)
+	$(BUILD_DIR)/bin/fz -sourceDirs=$(MOD_JDK_ZIPFS_DIR) -modules=java.base -saveLib=$@
 
 $(BUILD_DIR)/tests: $(FZ_SRC)/tests
 	mkdir -p $(@D)

--- a/bin/fzjava
+++ b/bin/fzjava
@@ -49,4 +49,4 @@ FUZION_BIN="$(dirname "$(readlink -f "$0")")"
 : ${FUZION_JAVA_STACK_SIZE=5m}
 : ${FUZION_JAVA_OPTIONS="-Xss$FUZION_JAVA_STACK_SIZE"}
 
-$FUZION_JAVA $FUZION_JAVA_OPTIONS -cp "$FUZION_JAVA_CLASSPATH" -Dfuzion.command="$FUZION_CMD" dev.flang.tools.fzjava.FZJava "$@"
+$FUZION_JAVA $FUZION_JAVA_OPTIONS -cp "$FUZION_JAVA_CLASSPATH" -Dfuzion.home="$FUZION_HOME" -Dfuzion.command="$FUZION_CMD" dev.flang.tools.fzjava.FZJava "$@"

--- a/src/dev/flang/fe/FrontEnd.java
+++ b/src/dev/flang/fe/FrontEnd.java
@@ -112,7 +112,7 @@ public class FrontEnd extends ANY
    * The library modules loaded so far.  Maps the module name, e.g. "base" to
    * the corresponding LibraryModule instance.
    */
-  private TreeMap<String, LibraryModule> _modules = new TreeMap<>();
+  public TreeMap<String, LibraryModule> _modules = new TreeMap<>();
 
 
   /**

--- a/src/dev/flang/fe/FrontEnd.java
+++ b/src/dev/flang/fe/FrontEnd.java
@@ -34,6 +34,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 
+import java.util.Collection;
 import java.util.EnumSet;
 import java.util.TreeMap;
 
@@ -112,7 +113,7 @@ public class FrontEnd extends ANY
    * The library modules loaded so far.  Maps the module name, e.g. "base" to
    * the corresponding LibraryModule instance.
    */
-  public TreeMap<String, LibraryModule> _modules = new TreeMap<>();
+  private TreeMap<String, LibraryModule> _modules = new TreeMap<>();
 
 
   /**
@@ -319,6 +320,15 @@ public class FrontEnd extends ANY
       {
         m.loadInnerFeatures(f);
       }
+  }
+
+
+  /**
+   * Return the collection of loaded modules.
+   */
+  public Collection<LibraryModule> getModules()
+  {
+    return _modules.values();
   }
 
 }

--- a/src/dev/flang/tools/Fuzion.java
+++ b/src/dev/flang/tools/Fuzion.java
@@ -371,16 +371,9 @@ class Fuzion extends Tool
 
 
   /**
-   * Value of property with name FUZION_HOME_PROPERTY.  Used only to initialize
-   * _fuzionHome.
-   */
-  private String _fuzionHomeProperty = System.getProperty(FUZION_HOME_PROPERTY);
-
-
-  /**
    * Home directory of the Fuzion installation.
    */
-  Path _fuzionHome = _fuzionHomeProperty != null ? Path.of(_fuzionHomeProperty) : null;
+  Path _fuzionHome = (new FuzionHome())._fuzionHome;
 
 
   /**

--- a/src/dev/flang/tools/FuzionHome.java
+++ b/src/dev/flang/tools/FuzionHome.java
@@ -1,0 +1,68 @@
+/*
+
+This file is part of the Fuzion language implementation.
+
+The Fuzion language implementation is free software: you can redistribute it
+and/or modify it under the terms of the GNU General Public License as published
+by the Free Software Foundation, version 3 of the License.
+
+The Fuzion language implementation is distributed in the hope that it will be
+useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+License for more details.
+
+You should have received a copy of the GNU General Public License along with The
+Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+*/
+
+/*-----------------------------------------------------------------------
+ *
+ * Tokiwa Software GmbH, Germany
+ *
+ * Source of class FuzionHome
+ *
+ *---------------------------------------------------------------------*/
+
+package dev.flang.tools;
+
+import dev.flang.util.ANY;
+
+import java.nio.file.Path;
+
+
+/**
+ * FuzionHome allows a Tool to retrieve the currently set value of the fuzion
+ * home Java property.
+ */
+public class FuzionHome extends ANY
+{
+
+
+  /*----------------------------  constants  ----------------------------*/
+
+
+  /**
+   * Names of Java properties accepted by tools that use the FuzionHome class:
+   */
+  static final String FUZION_HOME_PROPERTY = "fuzion.home";
+
+
+  /*----------------------------  variables  ----------------------------*/
+
+
+  /**
+   * Value of property with name FUZION_HOME_PROPERTY.  Used only to initialize
+   * _fuzionHome.
+   */
+  private String _fuzionHomeProperty = System.getProperty(FUZION_HOME_PROPERTY);
+
+
+  /**
+   * Home directory of the Fuzion installation.
+   */
+  public Path _fuzionHome = _fuzionHomeProperty != null ? Path.of(_fuzionHomeProperty) : null;
+
+}
+
+/* end of file */

--- a/src/dev/flang/tools/fzjava/FZJava.java
+++ b/src/dev/flang/tools/fzjava/FZJava.java
@@ -31,6 +31,7 @@ import dev.flang.ast.AbstractFeature;
 import dev.flang.fe.FrontEnd;
 import dev.flang.fe.FrontEndOptions;
 
+import dev.flang.tools.FuzionHome;
 import dev.flang.tools.Tool;
 
 import dev.flang.util.Errors;
@@ -213,7 +214,7 @@ public class FZJava extends Tool
       {
         List<String> emptyList = new List<>();
         var feOptions = new FrontEndOptions(/* verbose */ 0,
-                                            /* fuzionHome */ _options._fuzionHome,
+                                            /* fuzionHome */ (new FuzionHome())._fuzionHome,
                                             /* loadBaseLib */ true,
                                             /* eraseInternalNamesInLib */ true,
                                             /* modules */ _options._loadModules,

--- a/src/dev/flang/tools/fzjava/FZJava.java
+++ b/src/dev/flang/tools/fzjava/FZJava.java
@@ -232,13 +232,7 @@ public class FZJava extends Tool
                                             true);
         _fe = new FrontEnd(feOptions);
 
-        for (var m : _fe._modules.values())
-          {
-            if (m.name() != "base")
-              {
-                recurseDeclaredFeatures(m, _fe._universe);
-              }
-          }
+        recurseDeclaredFeatures(_fe, _fe._universe);
 
 
         for (var m : _options._modules)
@@ -254,25 +248,28 @@ public class FZJava extends Tool
 
 
   /**
-   * Add the qualified name of all features declared by a given library module
+   * Add the qualified name of all features declared by all the loaded modules
    * and that are children of a given feature to _existingFeatures.
    *
    * This is usually called with the universe as given feature in the first
-   * iteration. Then the qualified names of all features declared by the given
-   * library module end up in _existingFeatures.
+   * iteration. Then the qualified names of all features declared by the loaded
+   * library modules end up in _existingFeatures.
    *
    * The recursion here ends because no feature can be both an outer and an inner
    * feature of some other feature, i.e. the outer-inner relationship defines a
    * tree of features.
    */
-  private void recurseDeclaredFeatures(LibraryModule m, AbstractFeature f)
+  private void recurseDeclaredFeatures(FrontEnd fe, AbstractFeature f)
   {
-    var df = m.declaredFeatures(f);
-
-    for (var fn : df.values())
+    for (var m : fe._modules.values())
       {
-        _existingFeatures.put(fn.qualifiedName(), fn.qualifiedName());
-        recurseDeclaredFeatures(m, fn);
+        var df = m.declaredFeatures(f);
+
+        for (var fn : df.values())
+          {
+            _existingFeatures.put(fn.qualifiedName(), fn.qualifiedName());
+            recurseDeclaredFeatures(fe, fn);
+          }
       }
   }
 

--- a/src/dev/flang/tools/fzjava/FZJava.java
+++ b/src/dev/flang/tools/fzjava/FZJava.java
@@ -211,7 +211,7 @@ public class FZJava extends Tool
   {
     if (createDestDir())
       {
-        List<String> emptyList = new List<String>();
+        List<String> emptyList = new List<>();
         var feOptions = new FrontEndOptions(0,
                                             _options._fuzionHome,
                                             true,

--- a/src/dev/flang/tools/fzjava/FZJava.java
+++ b/src/dev/flang/tools/fzjava/FZJava.java
@@ -240,7 +240,7 @@ public class FZJava extends Tool
   /**
    * Create Fuzion features to interface Java code for given module.
    *
-   * @param a module such as 'java.base.mod'
+   * @param m a module such as 'java.base.mod'
    */
   void processModule(String m)
   {

--- a/src/dev/flang/tools/fzjava/FZJava.java
+++ b/src/dev/flang/tools/fzjava/FZJava.java
@@ -506,6 +506,11 @@ public class FZJava extends Tool
     if (!_pkgs.contains(pkg))
       {
         _pkgs.add(pkg);
+        if (_existingFeatures.get(pkg.replace("/", ".")) != null)
+          {
+            // do not generate duplicate features
+            return;
+          }
         FeatureWriter.write(this, pkg, "_pkg", FeatureWriter.mangle(pkg.replace("/",".")) + " is\n");
       }
   }

--- a/src/dev/flang/tools/fzjava/FZJava.java
+++ b/src/dev/flang/tools/fzjava/FZJava.java
@@ -30,7 +30,6 @@ import dev.flang.ast.AbstractFeature;
 
 import dev.flang.fe.FrontEnd;
 import dev.flang.fe.FrontEndOptions;
-import dev.flang.fe.LibraryModule;
 
 import dev.flang.tools.Tool;
 

--- a/src/dev/flang/tools/fzjava/FZJava.java
+++ b/src/dev/flang/tools/fzjava/FZJava.java
@@ -100,11 +100,8 @@ public class FZJava extends Tool
 
   /**
    * The features that have already been defined in the loaded library modules.
-   * Maps the qualified name of the feature to the qualified name of the feature.
-   * This is a map rather than a set because Java's Sets do not provide efficient
-   * methods for checking whether an element is in a set.
    */
-  TreeMap<String, String> _existingFeatures = new TreeMap<String, String>();
+  TreeSet<String> _existingFeatures = new TreeSet<String>();
 
 
   /*--------------------------  static methods  -------------------------*/
@@ -266,7 +263,7 @@ public class FZJava extends Tool
 
         for (var fn : df.values())
           {
-            _existingFeatures.put(fn.qualifiedName(), fn.qualifiedName());
+            _existingFeatures.add(fn.qualifiedName());
             recurseDeclaredFeatures(fe, fn);
           }
       }
@@ -502,7 +499,7 @@ public class FZJava extends Tool
     if (!_pkgs.contains(pkg))
       {
         _pkgs.add(pkg);
-        if (_existingFeatures.get(pkg.replace("/", ".")) != null)
+        if (_existingFeatures.contains(pkg.replace("/", ".")))
           {
             // do not generate duplicate features
             return;

--- a/src/dev/flang/tools/fzjava/FZJava.java
+++ b/src/dev/flang/tools/fzjava/FZJava.java
@@ -212,20 +212,20 @@ public class FZJava extends Tool
     if (createDestDir())
       {
         List<String> emptyList = new List<>();
-        var feOptions = new FrontEndOptions(0,
-                                            _options._fuzionHome,
-                                            true,
-                                            true,
-                                            _options._loadModules,
-                                            _options._moduleDirs,
-                                            emptyList,
-                                            0,
-                                            true,
-                                            true,
-                                            emptyList,
-                                            false,
-                                            null,
-                                            true);
+        var feOptions = new FrontEndOptions(/* verbose */ 0,
+                                            /* fuzionHome */ _options._fuzionHome,
+                                            /* loadBaseLib */ true,
+                                            /* eraseInternalNamesInLib */ true,
+                                            /* modules */ _options._loadModules,
+                                            /* moduleDirs */ _options._moduleDirs,
+                                            /* dumpModules */ emptyList,
+                                            /* fuzionDebugLevel */ 0,
+                                            /* fuzionSafety */ true,
+                                            /* enableUnsafeIntrinsics */ true,
+                                            /* sourceDirs */ emptyList,
+                                            /* readStdin */ false,
+                                            /* main */ null,
+                                            /* loadSources */ true);
         _fe = new FrontEnd(feOptions);
 
         recurseDeclaredFeatures(_fe, _fe._universe);

--- a/src/dev/flang/tools/fzjava/FZJava.java
+++ b/src/dev/flang/tools/fzjava/FZJava.java
@@ -260,7 +260,7 @@ public class FZJava extends Tool
    */
   private void recurseDeclaredFeatures(FrontEnd fe, AbstractFeature f)
   {
-    for (var m : fe._modules.values())
+    for (var m : fe.getModules())
       {
         var df = m.declaredFeatures(f);
 

--- a/src/dev/flang/tools/fzjava/FZJava.java
+++ b/src/dev/flang/tools/fzjava/FZJava.java
@@ -499,12 +499,11 @@ public class FZJava extends Tool
     if (!_pkgs.contains(pkg))
       {
         _pkgs.add(pkg);
-        if (_existingFeatures.contains(pkg.replace("/", ".")))
+        // do not generate duplicate features
+        if (!_existingFeatures.contains(pkg.replace("/", ".")))
           {
-            // do not generate duplicate features
-            return;
+            FeatureWriter.write(this, pkg, "_pkg", FeatureWriter.mangle(pkg.replace("/",".")) + " is\n");
           }
-        FeatureWriter.write(this, pkg, "_pkg", FeatureWriter.mangle(pkg.replace("/",".")) + " is\n");
       }
   }
 

--- a/src/dev/flang/tools/fzjava/FZJava.java
+++ b/src/dev/flang/tools/fzjava/FZJava.java
@@ -29,6 +29,7 @@ package dev.flang.tools.fzjava;
 import dev.flang.tools.Tool;
 
 import dev.flang.util.Errors;
+import dev.flang.util.List;
 
 import java.io.IOException;
 
@@ -158,6 +159,14 @@ public class FZJava extends Tool
             else if (a.startsWith("-overwrite="))
               {
                 _options._overwrite = parseOnOffArg(a);
+              }
+            else if (a.startsWith("-modules="))
+              {
+                _options._loadModules.addAll(parseStringListArg(a));
+              }
+            else if (a.startsWith("-moduleDirs="))
+              {
+                _options._moduleDirs.addAll(parseStringListArg(a));
               }
             else if (a.startsWith("-"))
               {

--- a/src/dev/flang/tools/fzjava/FZJavaOptions.java
+++ b/src/dev/flang/tools/fzjava/FZJavaOptions.java
@@ -44,6 +44,12 @@ public class FZJavaOptions extends ANY
 
 
   /**
+   * Names of Java properties accepted by fzjava:
+   */
+  static final String FUZION_HOME_PROPERTY = "fuzion.home";
+
+
+  /**
    * Some public members in a Java module may return a result type or expect an
    * argument that that is not public.  This flag enables warnings in this case.
    */
@@ -77,6 +83,19 @@ public class FZJavaOptions extends ANY
    * Should existing files be overwritten?
    */
   boolean _overwrite = false;
+
+
+  /**
+   * Value of property with name FUZION_HOME_PROPERTY.  Used only to initialize
+   * _fuzionHome.
+   */
+  private String _fuzionHomeProperty = System.getProperty(FUZION_HOME_PROPERTY);
+
+
+  /**
+   * Home directory of the Fuzion installation.
+   */
+  Path _fuzionHome = _fuzionHomeProperty != null ? Path.of(_fuzionHomeProperty) : null;
 
 }
 

--- a/src/dev/flang/tools/fzjava/FZJavaOptions.java
+++ b/src/dev/flang/tools/fzjava/FZJavaOptions.java
@@ -44,12 +44,6 @@ public class FZJavaOptions extends ANY
 
 
   /**
-   * Names of Java properties accepted by fzjava:
-   */
-  static final String FUZION_HOME_PROPERTY = "fuzion.home";
-
-
-  /**
    * Some public members in a Java module may return a result type or expect an
    * argument that that is not public.  This flag enables warnings in this case.
    */
@@ -95,19 +89,6 @@ public class FZJavaOptions extends ANY
    * Should existing files be overwritten?
    */
   boolean _overwrite = false;
-
-
-  /**
-   * Value of property with name FUZION_HOME_PROPERTY.  Used only to initialize
-   * _fuzionHome.
-   */
-  private String _fuzionHomeProperty = System.getProperty(FUZION_HOME_PROPERTY);
-
-
-  /**
-   * Home directory of the Fuzion installation.
-   */
-  Path _fuzionHome = _fuzionHomeProperty != null ? Path.of(_fuzionHomeProperty) : null;
 
 }
 

--- a/src/dev/flang/tools/fzjava/FZJavaOptions.java
+++ b/src/dev/flang/tools/fzjava/FZJavaOptions.java
@@ -67,6 +67,18 @@ public class FZJavaOptions extends ANY
 
 
   /**
+   * List of modules to check for existing features given by '-modules'.
+   */
+  List<String> _loadModules = new List<String>();
+
+
+  /**
+   * List of module directories added using '-moduleDirs'.
+   */
+  List<String> _moduleDirs = new List<String>();
+
+
+  /**
    * The set of regex patterns to use to filter java classes, e.g., ["java..*",
    * "javax..*"]
    */

--- a/src/dev/flang/tools/fzjava/ForClass.java
+++ b/src/dev/flang/tools/fzjava/ForClass.java
@@ -318,11 +318,6 @@ class ForClass extends ANY
   {
     var cn  = _class.getName();
     var ccn = FeatureWriter.cleanName(cn);
-    if (fzj._existingFeatures.get(ccn) != null)
-      {
-        // no need to generate that feature again
-        return;
-      }
     var jfn = "Java/" + ccn.replace('.', '/');
     var jtn = typeName(_class);
     var n = jfn.substring(jfn.lastIndexOf("/") + 1);

--- a/src/dev/flang/tools/fzjava/ForClass.java
+++ b/src/dev/flang/tools/fzjava/ForClass.java
@@ -318,6 +318,11 @@ class ForClass extends ANY
   {
     var cn  = _class.getName();
     var ccn = FeatureWriter.cleanName(cn);
+    if (fzj._existingFeatures.get(ccn) != null)
+      {
+        // no need to generate that feature again
+        return;
+      }
     var jfn = "Java/" + ccn.replace('.', '/');
     var jtn = typeName(_class);
     var n = jfn.substring(jfn.lastIndexOf("/") + 1);


### PR DESCRIPTION
My current working state of a fix for issue #463. It works already, hence the 'rm's have been removed from the Makefile, except for one:
```bash
rm -f $(BUILD_DIR)/modules/java.desktop/Java/java/awt_pkg.fz
```
It seems that this file does not even get generated without this change. Perhaps it's just wrong copy and paste from java.datatransfer?

Fixes #463.