### PR TITLE
lib: Fix precondition of effect.use0

### DIFF
--- a/lib/effect.fz
+++ b/lib/effect.fz
@@ -95,7 +95,7 @@ is
       code ()->unit
      )
     pre
-      match mode
+      match r
         effectMode.new => true
         * => false
   is


### PR DESCRIPTION
'mode' in the old code always resulted in 'plain' or 'repl', causing 'use0' to always fail on its precondition.  The idea is that 'use0' is used on an effect that was just created but not installed when created, i.e., 'new'.