### PR TITLE
lib/list: remove forceHead

### DIFF
--- a/lib/Sequence.fz
+++ b/lib/Sequence.fz
@@ -77,7 +77,7 @@ Sequence(T type) ref is
   first
     pre
       debug: !isEmpty
-    => asList.forceHead
+    => asList.head.get
 
 
   # get the first element of this Sequence or default if sequence is empty

--- a/lib/list.fz
+++ b/lib/list.fz
@@ -98,15 +98,6 @@ list(A type) : choice nil (Cons A (list A)), Sequence A is
               | c Cons => f c.head; c.tail.for_each f
 
 
-  # get the head of this list, panic if list is empty
-  #
-  forceHead
-    pre
-      debug: !isEmpty
-    => (list.this ? nil    => fuzion.std.panic "list.forceHead called on empty list"
-                  | c Cons => c.head)
-
-
   # get the tail of this list, panic if list is empty
   #
   forceTail
@@ -121,7 +112,7 @@ list(A type) : choice nil (Cons A (list A)), Sequence A is
   redef first
     pre
       debug: !isEmpty
-    => forceHead
+    => head.get
 
 
   # get the last element of this list, panic if list is empty
@@ -352,7 +343,7 @@ list(A type) : choice nil (Cons A (list A)), Sequence A is
     redef hasNext => (cur ? Cons => true
                           | nil  => false)
     redef next =>
-      res := cur.forceHead
+      res := cur.head.get
       set cur := cur.forceTail
       res
 

--- a/lib/sum.fz
+++ b/lib/sum.fz
@@ -41,7 +41,7 @@ sum(T (numeric T).type, l Sequence T)
   #
   #  l.fold T.sum
   #
-  n := l.asList.forceHead
+  n := l.asList.head.get
   sum0 n l
 
 


### PR DESCRIPTION
It is equivalent to `head.get`.

Fixes #679.