### PR TITLE
be/c: remove noFileIo placeholder intrinsic

### DIFF
--- a/src/dev/flang/be/c/Intrinsics.java
+++ b/src/dev/flang/be/c/Intrinsics.java
@@ -101,9 +101,6 @@ public class Intrinsics extends ANY
                                 outOrErr(in)
                               ));
         });
-    IntrinsicCode noFileIo = (c,cl,outer,in) ->
-      CStmnt.seq(CExpr.fprintfstderr("*** C backend does not support this fileio feature (yet).\n"),
-                 CExpr.exit(1));
     put("fuzion.std.fileio.read"         , (c,cl,outer,in) ->
         {
           var readingIdent = new CIdent("reading");


### PR DESCRIPTION
We do have file I/O intrinsics implemented now, so this is no longer relevant.