### PR TITLE
lib/marray: implement sequence via asList instead of asStream

### DIFF
--- a/lib/marray.fz
+++ b/lib/marray.fz
@@ -92,9 +92,14 @@ is
   as_array =>
     array T length (i -> marray.this[i])
 
-  # create a stream from this marray
+
+  # create a list from this marray
   #
-  redef asStream => as_array.asStream
+  redef asList =>
+    # since marray is mutable,
+    # we first copy the elements
+    # to an immutable array.
+    as_array.asList
 
 
   # map the array to a new array applying function f to all elements


### PR DESCRIPTION
There are only few places left where streams are present in the std lib:
- array, asStream could be deleted because it also implements asList
- hasInterval, would need re implementation using list
- integer, #734 would change this
- stdin, #567 would change this
- Sequence,  ~4-5 features would need change of implementation

The biggest blocker for removing streams is actually `Loop.java` which uses stream quite extensively.