### PR TITLE
ast: fix ensure condition failure

### DIFF
--- a/src/dev/flang/ast/Resolution.java
+++ b/src/dev/flang/ast/Resolution.java
@@ -462,7 +462,7 @@ public class Resolution extends ANY
       }
 
     if (POSTCONDITIONS) ensure
-      (af.state().atLeast(Feature.State.RESOLVED_TYPES));
+      (Errors.count() > 0 || af.state().atLeast(Feature.State.RESOLVED_TYPES));
   }
 
 


### PR DESCRIPTION
```
ex =>
  ident : choice unit nil is
    redef asString =>
      match another_ident.this
        * =>
```