### PR TITLE
parser: add 'fixed' moidifier for methods

### DIFF
--- a/src/dev/flang/ast/Consts.java
+++ b/src/dev/flang/ast/Consts.java
@@ -50,6 +50,12 @@ public class Consts
   public static final int MODIFIER_REDEFINE     = 0x0010;
 
   /**
+   * 'fixed' modifier to force feature to be fixed, i.e., not inherited by
+   * heirs.
+   */
+  public static final int MODIFIER_FIXED        = 0x0100;
+
+  /**
    * 'dyn' modifier to force feature within type feature to be dynamic.
    */
   public static final int MODIFIER_DYN          = 0x0100;

--- a/src/dev/flang/parser/Lexer.java
+++ b/src/dev/flang/parser/Lexer.java
@@ -161,6 +161,7 @@ public class Lexer extends SourceFile
     t_in("in"),
     t_do("do"),
     t_dyn("dyn"),
+    t_fixed("fixed"),
     t_loop("loop"),
     t_while("while"),
     t_until("until"),

--- a/src/dev/flang/parser/Parser.java
+++ b/src/dev/flang/parser/Parser.java
@@ -801,6 +801,7 @@ modifier    : "lazy"
           case t_lazy        : m = Consts.MODIFIER_LAZY        ; break;
           case t_redef       : m = Consts.MODIFIER_REDEFINE    ; break;
           case t_redefine    : m = Consts.MODIFIER_REDEFINE    ; break;
+          case t_fixed       : m = Consts.MODIFIER_FIXED       ; break;
           case t_dyn         : m = Consts.MODIFIER_DYN         ; break;
           default            : throw new Error();
           }
@@ -832,6 +833,7 @@ modifier    : "lazy"
       case t_lazy        :
       case t_redef       :
       case t_redefine    :
+      case t_fixed       :
       case t_dyn         : return true;
       default            : return false;
       }


### PR DESCRIPTION
This is the opposite of 'dyn', maybe gonna drop 'dyn' later.