### PR TITLE
tools/fzjava: when building multiple modules, separate them

### DIFF
--- a/src/dev/flang/tools/fzjava/FZJava.java
+++ b/src/dev/flang/tools/fzjava/FZJava.java
@@ -104,6 +104,11 @@ public class FZJava extends Tool
    */
   TreeSet<String> _existingFeatures = new TreeSet<String>();
 
+  /**
+   * The name of the module that is currently being processed.
+   */
+  String _currentModule;
+
 
   /*--------------------------  static methods  -------------------------*/
 
@@ -309,6 +314,11 @@ public class FZJava extends Tool
    */
   void processModule(String m)
   {
+    // clean up in case a previous run of processModule filled this already:
+    _currentModule = m.substring(0, m.length() - 5);
+    _pkgs.clear();
+    _classes.clear();
+
     var p = modulePath(m);
     if (_verbose > 0)
       {

--- a/src/dev/flang/tools/fzjava/FeatureWriter.java
+++ b/src/dev/flang/tools/fzjava/FeatureWriter.java
@@ -63,6 +63,11 @@ class FeatureWriter extends ANY
   static void write(FZJava fzj, String fn, String suffix, String data)
   {
     var fzp = fzj._options._dest;
+    if (fzj._options._modules.size() > 1)
+      {
+        fzp = fzp.resolve(fzj._currentModule);
+      }
+
     while (fn.indexOf("/") >= 0)
       {
         var d = mangle(fn.substring(0, fn.indexOf("/")));


### PR DESCRIPTION
Previously, fzjava would put the Fuzion features for all given modules in a single directory. Now, if more than one module is given, we put the Fuzion features for a Java module x into dest/x, for a Java module y into dest/y, and so on, where dest is the destination directory given by the -to command line argument.

We do not address the case where the given modules may depend on each other, and hence might contain duplicate features afterwards. In this case, building the first module as a single module, then compiling it into a fum file, and then loading the fum file with -modules is still necessary to avoid duplicate features.

Closes #599.