### PR TITLE
lib/tests: Replaced Type_STATIC.equality by has_equality.type.equality

### DIFF
--- a/lib/Type.fz
+++ b/lib/Type.fz
@@ -55,19 +55,6 @@ Type ref is
 #
 Type_STATIC(STATIC_THIS_TYPE type) is
 
-  # equality implements the default equality relation for values of this type.
-  #
-  # This relation must be
-  #
-  #  - reflexive (equality a b),
-  #  - symmetric (equality a b = equality b a), and
-  #  - transitive ((equality a b && equality b c) : equality a c).
-  #
-  # result is true iff 'a' is considered to represent the same abstract value
-  # as 'b'.
-  #
-  equality(a, b STATIC_THIS_TYPE) bool is abstract
-
 
 # Types -- features related to Type but not requiring an instance of Type
 #

--- a/lib/bitset.fz
+++ b/lib/bitset.fz
@@ -28,6 +28,7 @@
 bitset : choice nil          # empty bitset
                 u64          # unit bitset
                 (array bool) # general
+       , has_equality
 is
 
   # test if the given bit is part of this bitset
@@ -86,7 +87,7 @@ is
          else
            r
 
-  bitset.type.equality(a, b bitset) bool is
+  type.equality(a, b bitset) bool is
      h := a.highest >>= i -> b.highest >>= j -> i.max j
      match h
        _ nil => a.highest!! && b.highest!!

--- a/lib/bool.fz
+++ b/lib/bool.fz
@@ -36,7 +36,7 @@
 # value of type 'bool'.
 #
 #
-bool : choice FALSE TRUE, hasEquals bool is
+bool : choice FALSE TRUE, has_equality, hasEquals bool is
 
   # not
   prefix ! bool is
@@ -67,7 +67,7 @@ bool : choice FALSE TRUE, hasEquals bool is
   infix = (other bool) bool is
     bool.this <=> other
 
-  bool.type.equality(a, b bool) =>
+  type.equality(a, b bool) =>
     if a
       b
     else

--- a/lib/equals.fz
+++ b/lib/equals.fz
@@ -26,11 +26,9 @@
 # equals -- feature that compares two values using the equality relation
 # defined in their type
 #
-equals(T type, a, b T) => T.equality a b
-equals2(T has_equality.type, a, b T) => T.equality2 a b
+equals(T has_equality.type, a, b T) => T.equality a b
 
 
 # infix ≟ -- infix operation as short-hand for 'equals'
 #
-infix ≟(T type, a, b T) => equals T a b
-infix ≟≟(T has_equality.type, a, b T) => equals2 T a b
+infix ≟(T has_equality.type, a, b T) => equals T a b

--- a/lib/f32.fz
+++ b/lib/f32.fz
@@ -53,7 +53,7 @@ f32(val f32) : float f32, f32s is
   redef infix >  (other f32) bool is intrinsic
   redef infix >= (other f32) bool is intrinsic
 
-  f32.type.equality(a, b f32) bool is intrinsic
+  type.equality(a, b f32) bool is intrinsic
 
 
   # conversion

--- a/lib/f64.fz
+++ b/lib/f64.fz
@@ -53,7 +53,7 @@ f64(val f64) : float f64, f64s is
   redef infix >  (other f64) bool is intrinsic
   redef infix >= (other f64) bool is intrinsic
 
-  f64.type.equality(a, b f64) bool is intrinsic
+  type.equality(a, b f64) bool is intrinsic
 
 
   # conversion

--- a/lib/has_equality.fz
+++ b/lib/has_equality.fz
@@ -39,4 +39,4 @@ has_equality is
   # result is true iff 'a' is considered to represent the same abstract value
   # as 'b'.
   #
-  type.equality2(aa, bb THIS_TYPE) bool is abstract
+  type.equality(a, b THIS_TYPE) bool is abstract

--- a/lib/i16.fz
+++ b/lib/i16.fz
@@ -84,7 +84,7 @@ i16(val i16) : wrappingInteger i16, hasInterval i16, i16s is
   redef infix >  (other i16) bool is intrinsic
   redef infix >= (other i16) bool is intrinsic
 
-  i16.type.equality(a, b i16) bool is intrinsic
+  type.equality(a, b i16) bool is intrinsic
 
   # conversion to u32, i64 and u64, with range check
   as_i8 i8

--- a/lib/i32.fz
+++ b/lib/i32.fz
@@ -84,7 +84,7 @@ i32(val i32) : wrappingInteger i32, hasInterval i32, i32s is
   redef infix >  (other i32) bool is intrinsic
   redef infix >= (other i32) bool is intrinsic
 
-  i32.type.equality(a, b i32) bool is intrinsic
+  type.equality(a, b i32) bool is intrinsic
 
   # conversion to u32, i64 and u64, with range check
   as_i8 i8

--- a/lib/i64.fz
+++ b/lib/i64.fz
@@ -84,7 +84,7 @@ i64(val i64) : wrappingInteger i64, hasInterval i64, i64s is
   redef infix >  (other i64) bool is intrinsic
   redef infix >= (other i64) bool is intrinsic
 
-  i64.type.equality(a, b i64) bool is intrinsic
+  type.equality(a, b i64) bool is intrinsic
 
   as_i8 i8
     pre

--- a/lib/i8.fz
+++ b/lib/i8.fz
@@ -84,7 +84,7 @@ i8(val i8) : wrappingInteger i8, hasInterval i8, i8s is
   redef infix >  (other i8) bool is intrinsic
   redef infix >= (other i8) bool is intrinsic
 
-  i8.type.equality(a, b i8) bool is intrinsic
+  type.equality(a, b i8) bool is intrinsic
 
   # conversion to u32, i64 and u64, with range check
   as_i16  => as_i32.as_i16

--- a/lib/int.fz
+++ b/lib/int.fz
@@ -144,7 +144,7 @@ is
   infix == (other int) bool is
     ns = other.ns & n = other.n
 
-  int.type.equality(a, b int) bool is
+  type.equality(a, b int) bool is
     (a.ns ≟ b.ns) & (a.n ≟ b.n)
 
   orderedThis int is int ns n
@@ -191,7 +191,7 @@ ints is
 
 plus is
 minus is
-sign : choice plus minus, hasEquals sign is
+sign : choice plus minus, has_equality, hasEquals sign is
   infix = (o sign) bool is
     match sign.this
       plus =>
@@ -218,4 +218,3 @@ sign : choice plus minus, hasEquals sign is
     match sign.this
       plus => ""
       minus => "-"
-

--- a/lib/partiallyOrdered.fz
+++ b/lib/partiallyOrdered.fz
@@ -32,7 +32,7 @@
 # NYI: the compiler should check that features inheriting from this are
 # actually immutable.
 #
-partiallyOrdered(P (partiallyOrdered P).type) : hasEquals P
+partiallyOrdered(P (partiallyOrdered P).type) : has_equality, hasEquals P
 
 /* NYI: quantor intrinsics not supported yet:
 

--- a/lib/string.fz
+++ b/lib/string.fz
@@ -77,10 +77,7 @@ string ref : has_equality, hasHash string, ordered string, strings is
   # result is true iff the strings have the same number of utf8 bytes and those
   # bytes are equal.
   #
-  string.type.equality(a, b string) =>
-    ((a.utf8.zip b.utf8 aa,bb->aa≟bb) ∀ x->x)
-      & a.utf8.count ≟ b.utf8.count
-  string.type.equality2(a, b string) =>
+  type.equality(a, b string) =>
     ((a.utf8.zip b.utf8 aa,bb->aa≟bb) ∀ x->x)
       & a.utf8.count ≟ b.utf8.count
 

--- a/lib/u128.fz
+++ b/lib/u128.fz
@@ -148,7 +148,7 @@ u128(hi, lo u64) : wrappingInteger u128, hasInterval u128, u128s is
   redef infix >  (other u128) bool is hi > other.hi || hi = other.hi && lo >  other.lo
   redef infix >= (other u128) bool is hi > other.hi || hi = other.hi && lo >= other.lo
 
-  u128.type.equality(a, b u128) =>
+  type.equality(a, b u128) =>
     a.hi ≟ b.hi && a.lo ≟ b.lo
 
   redef infix =  (other u128) bool is hi = other.hi && lo = other.lo

--- a/lib/u16.fz
+++ b/lib/u16.fz
@@ -84,7 +84,7 @@ u16(val u16) : wrappingInteger u16, hasInterval u16, u16s is
   redef infix >  (other u16) bool is intrinsic
   redef infix >= (other u16) bool is intrinsic
 
-  u16.type.equality(a, b u16) bool is intrinsic
+  type.equality(a, b u16) bool is intrinsic
 
   as_i8 i8
     pre

--- a/lib/u32.fz
+++ b/lib/u32.fz
@@ -84,7 +84,7 @@ u32(val u32) : wrappingInteger u32, hasInterval u32, u32s is
   redef infix >  (other u32) bool is intrinsic
   redef infix >= (other u32) bool is intrinsic
 
-  u32.type.equality(a, b u32) bool is intrinsic
+  type.equality(a, b u32) bool is intrinsic
 
   as_i8 i8
     pre

--- a/lib/u64.fz
+++ b/lib/u64.fz
@@ -84,7 +84,7 @@ u64(val u64) : wrappingInteger u64, hasInterval u64, u64s is
   redef infix >  (other u64) bool is intrinsic
   redef infix >= (other u64) bool is intrinsic
 
-  u64.type.equality(a, b u64) bool is intrinsic
+  type.equality(a, b u64) bool is intrinsic
 
   as_i8 i8
     pre

--- a/lib/uint.fz
+++ b/lib/uint.fz
@@ -243,7 +243,7 @@ is
     data.count = other.data.count &
       ((data.zip other.data (a,b -> a = b)) ∀ (x->x))
 
-  uint.type.equality(a, b uint) bool is
+  type.equality(a, b uint) bool is
     a.data.count ≟ b.data.count &&
       ((a.data.zip b.data (c,d -> c ≟ d)) ∀ (x->x))
 

--- a/tests/equals/test_equals.fz
+++ b/tests/equals/test_equals.fz
@@ -109,7 +109,7 @@ test_equals_types is
   # Has_color provides an equality relation for instances that provide
   # a 'col' feature
   #
-  Has_color ref is
+  Has_color ref : has_equality is
 
     # the color of this instance
     #
@@ -117,7 +117,7 @@ test_equals_types is
 
     # equality relation comparing the value produced by 'col'
     #
-    redef type.equality(a, b test_equals_types.Has_color) =>
+    type.equality(a, b test_equals_types.Has_color) =>
 
       # NYI: There is currently no easy way to compare choice types, so we do exhaustive
       # matches:
@@ -144,10 +144,10 @@ test_equals_types is
     # the string
     utf8 Sequence u8)
 
-   : Has_color, string is
+   : Has_color, string, has_equality is
 
     # equality relation comparing color and strings
     #
-    redef type.equality(a, b test_equals_types.colored_text) =>
+    type.equality(a, b test_equals_types.colored_text) =>
       (test_equals_types.eq_color a b &&
-       string.type.equality a b   )
+       string.type.equality       a b   )

--- a/tests/equals_negative/equals_test_negative.fz
+++ b/tests/equals_negative/equals_test_negative.fz
@@ -37,23 +37,23 @@ equals_test_negative is
   a1 := equals_test_a 42
   a2 := equals_test_a 42
 
-  say "equals a1 a2 is {equals a1 a2}"     # NYI: would be better if the error was flagged here
+  say "equals a1 a2 is {equals a1 a2}"      # 1. should flag an error: equals_test_a does not implement equality
 
   b1 := equals_test_b 42
   b2 := equals_test_b 42
 
-  say "b1.infix ≟ b2 is {b1.infix ≟ b2}"   # NYI: would be better if the error was flagged here
+  say "b1.infix ≟ b2 is {b1.infix ≟ b2}"    # 2. should flag an error: equals_test_b does not implement equality
 
   c1 := equals_test_c 42
   c2 := equals_test_c 42
 
-  say "c1 ≟ c2 is {c1 ≟ c2}"               # NYI: would be better if the error was flagged here
+  say "c1 ≟ c2 is {c1 ≟ c2}"                # 3. should flag an error: equals_test_c does not implement equality
 
 # control test that should pass
-equals_test_ok(x i32) is
+equals_test_ok(x i32) : has_equality is
   equals_test_ok.type.equality(a, b equals_test_ok) => a.x = b.x
 
 # negative tests should fail
-equals_test_a(x i32) is  # 1. should flag an error: equals_test_a does not implement equality
-equals_test_b(x i32) is  # 2. should flag an error: equals_test_b does not implement equality
-equals_test_c(x i32) is  # 3. should flag an error: equals_test_c does not implement equality
+equals_test_a(x i32) is
+equals_test_b(x i32) is
+equals_test_c(x i32) is


### PR DESCRIPTION
Added parent `has_equality` to features that provide `type.equality`.

Renames `has_equality.type.equality2` as `has_equalty.type.equality`. Removed `equals2' and 'infix ≟≟`, move the code to `equals` and `infix ≟`.

In declarations
```
  abc ... is
    ...
    abc.type.equality(a, b abc) => ...'
```
removed the redundant 'abc.', such that they are
```
  abc ... is
    ...
    type.equality(a, b abc) => ...'
```
Updated tests. Luckily, this change improves the error message location in tests/equals_negative.