### PR TITLE
fe: Add automatic detection of tail recursive calls

### DIFF
--- a/src/dev/flang/ast/If.java
+++ b/src/dev/flang/ast/If.java
@@ -158,7 +158,7 @@ public class If extends ExprWithPos
    * Create an Iterator over all branches in this if statement, including all
    * else-if branches.
    */
-  private Iterator<Expr> branches()
+  Iterator<Expr> branches()
   {
     return new Iterator<Expr>()
     {

--- a/tests/typeinference_negative/typeinference_negative.fz
+++ b/tests/typeinference_negative/typeinference_negative.fz
@@ -159,7 +159,7 @@ typeinference_negative is
     x => z; y => x;  z => y; // 36. r3.z should flag an error, cyclic result type inference
 
   result4 is
-    x => x // 37. r4. should flag an error, cannot infer result type from itself
+    x => x // this is fine, inferring result type from itself results in result type being void!
 
   result5 is
     x => y // 38. r5.x should flag an error, cyclic result type inference


### PR DESCRIPTION
Before, tail recursion flag was set explicitly for loops that are known to be tail recursive.  Now, this is detected automagically.