### PR TITLE
parser: do not use empty blocks as else blocks.

### DIFF
--- a/src/dev/flang/parser/Parser.java
+++ b/src/dev/flang/parser/Parser.java
@@ -2844,14 +2844,17 @@ ifstmnt      : "if" exprInLine thenPart elseBlockOpt
           {
             result.setElse(i);
           }
-        else if (els instanceof Block blk)
+        else if (els instanceof Block blk
+                // do no set empty blocks as else blocks since the source position
+                // of those block might be somewhere unexpected.
+                 && !blk._statements.isEmpty())
           {
             result.setElse(blk);
           }
         else
           {
             if (CHECKS) check
-              (els == null);
+              (els == null || (els instanceof Block blk && blk._statements.isEmpty()));
           }
         return result;
       });

--- a/tests/reg_issue440_incomplete_else_block_confusing_error_message/Makefile
+++ b/tests/reg_issue440_incomplete_else_block_confusing_error_message/Makefile
@@ -1,0 +1,27 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test Makefile
+#
+#  Author: Fridtjof Siebert (siebert@tokiwa.software)
+#
+# -----------------------------------------------------------------------
+
+override NAME = issue440
+include ../negative.mk

--- a/tests/reg_issue440_incomplete_else_block_confusing_error_message/issue440.fz
+++ b/tests/reg_issue440_incomplete_else_block_confusing_error_message/issue440.fz
@@ -1,0 +1,31 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test issue440
+#
+# -----------------------------------------------------------------------
+
+issue440 is
+  something i32 is
+    if true // 1. should flag an error, Incompatible types in assignment
+      1
+    else
+
+  next_feat i64 is
+    3


### PR DESCRIPTION
fixes #440 