### PR TITLE
flake.nix: init

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,42 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1668984258,
+        "narHash": "sha256-0gDMJ2T3qf58xgcSbYoXiRGUkPWmKyr5C3vcathWhKs=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "cf63ade6f74bbc9d2a017290f1b2e33e8fbfa70a",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-22.05",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,74 @@
+{
+  description = "The Fuzion Language Implementation";
+
+  inputs = {
+    nixpkgs.url = "nixpkgs/nixos-22.05";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = inputs @ { self, nixpkgs, flake-utils, ... }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+      in rec {
+        packages = flake-utils.lib.flattenTree rec {
+          fuzion = pkgs.stdenv.mkDerivation {
+            pname = "fuzion";
+            version = "${nixpkgs.lib.fileContents ./version.txt}-${nixpkgs.lib.substring 0 8 self.lastModifiedDate}-${self.shortRev or "dirty"}";
+
+            src = nixpkgs.lib.cleanSource ./.;
+
+            nativeBuildInputs = with pkgs; [
+              antlr
+              jdk
+              makeWrapper
+              pcre
+            ];
+
+            makeFlags = [ "FUZION_BIN_BASH=${pkgs.bash}/bin/bash" ];
+
+            # NOTE patchShebangs only patches executable files
+            patchPhase = ''
+              patchShebangs bin/ebnf.sh
+              chmod +x bin/fz
+              patchShebangs bin/fz
+              chmod +x bin/fzjava
+              patchShebangs bin/fzjava
+            '';
+
+            installPhase = ''
+              cp -r build $out
+            '';
+
+            postFixup = ''
+              wrapProgram $out/bin/fz \
+                --set FUZION_JAVA ${pkgs.jdk.home}/bin/java \
+                --prefix PATH : ${pkgs.lib.makeBinPath [ pkgs.clang_10 ]} \
+                --prefix CPATH : ${pkgs.lib.getDev pkgs.boehmgc}/include \
+                --prefix LIBRARY_PATH : ${pkgs.lib.getLib pkgs.boehmgc}/lib
+              wrapProgram $out/bin/fzjava \
+                --set FUZION_JAVA ${pkgs.jdk.home}/bin/java \
+                --prefix PATH : ${pkgs.lib.makeBinPath [ pkgs.clang_10 ]} \
+                --prefix CPATH : ${pkgs.lib.getDev pkgs.boehmgc}/include \
+                --prefix LIBRARY_PATH : ${pkgs.lib.getLib pkgs.boehmgc}/lib
+            '';
+          };
+
+          default = fuzion;
+        };
+
+        devShell = pkgs.mkShell {
+          buildInputs = with pkgs; [
+            antlr
+            clang_10
+            jdk
+            pcre
+          ];
+
+          shellHook = ''
+            export PATH="$PWD/build/bin:$PATH"
+            export MAKEFLAGS="FUZION_BIN_BASH=${pkgs.bash}/bin/bash"
+          '';
+        };
+      });
+}


### PR DESCRIPTION
This provides:

- a Fuzion package for Nix, if Nix is installed a shell with the `fz` and `fzjava` executables can be launched with `nix shell github:tokiwa-software/fuzion` (once merged)
- if Nix is installed and one uses `nix develop`, all necessary dependencies will be installed and `PATH` and `MAKEFLAGS` will be configured automatically.