### PR TITLE
lib/ast/fe: Support for implicit `a.b.c.this.type` (improving #167 and #706)

### DIFF
--- a/lib/list.fz
+++ b/lib/list.fz
@@ -338,7 +338,7 @@ list(A type) : choice nil (Cons A (list A)), Sequence A is
   #
   redef tails list (list A) is
     ref : Cons (list A) (list (list A))
-      head => list.this
+      head list A is list.this
       tail => (list.this ? nil    => nil
                          | c Cons => c.tail.tails)
 
@@ -348,7 +348,7 @@ list(A type) : choice nil (Cons A (list A)), Sequence A is
   # it cannot be shared with threads or used in pure functions
   #
   redef asStream ref : stream A is
-    cur := list.this
+    cur list A := list.this
     redef hasNext => (cur ? Cons => true
                           | nil  => false)
     redef next =>

--- a/lib/outcome.fz
+++ b/lib/outcome.fz
@@ -126,10 +126,8 @@ outcome(T type) : choice T error /* ...  NYI: this should be open generic! */ is
   # returns o if outcome is ok, otherwise return the outcome's own
   # error.
   and (O type, o outcome O) outcome O is
-    if ok
-      o
-    else
-      outcome.this
+    outcome.this ? _ T     => o
+                 | e error => e
 
   # returns o if outcome is not ok, otherwise return this outcome's value.
   or (o outcome T) outcome T is

--- a/src/dev/flang/ast/AbstractAssign.java
+++ b/src/dev/flang/ast/AbstractAssign.java
@@ -232,7 +232,7 @@ public abstract class AbstractAssign extends ANY implements Stmnt, HasSourcePosi
         if (CHECKS) check
           (Errors.count() > 0 || frmlT != Types.t_ERROR);
 
-        if (!frmlT.isAssignableFrom(_value))
+        if (!frmlT.isAssignableFrom(_value.type()))
           {
             AstErrors.incompatibleTypeInAssignment(pos(), f, frmlT, _value);
           }

--- a/src/dev/flang/ast/AbstractType.java
+++ b/src/dev/flang/ast/AbstractType.java
@@ -273,25 +273,6 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
 
 
   /**
-   * Check if given value can be assigned to this static type.  In addition to
-   * isAssignableFromOrContainsError, this checks if 'expr' is not '<xyz>.this'
-   * (Current or an outer ref) that might be a value type that is an heir of this
-   * type.
-   *
-   * @param expr the expression to be assigned to a variable of this type.
-   *
-   * @return true iff the assignment is ok.
-   */
-  public boolean isAssignableFrom(Expr expr)
-  {
-    var actlT = expr.type();
-
-    return isAssignableFromOrContainsError(actlT) &&
-      (!expr.isCallToOuterRef() && !(expr instanceof Current) || actlT.isRef() || actlT.isChoice());
-  }
-
-
-  /**
    * Check if a value of static type actual can be assigned to a field of static
    * type this.  This performs static type checking, i.e., the types may still
    * be or depend on generic parameters.
@@ -315,6 +296,10 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
     var result =
       this  .compareTo(actual               ) == 0 ||
       actual.compareTo(Types.resolved.t_void) == 0 ||
+
+      // NYI: CLEANUP: This clumsy workaround could be avoided if t.asThisType() == t for choice types.
+      actual.isThisType() && isChoice() && this.compareTo(actual.asRef().asValue()) == 0 ||
+
       this   == Types.t_ERROR                      ||
       actual == Types.t_ERROR;
     if (!result && !isGenericArgument() && isRef() && actual.isRef())
@@ -938,6 +923,13 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
                 result = isRef() ? -1 : 1;
               }
           }
+        if (result == 0)
+          {
+            if (isThisType() ^ other.isThisType())
+              {
+                result = isThisType() ? -1 : 1;
+              }
+          }
         if (isGenericArgument())
           {
             if (result == 0)
@@ -1072,6 +1064,8 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
   public abstract AbstractType asRef();
   public abstract AbstractType asValue();
   public abstract boolean isRef();
+  public abstract AbstractType asThis();
+  public abstract boolean isThisType();
   public abstract SourcePosition pos();
   public abstract List<AbstractType> generics();
   public abstract boolean isGenericArgument();
@@ -1113,6 +1107,10 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
                 gs = "(" + gs + ")";
               }
             result = result + " " + gs;
+          }
+        if (isThisType())
+          {
+            result = result + ".this.type";
           }
       }
     return result;

--- a/src/dev/flang/ast/AstErrors.java
+++ b/src/dev/flang/ast/AstErrors.java
@@ -302,8 +302,7 @@ public class AstErrors extends ANY
     String remedy = null;
     var assignableToSB = new StringBuilder();
     var actlT = value.type();
-    var valueThisOrOuter = !actlT.isRef() && (value.isCallToOuterRef() || value instanceof Current);
-    if (valueThisOrOuter)
+    if (actlT.isThisType())
       {
         assignableToSB
           .append("assignable to       : ref ")
@@ -326,7 +325,7 @@ public class AstErrors extends ANY
               .append(st(ts));
           }
       }
-    if (remedy == null && frmlT.asRef().isAssignableFrom(value))
+    if (remedy == null && frmlT.asRef().isAssignableFrom(actlT))
       {
         remedy = "To solve this, you could change the type of " + ss(target) + " to a " + st("ref")+ " type like " + s(frmlT.asRef()) + ".\n";
       }
@@ -352,7 +351,7 @@ public class AstErrors extends ANY
           "Incompatible types " + where,
           detail +
           "expected formal type: " + s(frmlT) + "\n" +
-          "actual type found   : " + s(actlT) + (valueThisOrOuter ? " or any subtype" : "") + "\n" +
+          "actual type found   : " + s(actlT) + "\n" +
           assignableToSB + (assignableToSB.length() > 0 ? "\n" : "") +
           "for value assigned  : " + s(value) + "\n" +
           remedy);

--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -1988,7 +1988,7 @@ public class Call extends AbstractCall
             for (Expr actl : _actuals)
               {
                 var frmlT = _resolvedFormalArgumentTypes[count];
-                if (frmlT != null /* NYI: make sure this is never null */ && !frmlT.isAssignableFrom(actl))
+                if (frmlT != null /* NYI: make sure this is never null */ && !frmlT.isAssignableFrom(actl.type()))
                   {
                     AstErrors.incompatibleArgumentTypeInCall(_calledFeature, count, frmlT, actl);
                   }

--- a/src/dev/flang/ast/Current.java
+++ b/src/dev/flang/ast/Current.java
@@ -61,7 +61,7 @@ public class Current extends AbstractCurrent
    */
   public Current(SourcePosition pos, AbstractType t)
   {
-    super(t);
+    super(Types.intern(t).asThis());
 
     if (PRECONDITIONS) require
       (pos != null,

--- a/src/dev/flang/ast/Expr.java
+++ b/src/dev/flang/ast/Expr.java
@@ -324,7 +324,9 @@ public abstract class Expr extends ANY implements Stmnt, HasSourcePosition
             result = new Box(result, frmlT);
             t = result.type();
           }
-        if (frmlT.isChoice() && frmlT.isAssignableFrom(t))
+        if (frmlT.isChoice() && frmlT.isAssignableFrom(t)
+            && !t.isThisType() // NYI: CLEANUP: Can this be removed if t.asThisType() == t for choice types?
+            )
           {
             result = tag(frmlT, result);
           }

--- a/src/dev/flang/ast/InlineArray.java
+++ b/src/dev/flang/ast/InlineArray.java
@@ -276,7 +276,7 @@ public class InlineArray extends ExprWithPos
 
     for (var e : _elements)
       {
-        if (!elementType.isAssignableFrom(e))
+        if (!elementType.isAssignableFrom(e.type()))
           {
             AstErrors.incompatibleTypeInArrayInitialization(e.pos(), _type, elementType, e);
           }

--- a/src/dev/flang/ast/This.java
+++ b/src/dev/flang/ast/This.java
@@ -260,7 +260,12 @@ public class This extends ExprWithPos
                   .resolveTypes(res, outer);
                 if (cur.isOuterRefAdrOfValue())
                   {
-                    c = new Unbox(c, cur.outer().thisType(), cur.outer())
+                    // NYI: CLEANUP: We are satting all outer types to
+                    // o.asThis(), while the constructor of Type undoes
+                    // this. Maybe we could use .asThis only for the outermost
+                    // type?
+                    var t = Types.intern(cur.outer().thisType()).asThis();
+                    c = new Unbox(c, t, cur.outer())
                       { public SourcePosition pos() { return This.this.pos(); } };
                   }
                 getOuter = c;

--- a/src/dev/flang/ast/Type.java
+++ b/src/dev/flang/ast/Type.java
@@ -72,9 +72,10 @@ public class Type extends AbstractType
    */
   public enum RefOrVal
   {
-    Ref,
-    Value,
-    LikeUnderlyingFeature,
+    Ref,                    // this is an explicit reference type
+    Value,                  // this is an explicit value type
+    LikeUnderlyingFeature,  // this is ref or value as declared for the underlying feature
+    ThisType,               // this is the type of featureOfType().this.type, i.e., it may be an heir type
   }
 
 
@@ -267,6 +268,13 @@ public class Type extends AbstractType
     this.pos = pos;
     this.name  = n;
     this._generics = ((g == null) || g.isEmpty()) ? NONE : g;
+    if (o instanceof Type ot && ot.isThisType())
+      {
+        // NYI: CLEANUP: Undo the asThisType() calls done in This.java for outer
+        // types. Is it possible to not create asThisType() in This.java in the
+        // first place?
+        o = new Type(ot, RefOrVal.LikeUnderlyingFeature);
+      }
     this._outer = o;
     this.feature = f;
     this.generic = null;
@@ -376,9 +384,7 @@ public class Type extends AbstractType
   public Type(Type original, RefOrVal refOrVal)
   {
     if (PRECONDITIONS) require
-      (refOrVal == RefOrVal.Ref ||
-       refOrVal == RefOrVal.Value,
-       (refOrVal == RefOrVal.Ref) != original.isRef());
+      (refOrVal != original._refOrVal);
 
     this.pos                = original.pos;
     this._refOrVal          = refOrVal;
@@ -429,6 +435,29 @@ public class Type extends AbstractType
       {
         result = Types.intern(new Type(this, RefOrVal.Ref));
       }
+    return result;
+  }
+
+
+  /**
+   * Create a Types.intern()ed this.type variant of this type.  Return this
+   * in case it is a this.type variant already.
+   */
+  public AbstractType asThis()
+  {
+    if (PRECONDITIONS) require
+      (this == Types.intern(this),
+       !isGenericArgument());
+
+    AbstractType result = this;
+    if (!isThisType() && this != Types.t_ERROR)
+      {
+        result = Types.intern(new Type(this, RefOrVal.ThisType));
+      }
+
+    if (POSTCONDITIONS) ensure
+      (result == Types.t_ERROR || result.isThisType());
+
     return result;
   }
 
@@ -492,13 +521,26 @@ public class Type extends AbstractType
    */
   public boolean isRef()
   {
-    switch (this._refOrVal)
+    return switch (this._refOrVal)
       {
-      case Ref                  : return true;
-      case Value                : return false;
-      case LikeUnderlyingFeature: return ((feature != null) && feature.isThisRef());
-      default: throw new Error("Unhandled switch case for RefOrVal");
-      }
+      case Ref                  -> true;
+      case Value                -> false;
+      case LikeUnderlyingFeature-> ((feature != null) && feature.isThisRef());
+      case ThisType             -> false;
+      };
+  }
+
+
+  /**
+   * isThisType
+   */
+  public boolean isThisType()
+  {
+    return switch (this._refOrVal)
+      {
+      case Ref, Value, LikeUnderlyingFeature -> false;
+      case ThisType                          -> true;
+      };
   }
 
 
@@ -547,9 +589,9 @@ public class Type extends AbstractType
           + (outer == "" ||
              outer == FuzionConstants.UNIVERSE_NAME ? ""
                                                     : outer + ".")
-          + ( isRef() && (feature == null || !feature.isThisRef()) ? "ref " :
-             !isRef() &&  feature != null &&  feature.isThisRef()  ? "value "
-                                                                   : "" )
+          + (_refOrVal == RefOrVal.Ref   && (feature == null || !feature.isThisRef()) ? "ref "   :
+             _refOrVal == RefOrVal.Value &&  feature != null &&  feature.isThisRef()  ? "value "
+                                                                                      : ""       )
           + (feature == null ? name
              : feature.featureName().baseName());
       }
@@ -560,6 +602,10 @@ public class Type extends AbstractType
     else
       {
         result = feature.qualifiedName();
+      }
+    if (isThisType())
+      {
+        result = result + ".this.type";
       }
     if (_generics != NONE)
       {

--- a/src/dev/flang/ast/Unbox.java
+++ b/src/dev/flang/ast/Unbox.java
@@ -57,7 +57,7 @@ public abstract class Unbox extends Expr
 
 
   /**
-   * This this Unbox needed, i.e, not a NOP. This might be a NOP if this is
+   * Is this Unbox needed, i.e, not a NOP. This might be a NOP if this is
    * used as a reference.
    */
   public boolean _needed = false;
@@ -179,7 +179,12 @@ public abstract class Unbox extends Expr
            frmlT.isAssignableFrom(t.asValue())))))
       {
         this._needed = true;
-        this._type = frmlT;
+        if (!t.isThisType())   // NYI: CLEANUP: when does this happen, i.e.,
+                               // when is unbox needed, but type remains the
+                               // same since isThisType. Can this be simplified?
+          {
+            this._type = frmlT;
+          }
       }
     return super.box(frmlT);
   }

--- a/src/dev/flang/fe/GenericType.java
+++ b/src/dev/flang/fe/GenericType.java
@@ -152,6 +152,19 @@ public class GenericType extends LibraryType
       case Ref -> true;
       case Value -> false;
       case LikeUnderlyingFeature -> false;
+      case ThisType -> throw new Error("dev.flang.fe.GenericType.isRef: unexpeted ThisType for GenericType '"+this+"'");
+      };
+  }
+
+  /**
+   * isThisType
+   */
+  public boolean isThisType()
+  {
+    return switch (this._refOrVal)
+      {
+      case Ref, Value, LikeUnderlyingFeature -> false;
+      case ThisType                          -> throw new Error("Unexpected ThisType in GenericType");
       };
   }
 
@@ -174,6 +187,11 @@ public class GenericType extends LibraryType
   {
     throw new Error("GenericType.asValue() not defined");
   }
+  public AbstractType asThis()
+  {
+    throw new Error("GenericType.asThis() not defined");
+  }
+
 
   public String toString()
   {

--- a/src/dev/flang/fe/LibraryModule.java
+++ b/src/dev/flang/fe/LibraryModule.java
@@ -445,6 +445,7 @@ public class LibraryModule extends Module
             if (CHECKS) check
               (k >= 0);
             var feature = libraryFeature(typeFeature(at));
+            var makeThisType = typeIsThisType(at);
             var makeRef = typeIsRef(at);
             var generics = Type.NONE;
             if (k > 0)
@@ -460,7 +461,11 @@ public class LibraryModule extends Module
                   }
               }
             var outer = type(typeOuterPos(at));
-            result = new NormalType(this, at, DUMMY_POS, feature, makeRef ? Type.RefOrVal.Ref : Type.RefOrVal.LikeUnderlyingFeature, generics, outer);
+            result = new NormalType(this, at, DUMMY_POS, feature,
+                                    makeThisType ? Type.RefOrVal.ThisType :
+                                    makeRef      ? Type.RefOrVal.Ref
+                                                 : Type.RefOrVal.LikeUnderlyingFeature,
+                                    generics, outer);
           }
         _libraryTypes.put(at, result);
       }
@@ -1185,7 +1190,7 @@ Type
    | tk==-2   | 1      | int           | index of type
    | tk==-1   | 1      | int           | index of type parameter feature
 .4+| tk>=0    | 1      | int           | index of feature of type
-              | 1      | bool          | isRef
+              | 1      | byte          | 0: default, 1: isRef, 2: isThisType
               | tk     | Type          | actual generics
               | 1      | Type          | outer type
 |====
@@ -1208,7 +1213,7 @@ Type
    *   +--------+--------+---------------+-----------------------------------------------+
    *   | tk>=0  | 1      | int           | index of feature of type                      |
    *   |        +--------+---------------+-----------------------------------------------+
-   *   |        | 1      | bool          | isRef                                         |
+   *   |        | 1      | byte          | 0: default, 1: isRef, 2: isThisType           |
    *   |        +--------+---------------+-----------------------------------------------+
    *   |        | tk     | Type          | actual generics                               |
    *   |        +--------+---------------+-----------------------------------------------+
@@ -1288,7 +1293,14 @@ Type
     if (PRECONDITIONS) require
       (typeKind(at) >= 0);
 
-    return data().get(typeIsRefPos(at)) != 0;
+    return data().get(typeIsRefPos(at)) == 1;
+  }
+  boolean typeIsThisType(int at)
+  {
+    if (PRECONDITIONS) require
+      (typeKind(at) >= 0);
+
+    return data().get(typeIsRefPos(at)) == 2;
   }
   int typeActualGenericsPos(int at)
   {

--- a/src/dev/flang/fe/LibraryOut.java
+++ b/src/dev/flang/fe/LibraryOut.java
@@ -531,7 +531,7 @@ class LibraryOut extends ANY
    *   +--------+--------+---------------+-----------------------------------------------+
    *   | tk>=0  | 1      | int           | index of feature of type                      |
    *   |        +--------+---------------+-----------------------------------------------+
-   *   |        | 1      | bool          | isRef                                         |
+   *   |        | 1      | byte          | 0: default, 1: isRef, 2: isThisType           |
    *   |        +--------+---------------+-----------------------------------------------+
    *   |        | tk     | Type          | actual generics                               |
    *   |        +--------+---------------+-----------------------------------------------+
@@ -566,13 +566,22 @@ class LibraryOut extends ANY
           }
         else
           {
-            boolean makeRef = t.isRef() && !t.featureOfType().isThisRef();
-            // there is no explicit value type at this phase:
-            if (CHECKS) check
-              (makeRef || t.isRef() == t.featureOfType().isThisRef());
+            var refOrThisType = 0;
+            if (t.isThisType())
+              {
+                refOrThisType = 2;
+              }
+            else
+              {
+                boolean makeRef = t.isRef() && !t.featureOfType().isThisRef();
+                // there is no explicit value type at this phase:
+                if (CHECKS) check
+                  (makeRef || t.isRef() == t.featureOfType().isThisRef());
+                refOrThisType = makeRef ? 1 : 0;
+              }
             _data.writeInt(t.generics().size());
             _data.writeOffset(t.featureOfType());
-            _data.writeBool(makeRef);
+            _data.write(refOrThisType);
             for (var gt : t.generics())
               {
                 type(gt);

--- a/src/dev/flang/fe/NormalType.java
+++ b/src/dev/flang/fe/NormalType.java
@@ -84,6 +84,7 @@ public class NormalType extends LibraryType
    */
   AbstractType _asRef = null;
   AbstractType _asValue = null;
+  AbstractType _asThis = null;
 
 
   /*--------------------------  constructors  ---------------------------*/
@@ -174,11 +175,25 @@ public class NormalType extends LibraryType
   {
     return switch (_refOrVal)
       {
-      case Ref -> true;
-      case Value -> false;
-      default -> _feature.isThisRef();
+      case Ref                   -> true;
+      case Value                 -> false;
+      case LikeUnderlyingFeature -> _feature.isThisRef();
+      case ThisType              -> false;
       };
   }
+
+  /**
+   * isThisType
+   */
+  public boolean isThisType()
+  {
+    return switch (this._refOrVal)
+      {
+      case Ref, Value, LikeUnderlyingFeature -> false;
+      case ThisType                          -> true;
+      };
+  }
+
 
   public AbstractType outer()
   {
@@ -204,6 +219,24 @@ public class NormalType extends LibraryType
       {
         result = !isRef() ? this :  new NormalType(_libModule, _at, _pos, _feature, Type.RefOrVal.Value, _generics, _outer);
         _asValue = result;
+      }
+    return result;
+  }
+
+  public AbstractType asThis()
+  {
+    var result = _asThis;
+    if (result == null)
+      {
+        if (isThisType())
+          {
+            result = this;
+          }
+        else
+          {
+            result = new NormalType(_libModule, _at, _pos, _feature, Type.RefOrVal.ThisType, _generics, _outer);
+          }
+        _asThis = result;
       }
     return result;
   }

--- a/tests/this_type/Makefile
+++ b/tests/this_type/Makefile
@@ -1,0 +1,27 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test Makefile
+#
+#  Author: Fridtjof Siebert (siebert@tokiwa.software)
+#
+# -----------------------------------------------------------------------
+
+override NAME = test_this_type
+include ../simple.mk

--- a/tests/this_type/test_this_type.fz
+++ b/tests/this_type/test_this_type.fz
@@ -1,0 +1,76 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test test_this_type
+#
+#  Author: Fridtjof Siebert (siebert@tokiwa.software)
+#
+# -----------------------------------------------------------------------
+
+# a simple test for 'this.type'
+#
+q is
+  x is
+    print
+    b1 := q.this
+    b2 := b1
+    b3 ref q := q.this
+    b4 ref q := b1
+    b5 ref q := b2
+
+  print => say "in q"
+
+r : q is
+  redef print => say "in r"
+
+q.x.b1.print
+q.x.b2.print
+# r.x.b1.print      # NYI: this does not work yet, should print 'in r'
+# r.x.b2.print      # NYI: this does not work yet, should print 'in r'
+
+
+/**  NYI: a.this.type syntax not supported yet:
+
+a is
+  op(v a.this.type) a.this.type is abstract
+
+
+
+b(val string) : a is
+  op(v b) b is if debug then b "debug" /* b.this */ else b "non-debug"
+  redef asString => "instance of {b.type.asString} with $val"
+
+b1 := b "1"
+b2 := b "2"
+say (b1.op b2)
+
+**/
+
+
+/* NYI: a.this.type redefinition to sub-class does not work yet
+
+c : b "from c" is
+  redef op(v c) c is if debug then c.this else c
+  redef asString => "instance of {c.type.asString}"
+
+c1 := c
+c2 := c
+say (c1.op c2)
+
+*/

--- a/tests/this_type/test_this_type.fz.expected_out
+++ b/tests/this_type/test_this_type.fz.expected_out
@@ -1,0 +1,4 @@
+in q
+in q
+in q
+in q

--- a/tests/this_type_negative/Makefile
+++ b/tests/this_type_negative/Makefile
@@ -1,0 +1,27 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test Makefile
+#
+#  Author: Fridtjof Siebert (siebert@tokiwa.software)
+#
+# -----------------------------------------------------------------------
+
+override NAME = visibility_negative
+include ../negative.mk

--- a/tests/this_type_negative/test_this_type_negative.fz
+++ b/tests/this_type_negative/test_this_type_negative.fz
@@ -1,0 +1,46 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test test_this_type_negative
+#
+#  Author: Fridtjof Siebert (siebert@tokiwa.software)
+#
+# -----------------------------------------------------------------------
+
+test_this_type_negative is
+
+  a is
+    x is
+      ax0       := a.this
+      ax1 a     := a.this  //  1. should flag an error: a.this not compatible to 'a'
+      ax2 ref a := a.this
+
+    # a0       := a.this  // NYI: this currently causes an error
+    a1 a     := a.this  //  2. should flag an error: a.this not compatible to 'a'
+    a2 ref a := a.this
+
+  b ref is
+    x is
+      bx0       := b.this
+      bx1 b     := b.this
+      bx2 ref b := b.this
+
+    b0       := b.this  // NYI: this currently causes an error
+    b1 b     := b.this
+    b2 ref b := b.this


### PR DESCRIPTION
There is no support for explicit use of `a.b.c.this.type` yet, but this patch defines a new flavour of types to be used for `a.b.c.this` and types inferred from this expression.

A new type variant `isThisType` in addition to `isRef` and `isValue` has been added for types that can be any heir of the underlying feature's type.

`Type.isAssignableFrom(Expr)` has been removed since the assingability for `a.b.c.this` can now be checked using the new isThisType variant `a.b.c.this.type`.

In the base library, fixes where needed in `outcome.and` (since `outcome.this` is not assignment compatible to the result) and `list.tails` since the result type for `head` must be `list A` and not `list.this.type`, which could be an heir (but also it could not since you cannot inherit from a choice feature...).

There are some NYI: CLEANUP: comments in this patch for which I will add new issues.