### PR TITLE
lib/unit: provide a unit.type.monoid feature

### DIFF
--- a/lib/unit.fz
+++ b/lib/unit.fz
@@ -92,3 +92,8 @@ unit is
 
   # human readable string
   redef asString => "unit"
+
+  type.monoid : Monoid unit is
+    redef infix ∙ (a, b unit) unit is unit
+    redef infix == (a, b unit) bool is true
+    redef e unit is unit

--- a/lib/unit.fz
+++ b/lib/unit.fz
@@ -93,6 +93,11 @@ unit is
   # human readable string
   redef asString => "unit"
 
+  # Monoid that can be used whenever a monoid of the unit type is expected.
+  # This is the case for example in some calls to `fold`-like features.
+  #
+  # Since there is exactly one value of type unit, the operation, the equality
+  # and the identity element of this monoid are canonically defined.
   type.monoid : Monoid unit is
     redef infix ∙ (a, b unit) unit is unit
     redef infix == (a, b unit) bool is true


### PR DESCRIPTION
This feature implements a Monoid of unit that essentially does not do anything, however it can be used when a `Monoid unit` type is expected, such as in some calls to `fold`.

Fixes #686.