### PR TITLE
lib/list: fix flatMap handling of empty sequences

### DIFF
--- a/lib/list.fz
+++ b/lib/list.fz
@@ -163,7 +163,7 @@ list(A type) : choice nil (Cons A (list A)), Sequence A is
       _ nil  => nil
       c Cons =>
         match (f c.head).asList
-          _ nil => nil
+          _ nil => c.tail.flatMap B f
           c2 Cons =>
             ref : Cons B (list B)
             // Cons B (list B) with    # NYI: better syntax for anonymous feature


### PR DESCRIPTION
When the mapping function returned an empty sequence, list.flatMap would consider the list as terminated rather than continuing with other, possibly non-empty elements.

Fixes #733.