### PR TITLE
be/c: use _Thread_local instead of __thread

### DIFF
--- a/src/dev/flang/be/c/C.java
+++ b/src/dev/flang/be/c/C.java
@@ -657,7 +657,7 @@ public class C extends ANY
                        )
                        .flatMap(x -> x)
                        .iterator())),
-                 CStmnt.decl("__thread", "struct " + CNames.fzThreadEffectsEnvironment.code() + "*", CNames.fzThreadEffectsEnvironment)
+                 CStmnt.decl("_Thread_local", "struct " + CNames.fzThreadEffectsEnvironment.code() + "*", CNames.fzThreadEffectsEnvironment)
                )
              );
            }


### PR DESCRIPTION
__thread is a non-standard GCC extension. It caused problems when building Fuzion programs on Windows, see #661. Use _Thread_local from the C11 standard instead. According to a Stack Overflow post [1], this should work.

**Note:** this seems to not break anything on Linux, but I have not tested it on Windows.

[1]: https://stackoverflow.com/questions/32245103/how-does-the-gcc-thread-work