### PR TITLE
fix #556, when choice elements of outer and inner choice are not disjoint

### DIFF
--- a/src/dev/flang/air/Clazz.java
+++ b/src/dev/flang/air/Clazz.java
@@ -1531,7 +1531,8 @@ public class Clazz extends ANY implements Comparable<Clazz>
     int index = 0;
     for (Clazz g : _choiceGenerics)
       {
-        if (g._type.isAssignableFrom(staticTypeOfValue))
+        if ((!g._type.isChoice() && g._type.isAssignableFrom(staticTypeOfValue))
+          || (g._type.isChoice() && g._type.equals(staticTypeOfValue)))
           {
             if (CHECKS) check
               (result < 0);

--- a/src/dev/flang/fuir/FUIR.java
+++ b/src/dev/flang/fuir/FUIR.java
@@ -30,7 +30,6 @@ import java.nio.charset.StandardCharsets;
 
 import java.util.BitSet;
 import java.util.TreeMap;
-import java.util.stream.Stream;
 
 import dev.flang.air.Clazz;
 import dev.flang.air.Clazzes;
@@ -1693,7 +1692,8 @@ hw25 is
             for (int tix = 0; tix < nt; tix++)
               {
                 var t = f != null ? f.resultType() : ts.get(tix);
-                if (t.isAssignableFrom(cg))
+                if ((!t.isChoice() && t.isAssignableFrom(cg))
+                  || (t.isChoice() && t.equals(cg)))
                   {
                     resultL.add(tag);
                   }

--- a/tests/reg_issue556_choice_elements_not_disjoint/Makefile
+++ b/tests/reg_issue556_choice_elements_not_disjoint/Makefile
@@ -1,0 +1,27 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test Makefile
+#
+#  Author: Fridtjof Siebert (siebert@tokiwa.software)
+#
+# -----------------------------------------------------------------------
+
+override NAME = issue556
+include ../positive.mk

--- a/tests/reg_issue556_choice_elements_not_disjoint/issue556.fz
+++ b/tests/reg_issue556_choice_elements_not_disjoint/issue556.fz
@@ -1,0 +1,46 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of regression test for issue #556
+#
+#  Author: Michael Lill (michael.lill@tokiwa.software)
+#
+# -----------------------------------------------------------------------
+
+issue556 =>
+  some_choice_including_nil : choice nil string is
+
+  a  some_choice_including_nil := nil
+  b  some_choice_including_nil := "string"
+
+  c := [a,b]
+
+  match (c.nth 0)
+    s some_choice_including_nil =>
+      match s
+        nil nil => say "n2"
+        string string => say "s"
+    nil nil => say "n1"
+
+  match (c.nth 1)
+    s some_choice_including_nil =>
+      match s
+        nil nil => say "n2"
+        string string => say "s"
+    nil nil => say "n1"


### PR DESCRIPTION
There might be other occurrences in the code where the use of `isAssignableFrom` is not sufficient.