### PR TITLE
lib: rename ref types

### DIFF
--- a/lib/concur/thread.fz
+++ b/lib/concur/thread.fz
@@ -28,7 +28,7 @@
 thread (
 
   # the provider this effect uses to spawn threads
-  p threadProvider,
+  p Thread_Provider,
 
   redef r effectMode.val
   ) : effect r
@@ -50,9 +50,9 @@ thread =>
   thread.env
 
 
-# threadProvider -- abstract source of concurrency
+# Thread_Provider -- abstract source of concurrency
 #
-threadProvider ref is
+Thread_Provider ref is
 
   # spawn a new thread using given code
   #
@@ -70,7 +70,7 @@ thread_type is
 
 # default concurrency provider
 #
-defaultThread : threadProvider is
+defaultThread : Thread_Provider is
 
   # spawn a new thread using given code
   #

--- a/lib/envir/vars.fz
+++ b/lib/envir/vars.fz
@@ -28,7 +28,7 @@
 private vars (
 
   # the provider this effect uses to read env vars
-  p varsProvider,
+  p Vars_Provider,
 
   # action to be taken: plain, install or replace?
   redef r effectMode.val,
@@ -51,7 +51,7 @@ is
 # short-hand for creating and installing vars effect using
 # given provider and running code rr
 #
-vars(p varsProvider, rr ()->unit) =>
+vars(p Vars_Provider, rr ()->unit) =>
   _ := vars p (effectMode.inst rr) unit
 
 
@@ -76,16 +76,16 @@ vars_type is
 
   # default provider using fuzion.sys.env_vars
   #
-  private defaultVarsProvider : varsProvider is
+  private defaultVarsProvider : Vars_Provider is
     get(v string) => fuzion.sys.env_vars.get v
 
 
-# varsProvider -- abstract source of environment vars
+# Vars_Provider -- abstract source of environment vars
 #
 # Different heirs of this feature may provided different sources for environemnt
 # variables
 #
-varsProvider ref is
+Vars_Provider ref is
 
   # If set, get the environment variable corresponding to v
   #

--- a/lib/exit.fz
+++ b/lib/exit.fz
@@ -28,7 +28,7 @@
 exit (
 
   # the handler this effect uses to exit
-  p exitHandler,
+  p Exit_Handler,
 
   redef r effectMode.val,
 
@@ -57,13 +57,13 @@ exit(code i32) => exit.exit code
 
 # install given exit handler and run code with it.
 #
-exit(handler exitHandler, code ()->unit) =>
+exit(handler Exit_Handler, code ()->unit) =>
   exit handler (effectMode.inst code) unit
 
 
-# exitHandler -- abstract exit
+# Exit_Handler -- abstract exit
 #
-exitHandler ref is
+Exit_Handler ref is
 
   # exit with the given message
   #
@@ -80,7 +80,7 @@ exit_type is
 
   # default exit handler using io.err and exit with return code 1
   #
-  defaultExitHandler : exitHandler is
+  defaultExitHandler : Exit_Handler is
 
     # exit with the given message and exit with return code 1
     #

--- a/lib/io/err.fz
+++ b/lib/io/err.fz
@@ -26,7 +26,7 @@
 # err -- effect providing an output stream
 #
 private err (
-  redef p canPrint,
+  redef p Can_Print,
 
   # action to be taken: install or default?
   redef r effectMode.val,
@@ -43,7 +43,7 @@ err(rr ()->unit) => err defaultPrintToErr rr
 
 # short-hand for creating and installing err effect
 #
-err(p canPrint, rr ()->unit) =>
+err(p Can_Print, rr ()->unit) =>
   err p (effectMode.inst rr) unit
   unit
 
@@ -55,7 +55,7 @@ err =>
   io.err.env
 
 
-defaultPrintToErr : canPrint is
+defaultPrintToErr : Can_Print is
 
   print(s Object) => fuzion.std.err.print s
 

--- a/lib/io/out.fz
+++ b/lib/io/out.fz
@@ -26,7 +26,7 @@
 # out -- effect providing an output stream
 #
 private out (
-  redef p canPrint,
+  redef p Can_Print,
 
   # action to be taken: install or default?
   redef r effectMode.val,
@@ -43,7 +43,7 @@ out(rr ()->unit) => out defaultPrintToOut rr
 
 # short-hand for creating and installing out effect
 #
-out(p canPrint, rr ()->unit) =>
+out(p Can_Print, rr ()->unit) =>
   out p (effectMode.inst rr) unit
   unit
 
@@ -55,7 +55,7 @@ out =>
   io.out.env
 
 
-defaultPrintToOut : canPrint is
+defaultPrintToOut : Can_Print is
 
   print(s Object) => stdout.print s
 

--- a/lib/io/printEffect.fz
+++ b/lib/io/printEffect.fz
@@ -28,7 +28,7 @@
 # This is used as heir feature for effects such as io.out and io.err.
 #
 private printEffect (
-  p canPrint,
+  p Can_Print,
 
   # action to be taken: plain nomad, install or replace?
   redef r effectMode.val
@@ -54,7 +54,7 @@ is
     replace
 
 
-canPrint ref is
+Can_Print ref is
 
   println(s Object) =>
     print s

--- a/lib/io/stdin.fz
+++ b/lib/io/stdin.fz
@@ -25,10 +25,10 @@
 
 
 # stdin -- effect providing several features
-# for consuming the given byteInputHandler
+# for consuming the given Byte_Input_Handler
 #
 private stdin(
-    ip byteInputHandler,
+    ip Byte_Input_Handler,
     # action to be taken: plain nomad, install or replace?
     redef r effectMode.val,
     _ unit
@@ -36,7 +36,7 @@ private stdin(
 
 
   # for a stdin instance installed in the current environment,
-  # install next instance of byteInputHandler,
+  # install next instance of Byte_Input_Handler,
   # 'stdin.env' will provide the new instance.
   #
   private next => stdin ip.next mode unit
@@ -105,7 +105,7 @@ private end_of_file is
 
 
 # short-hand for creating and installing stdin effect
-stdin(h byteInputHandler, f () -> unit) =>
+stdin(h Byte_Input_Handler, f () -> unit) =>
   s := stdin h effectMode.new unit
   s.use0 f
   unit
@@ -123,18 +123,18 @@ stdins is
       s.default
 
 
-byteInputHandler ref is
+Byte_Input_Handler ref is
 
-  next byteInputHandler is abstract
+  next Byte_Input_Handler is abstract
 
   # NYI using choice, until open generic for error in outcome is implemented
   get choice u8 end_of_file error is abstract
 
 
 # the default input handler reading bytes via fuzion.stdin.nextByte
-defaultInputHandler(r choice u8 end_of_file error) : byteInputHandler is
+defaultInputHandler(r choice u8 end_of_file error) : Byte_Input_Handler is
 
-  next byteInputHandler is
+  next Byte_Input_Handler is
     v := fuzion.stdin.nextByte
     if v = -1
       defaultInputHandler end_of_file

--- a/lib/panic.fz
+++ b/lib/panic.fz
@@ -28,7 +28,7 @@
 panic (
 
   # the provider this effect uses to panic
-  p panicProvider,
+  p Panic_Provider,
 
   redef r effectMode.val
   ) : effect r
@@ -53,9 +53,9 @@ panic =>
 panic(msg string) => panic.panic msg
 
 
-# panicProvider -- abstract panic
+# Panic_Provider -- abstract panic
 #
-panicProvider ref is
+Panic_Provider ref is
 
   # panic with the given message
   #
@@ -72,7 +72,7 @@ panic_type is
 
   # default panic provider using io.err and exit with return code 1
   #
-  defaultPanicProvider : panicProvider is
+  defaultPanicProvider : Panic_Provider is
 
     # panic with the given message and exit with return code 1
     #

--- a/lib/random.fz
+++ b/lib/random.fz
@@ -102,7 +102,7 @@ random =>
   randoms.installDefault
   random.env
 
-simpleRandom(seed u64, rr ()->unit) =>
+simple_random(seed u64, rr ()->unit) =>
   _ := random (simple_random_provider seed seed) (effectMode.inst rr)
 
 timeSeededRandom(rr ()->unit) =>

--- a/lib/random.fz
+++ b/lib/random.fz
@@ -28,7 +28,7 @@
 random (
 
   # the provider this effect uses to create random numbers
-  p randomProvider,
+  p Random_Provider,
 
   redef r effectMode.val
   ) : effect r
@@ -109,27 +109,27 @@ timeSeededRandom(rr ()->unit) =>
   _ := random simpleRandomProviders.timeSeeded (effectMode.inst rr)
 
 
-# randomProvider -- abstract source of random numbers
+# Random_Provider -- abstract source of random numbers
 #
 # This provides the random number input to be used by the 'random' effect.
 # Implementation may be dumb sequences of pseudo-random numbers or high-qualiity
 # cryptographic random number generators
 #
-# A randomProvider contains an immutable state, repeated calls to 'get' result
+# A Random_Provider contains an immutable state, repeated calls to 'get' result
 # in the same value.  To produce a sequence of different random numbers, 'next'
-# must be used to create a new instance of 'randomProvider' before 'get' can be
+# must be used to create a new instance of 'Random_Provider' before 'get' can be
 # used to obtain the new random number.
 #
-randomProvider ref is
+Random_Provider ref is
 
-  # create a new instance of randomProvider containing a new state. Depending
+  # create a new instance of Random_Provider containing a new state. Depending
   # on the qualifity of this random number generator, this might be a simple
-  # function of the original randomProvider or it might use an external source
+  # function of the original Random_Provider or it might use an external source
   # of entropy to create a new instance.
   #
-  next randomProvider is abstract
+  next Random_Provider is abstract
 
-  # Return the random number stored in this instance of randomProvider, in the
+  # Return the random number stored in this instance of Random_Provider, in the
   # range 0..u64.max
   #
   # NOTE: this feature is pure, i.e., repeated calls on the same target result
@@ -152,11 +152,11 @@ randoms is
 # for security and that do not meet typical requirements for a good
 # random number generator.
 #
-simpleRandomProvider(seed1 u64, seed2 u64) : randomProvider is
+simpleRandomProvider(seed1 u64, seed2 u64) : Random_Provider is
 
   # get next instance by shuffling bits in seeds around
   #
-  next randomProvider is
+  next Random_Provider is
     # NYI: This does not meet any requirements on a decent random number generator
     s1 := (seed1 *° 1717171717 +° 13113131313) ^ seed2
     s2 := (seed2 *° 9191919191 +° 37637373737) ^ seed1
@@ -200,7 +200,7 @@ simpleRandomProviders is
   # for security and that do not meet typical requirements for a good
   # random number generator.
   #
-  timeSeeded randomProvider is
+  timeSeeded Random_Provider is
     # initialize with large numbers XORed with nano time
     #
     simpleRandomProvider (u64 77777777777777 ^ time.nano.read) 98765432109876543

--- a/lib/random.fz
+++ b/lib/random.fz
@@ -103,10 +103,10 @@ random =>
   random.env
 
 simpleRandom(seed u64, rr ()->unit) =>
-  _ := random (simpleRandomProvider seed seed) (effectMode.inst rr)
+  _ := random (simple_random_provider seed seed) (effectMode.inst rr)
 
 timeSeededRandom(rr ()->unit) =>
-  _ := random simpleRandomProviders.timeSeeded (effectMode.inst rr)
+  _ := random simple_random_providers.timeSeeded (effectMode.inst rr)
 
 
 # Random_Provider -- abstract source of random numbers
@@ -144,7 +144,7 @@ randoms is
 
   installDefault is
     if !effects.exists random
-      _ := random simpleRandomProviders.default effectMode.default
+      _ := random simple_random_providers.default effectMode.default
 
 
 
@@ -152,7 +152,7 @@ randoms is
 # for security and that do not meet typical requirements for a good
 # random number generator.
 #
-simpleRandomProvider(seed1 u64, seed2 u64) : Random_Provider is
+simple_random_provider(seed1 u64, seed2 u64) : Random_Provider is
 
   # get next instance by shuffling bits in seeds around
   #
@@ -162,18 +162,18 @@ simpleRandomProvider(seed1 u64, seed2 u64) : Random_Provider is
     s2 := (seed2 *° 9191919191 +° 37637373737) ^ seed1
     rot1 := s2 & 0x3f
     rot2 := s1 & 0x3f
-    (simpleRandomProvider ((s2 << rot2) | (s2 >> (u64 64 - rot2)))
-                          ((s1 << rot1) | (s1 >> (u64 64 - rot1))))
+    (simple_random_provider ((s2 << rot2) | (s2 >> (u64 64 - rot2)))
+                            ((s1 << rot1) | (s1 >> (u64 64 - rot1))))
 
   # get current random number
   #
   get u64 is seed1
 
 
-# type related to simpleRandomProvider declaring features not requiring an instance
-# of simpleRandomProvider
+# type related to simple_random_provider declaring features not requiring an instance
+# of simple_random_provider
 #
-simpleRandomProviders is
+simple_random_providers is
 
   # name of env var to provide default random seed.
   #
@@ -191,7 +191,7 @@ simpleRandomProviders is
     match envir.vars.get random_seed_env_var
      s string =>
        match s.parse_u64
-         seed u64 => simpleRandomProvider seed 98765432109876543
+         seed u64 => simple_random_provider seed 98765432109876543
          e error  => panic "Failed to parse value in env var '$random_seed_env_var': $e"
      nil      => timeSeeded
 
@@ -203,7 +203,7 @@ simpleRandomProviders is
   timeSeeded Random_Provider is
     # initialize with large numbers XORed with nano time
     #
-    simpleRandomProvider (u64 77777777777777 ^ time.nano.read) 98765432109876543
+    simple_random_provider (u64 77777777777777 ^ time.nano.read) 98765432109876543
 
   # create a time-seed sprovider for pseudo random numbers that are not safe
   # for security and that do not meet typical requirements for a good

--- a/lib/random.fz
+++ b/lib/random.fz
@@ -105,8 +105,8 @@ random =>
 simple_random(seed u64, rr ()->unit) =>
   _ := random (simple_random_provider seed seed) (effectMode.inst rr)
 
-timeSeededRandom(rr ()->unit) =>
-  _ := random simple_random_providers.timeSeeded (effectMode.inst rr)
+time_seeded_random(rr ()->unit) =>
+  _ := random simple_random_providers.time_seeded (effectMode.inst rr)
 
 
 # Random_Provider -- abstract source of random numbers
@@ -193,14 +193,14 @@ simple_random_providers is
        match s.parse_u64
          seed u64 => simple_random_provider seed 98765432109876543
          e error  => panic "Failed to parse value in env var '$random_seed_env_var': $e"
-     nil      => timeSeeded
+     nil      => time_seeded
 
 
   # create a time-seeded simple provider for pseudo random numbers that are not safe
   # for security and that do not meet typical requirements for a good
   # random number generator.
   #
-  timeSeeded Random_Provider is
+  time_seeded Random_Provider is
     # initialize with large numbers XORed with nano time
     #
     simple_random_provider (u64 77777777777777 ^ time.nano.read) 98765432109876543
@@ -209,5 +209,5 @@ simple_random_providers is
   # for security and that do not meet typical requirements for a good
   # random number generator.
   #
-  timeSeeded(rr ()->unit) =>
-    _ := random timeSeeded (effectMode.inst rr)
+  time_seeded(rr ()->unit) =>
+    _ := random time_seeded (effectMode.inst rr)

--- a/lib/time/nano.fz
+++ b/lib/time/nano.fz
@@ -35,7 +35,7 @@
 # wake you up at 6h30 every morning.
 #
 private nano (
-  p nanoTimeProvider,
+  p Nano_Time_Provider,
 
   # action to be taken: install or default?
   redef r effectMode.val,
@@ -64,7 +64,7 @@ nano(rr ()->unit) => nano defaultNanoTime rr
 
 # short-hand for creating and installing time.nano effect
 #
-nano(p nanoTimeProvider, rr ()->unit) =>
+nano(p Nano_Time_Provider, rr ()->unit) =>
   nano p (effectMode.inst rr) unit
   unit
 
@@ -78,7 +78,7 @@ nano =>
 
 # abstract provider that can deliver a nano time
 #
-nanoTimeProvider ref is
+Nano_Time_Provider ref is
 
   # no guarantee can be given for precision nor resolution
   read u64 is abstract
@@ -87,7 +87,7 @@ nanoTimeProvider ref is
   sleep(d duration) unit is abstract
 
 
-defaultNanoTime : nanoTimeProvider is
+defaultNanoTime : Nano_Time_Provider is
 
   # no guarantee can be given for precision nor resolution
   read => fuzion.std.nano_time


### PR DESCRIPTION
Use the new `Upper_Case` style. This does not rename the notable ref types map, string, and stream.

For `simple_random`, `time_seeded_random`, and `Exit_Handler`, `flang_dev` needs to be adapted.