### PR TITLE
fe/air: Add support for inheriting features defined in type features

### DIFF
--- a/lib/has_equality.fz
+++ b/lib/has_equality.fz
@@ -17,20 +17,26 @@
 #
 #  Tokiwa Software GmbH, Germany
 #
-#  Source code of Fuzion standard library feature equals
+#  Source code of Fuzion standard library feature has_equality
 #
 #  Author: Fridtjof Siebert (siebert@tokiwa.software)
 #
 # -----------------------------------------------------------------------
 
-# equals -- feature that compares two values using the equality relation
-# defined in their type
+# has_equality -- feature for immutable values that define an equality relation
 #
-equals(T type, a, b T) => T.equality a b
-equals2(T has_equality.type, a, b T) => T.equality2 a b
+has_equality is
 
 
-# infix ≟ -- infix operation as short-hand for 'equals'
-#
-infix ≟(T type, a, b T) => equals T a b
-infix ≟≟(T has_equality.type, a, b T) => equals2 T a b
+  # equality implements the default equality relation for values of this type.
+  #
+  # This relation must be
+  #
+  #  - reflexive (equality a b),
+  #  - symmetric (equality a b = equality b a), and
+  #  - transitive ((equality a b && equality b c) : equality a c).
+  #
+  # result is true iff 'a' is considered to represent the same abstract value
+  # as 'b'.
+  #
+  type.equality2(aa, bb THIS_TYPE) bool is abstract

--- a/lib/string.fz
+++ b/lib/string.fz
@@ -25,7 +25,7 @@
 
 # string -- immutable sequences of utf8 encoded unicode characters
 #
-string ref : hasHash string, ordered string, strings is
+string ref : has_equality, hasHash string, ordered string, strings is
 
   redef orderedThis => string.this
 
@@ -78,6 +78,9 @@ string ref : hasHash string, ordered string, strings is
   # bytes are equal.
   #
   string.type.equality(a, b string) =>
+    ((a.utf8.zip b.utf8 aa,bb->aa≟bb) ∀ x->x)
+      & a.utf8.count ≟ b.utf8.count
+  string.type.equality2(a, b string) =>
     ((a.utf8.zip b.utf8 aa,bb->aa≟bb) ∀ x->x)
       & a.utf8.count ≟ b.utf8.count
 

--- a/src/dev/flang/air/Clazz.java
+++ b/src/dev/flang/air/Clazz.java
@@ -53,6 +53,7 @@ import dev.flang.ast.SrcModule; // NYI: remove dependency!
 import dev.flang.ast.StatementVisitor; // NYI: remove dependency!
 import dev.flang.ast.Stmnt; // NYI: remove dependency!
 import dev.flang.ast.Tag; // NYI: remove dependency!
+import dev.flang.ast.Type; // NYI: remove dependency!
 import dev.flang.ast.Types; // NYI: remove dependency!
 import dev.flang.ast.Unbox; // NYI: remove dependency!
 
@@ -1951,20 +1952,13 @@ public class Clazz extends ANY implements Comparable<Clazz>
 
   /**
    * For a clazz a.b.c the corresponding type clazz a.b.c.type, which is,
-   * actually, a.type.b.type.c.type.
+   * actually, '((a.type a).b.type b).c.type c'.
    */
   Clazz typeClazz()
   {
-    var cf = _type.featureOfType();
-    if (cf.isUniverse())
-      {
-        return this;
-      }
-    else
-      {
-        var tf = cf.typeFeature();
-        return Clazzes.create(tf.thisType(), _outer.typeClazz());
-      }
+    return feature().isUniverse() ? this
+                                  : Clazzes.create(_type.typeType(),
+                                                   _outer.typeClazz());
   }
 
 

--- a/src/dev/flang/ast/AbstractFeature.java
+++ b/src/dev/flang/ast/AbstractFeature.java
@@ -457,6 +457,51 @@ public abstract class AbstractFeature extends ANY implements Comparable<Abstract
 
 
   /**
+   * Is this a type feature?
+   */
+  public boolean isTypeFeature()
+  {
+    return isStaticTypeFeature() || isDynamicTypeFeature();
+  }
+
+
+  /**
+   * Is this a dynamic type feature?
+   */
+  public boolean isDynamicTypeFeature()
+  {
+    // NYI: CLEANUP: Replace string operation by a flag marking this features as a dynamic type feature
+    return featureName().baseName().endsWith(FuzionConstants.TYPE_NAME) && !isOuterRef();
+  }
+
+
+  /**
+   * Is this a static type feature?
+   */
+  public boolean isStaticTypeFeature()
+  {
+    // NYI: CLEANUP: Replace string operation by a flag marking this features as a static type feature
+    return featureName().baseName().endsWith(FuzionConstants.TYPE_STATIC_NAME) && !isOuterRef();
+  }
+
+
+  /**
+   * This type feature declared as
+   *
+   *    abc.type.xyz is ...
+   *
+   * will go to abc's static type unless this is true.
+   */
+  public boolean belongsToNonStaticType()
+  {
+    // currently, only abstract features go to the dynamic type.  We might be
+    // more flexible here and let all features that depend on generic parameter
+    // FuzionConstants.TYPE_FEATURE_THIS_TYPE go to the dynamic type.
+    return isAbstract();
+  }
+
+
+  /**
    * For a type feature, create the inheritance call for a parent type feature.
    *
    * @param p the source position
@@ -475,7 +520,7 @@ public abstract class AbstractFeature extends ANY implements Comparable<Abstract
     var o = outer();
     var oc = o == null || o.isUniverse()
       ? new Universe()
-      : outer().typeCall(p, new List<>(), res, false);
+      : outer().typeCall(p, new List<>(outer().thisType()), res, false);
     var tf = nonStatic ? nonStaticTypeFeature(res) : typeFeature(res);
     return new Call(p,
                     tf.featureName().baseName(),
@@ -499,7 +544,7 @@ public abstract class AbstractFeature extends ANY implements Comparable<Abstract
    * @return The feature that should be the direct ancestor of this feature's
    * type feature.
    */
-  private AbstractFeature nonStaticTypeFeature(Resolution res)
+  public AbstractFeature nonStaticTypeFeature(Resolution res)
   {
     if (PRECONDITIONS) require
       (state().atLeast(Feature.State.FINDING_DECLARATIONS),
@@ -521,13 +566,19 @@ public abstract class AbstractFeature extends ANY implements Comparable<Abstract
             var inh = new List<AbstractCall>();
             for (var pc: inherits())
               {
-                inh.add(pc.calledFeature().typeCall(pos(), new List<>(), res, true));
+                var thisType = new Type(pos(),
+                                        FuzionConstants.TYPE_FEATURE_THIS_TYPE,
+                                        new List<>(),
+                                        null);
+                inh.add(pc.calledFeature().typeCall(pos(), new List<>(thisType),
+                                                    res,
+                                                    true));
               }
             if (inh.isEmpty())
               {
                 inh.add(new Call(pos(), "Type"));
               }
-            _nonStaticTypeFeature = existingOrNewTypeFeature(res, name, inh);
+            _nonStaticTypeFeature = existingOrNewTypeFeature(false, res, name, inh);
           }
       }
     return _nonStaticTypeFeature;
@@ -576,11 +627,11 @@ public abstract class AbstractFeature extends ANY implements Comparable<Abstract
           (i >= 0); // TYPE_NAME must be part of aname
         var name = aname.substring(0, i) + FuzionConstants.TYPE_STATIC_NAME + aname.substring(i + FuzionConstants.TYPE_NAME.length());
         var inh = new List<AbstractCall>
-          (new Call(pos(), aname),  // call to non-static parent, must be first inherits call, see typeFeaturesNonStaticParent()!
+          (new Call(pos(), null, aname, null, new List<>(new Actual(thisType(), null)), null),  // call to non-static parent, must be first inherits call, see typeFeaturesNonStaticParent()!
            new Call(pos(), null, "Type_STATIC", null, new List<>(new Actual(thisType(), null)), null));
         // make sure outer type feature exists, otherwise tests/reg_issues455-456_dot_type fails (NYI: check why exactly?)
         var ot = outer() == null || outer().isUniverse() ? universe() : outer().typeFeature(res);
-        _typeFeature = existingOrNewTypeFeature(res, name, inh);
+        _typeFeature = existingOrNewTypeFeature(true, res, name, inh);
       }
     var result = typeFeature();
     check
@@ -600,7 +651,7 @@ public abstract class AbstractFeature extends ANY implements Comparable<Abstract
    *
    * @param inh the inheritance clause of the new type feature.
    */
-  private AbstractFeature existingOrNewTypeFeature(Resolution res, String name, List<AbstractCall> inh)
+  private AbstractFeature existingOrNewTypeFeature(boolean statc, Resolution res, String name, List<AbstractCall> inh)
   {
     var nonStaticOuterType = outer() == null || outer().isUniverse() ? universe() : outer().nonStaticTypeFeature(res);
     var outerType          = outer() == null || outer().isUniverse() ? universe() : outer().typeFeature(res);
@@ -608,7 +659,14 @@ public abstract class AbstractFeature extends ANY implements Comparable<Abstract
     if (result == null)
       {
         var p = pos();
-        var typeFeature = new Feature(p, visibility(), 0, NoType.INSTANCE, new List<>(name), new List<Feature>(),
+        var typeArg = new Feature(p,
+                                  visibility(),
+                                  outer().isUniverse() && featureName().baseName().equals("Object") && !statc ? 0 : Consts.MODIFIER_REDEFINE,
+                                  new Type("Object"),
+                                  FuzionConstants.TYPE_FEATURE_THIS_TYPE,
+                                  Contract.EMPTY_CONTRACT,
+                                  Impl.TYPE_PARAMETER);
+        var typeFeature = new Feature(p, visibility(), 0, NoType.INSTANCE, new List<>(name), new List<Feature>(typeArg),
                                       inh,
                                       Contract.EMPTY_CONTRACT,
                                       new Impl(p, new Block(p, new List<>()), Impl.Kind.Routine));
@@ -746,7 +804,8 @@ public abstract class AbstractFeature extends ANY implements Comparable<Abstract
       {
         res.resolveTypes(this);
       }
-    var result = resultTypeRaw(generics);
+    var result = isStaticTypeFeature() ? generics.get(0).typeType(res)
+                                       : resultTypeRaw(generics);
     if (result != null && result instanceof Type rt)
       {
         result = rt.visit(Feature.findGenerics,outer());

--- a/src/dev/flang/ast/AbstractType.java
+++ b/src/dev/flang/ast/AbstractType.java
@@ -959,6 +959,115 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
   }
 
 
+  /**
+   * For a given type t, get the type of t's type feature. E.g., for t==string,
+   * this will return the type of string.type.
+   *
+   * @param t the type whose type's type we want to get
+   *
+   * @return the type of t's type.
+   */
+  public AbstractType typeType()
+  {
+    if (PRECONDITIONS) require
+      (!isGenericArgument(),
+       featureOfType().state().atLeast(Feature.State.RESOLVED));
+
+    return typeType(null);
+  }
+
+
+  /**
+   * For a given type t, get the type of t's type feature. E.g., for t==string,
+   * this will return the type of string.type, which is 'string.#type_STATIC
+   * string'
+   *
+   * @param res Resolution instance used to resolve the type feature that might
+   * need to be created.
+   *
+   * @param t the type whose type's type we want to get
+   *
+   * @return the type of t's type.
+   */
+  AbstractType typeType(Resolution res)
+  {
+    if (PRECONDITIONS) require
+      (!isGenericArgument(),
+       res != null || featureOfType().state().atLeast(Feature.State.RESOLVED));
+
+    var result = this;
+    if (!featureOfType().isUniverse())
+      {
+        var f = res == null ? featureOfType().typeFeature()
+                            : featureOfType().typeFeature(res);
+        result = Types.intern(new Type(f.pos(),
+                                       f.featureName().baseName(),
+                                       new List<>(this),
+                                       outer().typeType(res),
+                                       f,
+                                       Type.RefOrVal.Value));
+      }
+    return result;
+  }
+
+
+  /**
+   * In a call on 'target' with formal argument type this, if target is a type
+   * parameter and this depends on that type feature's THIS_TYPE, then replace
+   * THIS_TYPE by the type of target.
+   *
+   * @param target the target of the call
+   */
+  AbstractType replace_THIS_TYPE(Expr target)
+  {
+    var result = this;
+    var tt = target.type();
+    if (!tt.isGenericArgument())
+      {
+        var tf = tt.featureOfType();
+        if (dependsOnGenerics() &&
+            tf.isStaticTypeFeature() &&
+            target instanceof AbstractCall tc && tc.calledFeature().isTypeParameter())
+          {
+            if (isGenericArgument())
+              {
+                if (genericArgument().typeParameter() == tf.typeFeaturesNonStaticParent().arguments().get(0))
+                  { // a call of the form 'T.f x' where 'f' is declared as 'abc.type.f(arg THIS_TYPE)', so replace 'THIS_TYPE' by 'T'.
+                    // NYI: replace THIS_TYPE recursively in frmlT, e.g., in case formT is 'Option THIS_TYPE'.
+                    result = new Type(tc.pos(), new Generic(tc.calledFeature()));
+                  }
+              }
+            else
+              {
+                var g = generics();
+                var ng = g;
+                for (int i = 0; i < g.size(); i++)
+                  {
+                    var gi = g.get(i);
+                    var gi2 = gi.replace_THIS_TYPE(target);
+                    if (gi != gi2)
+                      {
+                        if (ng != g)
+                          {
+                            ng = new List<>();
+                            ng.addAll(g);
+                          }
+                        ng.set(i, gi2);
+                      }
+                  }
+                var o = outer();
+                var no = o != null ? o.replace_THIS_TYPE(target) : null;
+                if (ng != g || no != o)
+                  {
+                    result = new Type(this, ng, no);
+                  }
+              }
+          }
+      }
+    return result;
+  }
+
+
   public abstract AbstractFeature featureOfType();
   public abstract AbstractType asRef();
   public abstract AbstractType asValue();

--- a/src/dev/flang/ast/AstErrors.java
+++ b/src/dev/flang/ast/AstErrors.java
@@ -836,6 +836,18 @@ public class AstErrors extends ANY
                          existing         != Types.f_ERROR &&
                          existing.outer() != Types.f_ERROR    ))
       {
+        // NYI: HACK: see #461: This is an ugly workaround that just ignores the
+        // fact that type features can be defined repeatedly.
+        if (f.isTypeFeature())
+          {
+            warning(pos,
+                    "Duplicate feature declaration (ignored since these are type features, see #461)",
+                    "Feature that was declared repeatedly: " + s(f) + "\n" +
+                    "originally declared at " + existing.pos().show() + "\n" +
+                    "To solve this, consider renaming one of these two features or changing its number of arguments");
+            return;
+          }
+
         error(pos,
               "Duplicate feature declaration",
               "Feature that was declared repeatedly: " + s(f) + "\n" +

--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -1174,6 +1174,14 @@ public class Call extends AbstractCall
 
     var declF = _calledFeature.outer();
     var heirF = targetTypeOrConstraint(res).featureOfType();
+    if (target() instanceof Call tc              &&
+        tc.calledFeature().isTypeParameter()     &&
+        heirF.isStaticTypeFeature()              &&
+        calledFeature().outer().isTypeFeature()  &&
+        calledFeature().belongsToNonStaticType()    )
+      {  // divert calls T.f with a type parameter as target to the non-static type if needed.
+        heirF = heirF.typeFeaturesNonStaticParent();
+      }
     if (declF != heirF)
       {
         var a = _calledFeature.handDown(res, new AbstractType[] { frmlT }, heirF);
@@ -1251,6 +1259,7 @@ public class Call extends AbstractCall
               }
             else
               {
+                frmlT = frmlT.replace_THIS_TYPE(target());
                 frmlT = targetTypeOrConstraint(res).actualType(frmlT);
                 frmlT = frmlT.actualType(_calledFeature, _generics);
                 frmlT = Types.intern(frmlT);
@@ -1425,7 +1434,7 @@ public class Call extends AbstractCall
           }
         else
           {
-            _type = gt.featureOfType().typeFeature(res).resultTypeIfPresent(res, t.generics());
+            _type = gt.featureOfType().typeFeature(res).resultTypeIfPresent(res, _generics);
             if (_type == null)
               {
                 throw new Error("NYI (see #283): resolveTypes for .type: resultType not present at "+pos().show());

--- a/src/dev/flang/fe/Module.java
+++ b/src/dev/flang/fe/Module.java
@@ -255,7 +255,7 @@ public abstract class Module extends ANY
           { // existing redefines f, so use existing
             f = existing;
           }
-        else if (existing == f && f.generics() != FormalGenerics.NONE ||
+        else if (existing == f && !existing.generics().equals(f.generics()) ||
                  existing != f && declaredFeatures(outer).get(fn) == null)
           { // NYI: Should be ok if existing or f is abstract.
             AstErrors.repeatedInheritanceCannotBeResolved(outer.pos(), outer, fn, existing, f);

--- a/src/dev/flang/fe/SourceModule.java
+++ b/src/dev/flang/fe/SourceModule.java
@@ -494,9 +494,10 @@ public class SourceModule extends Module implements SrcModule, MirModule
        {
          var q = inner._qname;
          var n = q.get(at);
-         var o = n == FuzionConstants.TYPE_NAME
-           ? outer.typeFeature(_res)
-           : lookupFeatureForType(inner.pos(), n, outer);
+         var o =
+           n != FuzionConstants.TYPE_NAME ? lookupFeatureForType(inner.pos(), n, outer) :
+           inner.belongsToNonStaticType() ? outer.nonStaticTypeFeature(_res)
+                                          : outer.typeFeature(_res);
          if (at < q.size()-2)
            {
              setOuterAndAddInnerForQualifiedRec(inner, at+1, o);
@@ -779,7 +780,11 @@ public class SourceModule extends Module implements SrcModule, MirModule
       }
     else if (existing.outer() == outer)
       {
-        if (Errors.count() == 0)
+        if (existing.isTypeFeature())
+          {
+            // NYI: see #461: type features may currently be declared repeatedly in different modules
+          }
+        else if (Errors.count() == 0)
           { // This can happen only as the result of previous errors since this
             // case was already handled in addDeclaredInnerFeature:
             throw new Error();

--- a/src/dev/flang/util/FuzionConstants.java
+++ b/src/dev/flang/util/FuzionConstants.java
@@ -107,6 +107,13 @@ public class FuzionConstants extends ANY
 
 
   /**
+   * Name of type parameter for type features.  This type parameter will be set
+   * to the actual static type.
+   */
+  public static final String TYPE_FEATURE_THIS_TYPE = "THIS_TYPE";
+
+
+  /**
    * Field introduced in, e.g.,
    *
    *   x := if a then 0 else 1


### PR DESCRIPTION
This adds a new feature 'has_equality' that onle defines a type feature 'has_equality.type.equality2'.  This feature uses the type itself via the type parameter 'THIS_TYPE'.

'string' now inherits 'has_equality' and 'string.type' redefines 'equality2'. Any feature inheriting 'has_equality' can make the type feature 'equality2' available.

For this to work, type features now have a type parameter 'THIS_TYPE' that presents the actual type. This type parameter can be used in type features.

To do:

- make all features that provide type.equality inherit from has_equality

- add some syntax for 'THIS_TYPE', e.g. 'this.type' or similar

- make 'THIS_TYPE' an internal name '#THIS_TYPE'

- add support for types with with parameters, e.g., 'option T'