### PR TITLE
be/c: use c11 threads instead of pthreads

### DIFF
--- a/src/dev/flang/be/c/C.java
+++ b/src/dev/flang/be/c/C.java
@@ -551,8 +551,8 @@ public class C extends ANY
       {
         command.addAll("-lgc");
       }
-    // NYI link libmath, libpthread only when needed
-    command.addAll("-lm", "-lpthread", "-o", name, cname);
+    // NYI link libmath only when needed
+    command.addAll("-lm", "-o", name, cname);
 
     _options.verbosePrintln(" * " + command.toString("", " ", ""));;
     try
@@ -593,7 +593,7 @@ public class C extends ANY
        "#include <assert.h>\n"+
        "#include <time.h>\n"+
        "#include <setjmp.h>\n"+
-       "#include <pthread.h>\n"+
+       "#include <threads.h>\n"+
        "#include <errno.h>\n"+
        "#include <sys/stat.h>\n"+
        "\n");

--- a/src/dev/flang/be/c/CNames.java
+++ b/src/dev/flang/be/c/CNames.java
@@ -206,7 +206,7 @@ public class CNames extends ANY
   static final CIdent fzThreadEffectsEnvironment = new CIdent(THRD_PREFIX + "effectsEnvironment");
 
   /*
-   * the identifier of the function passed to pthread_create
+   * the identifier of the function passed to thrd_create
    */
   static final CIdent fzThreadStartRoutine       = new CIdent(THRD_PREFIX + "startRoutine");
 

--- a/src/dev/flang/be/c/Intrinsics.java
+++ b/src/dev/flang/be/c/Intrinsics.java
@@ -579,14 +579,11 @@ public class Intrinsics extends ANY
               var pt = new CIdent("pt");
               var res = new CIdent("res");
               var arg = new CIdent("arg");
-              return CStmnt.seq(CExpr.decl("pthread_t *", pt),
+              return CStmnt.seq(
+                                CExpr.decl(null, "thrd_t", pt, CExpr.int32const(1), null),
                                 CExpr.decl("int", res),
                                 CExpr.decl("struct " + CNames.fzThreadStartRoutineArg.code() + "*", arg),
 
-                                pt.assign(CExpr.call(c.malloc(), new List<>(CExpr.sizeOfType("pthread_t")))),
-                                CExpr.iff(pt.eq(CNames.NULL),
-                                          CStmnt.seq(CExpr.fprintfstderr("*** " + c.malloc() + "(%zu) failed\n", CExpr.sizeOfType("pthread_t")),
-                                                     CExpr.call("exit", new List<>(CExpr.int32const(1))))),
 
                                 arg.assign(CExpr.call(c.malloc(), new List<>(CExpr.sizeOfType("struct " + CNames.fzThreadStartRoutineArg.code())))),
                                 CExpr.iff(arg.eq(CNames.NULL),
@@ -596,14 +593,12 @@ public class Intrinsics extends ANY
                                 arg.deref().field(CNames.fzThreadStartRoutineArgFun).assign(CExpr.ident(c._names.function(call, false)).adrOf().castTo("void *")),
                                 arg.deref().field(CNames.fzThreadStartRoutineArgArg).assign(A0.castTo("void *")),
 
-                                res.assign(CExpr.call("pthread_create", new List<>(pt,
-                                                                                   CNames.NULL,
-                                                                                   CNames.fzThreadStartRoutine.adrOf(),
+                                res.assign(CExpr.call("thrd_create", new List<>(pt.index(CExpr.int32const(0)).adrOf(),
+                                                                                   CNames.fzThreadStartRoutine.castTo("thrd_start_t"),
                                                                                    arg))),
-                                CExpr.iff(res.ne(CExpr.int32const(0)),
-                                          CStmnt.seq(CExpr.fprintfstderr("*** pthread_create failed with return code %d\n",res),
+                                CExpr.iff(res.eq(new CIdent("thrd_error")),
+                                          CStmnt.seq(CExpr.fprintfstderr("*** thrd_create failed with return code %d\n",res),
                                                      CExpr.call("exit", new List<>(CExpr.int32const(1))))));
-              // NYI: free(pt)!
             }
           else
             {


### PR DESCRIPTION
generated code:
```c
  thrd_t pt[1];
  int res;
  struct fzThrd_startRoutineArg* arg;
  arg = malloc(sizeof(struct fzThrd_startRoutineArg));
  if (arg==NULL)
  {
    fprintf(stderr,"*** malloc(%zu) failed\012",sizeof(struct fzThrd_startRoutineArg));
    exit(1);
  }
  arg->fzThrd_startRoutineArgFun = (void *)&fzC__L1357fuzion__sy__all__call;
  arg->fzThrd_startRoutineArgArg = (void *)arg0;
  res = thrd_create(&pt[0],(thrd_start_t)fzThrd_startRoutine,arg);
  if (res==thrd_error)
  {
    fprintf(stderr,"*** thrd_create failed with return code %d\012",res);
    exit(1);
  }
```