### PR TITLE
lib/fe: Make 'this.type' for choice type c equal to c, fix #736

### DIFF
--- a/lib/list.fz
+++ b/lib/list.fz
@@ -51,7 +51,7 @@ list(A type) : choice nil (Cons A (list A)), Sequence A is
   # This is a helper function that needs to be defined because list is an heir
   # of Sequence.
   #
-  redef asList list A is list.this
+  redef asList => list.this
 
 
   # is this list empty?
@@ -338,7 +338,7 @@ list(A type) : choice nil (Cons A (list A)), Sequence A is
   #
   redef tails list (list A) is
     ref : Cons (list A) (list (list A))
-      head list A is list.this    # NYI: CLEANUP: #736: use type inference: head => list.this
+      head => list.this
       tail => (list.this ? nil    => nil
                          | c Cons => c.tail.tails)
 
@@ -348,7 +348,7 @@ list(A type) : choice nil (Cons A (list A)), Sequence A is
   # it cannot be shared with threads or used in pure functions
   #
   redef asStream ref : stream A is
-    cur list A := list.this
+    cur := list.this
     redef hasNext => (cur ? Cons => true
                           | nil  => false)
     redef next =>

--- a/src/dev/flang/ast/AbstractType.java
+++ b/src/dev/flang/ast/AbstractType.java
@@ -296,10 +296,6 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
     var result =
       this  .compareTo(actual               ) == 0 ||
       actual.compareTo(Types.resolved.t_void) == 0 ||
-
-      // NYI: CLEANUP: #736: This clumsy workaround could be avoided if t.asThisType() == t for choice types.
-      actual.isThisType() && isChoice() && this.compareTo(actual.asRef().asValue()) == 0 ||
-
       this   == Types.t_ERROR                      ||
       actual == Types.t_ERROR;
     if (!result && !isGenericArgument() && isRef() && actual.isRef())

--- a/src/dev/flang/ast/Expr.java
+++ b/src/dev/flang/ast/Expr.java
@@ -324,9 +324,7 @@ public abstract class Expr extends ANY implements Stmnt, HasSourcePosition
             result = new Box(result, frmlT);
             t = result.type();
           }
-        if (frmlT.isChoice() && frmlT.isAssignableFrom(t)
-            && !t.isThisType() // NYI: CLEANUP: #736: Can this be removed if t.asThisType() == t for choice types?
-            )
+        if (frmlT.isChoice() && frmlT.isAssignableFrom(t))
           {
             result = tag(frmlT, result);
           }

--- a/src/dev/flang/ast/Type.java
+++ b/src/dev/flang/ast/Type.java
@@ -441,7 +441,7 @@ public class Type extends AbstractType
 
   /**
    * Create a Types.intern()ed this.type variant of this type.  Return this
-   * in case it is a this.type variant already.
+   * in case it is a this.type or a choice variant already.
    */
   public AbstractType asThis()
   {
@@ -450,13 +450,14 @@ public class Type extends AbstractType
        !isGenericArgument());
 
     AbstractType result = this;
-    if (!isThisType() && this != Types.t_ERROR)
+    if (!isThisType() && !isChoice() && this != Types.t_ERROR)
       {
         result = Types.intern(new Type(this, RefOrVal.ThisType));
       }
 
     if (POSTCONDITIONS) ensure
-      (result == Types.t_ERROR || result.isThisType());
+      (result == Types.t_ERROR || result.isThisType() || result.isChoice(),
+       !(isThisType() || isChoice()) || result == this);
 
     return result;
   }


### PR DESCRIPTION
You cannot inherit from a choice type anyways, so 'this.type' of a choice type is just that choice type.