### PR TITLE
fe: Fix LibraryFeature.compareTo to work with several modules

### DIFF
--- a/src/dev/flang/fe/LibraryFeature.java
+++ b/src/dev/flang/fe/LibraryFeature.java
@@ -184,6 +184,15 @@ public class LibraryFeature extends AbstractFeature
 
 
   /**
+   * Unique global index of this feature.
+   */
+  int globalIndex()
+  {
+    return _libModule.globalIndex(_index);
+  }
+
+
+  /**
    * What is this Feature's kind?
    *
    * @return Routine, Field, Intrinsic, Abstract or Choice.
@@ -464,7 +473,7 @@ public class LibraryFeature extends AbstractFeature
         var id = _libModule.featureId(_index);
         if (bytes.length == 0)
           {
-            var gi = _libModule.globalIndex(_index);
+            var gi = globalIndex();
             result = FeatureName.get(gi, ac, id);
           }
         else
@@ -813,9 +822,20 @@ public class LibraryFeature extends AbstractFeature
    */
   public int compareTo(AbstractFeature other)
   {
-    return (other instanceof Feature)
-      ? -1
-      : _index - ((LibraryFeature) other)._index;  // there are only two subclasses: Feature and LibraryFeature.
+    int result;
+    if (other instanceof Feature)
+      {
+        result = -1;
+      }
+    else if (other instanceof LibraryFeature lf)
+      {
+        result = globalIndex() - lf.globalIndex();
+      }
+    else
+      {
+        throw new Error("LibraryFeature.compareTo expects that there are only two subclasses: Feature and LibraryFeature.");
+      }
+    return result;
   }
 
 

--- a/src/dev/flang/fe/LibraryModule.java
+++ b/src/dev/flang/fe/LibraryModule.java
@@ -97,6 +97,13 @@ public class LibraryModule extends Module
 
 
   /**
+   * The base index of this module. When converting local indices to global
+   * indices, the _globalBase will be added.
+   */
+  final int _globalBase;
+
+
+  /**
    * The module binary data, contents of .mir file.
    */
   final ByteBuffer _data;
@@ -166,10 +173,11 @@ public class LibraryModule extends Module
   /**
    * Create LibraryModule for given options and sourceDirs.
    */
-  LibraryModule(FrontEnd fe, ByteBuffer data, LibraryModule[] dependsOn, AbstractFeature universe)
+  LibraryModule(int globalBase, FrontEnd fe, ByteBuffer data, LibraryModule[] dependsOn, AbstractFeature universe)
   {
     super(dependsOn);
 
+    _globalBase = globalBase;
     _fe = fe;
     _mir = null;
     _data = data;
@@ -222,11 +230,21 @@ public class LibraryModule extends Module
 
 
   /**
-   * NYI: Convert local index of this module into global index.
+   * Convert local index of this module into global index.
    */
   int globalIndex(int index)
   {
-    return index;
+    if (PRECONDITIONS) require
+      (0 < index,
+       index < _data.limit());
+
+    var result = _globalBase + index;
+
+    if (POSTCONDITIONS) ensure
+      (_globalBase - FrontEnd.GLOBAL_INDEX_OFFSET <  result - FrontEnd.GLOBAL_INDEX_OFFSET,
+       result      - FrontEnd.GLOBAL_INDEX_OFFSET <= Integer.MAX_VALUE                    );
+
+    return result;
   }
 
 


### PR DESCRIPTION
LibraryFeature.compareTo compared the local indices, which are not unique in case there are several module files.

This patch introduces code to convert local indices in module files into global indices and uses these global indices for LibraryFeature.compareTo.

A large offset is added to global indices such that accidental use of the wrong index type will very likely result in an illegal index.