### PR TITLE
Chained bool for infix with two args

### DIFF
--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -589,7 +589,8 @@ public class Call extends AbstractCall
     var cb = chainedBoolTarget(res, thiz);
     if (cb != null && _actuals.size() == 1)
       {
-        var b = cb._actuals.get(0);
+        var bix = cb._actuals.size() - 1; // index of 'b' in first call 'a < b'
+        var b = cb._actuals.get(bix);
         b = res.resolveType(b, thiz);
         String tmpName = FuzionConstants.CHAINED_BOOL_TMP_PREFIX + (_chainedBoolTempId_++);
         var tmp = new Feature(res,
@@ -608,7 +609,8 @@ public class Call extends AbstractCall
         t1 = res.resolveType(t1    , thiz);
         as = res.resolveType(as    , thiz);
         result = res.resolveType(result, thiz);
-        cb._actuals = new List<Expr>(new Block(b.pos(),new List<Stmnt>(as, t1)));
+        cb._actuals.set(cb._actuals.size()-1,
+                        new Block(b.pos(),new List<Stmnt>(as, t1)));
         _actuals = new List<Expr>(result);
         _calledFeature = Types.resolved.f_bool_AND;
         name = _calledFeature.featureName().baseName();
@@ -640,8 +642,9 @@ public class Call extends AbstractCall
   {
     return
       name.startsWith("infix ") &&
-      _actuals.size() == 1 &&
-      _generics == NO_GENERICS;
+      (_actuals.size() == 1 /* normal infix operator 'a.infix + b' */                ||
+       _actuals.size() == 2 /* infix on different target 'X.Y.Z.this.infix + a b' */    ) &&
+      true; /* no check for _generics.size(), we allow infix operator to infer arbitrary number of type parameters */
   }
 
 

--- a/tests/equals/test_equals.fz
+++ b/tests/equals/test_equals.fz
@@ -74,6 +74,7 @@ test_equals =>
   #
   red_cat  := test_equals_types.colored_text test_equals_types.red  "cat".utf8
   blue_cat := test_equals_types.colored_text test_equals_types.blue "cat".utf8
+  red_dog  := test_equals_types.colored_text test_equals_types.red  "dog".utf8
   blue_dog := test_equals_types.colored_text test_equals_types.blue "dog".utf8
 
   say "comparing red cat and blue cat as strings: {eq3 red_cat blue_cat}"
@@ -86,6 +87,15 @@ test_equals =>
   say "comparing red cat and red cat as colored_text: {infix ≟ red_cat red_cat}"
   say "comparing red cat and blue cat as colored_text: {red_cat ≟ blue_cat}"
   say "comparing red cat and red cat as colored_text: {red_cat ≟ red_cat}"
+  say "comparing red cat, blue cat and blue dog as colored_text: {red_cat ≟ blue_cat ≟ blue_dog}"
+  say "comparing blue dog, blue dog and blue dog as colored_text: {blue_dog ≟ blue_dog ≟ blue_dog}"
+  say "comparing red dog, blue dog and blue dog as colored_text: {red_dog ≟ blue_dog ≟ blue_dog}"
+  say "comparing blue dog, blue dog and blue cat as colored_text: {blue_dog ≟ blue_dog ≟ blue_cat}"
+  say "comparing red dog, red dog, red dog and red dog as colored_text: {red_dog ≟ red_dog ≟ red_dog ≟ red_dog}"
+  say "comparing red cat, red dog, red dog and red dog as colored_text: {red_cat ≟ red_dog ≟ red_dog ≟ red_dog}"
+  say "comparing red dog, red cat, red dog and red dog as colored_text: {red_dog ≟ red_cat ≟ red_dog ≟ red_dog}"
+  say "comparing red dog, red dog, red cat and red dog as colored_text: {red_dog ≟ red_dog ≟ red_cat ≟ red_dog}"
+  say "comparing red dog, red dog, red dog and red cat as colored_text: {red_dog ≟ red_dog ≟ red_dog ≟ red_cat}"
 
 
 test_equals

--- a/tests/equals/test_equals.fz.expected_out
+++ b/tests/equals/test_equals.fz.expected_out
@@ -20,3 +20,12 @@ comparing red cat and blue cat as colored_text: false
 comparing red cat and red cat as colored_text: true
 comparing red cat and blue cat as colored_text: false
 comparing red cat and red cat as colored_text: true
+comparing red cat, blue cat and blue dog as colored_text: false
+comparing blue dog, blue dog and blue dog as colored_text: true
+comparing red dog, blue dog and blue dog as colored_text: false
+comparing blue dog, blue dog and blue cat as colored_text: false
+comparing red dog, red dog, red dog and red dog as colored_text: true
+comparing red cat, red dog, red dog and red dog as colored_text: false
+comparing red dog, red cat, red dog and red dog as colored_text: false
+comparing red dog, red dog, red cat and red dog as colored_text: false
+comparing red dog, red dog, red dog and red cat as colored_text: false


### PR DESCRIPTION
Permit chained boolean expressions for infix operators with 2 arguments

This enables chained booleans for infix operators declared in outer features
such as

```
  infix ≟(T type, a, b T) => equals T a b
```
defined in the universe.

