### PR TITLE
lib: io: improve error handling for stat/lstat

### DIFF
--- a/lib/fuzion/sys/fileio.fz
+++ b/lib/fuzion/sys/fileio.fz
@@ -168,6 +168,9 @@ public fileio is
   # returns TRUE in case the operation was successful and FALSE in case of failure
   # in case the path refers to a symbolic link it resolves it and returns info about the actual file
   #
+  # in case an error is returned (the result of this feature is false), then the size field of
+  # the meta_data array will contain the errno for the stat call.
+  #
   stats(
         # the internal array data representing the file/dir path in bytes
         path Any,
@@ -177,6 +180,9 @@ public fileio is
   # intrinsic that fills an array with some metadata of the file/dir provided by the path
   # returns TRUE in case the operation was successful and FALSE in case of failure
   # in case the path refers to a symbolic link it does not attempt to follow it and returns info about the link itself
+  #
+  # in case an error is returned (the result of this feature is false), then the size field of
+  # the meta_data array will contain the errno for the lstat call.
   #
   lstats(path Any, meta_data Any) bool is intrinsic # NYI behaves the same as stats in the interpreter
 

--- a/lib/io/file/stat.fz
+++ b/lib/io/file/stat.fz
@@ -57,7 +57,7 @@ private stat(
       meta_data data[0] data[1] (data[2] == 1) (data[3] == 1)
     else
       replace
-      error "error while retrieving meta_data for the following file/dir: $path"
+      error "stat error {data[0]} for {path}"
 
   # returns stats of the file/dir passed in the pathname
   # in success it will return a meta_data outcome storing stats regarding the file/dir
@@ -73,7 +73,7 @@ private stat(
       meta_data data[0] data[1] (data[2] == 1) (data[3] == 1)
     else
       replace
-      error "error while retrieving meta_data for the following file/dir: $path"
+      error "lstat error {data[0]} for {path}"
 
 # short-hand for installing the default stat effect to the provided code
 #

--- a/src/dev/flang/be/c/Intrinsics.java
+++ b/src/dev/flang/be/c/Intrinsics.java
@@ -192,6 +192,10 @@ public class Intrinsics extends ANY
                 )
               ),
             // return false if stat failed
+            metadata.index(CExpr.ident("0")).assign(new CIdent("errno")),
+            metadata.index(CExpr.ident("1")).assign(CExpr.int64const(0)),
+            metadata.index(CExpr.ident("2")).assign(CExpr.int64const(0)),
+            metadata.index(CExpr.ident("3")).assign(CExpr.int64const(0)),
             c._names.FZ_FALSE.ret()
             );
         }
@@ -216,6 +220,10 @@ public class Intrinsics extends ANY
                 )
               ),
             // return false if lstat failed
+            metadata.index(CExpr.ident("0")).assign(new CIdent("errno")),
+            metadata.index(CExpr.ident("1")).assign(CExpr.int64const(0)),
+            metadata.index(CExpr.ident("2")).assign(CExpr.int64const(0)),
+            metadata.index(CExpr.ident("3")).assign(CExpr.int64const(0)),
             c._names.FZ_FALSE.ret()
             );
         }


### PR DESCRIPTION
For the C backend, return the error number directly in case of a failure. For the interpreter backend, match the possible exceptions returned by Files.readAttributes to similar C error numbers.