### PR TITLE
lib/try: remove a leftover semicolon

### DIFF
--- a/lib/try.fz
+++ b/lib/try.fz
@@ -46,7 +46,7 @@ is
   # terminate immediately with the given error wrapped in 'outcome'.
   #
   raise(e error) =>
-    set err := e;
+    set err := e
     abort
 
 # convenience routine to create a new instance of 'try' and run 'f' in


### PR DESCRIPTION
Remove a semicolon that was probably forgotten when moving from the old code style to the modern code style.