### PR TITLE
docs: detect code in comments and convert it to runcode box

### DIFF
--- a/src/dev/flang/tools/docs/Html.java
+++ b/src/dev/flang/tools/docs/Html.java
@@ -28,6 +28,8 @@ package dev.flang.tools.docs;
 
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map.Entry;
 import java.util.SortedSet;
@@ -171,10 +173,10 @@ public class Html
       .map(af -> {
         // NYI summary tag must not contain div
         return "<details id='" + htmlID(af)
-          + "'><summary>$1</summary><p class='fd-comment'>$2</p></details>"
+          + "'><summary>$1</summary><div class='fd-comment'>$2</div></details>"
             .replace("$1",
               summary(af))
-            .replace("$2", htmlEncode(Util.commentOf(af), false));
+            .replace("$2", Util.commentOf(af));
       })
       .collect(Collectors.joining(System.lineSeparator()));
   }
@@ -187,11 +189,11 @@ public class Html
    */
   private String headingSection(AbstractFeature f)
   {
-    return "<h1 class='$5'>$0</h1><h2>$4$3</h2><h3>$1</h3><p class='fd-comment'>$2</p>"
+    return "<h1 class='$5'>$0</h1><h2>$4$3</h2><h3>$1</h3><div class='fd-comment'>$2</div>"
       .replace("$0", f.isUniverse() ? "API-Documentation": basename(f))
       .replace("$3", f.isUniverse() ? "": anchorTags(f))
       .replace("$1", f.isUniverse() ? "": summary(f))
-      .replace("$2", htmlEncode(Util.commentOf(f), false))
+      .replace("$2", Util.commentOf(f))
       .replace("$4", f.isUniverse() ? "": "<a class='mr-5' href='" + config.docsRoot() + "/'>🌌</a>")
       .replace("$5", f.isUniverse() ? "": "d-none");
   }
@@ -216,6 +218,52 @@ public class Html
   {
     return "<div class='pl-5'><a href='$1'>[src]</a></div>"
       .replace("$1", featureURL(feature));
+  }
+
+  static String processComment(String name, String s)
+  {
+    var codeNo = new ArrayList<Integer>();
+    var codeLines = new ArrayList<String>();
+    var codeParsedLines = new ArrayList<String>();
+    var resultLines = new ArrayList<String>();
+
+    s.lines().forEach(l ->
+      {
+        if (l.matches("^\\s\\s\\s\\s.*"))
+          {
+            /* code comment */
+            codeLines.add(l);
+          }
+        else if (l.matches("^$"))
+          {
+            /* avoid adding lots of line breaks after code comments */
+            if (codeLines.isEmpty()) {
+              resultLines.add(l);
+            }
+          }
+        else
+          {
+            if (!codeLines.isEmpty())
+              {
+                var id = "fzdocs." + name + codeNo.size();
+                /* dump codeLines into a <code></code> block */
+                codeParsedLines.add("<div class=\"runcode-wrapper\"><i class=\"far fa-spinner fa-spin\"></i><div class=\"mb-15 runcode\" style=\"display: grid; grid-template-columns: repeat(auto-fill, minmax(min(100%,40ch), min(100%, 80ch))); max-width: 49rem; opacity: 0;\"><div class=\"position-relative\"><form id=\"" + id + "\"><textarea class=\"codeinput\" required=\"required\" maxlength=\"4096\" id=\"" + id + ".code\" name=\"code\" rows=\"3\" spellcheck=\"false\">");
+                codeLines.forEach(cl -> { codeParsedLines.add(cl.replaceAll("^    ", "")); });
+                codeParsedLines.add("</textarea><div class=\"position-absolute runbuttons\"><input type=\"button\" onclick=\"runit('" + id + "')\" class=\"runbutton\" name=\"run\" value=\"Run!\" /><input type=\"button\" onclick=\"runiteff('" + id + "')\" class=\"runbutton\" name=\"run\" value=\"Effects!\" /><a href=\"/tutorial/effects.html\"><i>What are effects?</i></a></div></form></div><div class=\"computeroutput\" id=\"" + id + ".result\"></div></div></div>");
+                resultLines.add(codeParsedLines.stream().collect(Collectors.joining(System.lineSeparator())));
+                codeLines.clear();
+                codeParsedLines.clear();
+                codeNo.add(1);
+              }
+
+            /* treat as normal line */
+            var replacedLine = htmlEncode(l, false);
+
+            resultLines.add(replacedLine);
+          }
+      });
+
+    return resultLines.stream().collect(Collectors.joining("<br />"));
   }
 
   private static String htmlEncode(String s, boolean spacesNoneBreaking)

--- a/src/dev/flang/tools/docs/Html.java
+++ b/src/dev/flang/tools/docs/Html.java
@@ -228,12 +228,12 @@ public class Html
 
     s.lines().forEach(l ->
       {
-        if (l.matches("^\\s\\s\\s\\s.*"))
+        if (l.startsWith("    "))
           {
             /* code comment */
             codeLines.add(l);
           }
-        else if (l.matches("^$"))
+        else if (l == "")
           {
             /* avoid adding lots of line breaks after code comments */
             if (codeLines.isEmpty()) {

--- a/src/dev/flang/tools/docs/Html.java
+++ b/src/dev/flang/tools/docs/Html.java
@@ -55,6 +55,27 @@ public class Html
   }
 
 
+  /*----------------------------  constants  ----------------------------*/
+
+  static final String RUNCODE_BOX_HTML = """
+    <div class="runcode-wrapper">
+      <i class="far fa-spinner fa-spin"></i>
+      <div class="mb-15 runcode" style="display: grid; grid-template-columns: repeat(auto-fill, minmax(min(100%,40ch), min(100%, 80ch))); max-width: 49rem; opacity: 0;">
+        <div class="position-relative">
+          <form id="##ID##">
+            <textarea class="codeinput" required="required" maxlength="4096" id="##ID##.code" name="code" rows="3" spellcheck="false">##CODE##</textarea>
+            <div class="position-absolute runbuttons">
+              <input type="button" onclick="runit('##ID##')" class="runbutton" name="run" value="Run!" />
+              <input type="button" onclick="runiteff('##ID##')" class="runbutton" name="run" value="Effects!" />
+              <a href="/tutorial/effects.html"><i>What are effects?</i></a>
+            </div>
+          </form>
+        </div>
+        <div class="computeroutput" id="##ID##.result"></div>
+      </div>
+    </div>""";
+
+
   /*-----------------------------  private methods  -----------------------------*/
 
 
@@ -220,6 +241,16 @@ public class Html
       .replace("$1", featureURL(feature));
   }
 
+
+  /**
+   * process the comment of a feature, in particular detects lines indented
+   * five spaces relative to the # as code blocks and puts them into a runcode
+   * box.
+   *
+   * @param name the name of the feature whose comment is being processed
+   * @param s the comment that is being processed
+   * @return the comment wrapped in HTML
+   */
   static String processComment(String name, String s)
   {
     var codeNo = new ArrayList<Integer>();
@@ -233,12 +264,13 @@ public class Html
             /* code comment */
             codeLines.add(l);
           }
-        else if (l == "")
+        else if (l.length() == 0)
           {
             /* avoid adding lots of line breaks after code comments */
-            if (codeLines.isEmpty()) {
-              resultLines.add(l);
-            }
+            if (codeLines.isEmpty())
+              {
+                resultLines.add(l);
+              }
           }
         else
           {
@@ -250,24 +282,7 @@ public class Html
                   .stream()
                   .map(cl -> { return cl.replaceAll("^    ", ""); })
                   .collect(Collectors.joining(System.lineSeparator()));
-                var runCodeWrapper = """
-                  <div class="runcode-wrapper">
-                    <i class="far fa-spinner fa-spin"></i>
-                    <div class="mb-15 runcode" style="display: grid; grid-template-columns: repeat(auto-fill, minmax(min(100%,40ch), min(100%, 80ch))); max-width: 49rem; opacity: 0;">
-                      <div class="position-relative">
-                        <form id="##ID##">
-                          <textarea class="codeinput" required="required" maxlength="4096" id="##ID##.code" name="code" rows="3" spellcheck="false">##CODE##</textarea>
-                          <div class="position-absolute runbuttons">
-                            <input type="button" onclick="runit('##ID##')" class="runbutton" name="run" value="Run!" />
-                            <input type="button" onclick="runiteff('##ID##')" class="runbutton" name="run" value="Effects!" />
-                            <a href="/tutorial/effects.html"><i>What are effects?</i></a>
-                          </div>
-                        </form>
-                      </div>
-                      <div class="computeroutput" id="##ID##.result"></div>
-                    </div>
-                  </div>""".replace("##ID##", id).replace("##CODE##", code);
-                resultLines.add(runCodeWrapper);
+                resultLines.add(RUNCODE_BOX_HTML.replace("##ID##", id).replace("##CODE##", code));
                 codeLines.clear();
                 codeNo.add(1);
               }
@@ -281,6 +296,7 @@ public class Html
 
     return resultLines.stream().collect(Collectors.joining("<br />"));
   }
+
 
   private static String htmlEncode(String s, boolean spacesNoneBreaking)
   {

--- a/src/dev/flang/tools/docs/Html.java
+++ b/src/dev/flang/tools/docs/Html.java
@@ -224,7 +224,6 @@ public class Html
   {
     var codeNo = new ArrayList<Integer>();
     var codeLines = new ArrayList<String>();
-    var codeParsedLines = new ArrayList<String>();
     var resultLines = new ArrayList<String>();
 
     s.lines().forEach(l ->
@@ -245,14 +244,31 @@ public class Html
           {
             if (!codeLines.isEmpty())
               {
+                /* dump codeLines into a flang.dev runcode box */
                 var id = "fzdocs." + name + codeNo.size();
-                /* dump codeLines into a <code></code> block */
-                codeParsedLines.add("<div class=\"runcode-wrapper\"><i class=\"far fa-spinner fa-spin\"></i><div class=\"mb-15 runcode\" style=\"display: grid; grid-template-columns: repeat(auto-fill, minmax(min(100%,40ch), min(100%, 80ch))); max-width: 49rem; opacity: 0;\"><div class=\"position-relative\"><form id=\"" + id + "\"><textarea class=\"codeinput\" required=\"required\" maxlength=\"4096\" id=\"" + id + ".code\" name=\"code\" rows=\"3\" spellcheck=\"false\">");
-                codeLines.forEach(cl -> { codeParsedLines.add(cl.replaceAll("^    ", "")); });
-                codeParsedLines.add("</textarea><div class=\"position-absolute runbuttons\"><input type=\"button\" onclick=\"runit('" + id + "')\" class=\"runbutton\" name=\"run\" value=\"Run!\" /><input type=\"button\" onclick=\"runiteff('" + id + "')\" class=\"runbutton\" name=\"run\" value=\"Effects!\" /><a href=\"/tutorial/effects.html\"><i>What are effects?</i></a></div></form></div><div class=\"computeroutput\" id=\"" + id + ".result\"></div></div></div>");
-                resultLines.add(codeParsedLines.stream().collect(Collectors.joining(System.lineSeparator())));
+                var code = codeLines
+                  .stream()
+                  .map(cl -> { return cl.replaceAll("^    ", ""); })
+                  .collect(Collectors.joining(System.lineSeparator()));
+                var runCodeWrapper = """
+                  <div class="runcode-wrapper">
+                    <i class="far fa-spinner fa-spin"></i>
+                    <div class="mb-15 runcode" style="display: grid; grid-template-columns: repeat(auto-fill, minmax(min(100%,40ch), min(100%, 80ch))); max-width: 49rem; opacity: 0;">
+                      <div class="position-relative">
+                        <form id="##ID##">
+                          <textarea class="codeinput" required="required" maxlength="4096" id="##ID##.code" name="code" rows="3" spellcheck="false">##CODE##</textarea>
+                          <div class="position-absolute runbuttons">
+                            <input type="button" onclick="runit('##ID##')" class="runbutton" name="run" value="Run!" />
+                            <input type="button" onclick="runiteff('##ID##')" class="runbutton" name="run" value="Effects!" />
+                            <a href="/tutorial/effects.html"><i>What are effects?</i></a>
+                          </div>
+                        </form>
+                      </div>
+                      <div class="computeroutput" id="##ID##.result"></div>
+                    </div>
+                  </div>""".replace("##ID##", id).replace("##CODE##", code);
+                resultLines.add(runCodeWrapper);
                 codeLines.clear();
-                codeParsedLines.clear();
                 codeNo.add(1);
               }
 

--- a/src/dev/flang/tools/docs/Util.java
+++ b/src/dev/flang/tools/docs/Util.java
@@ -89,17 +89,17 @@ public class Util
     var commentsOfRedefinedFeatures = af
       .redefines()
       .stream()
-      .map(f -> System.lineSeparator() + "redefines " + f.qualifiedName() + ":" + System.lineSeparator()
+      .map(f -> "<br />" + "redefines " + f.qualifiedName() + ":" + "<br />"
         + commentOf(f))
       .collect(Collectors.joining(System.lineSeparator()));
 
-    var result = commentLines
+    var result = Html.processComment(af.qualifiedName(), commentLines
       .stream()
       .map(l -> l.trim())
       .map(l -> l
         .replaceAll("^#", "")
-        .trim())
-      .collect(Collectors.joining(System.lineSeparator()))
+        .replaceAll("^ ", ""))
+      .collect(Collectors.joining(System.lineSeparator())))
       + commentsOfRedefinedFeatures;
     return result;
   }


### PR DESCRIPTION
A block of code is being detected in a comment when there is a continous block of lines that are indented five spaces from the # (or four spaces from where the text begins, when you separate the # and the text with a single space). The code is then inserted into a runcode wrapper which will be displayed on flang.dev as a box containing executable and modifiable code.

Currently, this is only useful when the docs generated by fzdocs are being included on flang.dev, as the necessary CSS and JavaScript stuff is missing otherwise.

Link: https://git.tokiwa.software/tokiwa/flang_dev/issues/110