### PR TITLE
scripts: Remove run_tests.failures files

### DIFF
--- a/bin/run_tests.sh
+++ b/bin/run_tests.sh
@@ -36,6 +36,7 @@ TESTS=$(echo "$BUILD_DIR"/tests/*/)
 VERBOSE="${VERBOSE:-""}"
 
 rm -rf "$BUILD_DIR"/run_tests.results
+rm -rf "$BUILD_DIR"/run_tests.failures
 
 # print collected results up until interruption
 trap "echo """"; cat ""$BUILD_DIR""/run_tests.results ""$BUILD_DIR""/run_tests.failures; exit 130;" INT

--- a/bin/run_tests_parallel.sh
+++ b/bin/run_tests_parallel.sh
@@ -64,6 +64,7 @@ TESTS=$(echo "$BUILD_DIR"/tests/*/)
 VERBOSE="${VERBOSE:-""}"
 
 rm -rf "$BUILD_DIR"/run_tests.results
+rm -rf "$BUILD_DIR"/run_tests.failures
 
 # print collected results up until interruption
 trap "echo """"; cat ""$BUILD_DIR""/run_tests.results ""$BUILD_DIR""/run_tests.failures; exit 130;" INT


### PR DESCRIPTION
This avoids printing previous and maybe outdated failure output repeatedly.