### PR TITLE
lib/fe: Add 'dyn' keyword for non-static type features

### DIFF
--- a/lib/i32.fz
+++ b/lib/i32.fz
@@ -173,6 +173,21 @@ i32(val i32) : wrappingInteger i32, hasInterval i32, i32s is
     val.castTo_u32.onesCount
 
 
+  # -----------------------------------------------------------------------
+  #
+  # type features:
+
+
+  # identity element for 'infix +'
+  #
+  type.zero => 0
+
+
+  # identity element for 'infix *'
+  #
+  type.one  => 1
+
+
 # i32s -- unit type defining features related to i32 but not requiring an
 # instance
 #

--- a/lib/numeric.fz
+++ b/lib/numeric.fz
@@ -181,6 +181,30 @@ numeric(redef T (numeric T).type) : hasHash T, ordered T, numerics T is
   infix ∉ (s Set T) => numeric.this.notElementOf s
 
 
+  # -----------------------------------------------------------------------
+  #
+  # type features:
+
+
+  # identity element for 'infix +'
+  #
+  type.zero THIS_TYPE is abstract
+
+
+  # identity element for 'infix *'
+  #
+  type.one  THIS_TYPE is abstract
+
+
+  # the value corresponding to v in whatever integer implementation we have,
+  # maximum in case of overflow
+  #
+  # NOTE: this is marked 'dyn' to get an implementation for all heirs for numeric
+  #
+  dyn type.from_u32(v u32) THIS_TYPE is
+    if v == 0 zero else one # NYI: #706: (from_u32 v-1) +^ one
+
+
 # numerics -- unit type defining features related to numeric but not
 # requiring an instance
 #
@@ -192,11 +216,11 @@ numerics(T (numeric T).type) is
 
   # identity element for 'infix +'
   #
-  zero T is abstract
+  zero T is abstract # NYI: #706: T.zero
 
   # identity element for 'infix *'
   #
-  one  T is abstract
+  one  T is abstract # NYI: #706: T.one
 
   # the constant '2' in whatever integer implementation we have, maximum in case of overflow
   two => from_u32(2)
@@ -205,8 +229,8 @@ numerics(T (numeric T).type) is
   ten => from_u32(10)
 
   # the value corresponding to v in whatever integer implementation we have, maximum in case of overflow
-  from_u32(v u32) T is
-    if v == 0 zero else from_u32(v-1) +^ one
+  from_u32(v u32) T is # T.from_u32 v
+    if v == 0 zero else (from_u32 v-1) +^ one
 
   # monoid of numeric with infix + operation.  Will create sum of all elements it
   # is applied to.

--- a/src/dev/flang/ast/AbstractFeature.java
+++ b/src/dev/flang/ast/AbstractFeature.java
@@ -486,18 +486,37 @@ public abstract class AbstractFeature extends ANY implements Comparable<Abstract
 
 
   /**
+   * Is this the 'THIS_TYPE' type parameter in a type feature?
+   */
+  public boolean isTypeFeaturesThisType()
+  {
+    // NYI: CLEANUP: #706: Replace string operation by a flag marking this features as a 'THIS_TYPE' type parameter
+    return
+      isTypeParameter() &&
+      outer().isTypeFeature() &&
+      featureName().baseName().equals(FuzionConstants.TYPE_FEATURE_THIS_TYPE);
+  }
+
+
+  /**
    * This type feature declared as
    *
    *    abc.type.xyz is ...
    *
    * will go to abc's static type unless this is true.
+   *
+   * Currently, this is true for abstract features and for those marked with the
+   * 'dyn' modifier.
+   *
+   * NYI: FUTURE ENHANCEMENT: 'dyn' type featurs: We might be more automatic
+   * here and, e.g., let all features that depend on generic parameter
+   * FuzionConstants.TYPE_FEATURE_THIS_TYPE go to the dynamic type.
    */
   public boolean belongsToNonStaticType()
   {
-    // currently, only abstract features go to the dynamic type.  We might be
-    // more flexible here and let all features that depend on generic parameter
-    // FuzionConstants.TYPE_FEATURE_THIS_TYPE go to the dynamic type.
-    return isAbstract();
+    return
+      isAbstract() ||
+      (this instanceof Feature f) && (f.modifiers() & Consts.MODIFIER_DYN) != 0;
   }
 
 
@@ -558,11 +577,12 @@ public abstract class AbstractFeature extends ANY implements Comparable<Abstract
           }
         else
           {
-            var name = featureName().baseName() + "." + FuzionConstants.TYPE_NAME;
+            var name = featureName().baseName() + ".";
             if (!isConstructor() && !isChoice())
               {
                 name = name + "_" + (_typeFeatureId_++);
               }
+            name = name + FuzionConstants.TYPE_NAME;
             var inh = new List<AbstractCall>();
             for (var pc: inherits())
               {
@@ -662,7 +682,7 @@ public abstract class AbstractFeature extends ANY implements Comparable<Abstract
         var typeArg = new Feature(p,
                                   visibility(),
                                   outer().isUniverse() && featureName().baseName().equals("Object") && !statc ? 0 : Consts.MODIFIER_REDEFINE,
-                                  new Type("Object"),
+                                  thisType(),
                                   FuzionConstants.TYPE_FEATURE_THIS_TYPE,
                                   Contract.EMPTY_CONTRACT,
                                   Impl.TYPE_PARAMETER);

--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -2025,7 +2025,10 @@ public class Call extends AbstractCall
             if (f != null && g != null &&
                 !f.constraint().constraintAssignableFrom(g))
               {
-                AstErrors.incompatibleActualGeneric(pos(), f, g);
+                if (!f.typeParameter().isTypeFeaturesThisType())  // NYI: CLEANUP: #706: remove special handling for 'THIS_TYPE'
+                  {
+                    AstErrors.incompatibleActualGeneric(pos(), f, g);
+                  }
               }
           }
       }

--- a/src/dev/flang/ast/Consts.java
+++ b/src/dev/flang/ast/Consts.java
@@ -79,6 +79,11 @@ public class Consts
    */
   public static final int MODIFIER_FINAL        = 0x0080;
 
+  /**
+   * 'dyn' modifier to force feature within type feature to be dynamic.
+   */
+  public static final int MODIFIER_DYN          = 0x0100;
+
 
   /**
    *

--- a/src/dev/flang/ast/Feature.java
+++ b/src/dev/flang/ast/Feature.java
@@ -150,6 +150,7 @@ public class Feature extends AbstractFeature implements Stmnt
    * the modifiers of this feature
    */
   public final int _modifiers;
+  public int modifiers() { return _modifiers; }
 
 
   /**

--- a/src/dev/flang/fe/SourceModule.java
+++ b/src/dev/flang/fe/SourceModule.java
@@ -1177,10 +1177,13 @@ public class SourceModule extends Module implements SrcModule, MirModule
 
         var t1 = o.handDownNonOpen(_res, o.resultType(), f.outer());
         var t2 = f.resultType();
-        if ((t1.isChoice()
-             ? t1.compareTo(t2) != 0  // we (currently) do not tag the result in a redefined feature, see testRedefine
-             : !t1.isAssignableFrom(t2)) &&
-            t2 != Types.resolved.t_void)
+        if (o.isTypeFeaturesThisType() && f.isTypeFeaturesThisType())
+          { // NYI: CLEANUP: #706: allow redefintion of THIS_TYPE in type features for now, these are created internally.
+          }
+        else if ((t1.isChoice()
+                  ? t1.compareTo(t2) != 0  // we (currently) do not tag the result in a redefined feature, see testRedefine
+                  : !t1.isAssignableFrom(t2)) &&
+                 t2 != Types.resolved.t_void)
           {
             AstErrors.resultTypeMismatchInRedefinition(o, t1, f);
           }

--- a/src/dev/flang/parser/Lexer.java
+++ b/src/dev/flang/parser/Lexer.java
@@ -160,6 +160,7 @@ public class Lexer extends SourceFile
     t_for("for"),
     t_in("in"),
     t_do("do"),
+    t_dyn("dyn"),
     t_loop("loop"),
     t_while("while"),
     t_until("until"),

--- a/src/dev/flang/parser/Parser.java
+++ b/src/dev/flang/parser/Parser.java
@@ -786,6 +786,7 @@ modifier    : "lazy"
             | "redefine"
             | "const"
             | "leaf"
+            | "dyn"
             ;
    *
    * @return logically or'ed set of Consts.MODIFIER_* constants found.
@@ -806,6 +807,7 @@ modifier    : "lazy"
           case t_redefine    : m = Consts.MODIFIER_REDEFINE    ; break;
           case t_const       : m = Consts.MODIFIER_CONST       ; break;
           case t_leaf        : m = Consts.MODIFIER_LEAF        ; break;
+          case t_dyn         : m = Consts.MODIFIER_DYN         ; break;
           default            : throw new Error();
           }
         if ((ms & m) != 0)
@@ -838,7 +840,8 @@ modifier    : "lazy"
       case t_redef       :
       case t_redefine    :
       case t_const       :
-      case t_leaf        : return true;
+      case t_leaf        :
+      case t_dyn         : return true;
       default            : return false;
       }
   }


### PR DESCRIPTION
A type feature declared as 'dyn' will be added to the non-static type feature, i.e., all type features of heir features will inherit it even if it is not abstract.

This permits implementing something like 'numerics.from_u32' in 'numeric.type.from_u32'.  However, this does not work yet since 'numeric.T' is incompatible with 'numeric.type.THIS_TYPE', so operations are not possible yet.

This is one small step towards solving #706.