### PR TITLE
ast: Call.findOperatorOnOuter. reset to oldTarget if not found

### DIFF
--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -33,6 +33,8 @@ import java.util.ListIterator;
 import java.util.Map;
 import java.util.SortedMap;
 import java.util.TreeMap;
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
 
 import dev.flang.util.Errors;
 import dev.flang.util.FuzionConstants;
@@ -819,6 +821,10 @@ public class Call extends AbstractCall
             var oldActuals = _actuals;
             _actuals = new List(oldTarget);
             _actuals.addAll(oldActuals);
+          }
+        else
+          {
+            _target = oldTarget;
           }
       }
   }

--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -26,15 +26,10 @@ Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
 
 package dev.flang.ast;
 
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Iterator;
 import java.util.ListIterator;
-import java.util.Map;
 import java.util.SortedMap;
 import java.util.TreeMap;
-import java.util.stream.Collector;
-import java.util.stream.Collectors;
 
 import dev.flang.util.Errors;
 import dev.flang.util.FuzionConstants;


### PR DESCRIPTION
This change is necessary/useful for the language server.