### PR TITLE
fe: for operator calls, look for called feature in outer features

### DIFF
--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -715,7 +715,7 @@ public class Call extends AbstractCall
               {
                 var fo = calledFeatureCandidates(targetFeature, res, thiz);
                 FeatureName calledName = FeatureName.get(name, _actuals.size());
-                _calledFeature = fo.filter(pos(), calledName, ff -> mayMatchArgList(ff) || ff.hasOpenGenericsArgList() /* remove? */);
+                _calledFeature = fo.filter(pos(), calledName, ff -> mayMatchArgList(ff, false) || ff.hasOpenGenericsArgList() /* remove? */);
                 if (_calledFeature != null &&
                     _generics.isEmpty() &&
                     _actuals.size() != _calledFeature.valueArguments().size() &&
@@ -728,14 +728,18 @@ public class Call extends AbstractCall
                 if (_calledFeature == null)
                   {
                     _calledFeature = fo.filter(pos(), calledName, ff -> isSpecialWrtArgs(ff));
-                    if (_calledFeature == null)
-                      {
-                        findChainedBooleans(res, thiz);
-                        if (_calledFeature == null) // nothing found, so flag error
-                          {
-                            AstErrors.calledFeatureNotFound(this, calledName, targetFeature);
-                          }
-                      }
+                  }
+                if (_calledFeature == null)
+                  {
+                    findChainedBooleans(res, thiz);
+                  }
+                if (_calledFeature == null)
+                  {
+                    findOperatorOnOuter(res, thiz);
+                  }
+                if (_calledFeature == null) // nothing found, so flag error
+                  {
+                    AstErrors.calledFeatureNotFound(this, calledName, targetFeature);
                   }
               }
           }
@@ -766,6 +770,53 @@ public class Call extends AbstractCall
                }
            }
        });
+  }
+
+
+  /**
+   * For an infix, prefix or postfix operator call of the form
+   *
+   *   a ⨁ b     -- or --
+   *   ⨁ a       -- or --
+   *   a ⨁
+   *
+   * that was not found within the target 'a', try to find this operator in 'thiz'
+   * or any outer feature.  If found in X.Y.Z.this, then convert this call into
+   *
+   *   X.Y.Z.this.infix  ⨁ a b     -- or --
+   *   X.Y.Z.this.prefix ⨁ a       -- or --
+   *   X.Y.Z.this.postix ⨁ a       ,
+   *
+   * respectively.  This permits the introduction of binary or unary operators
+   * within any feature, e.g., within unit type features that can be inherited
+   * from or even in the universe.
+   *
+   * If successful, field _calledFeature will be set to the called feature and
+   * fields target and _actuals will be changed accordingly.
+   *
+   * @param res this is called during type resolution, res gives the resolution
+   * instance.
+   *
+   * @param thiz the surrounding feature
+   */
+  void findOperatorOnOuter(Resolution res, AbstractFeature thiz)
+  {
+    if (name.startsWith("infix "  ) ||
+        name.startsWith("prefix " ) ||
+        name.startsWith("postfix ")    )
+      {
+        var calledName = FeatureName.get(name, _actuals.size()+1);
+        var oldTarget = target;
+        target = null;
+        var fo = calledFeatureCandidates(thiz, res, thiz);
+        _calledFeature = fo.filter(pos(), calledName, ff -> mayMatchArgList(ff, true));
+        if (_calledFeature != null)
+          {
+            var oldActuals = _actuals;
+            _actuals = new List(oldTarget);
+            _actuals.addAll(oldActuals);
+          }
+      }
   }
 
 
@@ -874,9 +925,20 @@ public class Call extends AbstractCall
   }
 
 
-  private boolean mayMatchArgList(AbstractFeature ff)
+  /**
+   * Check if the actual arguments to this call may match the formal arguments
+   * for calling ff.
+   *
+   * @param ff the candidate that might be called
+   *
+   * @param addOne true iff one actual argument will be added (used in
+   * findOperatorOnOuter wich will add the target to the actual arguments).
+   *
+   * @return true if ff is a valid candidate to be called.
+   */
+  private boolean mayMatchArgList(AbstractFeature ff, boolean addOne)
   {
-    var asz = _actuals.size();
+    var asz = _actuals.size() + (addOne ? 1 : 0);
     var fvsz = ff.valueArguments().size();
     var ftsz = ff.typeArguments().size();
 

--- a/tests/equals/test_equals.fz
+++ b/tests/equals/test_equals.fz
@@ -55,9 +55,7 @@ test_equals =>
   # compare two strings using infix ≟ with infix syntax and with type
   # inference for the type parameter
   #
-  # NYI: This does not compile yet:
-  #
-  #  eq6(a, b string) => a ≟ b
+  eq6(a, b string) => a ≟ b
 
   say "comparing A and B {eq1 "A" "B"}"
   say "comparing A and A {eq1 "A" "A"}"
@@ -69,8 +67,8 @@ test_equals =>
   say "comparing A and A {eq4 "A" "A"}"
   say "comparing A and B {eq5 "A" "B"}"
   say "comparing A and A {eq5 "A" "A"}"
-#  say "comparing A and B {eq6 "A" "B"}"
-#  say "comparing A and A {(eq6 "A" "A"}"
+  say "comparing A and B {eq6 "A" "B"}"
+  say "comparing A and A {eq6 "A" "A"}"
 
   # create some colored text:
   #
@@ -84,10 +82,10 @@ test_equals =>
   say "comparing blue cat and blue dog as Has_color: {test_equals_types.eq_color blue_cat blue_dog}"
   say "comparing red cat and blue cat as colored_text: {equals red_cat blue_cat}"
   say "comparing red cat and red cat as colored_text: {equals red_cat red_cat}"
-
-  # NYI: does not work yet:
-  #
-  #  say (infix ≟ red_cat blue_cat)
+  say "comparing red cat and blue cat as colored_text: {infix ≟ red_cat blue_cat}"
+  say "comparing red cat and red cat as colored_text: {infix ≟ red_cat red_cat}"
+  say "comparing red cat and blue cat as colored_text: {red_cat ≟ blue_cat}"
+  say "comparing red cat and red cat as colored_text: {red_cat ≟ red_cat}"
 
 
 test_equals

--- a/tests/equals/test_equals.fz.expected_out
+++ b/tests/equals/test_equals.fz.expected_out
@@ -8,9 +8,15 @@ comparing A and B false
 comparing A and A true
 comparing A and B false
 comparing A and A true
+comparing A and B false
+comparing A and A true
 comparing red cat and blue cat as strings: true
 comparing red cat and blue dog as strings: false
 comparing red cat and blue cat as Has_color: false
 comparing blue cat and blue dog as Has_color: true
+comparing red cat and blue cat as colored_text: false
+comparing red cat and red cat as colored_text: true
+comparing red cat and blue cat as colored_text: false
+comparing red cat and red cat as colored_text: true
 comparing red cat and blue cat as colored_text: false
 comparing red cat and red cat as colored_text: true


### PR DESCRIPTION
For an infix, prefix or postfix operator call of the form
    
```
      a ⨁ b     -- or --
      ⨁ a       -- or --
      a ⨁
```   
that was not found within the target 'a', try to find this operator in 'this' or any outer feature.  If found in X.Y.Z.this, then convert this call into
    
```
      X.Y.Z.this.infix  ⨁ a b     -- or --
      X.Y.Z.this.prefix ⨁ a       -- or --
      X.Y.Z.this.postix ⨁ a       ,
```