### PR TITLE
tools/fzjava: just process exactly one module

### DIFF
--- a/src/dev/flang/tools/fzjava/FZJava.java
+++ b/src/dev/flang/tools/fzjava/FZJava.java
@@ -196,9 +196,9 @@ public class FZJava extends Tool
               }
           }
       }
-    if (_options._modules.isEmpty())
+    if (_options._modules.isEmpty() || _options._modules.size() != 1)
       {
-        fatal("require at least one module given as a command line argument");
+        fatal("require exactly one module given as a command line argument");
       }
     return () -> execute();
   }


### PR DESCRIPTION
...instead of building an arbitary number of modules. This is because we can't make use of the duplicate feature detection in fzjava if we build multiple modules in the same command.