### PR TITLE
parser/OpExpr: adjust precedence for ≟

### DIFF
--- a/src/dev/flang/parser/OpExpr.java
+++ b/src/dev/flang/parser/OpExpr.java
@@ -373,7 +373,7 @@ public class OpExpr extends ANY
                                             new Precedence( 8,        "#"  ),
                                             new Precedence(14, 7, 14, "$"  ),
                                             new Precedence( 6,        ""   ),
-                                            new Precedence( 5,        "<>=⧁⧀⊜⩹⩺⩻⩼⩽⩾⩿⪀⪁⪂⪃⪄⪅⪆⪇⪈⪉⪊⪋⪌⪍⪎⪏⪐⪑⪒⪓⪔⪕⪖⪗⪘⪙⪚⪛⪜⪝⪞⪟⪠⪡⪢⪤⪥⪦⪧⪨⪩⪪⪫⪬⪭⪮⪯⪰⪱⪲⪴⪵⪶⪷⪸⪹⪺⪻⪼⫷⫸⫹⫺"),
+                                            new Precedence( 5,        "<>=⧁⧀⊜⩹⩺⩻⩼⩽⩾⩿⪀⪁⪂⪃⪄⪅⪆⪇⪈⪉⪊⪋⪌⪍⪎⪏⪐⪑⪒⪓⪔⪕⪖⪗⪘⪙⪚⪛⪜⪝⪞⪟⪠⪡⪢⪤⪥⪦⪧⪨⪩⪪⪫⪬⪭⪮⪯⪰⪱⪲⪴⪵⪶⪷⪸⪹⪺⪻⪼⫷⫸⫹⫺≟"),
                                             new Precedence( 4,        "&"  ),
                                             new Precedence( 3,        "|⦶⦷"),
                                             new Precedence( 2,        "∀"  ),


### PR DESCRIPTION
This works:
```
true & a = b
```
Previously however, this did not work:
```
true & a ≟ b
```
Instead it was necessary to mark the precedence of the equality check manually. Hence we adjust the precedence of ≟ to be the same as =.

Fixes #647.