### PR TITLE
lib: io: implement get_file_size as a fuzion feature

### DIFF
--- a/lib/fuzion/sys/fileio.fz
+++ b/lib/fuzion/sys/fileio.fz
@@ -59,23 +59,13 @@ public fileio is
 
   # retrieves the file size in bytes and returns an outcome of error in case of an error
   #
-  public get_file_size(
-                       # the (relative or absolute) file name, using platform specific path separators
-                       path String) outcome i64 is
-    arr := fuzion.sys.c_string path
-    size := get_file_size arr unit
-    if size != -1
-      size
-    else
-      error "an error occurred while retrieving the size of the file/dir: \"$path\""
-
-  # intrinsic that returns the file size in bytes or -1 in case of an error
-  #
   private get_file_size(
-                        # the internal array data representing the file path in bytes
-                        path Any,
-                        # dummy parameter for overloading
-                        _ unit) i64 is intrinsic
+                        # the (relative or absolute) file name, using platform specific path separators
+                        path String) outcome i64 is
+    md := array 4 i->(i64 0)
+    match stats (fuzion.sys.c_string path) md.internalArray.data
+      TRUE => md[0]
+      FALSE => error "error getting file size"
 
 
   # writes the content of an array of bytes to a file opened as fd

--- a/src/dev/flang/be/c/Intrinsics.java
+++ b/src/dev/flang/be/c/Intrinsics.java
@@ -120,20 +120,6 @@ public class Intrinsics extends ANY
                 CExpr.call("clearerr", new List<>(A0.castTo("FILE *"))))),
             resultIdent.ret());
         });
-    put("fuzion.sys.fileio.get_file_size", (c,cl,outer,in) ->
-        {
-          var statIdent = new CIdent("statbuf");
-          var resultIdent = new CIdent("result");
-          return CStmnt.seq(
-            CExpr.decl("size_t", resultIdent, CExpr.int64const(-1)),
-            CExpr.decl("struct stat", statIdent),
-            // result = size if successful
-            CExpr.iff(CExpr.call("stat", new List<>(A0.castTo("char *"), statIdent.adrOf())).eq(CExpr.int8const(0)), resultIdent.assign(statIdent.field(new CIdent("st_size")))),
-            // result = -1 if it failed
-            resultIdent.ret()
-            );
-        }
-        );
     put("fuzion.sys.fileio.write"        , (c,cl,outer,in) ->
         {
           var writingIdent = new CIdent("writing");

--- a/src/dev/flang/be/interpreter/Intrinsics.java
+++ b/src/dev/flang/be/interpreter/Intrinsics.java
@@ -259,23 +259,6 @@ public class Intrinsics extends ANY
               return new i64Value(-1);
             }
         });
-    put("fuzion.sys.fileio.get_file_size", (interpreter, innerClazz) -> args ->
-        {
-          if (!ENABLE_UNSAFE_INTRINSICS)
-            {
-              Errors.fatal("*** error: unsafe feature "+innerClazz+" disabled");
-            }
-          Path path = Path.of(utf8ByteArrayDataToString(args.get(1)));
-          try
-            {
-              long fileLength = Files.size(path);
-              return new i64Value(fileLength);
-            }
-          catch (Exception e)
-            {
-              return new i64Value(-1);
-            }
-        });
     put("fuzion.sys.fileio.write", (interpreter, innerClazz) -> args ->
         {
           if (!ENABLE_UNSAFE_INTRINSICS)

--- a/src/dev/flang/fuir/analysis/dfa/DFA.java
+++ b/src/dev/flang/fuir/analysis/dfa/DFA.java
@@ -930,7 +930,6 @@ public class DFA extends ANY
     put("fuzion.sys.out.write"           , cl -> Value.UNIT );
     put("fuzion.sys.err.write"           , cl -> Value.UNIT );
     put("fuzion.sys.fileio.read"         , cl -> new NumericValue(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc)) ); // NYI : manipulation of an array passed as argument needs to be tracked and recorded
-    put("fuzion.sys.fileio.get_file_size", cl -> new NumericValue(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc)) );
     put("fuzion.sys.fileio.write"        , cl -> new NumericValue(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc)) );
     put("fuzion.sys.fileio.delete"       , cl -> cl._dfa._bool );
     put("fuzion.sys.fileio.move"         , cl -> cl._dfa._bool );
@@ -944,7 +943,6 @@ public class DFA extends ANY
     put("fuzion.sys.out.flush"           , cl -> Value.UNIT );
     put("fuzion.sys.err.flush"           , cl -> Value.UNIT );
     put("fuzion.sys.stdin.next_byte"     , cl -> new NumericValue(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc)) );
-
     put("i8.prefix -°"                   , cl -> { return new NumericValue(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc)); } );
     put("i16.prefix -°"                  , cl -> { return new NumericValue(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc)); } );
     put("i32.prefix -°"                  , cl -> { return new NumericValue(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc)); } );

--- a/src/dev/flang/fuir/cfg/CFG.java
+++ b/src/dev/flang/fuir/cfg/CFG.java
@@ -225,7 +225,6 @@ public class CFG extends ANY
     put("fuzion.sys.out.write"           , (cfg, cl) -> { } );
     put("fuzion.sys.err.write"           , (cfg, cl) -> { } );
     put("fuzion.sys.fileio.read"         , (cfg, cl) -> { } );
-    put("fuzion.sys.fileio.get_file_size", (cfg, cl) -> { } );
     put("fuzion.sys.fileio.write"        , (cfg, cl) -> { } );
     put("fuzion.sys.fileio.delete"       , (cfg, cl) -> { } );
     put("fuzion.sys.fileio.move"         , (cfg, cl) -> { } );


### PR DESCRIPTION
Previously, get_file_size was implemented as an intrinsic which, in the C backend, called to stat. So does the stats intrinsic, therefore we can actually move to using that.

Also mark get_file_size private for now. It uses the stats intrinsic, but without using the stat effect. We might want to change this. Keep it private until a decision is made.