### PR TITLE
lib/string: add split_n, split_after, split_after_n features

### DIFF
--- a/lib/String.fz
+++ b/lib/String.fz
@@ -525,13 +525,75 @@ String ref : has_equality, hasHash String, ordered String is
     pre
       !s.is_empty
     is
-    match (find s)
-      nil => [as_string].as_list
-      idx i32 => ref : Cons String (list String)
-                   head => substring 0 idx
-                   tail =>
-                     rest := substring (idx + s.byte_length) String.this.byte_length
-                     rest.split s
+      split0 s nil false
+
+
+  # split string after s, that is do the same thing as split but
+  # include the separator s in the resulting strings
+  #
+  split_after(s String) list String
+    pre
+      !s.is_empty
+    is
+      split0 s nil true
+
+
+  # split string at s, for at most n occurences of s
+  #
+  # if s occurs in the string less than n times, the resulting list will have
+  # less than n elements
+  #
+  split_n(s String, n u32) list String
+    pre
+      !s.is_empty,
+      n > 0
+    is
+      split0 s n false
+
+
+  # split string after s, for at most n occurences of s
+  #
+  # if s occurs in the string less than n times, the resulting list will have
+  # less than n elements
+  #
+  split_after_n(s String, n u32) list String
+    pre
+      !s.is_empty,
+      n > 0
+    is
+      split0 s n true
+
+
+  # split string at s, if there is no limit, otherwise if limit is an integer n,
+  # for at most n occurrences of s
+  #
+  # if split_after is true, all but the last element of the resulting list include
+  # the separator
+  #
+  # helper feature which unifies the code of the different split features in one
+  #
+  private split0(s String, limit option u32, split_after bool) list String
+    pre
+      !s.is_empty,
+      match limit
+        nil => true
+        n u32 => n > 0
+    is
+      match (find s)
+        nil => [as_string].as_list
+        idx i32 =>
+          ref : Cons String (list String)
+            head => substring 0 (if split_after then idx + s.byte_length else idx)
+            tail =>
+              rest := substring (idx + s.byte_length) String.this.byte_length
+
+              match limit
+                nil => rest.split0 s nil split_after
+                n u32 =>
+                  if n > 1
+                    rest.split0 s (n - 1) split_after
+                  else
+                    [rest].as_list
 
 
   # remove leading and trailing white space from this string


### PR DESCRIPTION
These features are similar to the eponymous ones found in the Go standard library [1]. They are however, not fully identical.

[1]: https://pkg.go.dev/strings

Reference: #697