### PR TITLE
lib/bitset: fix equality when one of the arguments is empty

### DIFF
--- a/lib/bitset.fz
+++ b/lib/bitset.fz
@@ -78,7 +78,7 @@ is
   infix == (other bitset) bool is
      h := highest >>= i -> other.highest >>= j -> i.max j
      match h
-       _ nil => true
+       _ nil => highest!! && other.highest!!
        m u64 =>
          for
            r := true, r && ((has i) <=> other.has i)


### PR DESCRIPTION
If one of the arguments is the empty bitset, then highest will be nil, and hence the bind operator in the definition of h will make the result nil as well. However, this does not mean that both bitsets are empty. Add the missing check for this case.

Fixes #638.