### PR TITLE
Add underscore to fields in Call

### DIFF
--- a/src/dev/flang/ast/AbstractFeature.java
+++ b/src/dev/flang/ast/AbstractFeature.java
@@ -542,11 +542,13 @@ public abstract class AbstractFeature extends ANY implements Comparable<Abstract
   {
     if (PRECONDITIONS) require
       (// An ugly, low-level way to check this is a static type feature
+       this == Types.f_ERROR ||
        featureName().baseName().indexOf(FuzionConstants.TYPE_STATIC_NAME) >= 0);
 
     // the first parent of a static type feature is the corresponding non-static
     // type feature
-    return inherits().get(0).calledFeature();
+    return
+      this == Types.f_ERROR ? this : inherits().get(0).calledFeature();
   }
 
   /**

--- a/src/dev/flang/ast/AstErrors.java
+++ b/src/dev/flang/ast/AstErrors.java
@@ -485,12 +485,12 @@ public class AstErrors extends ANY
 
   static void wrongNumberOfActualArguments(Call call)
   {
-    int fsz = call.resolvedFormalArgumentTypes.length;
+    int fsz = call._resolvedFormalArgumentTypes.length;
     boolean ferror = false;
     StringBuilder fstr = new StringBuilder();
     var fargs = call.calledFeature().valueArguments().iterator();
     AbstractFeature farg = null;
-    for (var t : call.resolvedFormalArgumentTypes)
+    for (var t : call._resolvedFormalArgumentTypes)
       {
         if (CHECKS) check
           (t != null);

--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -89,7 +89,8 @@ public class Call extends AbstractCall
   /**
    * name of called feature, set by parser
    */
-  public String name;
+  private String _name;
+  public String name() { return _name; }
 
 
   /**
@@ -118,8 +119,8 @@ public class Call extends AbstractCall
   /**
    * the target of the call, null for "this". Set by parser
    */
-  public Expr target;
-  public Expr target() { return target; }
+  private Expr _target;
+  public Expr target() { return _target; }
 
 
   /**
@@ -140,7 +141,7 @@ public class Call extends AbstractCall
    * call to "b" in "x(fun a.b)". In this case, the actual arguments list must
    * be empty, independent of the formal arguments expected by b.
    */
-  boolean forFun = false;
+  boolean _forFun = false;
 
 
   /**
@@ -152,7 +153,7 @@ public class Call extends AbstractCall
    * formal arguments in case the last formal argument is of an open generic
    * type.
    */
-  AbstractType[] resolvedFormalArgumentTypes = null;
+  AbstractType[] _resolvedFormalArgumentTypes = null;
 
 
   /**
@@ -250,8 +251,8 @@ public class Call extends AbstractCall
           }
       }
     this._pos = pos;
-    this.target = t;
-    this.name = n;
+    this._target = t;
+    this._name = n;
     this._select = -1;
     this._generics = (g == null) ? NO_GENERICS : g;
     this._actualsNew = la;
@@ -307,8 +308,8 @@ public class Call extends AbstractCall
               Expr t, String n, String select)
   {
     this._pos = pos;
-    this.target = t;
-    this.name = n;
+    this._target = t;
+    this._name = n;
     int s = -1;
     try
       {
@@ -340,8 +341,8 @@ public class Call extends AbstractCall
   public Call(SourcePosition pos, Expr t, String n, int select)
   {
     this._pos = pos;
-    this.target = t;
-    this.name = n;
+    this._target = t;
+    this._name = n;
     this._select = select;
     this._generics = NO_GENERICS;
     this._actuals = NO_PARENTHESES;
@@ -362,11 +363,11 @@ public class Call extends AbstractCall
   public Call(SourcePosition pos, Expr t, AbstractFeature calledFeature, int select)
   {
     this._pos = pos;
-    this.name = calledFeature.featureName().baseName();
+    this._name = calledFeature.featureName().baseName();
     this._select = select;
     this._generics = NO_GENERICS;
     this._actuals = NO_PARENTHESES;
-    this.target = t;
+    this._target = t;
     this._calledFeature = calledFeature;
     this._type = null;
   }
@@ -401,8 +402,8 @@ public class Call extends AbstractCall
               AbstractFeature anonymous)
   {
     this._pos = pos;
-    this.target         = target;
-    this.name           = null;
+    this._target         = target;
+    this._name           = null;
     this._select        = -1;
     this._generics       = NO_GENERICS;
     this._actuals       = Expr.NO_EXPRS;
@@ -431,11 +432,11 @@ public class Call extends AbstractCall
               String name, List<AbstractType> generics, List<Expr> actuals, Expr target, AbstractFeature calledFeature, AbstractType type)
   {
     this._pos = pos;
-    this.name = name;
+    this._name = name;
     this._select = -1;
     this._generics = generics;
     this._actuals = actuals;
-    this.target = target;
+    this._target = target;
     this._calledFeature = calledFeature;
     this._type = type;
   }
@@ -476,9 +477,9 @@ public class Call extends AbstractCall
   private AbstractType targetTypeOrConstraint(Resolution res)
   {
     if (PRECONDITIONS) require
-                         (target != null);
+      (_target != null);
 
-    var result = target.type();
+    var result = _target.type();
     if (result.isGenericArgument())
       {
         var g = result.genericArgument();
@@ -508,9 +509,9 @@ public class Call extends AbstractCall
     // are we searching for features called via thiz' inheritance calls?
     if (thiz.state() == Feature.State.RESOLVING_INHERITANCE)
       {
-        if (target instanceof Call tc)
+        if (_target instanceof Call tc)
           {
-            target.loadCalledFeature(res, thiz);
+            _target.loadCalledFeature(res, thiz);
             return tc.calledFeature();
           }
         else
@@ -519,9 +520,9 @@ public class Call extends AbstractCall
                                    // but only to the outer clazz' features:
           }
       }
-    else if (target != null)
+    else if (_target != null)
       {
-        target.loadCalledFeature(res, thiz);
+        _target.loadCalledFeature(res, thiz);
         return targetTypeOrConstraint(res).featureOfType();
       }
     else
@@ -553,17 +554,17 @@ public class Call extends AbstractCall
     FeaturesAndOuter result;
     // are we searching for features called via thiz' inheritance calls?
     SortedMap<FeatureName, Feature> fs = EMPTY_MAP;
-    if (target != null)
+    if (_target != null)
       {
         res.resolveDeclarations(targetFeature);
         result = new FeaturesAndOuter();
-        result.features = res._module.lookupFeatures(targetFeature, name);
+        result.features = res._module.lookupFeatures(targetFeature, _name);
         result.outer = targetFeature;
       }
     else
       { /* search for feature in thiz and outer classes */
-        result = res._module.lookupNoTarget(targetFeature, name, this, null, null);
-        target = result.target(pos(), res, thiz);
+        result = res._module.lookupNoTarget(targetFeature, _name, this, null, null);
+        _target = result.target(pos(), res, thiz);
       }
     return result;
   }
@@ -601,7 +602,7 @@ public class Call extends AbstractCall
                               thiz);
         Expr t1 = new Call(pos(), new Current(pos(), thiz.thisType()), tmp, -1);
         Expr t2 = new Call(pos(), new Current(pos(), thiz.thisType()), tmp, -1);
-        Expr result = new Call(pos(), t2, name, _actuals)
+        Expr result = new Call(pos(), t2, _name, _actuals)
           {
             boolean isChainedBoolRHS() { return true; }
           };
@@ -613,7 +614,7 @@ public class Call extends AbstractCall
                         new Block(b.pos(),new List<Stmnt>(as, t1)));
         _actuals = new List<Expr>(result);
         _calledFeature = Types.resolved.f_bool_AND;
-        name = _calledFeature.featureName().baseName();
+        _name = _calledFeature.featureName().baseName();
       }
   }
 
@@ -641,7 +642,7 @@ public class Call extends AbstractCall
   boolean isInfixOperator()
   {
     return
-      name.startsWith("infix ") &&
+      _name.startsWith("infix ") &&
       (_actuals.size() == 1 /* normal infix operator 'a.infix + b' */                ||
        _actuals.size() == 2 /* infix on different target 'X.Y.Z.this.infix + a b' */    ) &&
       true; /* no check for _generics.size(), we allow infix operator to infer arbitrary number of type parameters */
@@ -670,7 +671,7 @@ public class Call extends AbstractCall
     if (Types.resolved != null &&
         targetFeature(res, thiz) == Types.resolved.f_bool &&
         isInfixOperator() &&
-        target instanceof Call tc &&
+        _target instanceof Call tc &&
         tc.isInfixOperator())
       {
         result = (tc._actuals.get(0) instanceof Call acc && acc.isChainedBoolRHS())
@@ -709,7 +710,7 @@ public class Call extends AbstractCall
     if (_calledFeature == null)
       {
         var actualsResolved = false;
-        if (name != Errors.ERROR_STRING)    // If call parsing failed, don't even try
+        if (_name != Errors.ERROR_STRING)    // If call parsing failed, don't even try
           {
             var targetFeature = targetFeature(res, thiz);
             if (CHECKS) check
@@ -717,7 +718,7 @@ public class Call extends AbstractCall
             if (targetFeature != null && targetFeature != Types.f_ERROR)
               {
                 var fo = calledFeatureCandidates(targetFeature, res, thiz);
-                FeatureName calledName = FeatureName.get(name, _actuals.size());
+                FeatureName calledName = FeatureName.get(_name, _actuals.size());
                 _calledFeature = fo.filter(pos(), calledName, ff -> mayMatchArgList(ff, false) || ff.hasOpenGenericsArgList() /* remove? */);
                 if (_calledFeature != null &&
                     _generics.isEmpty() &&
@@ -754,7 +755,7 @@ public class Call extends AbstractCall
 
     if (POSTCONDITIONS) ensure
       (Errors.count() > 0 || calledFeature() != null,
-       Errors.count() > 0 || target          != null);
+       Errors.count() > 0 || _target         != null);
   }
 
 
@@ -795,7 +796,7 @@ public class Call extends AbstractCall
    * from or even in the universe.
    *
    * If successful, field _calledFeature will be set to the called feature and
-   * fields target and _actuals will be changed accordingly.
+   * fields _target and _actuals will be changed accordingly.
    *
    * @param res this is called during type resolution, res gives the resolution
    * instance.
@@ -804,13 +805,13 @@ public class Call extends AbstractCall
    */
   void findOperatorOnOuter(Resolution res, AbstractFeature thiz)
   {
-    if (name.startsWith("infix "  ) ||
-        name.startsWith("prefix " ) ||
-        name.startsWith("postfix ")    )
+    if (_name.startsWith("infix "  ) ||
+        _name.startsWith("prefix " ) ||
+        _name.startsWith("postfix ")    )
       {
-        var calledName = FeatureName.get(name, _actuals.size()+1);
-        var oldTarget = target;
-        target = null;
+        var calledName = FeatureName.get(_name, _actuals.size()+1);
+        var oldTarget = _target;
+        _target = null;
         var fo = calledFeatureCandidates(thiz, res, thiz);
         _calledFeature = fo.filter(pos(), calledName, ff -> mayMatchArgList(ff, true));
         if (_calledFeature != null)
@@ -902,11 +903,11 @@ public class Call extends AbstractCall
             g.add(a.asType(outer, tp));
           }
       }
-    AbstractType result = new Type(pos(), name, g,
-                                   target == null             ||
-                                   target instanceof Universe ||
-                                   target instanceof Current     ? null
-                                                                 : target.asType(outer, tp));
+    AbstractType result = new Type(pos(), _name, g,
+                                   _target == null             ||
+                                   _target instanceof Universe ||
+                                   _target instanceof Current     ? null
+                                                                  : _target.asType(outer, tp));
     return result.visit(Feature.findGenerics, outer);
   }
 
@@ -923,7 +924,7 @@ public class Call extends AbstractCall
    */
   private boolean isSpecialWrtArgs(AbstractFeature ff)
   {
-    return forFun                                      /* a fun-declaration "fun a.b.f" */
+    return _forFun                                     /* a fun-declaration "fun a.b.f" */
       || ff.arguments().size()==0 && hasParentheses(); /* maybe an implicit call to a Function / Routine, see resolveImmediateFunctionCall() */
   }
 
@@ -997,12 +998,12 @@ public class Call extends AbstractCall
    */
   public String toString()
   {
-    return (target == null ||
-            (target instanceof Universe) ||
-            (target instanceof This t && t.toString().equals(FuzionConstants.UNIVERSE_NAME + ".this"))
+    return (_target == null ||
+            (_target instanceof Universe) ||
+            (_target instanceof This t && t.toString().equals(FuzionConstants.UNIVERSE_NAME + ".this"))
             ? ""
-            : target.toString() + ".")
-      + (name != null ? name : _calledFeature.featureName().baseName())
+            : _target.toString() + ".")
+      + (_name != null ? _name : _calledFeature.featureName().baseName())
       + (_generics.isEmpty() ? "" : "<" + _generics + ">")
       + (_actuals.isEmpty() ? "" : "(" + _actuals +")")
       + (_select < 0        ? "" : "." + _select);
@@ -1016,7 +1017,7 @@ public class Call extends AbstractCall
    */
   public void setTarget(Expr t)
   {
-    Expr ot = this.target;
+    Expr ot = this._target;
     if (ot instanceof Call)
       {
         ((Call)ot).setTarget(t);
@@ -1027,7 +1028,7 @@ public class Call extends AbstractCall
       }
     else
       {
-        this.target = t;
+        this._target = t;
       }
   }
 
@@ -1092,9 +1093,9 @@ public class Call extends AbstractCall
               }
           }
       }
-    if (target != null)
+    if (_target != null)
       {
-        target = target.visit(v, outer);
+        _target = _target.visit(v, outer);
       }
     v.action((AbstractCall) this);
     return v.action(this, outer);
@@ -1124,7 +1125,7 @@ public class Call extends AbstractCall
   private Call resolveImmediateFunctionCall(Resolution res, AbstractFeature outer)
   {
     Call result = this;
-    if (!forFun && // not a call to "b" within an expression of the form "fun a.b", will be handled after syntactic sugar
+    if (!_forFun && // not a call to "b" within an expression of the form "fun a.b", will be handled after syntactic sugar
         _type.isFunType() &&
         _calledFeature != Types.resolved.f_function && // exclude inherits call in function type
         _calledFeature.arguments().size() == 0 &&
@@ -1152,7 +1153,7 @@ public class Call extends AbstractCall
    * of a formal argument after inheritance.
    *
    * The result will be stored in
-   * resolvedFormalArgumentTypes[argnum..argnum+result-1].
+   * _resolvedFormalArgumentTypes[argnum..argnum+result-1].
    *
    * @param res Resolution instance
    *
@@ -1180,13 +1181,13 @@ public class Call extends AbstractCall
             // Check that the number or args can only change for the
             // last argument (when it is of an open generic type).  if
             // it would change for other arguments, changing the
-            // resolvedFormalArgumentTypes array would invalidate
+            // _resolvedFormalArgumentTypes array would invalidate
             // argnum for following arguments.
             if (CHECKS) check
-              (Errors.count() > 0 || argnum == resolvedFormalArgumentTypes.length - 1);
-            if (argnum != resolvedFormalArgumentTypes.length -1)
+              (Errors.count() > 0 || argnum == _resolvedFormalArgumentTypes.length - 1);
+            if (argnum != _resolvedFormalArgumentTypes.length -1)
               {
-                a = new AbstractType[] { Types.t_ERROR }; /* do not change resolvedFormalArgumentTypes array length */
+                a = new AbstractType[] { Types.t_ERROR }; /* do not change _resolvedFormalArgumentTypes array length */
               }
           }
         addToResolvedFormalArgumentTypes(res, argnum, a, frml);
@@ -1195,13 +1196,13 @@ public class Call extends AbstractCall
     else
       {
         if (CHECKS) check
-          (Errors.count() > 0 || argnum <= resolvedFormalArgumentTypes.length);
+          (Errors.count() > 0 || argnum <= _resolvedFormalArgumentTypes.length);
 
-        if (argnum < resolvedFormalArgumentTypes.length)
+        if (argnum < _resolvedFormalArgumentTypes.length)
           {
             if (CHECKS) check
               (frmlT != null);
-            resolvedFormalArgumentTypes[argnum] = frmlT;
+            _resolvedFormalArgumentTypes[argnum] = frmlT;
           }
       }
     return result;
@@ -1213,8 +1214,8 @@ public class Call extends AbstractCall
    * of a formal argument from the target type and generics provided to the call.
    *
    * The type(s) will be takenb from
-   * resolvedFormalArgumentTypes[argnum..argnum+n-1], the result will be stored
-   * in resolvedFormalArgumentTypes[argnum..].
+   * _resolvedFormalArgumentTypes[argnum..argnum+n-1], the result will be stored
+   * in _resolvedFormalArgumentTypes[argnum..].
    *
    * @param res Resolution instance
    *
@@ -1231,18 +1232,18 @@ public class Call extends AbstractCall
     for (int i = 0; i < n; i++)
       {
         if (CHECKS) check
-          (Errors.count() > 0 || argnum + i <= resolvedFormalArgumentTypes.length);
+          (Errors.count() > 0 || argnum + i <= _resolvedFormalArgumentTypes.length);
 
-        if (argnum + i < resolvedFormalArgumentTypes.length)
+        if (argnum + i < _resolvedFormalArgumentTypes.length)
           {
-            var frmlT = resolvedFormalArgumentTypes[argnum + i];
+            var frmlT = _resolvedFormalArgumentTypes[argnum + i];
 
             if (frmlT.isOpenGeneric())
               { // formal arg is open generic, i.e., this expands to 0 or more actual args depending on actual generics for target:
                 Generic g = frmlT.genericArgument();
                 var frmlTs = g.replaceOpen(g.feature() == _calledFeature
                                            ? _generics
-                                           : target.type().generics());
+                                           : _target.type().generics());
                 addToResolvedFormalArgumentTypes(res, argnum + i, frmlTs.toArray(new AbstractType[frmlTs.size()]), frml);
                 i = i + frmlTs.size() - 1;
                 n = n + frmlTs.size() - 1;
@@ -1254,7 +1255,7 @@ public class Call extends AbstractCall
                 frmlT = Types.intern(frmlT);
                 if (CHECKS) check
                   (frmlT != null);
-                resolvedFormalArgumentTypes[argnum + i] = frmlT;
+                _resolvedFormalArgumentTypes[argnum + i] = frmlT;
               }
           }
       }
@@ -1263,7 +1264,7 @@ public class Call extends AbstractCall
 
   /**
    * Helper routine for handDownFormalArg and replaceGenericsInFormalArg to
-   * extend the resolvedFormalArgumentTypes array.
+   * extend the _resolvedFormalArgumentTypes array.
    *
    * In case frml.resultType().isOpenGeneric(), this will call frml.select() for
    * all the actual types the open generic is replaced by to make sure the
@@ -1271,18 +1272,18 @@ public class Call extends AbstractCall
    *
    * @param res Resolution instance
    *
-   * @param argnum index in resolvedFormalArgumentTypes at which we add new
+   * @param argnum index in _resolvedFormalArgumentTypes at which we add new
    * elements
    *
-   * @param a the new elements to add to resolvedFormalArgumentTypes
+   * @param a the new elements to add to _resolvedFormalArgumentTypes
    *
    * @param frml the argument whose type we are resolving.
    */
   private void addToResolvedFormalArgumentTypes(Resolution res, int argnum, AbstractType[] a, AbstractFeature frml)
   {
-    var na = new AbstractType[resolvedFormalArgumentTypes.length - 1 + a.length];
+    var na = new AbstractType[_resolvedFormalArgumentTypes.length - 1 + a.length];
     var j = 0;
-    for (var i = 0; i < resolvedFormalArgumentTypes.length; i++)
+    for (var i = 0; i < _resolvedFormalArgumentTypes.length; i++)
       {
         if (i == argnum)
           {
@@ -1296,25 +1297,25 @@ public class Call extends AbstractCall
           }
         else
           {
-            na[j] = resolvedFormalArgumentTypes[i];
+            na[j] = _resolvedFormalArgumentTypes[i];
             j++;
           }
       }
-    resolvedFormalArgumentTypes = na;
+    _resolvedFormalArgumentTypes = na;
   }
 
 
   /**
    * Helper routine for resolveTypes to resolve the formal argument types of the
    * arguments in this call. Results will be stored in
-   * resolvedFormalArgumentTypes array.
+   * _resolvedFormalArgumentTypes array.
    */
   private void resolveFormalArgumentTypes(Resolution res)
   {
     var fargs = _calledFeature.valueArguments();
-    resolvedFormalArgumentTypes = fargs.size() == 0 ? Type.NO_TYPES
+    _resolvedFormalArgumentTypes = fargs.size() == 0 ? Type.NO_TYPES
                                                     : new AbstractType[fargs.size()];
-    Arrays.fill(resolvedFormalArgumentTypes, Types.t_ERROR);
+    Arrays.fill(_resolvedFormalArgumentTypes, Types.t_ERROR);
     int count = 0;
     for (var frml : fargs)
       {
@@ -1330,7 +1331,7 @@ public class Call extends AbstractCall
         count++;
       }
     if (POSTCONDITIONS) ensure
-      (resolvedFormalArgumentTypes != null);
+      (_resolvedFormalArgumentTypes != null);
   }
 
 
@@ -1371,7 +1372,7 @@ public class Call extends AbstractCall
       }
     else if (_select >= 0 && !t.isOpenGeneric())
       {
-        AstErrors.useOfSelectorRequiresCallWithOpenGeneric(pos(), _calledFeature, name, _select, t);
+        AstErrors.useOfSelectorRequiresCallWithOpenGeneric(pos(), _calledFeature, _name, _select, t);
         t = Types.t_ERROR;
       }
     else if (_select < 0)
@@ -1380,7 +1381,7 @@ public class Call extends AbstractCall
         t = (target() instanceof Current) || tt.isGenericArgument() ? t : tt.actualType(t);
         if (_calledFeature.isConstructor() && t.compareTo(Types.resolved.t_void) != 0)
           {  /* specialize t for the target type here */
-            t = new Type(t, t.generics(), target.type());
+            t = new Type(t, t.generics(), _target.type());
           }
       }
     else
@@ -1389,7 +1390,7 @@ public class Call extends AbstractCall
         int sz = types.size();
         if (_select >= sz)
           {
-            AstErrors.selectorRange(pos(), sz, _calledFeature, name, _select, types);
+            AstErrors.selectorRange(pos(), sz, _calledFeature, _name, _select, types);
             _calledFeature = Types.f_ERROR;
             t = Types.t_ERROR;
           }
@@ -1884,17 +1885,17 @@ public class Call extends AbstractCall
    */
   public void propagateExpectedType(Resolution res, AbstractFeature outer)
   {
-    if (!forFun &&
+    if (!_forFun &&
         _type != Types.t_ERROR &&
-        resolvedFormalArgumentTypes != null &&
-        _actuals.size() == resolvedFormalArgumentTypes.length /* this will cause an error in checkTypes() */ )
+        _resolvedFormalArgumentTypes != null &&
+        _actuals.size() == _resolvedFormalArgumentTypes.length /* this will cause an error in checkTypes() */ )
       {
         int count = 0;
         ListIterator<Expr> i = _actuals.listIterator();
         while (i.hasNext())
           {
             Expr actl = i.next();
-            var frmlT = resolvedFormalArgumentTypes[count];
+            var frmlT = _resolvedFormalArgumentTypes[count];
             if (CHECKS) check
               (frmlT != null,
                frmlT != Types.t_ERROR || Errors.count() > 0);
@@ -1902,12 +1903,12 @@ public class Call extends AbstractCall
             count++;
           }
 
-        if (target != null)
+        if (_target != null)
           {
             // NYI: Need to check why this is needed, it does not make sense to
             // propagate the target's type to target. But if removed,
             // tests/reg_issue16_chainedBool/ fails with C backend:
-            target = target.propagateExpectedType(res, outer, target.typeForFeatureResultTypeInferencing());
+            _target = _target.propagateExpectedType(res, outer, _target.typeForFeatureResultTypeInferencing());
           }
       }
   }
@@ -1921,9 +1922,9 @@ public class Call extends AbstractCall
    */
   public void box(AbstractFeature outer)
   {
-    if (!forFun && _type != Types.t_ERROR)
+    if (!_forFun && _type != Types.t_ERROR)
       {
-        int fsz = resolvedFormalArgumentTypes.length;
+        int fsz = _resolvedFormalArgumentTypes.length;
         if (_actuals.size() ==  fsz)
           {
             int count = 0;
@@ -1931,7 +1932,7 @@ public class Call extends AbstractCall
             while (i.hasNext())
               {
                 Expr actl = i.next();
-                var rft = resolvedFormalArgumentTypes[count];
+                var rft = _resolvedFormalArgumentTypes[count];
                 if (CHECKS) check
                   (rft != null,
                    rft != Types.t_ERROR || Errors.count() > 0);
@@ -1951,7 +1952,7 @@ public class Call extends AbstractCall
    */
   public void checkTypes(AbstractFeature outer)
   {
-    if (forFun)
+    if (_forFun)
       { // this is a call to "b" within an expression of the form "fun a.b". In
         // this case, there must be no generics nor actual arguments to "b", the
         // call will be replaced during Function.resolveSyntacticSugar.
@@ -1966,7 +1967,7 @@ public class Call extends AbstractCall
       }
     else if (_type != Types.t_ERROR)
       {
-        int fsz = resolvedFormalArgumentTypes.length;
+        int fsz = _resolvedFormalArgumentTypes.length;
         if (_actuals.size() !=  fsz)
           {
             AstErrors.wrongNumberOfActualArguments(this);
@@ -1976,7 +1977,7 @@ public class Call extends AbstractCall
             int count = 0;
             for (Expr actl : _actuals)
               {
-                var frmlT = resolvedFormalArgumentTypes[count];
+                var frmlT = _resolvedFormalArgumentTypes[count];
                 if (frmlT != null /* NYI: make sure this is never null */ && !frmlT.isAssignableFrom(actl))
                   {
                     AstErrors.incompatibleArgumentTypeInCall(_calledFeature, count, frmlT, actl);
@@ -2057,10 +2058,10 @@ public class Call extends AbstractCall
         //   a: b   into if a b     else true
         //   !a     into if a false else true
         var cf = _calledFeature;
-        if      (cf == Types.resolved.f_bool_AND    ) { result = newIf(target, _actuals.get(0), BoolConst.FALSE); }
-        else if (cf == Types.resolved.f_bool_OR     ) { result = newIf(target, BoolConst.TRUE , _actuals.get(0)); }
-        else if (cf == Types.resolved.f_bool_IMPLIES) { result = newIf(target, _actuals.get(0), BoolConst.TRUE ); }
-        else if (cf == Types.resolved.f_bool_NOT    ) { result = newIf(target, BoolConst.FALSE, BoolConst.TRUE ); }
+        if      (cf == Types.resolved.f_bool_AND    ) { result = newIf(_target, _actuals.get(0), BoolConst.FALSE); }
+        else if (cf == Types.resolved.f_bool_OR     ) { result = newIf(_target, BoolConst.TRUE , _actuals.get(0)); }
+        else if (cf == Types.resolved.f_bool_IMPLIES) { result = newIf(_target, _actuals.get(0), BoolConst.TRUE ); }
+        else if (cf == Types.resolved.f_bool_NOT    ) { result = newIf(_target, BoolConst.FALSE, BoolConst.TRUE ); }
       }
     return result;
   }

--- a/src/dev/flang/ast/Function.java
+++ b/src/dev/flang/ast/Function.java
@@ -150,7 +150,7 @@ public class Function extends ExprWithPos
       (c._actuals.size() == 0);
 
     this._call = c;
-    c.forFun = true;
+    c._forFun = true;
     this._wrapper = null;
   }
 
@@ -538,7 +538,7 @@ public class Function extends ExprWithPos
              * [..]
              */
             Call call = this._call;
-            call.forFun = false;  // the call is no longer for fun (i.e., ignored in Call.resolveTypes)
+            call._forFun = false;  // the call is no longer for fun (i.e., ignored in Call.resolveTypes)
             var calledFeature = call.calledFeature();
             /* NYI: "fun a.b" special cases: check what can go wrong with
              * calledTarget and flag an error. Possible errors aor special case
@@ -559,7 +559,7 @@ public class Function extends ExprWithPos
                 formal_args.add(new Feature(pos(), Consts.VISIBILITY_LOCAL, 0, f.resultType(), name, Contract.EMPTY_CONTRACT));
                 argnum++;
               }
-            Call callWithArgs = new Call(pos(), null, call.name, actual_args);
+            Call callWithArgs = new Call(pos(), null, call.name(), actual_args);
             Feature fcall = new Feature(pos(), Consts.VISIBILITY_PUBLIC,
                                         Consts.MODIFIER_REDEFINE,
                                         NoType.INSTANCE, // calledFeature.returnType,
@@ -585,9 +585,9 @@ public class Function extends ExprWithPos
                                            inherits,
                                            Contract.EMPTY_CONTRACT,
                                            new Impl(pos(), new Block(pos(), statements), Impl.Kind.Routine));
-            res._module.findDeclarations(function, call.target.type().featureOfType());
+            res._module.findDeclarations(function, call.target().type().featureOfType());
             result = new Call(pos(),
-                              call.target,
+                              call.target(),
                               function)
               .resolveTypes(res, outer);
           }

--- a/src/dev/flang/fe/LibraryOut.java
+++ b/src/dev/flang/fe/LibraryOut.java
@@ -779,7 +779,7 @@ class LibraryOut extends ANY
       }
     else if (s instanceof Call c)
       {
-        lastPos = expressions(c.target, lastPos);
+        lastPos = expressions(c.target(), lastPos);
         for (var a : c._actuals)
           {
             lastPos = expressions(a, lastPos);

--- a/src/dev/flang/fe/SourceModule.java
+++ b/src/dev/flang/fe/SourceModule.java
@@ -565,7 +565,7 @@ public class SourceModule extends Module implements SrcModule, MirModule
     inner.visit(new FeatureVisitor()
       {
         public Call      action(Call      c, AbstractFeature outer) {
-          if (c.name == null)
+          if (c.name() == null)
             { /* this is an anonymous feature declaration */
               if (CHECKS) check
                 (Errors.count() > 0  || c.calledFeature() != null);

--- a/src/dev/flang/parser/OpExpr.java
+++ b/src/dev/flang/parser/OpExpr.java
@@ -331,7 +331,7 @@ public class OpExpr extends ANY
       {
         Object o = els.get(i);
         if (o instanceof String) System.out.print(o);
-        else if (o instanceof Call) System.out.print(((Call)o).name);
+        else if (o instanceof Call c) System.out.print(c.name());
         else System.out.print("E");
       }
     System.out.println();


### PR DESCRIPTION
Also made code `AbstractFeature.typeFeaturesNonStaticParent()` robust against previous compilation errors. 