### PR TITLE
make build less noisy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@
 # -----------------------------------------------------------------------
 
 JAVA = java
-JAVAC = javac -encoding UTF8 -source 17
+JAVAC = javac -nowarn -encoding UTF8 -source 17
 FZ_SRC = $(patsubst %/,%,$(dir $(lastword $(MAKEFILE_LIST))))
 SRC = $(FZ_SRC)/src
 BUILD_DIR = ./build
@@ -357,10 +357,12 @@ javac: $(CLASS_FILES_TOOLS) $(CLASS_FILES_TOOLS_FZJAVA) $(CLASS_FILES_TOOLS_DOCS
 $(BUILD_DIR)/%.md: $(FZ_SRC)/%.md
 	cp $^ $@
 
+.SILENT: $(FUZION_EBNF)
 $(FUZION_EBNF): $(SRC)/dev/flang/parser/Parser.java
 	mkdir -p $(@D)
 	$(FZ_SRC)/bin/ebnf.sh > $@
 
+.SILENT: $(JAVA_FILE_TOOLS_VERSION)
 $(JAVA_FILE_TOOLS_VERSION): $(FZ_SRC)/version.txt $(JAVA_FILE_TOOLS_VERSION_IN)
 	mkdir -p $(@D)
 	cat $(JAVA_FILE_TOOLS_VERSION_IN) \
@@ -369,101 +371,121 @@ $(JAVA_FILE_TOOLS_VERSION): $(FZ_SRC)/version.txt $(JAVA_FILE_TOOLS_VERSION_IN)
           | sed "s^@@DATE@@^`date +%Y-%m-%d\ %H:%M:%S`^g"  \
           | sed "s^@@BUILTBY@@^`echo -n $(USER)@; hostname`^g" >$@
 
+.SILENT: $(CLASS_FILES_UTIL)
 $(CLASS_FILES_UTIL): $(JAVA_FILES_UTIL)
 	mkdir -p $(CLASSES_DIR)
 	$(JAVAC) -d $(CLASSES_DIR) $(JAVA_FILES_UTIL)
 	touch $@
 
+.SILENT: $(CLASS_FILES_UTIL_UNICODE)
 $(CLASS_FILES_UTIL_UNICODE): $(JAVA_FILES_UTIL_UNICODE) $(CLASS_FILES_UTIL)
 	mkdir -p $(CLASSES_DIR)
 	$(JAVAC) -cp $(CLASSES_DIR) -d $(CLASSES_DIR) $(JAVA_FILES_UTIL_UNICODE)
 	touch $@
 
+.SILENT: $(CLASS_FILES_AST)
 $(CLASS_FILES_AST): $(JAVA_FILES_AST) $(CLASS_FILES_UTIL)
 	mkdir -p $(CLASSES_DIR)
 	$(JAVAC) -cp $(CLASSES_DIR) -d $(CLASSES_DIR) $(JAVA_FILES_AST)
 	touch $@
 
+.SILENT: $(CLASS_FILES_PARSER)
 $(CLASS_FILES_PARSER): $(JAVA_FILES_PARSER) $(CLASS_FILES_AST) $(FUZION_EBNF)
 	mkdir -p $(CLASSES_DIR)
 	$(JAVAC) -cp $(CLASSES_DIR) -d $(CLASSES_DIR) $(JAVA_FILES_PARSER)
 	touch $@
 
+.SILENT: $(CLASS_FILES_IR)
 $(CLASS_FILES_IR): $(JAVA_FILES_IR) $(CLASS_FILES_UTIL) $(CLASS_FILES_AST)  # NYI: remove dependency on $(CLASS_FILES_AST)
 	mkdir -p $(CLASSES_DIR)
 	$(JAVAC) -cp $(CLASSES_DIR) -d $(CLASSES_DIR) $(JAVA_FILES_IR)
 	touch $@
 
+.SILENT: $(CLASS_FILES_MIR)
 $(CLASS_FILES_MIR): $(JAVA_FILES_MIR) $(CLASS_FILES_IR)
 	mkdir -p $(CLASSES_DIR)
 	$(JAVAC) -cp $(CLASSES_DIR) -d $(CLASSES_DIR) $(JAVA_FILES_MIR)
 	touch $@
 
+.SILENT: $(CLASS_FILES_FE)
 $(CLASS_FILES_FE): $(JAVA_FILES_FE) $(CLASS_FILES_PARSER) $(CLASS_FILES_AST) $(CLASS_FILES_MIR)
 	mkdir -p $(CLASSES_DIR)
 	$(JAVAC) -cp $(CLASSES_DIR) -d $(CLASSES_DIR) $(JAVA_FILES_FE)
 	touch $@
 
+.SILENT: $(CLASS_FILES_AIR)
 $(CLASS_FILES_AIR): $(JAVA_FILES_AIR) $(CLASS_FILES_UTIL) $(CLASS_FILES_IR)
 	mkdir -p $(CLASSES_DIR)
 	$(JAVAC) -cp $(CLASSES_DIR) -d $(CLASSES_DIR) $(JAVA_FILES_AIR)
 	touch $@
 
+.SILENT: $(CLASS_FILES_ME)
 $(CLASS_FILES_ME): $(JAVA_FILES_ME) $(CLASS_FILES_MIR) $(CLASS_FILES_AIR)
 	mkdir -p $(CLASSES_DIR)
 	$(JAVAC) -cp $(CLASSES_DIR) -d $(CLASSES_DIR) $(JAVA_FILES_ME)
 	touch $@
 
+.SILENT: $(CLASS_FILES_FUIR)
 $(CLASS_FILES_FUIR): $(JAVA_FILES_FUIR) $(CLASS_FILES_UTIL) $(CLASS_FILES_IR)
 	mkdir -p $(CLASSES_DIR)
 	$(JAVAC) -cp $(CLASSES_DIR) -d $(CLASSES_DIR) $(JAVA_FILES_FUIR)
 	touch $@
 
+.SILENT: $(CLASS_FILES_FUIR_ANALYSIS)
 $(CLASS_FILES_FUIR_ANALYSIS): $(JAVA_FILES_FUIR_ANALYSIS) $(CLASS_FILES_UTIL) $(CLASS_FILES_FUIR)
 	mkdir -p $(CLASSES_DIR)
 	$(JAVAC) -cp $(CLASSES_DIR) -d $(CLASSES_DIR) $(JAVA_FILES_FUIR_ANALYSIS)
 	touch $@
 
+.SILENT: $(CLASS_FILES_FUIR_ANALYSIS_DFA)
 $(CLASS_FILES_FUIR_ANALYSIS_DFA): $(JAVA_FILES_FUIR_ANALYSIS_DFA) $(CLASS_FILES_FUIR_ANALYSIS) $(CLASS_FILES_UTIL) $(CLASS_FILES_FUIR)
 	mkdir -p $(CLASSES_DIR)
 	$(JAVAC) -cp $(CLASSES_DIR) -d $(CLASSES_DIR) $(JAVA_FILES_FUIR_ANALYSIS_DFA)
 	touch $@
 
+.SILENT: $(CLASS_FILES_FUIR_CFG)
 $(CLASS_FILES_FUIR_CFG): $(JAVA_FILES_FUIR_CFG) $(CLASS_FILES_UTIL) $(CLASS_FILES_FUIR)
 	mkdir -p $(CLASSES_DIR)
 	$(JAVAC) -cp $(CLASSES_DIR) -d $(CLASSES_DIR) $(JAVA_FILES_FUIR_CFG)
 	touch $@
 
+.SILENT: $(CLASS_FILES_OPT)
 $(CLASS_FILES_OPT): $(JAVA_FILES_OPT) $(CLASS_FILES_AIR) $(CLASS_FILES_FUIR)
 	mkdir -p $(CLASSES_DIR)
 	$(JAVAC) -cp $(CLASSES_DIR) -d $(CLASSES_DIR) $(JAVA_FILES_OPT)
 	touch $@
 
+.SILENT: $(CLASS_FILES_BE_INTERPRETER)
 $(CLASS_FILES_BE_INTERPRETER): $(JAVA_FILES_BE_INTERPRETER) $(CLASS_FILES_FUIR) $(CLASS_FILES_AIR) $(CLASS_FILES_AST)  # NYI: remove dependency on $(CLASS_FILES_AST), replace by $(CLASS_FILES_FUIR)
 	mkdir -p $(CLASSES_DIR)
 	$(JAVAC) -cp $(CLASSES_DIR) -d $(CLASSES_DIR) $(JAVA_FILES_BE_INTERPRETER)
 	touch $@
 
+.SILENT: $(CLASS_FILES_BE_C)
 $(CLASS_FILES_BE_C): $(JAVA_FILES_BE_C) $(CLASS_FILES_FUIR) $(CLASS_FILES_FUIR_ANALYSIS_DFA)
 	mkdir -p $(CLASSES_DIR)
 	$(JAVAC) -cp $(CLASSES_DIR) -d $(CLASSES_DIR) $(JAVA_FILES_BE_C)
 	touch $@
 
+.SILENT: $(CLASS_FILES_BE_EFFECTS)
 $(CLASS_FILES_BE_EFFECTS): $(JAVA_FILES_BE_EFFECTS) $(CLASS_FILES_FUIR_CFG)
 	mkdir -p $(CLASSES_DIR)
 	$(JAVAC) -cp $(CLASSES_DIR) -d $(CLASSES_DIR) $(JAVA_FILES_BE_EFFECTS)
 	touch $@
 
+.SILENT: $(CLASS_FILES_TOOLS)
 $(CLASS_FILES_TOOLS): $(JAVA_FILES_TOOLS) $(CLASS_FILES_FE) $(CLASS_FILES_ME) $(CLASS_FILES_OPT) $(CLASS_FILES_BE_C) $(CLASS_FILES_FUIR_ANALYSIS_DFA) $(CLASS_FILES_BE_EFFECTS) $(CLASS_FILES_BE_INTERPRETER)
 	mkdir -p $(CLASSES_DIR)
 	$(JAVAC) -cp $(CLASSES_DIR) -d $(CLASSES_DIR) $(JAVA_FILES_TOOLS)
 	touch $@
 
+.SILENT: $(CLASS_FILES_TOOLS_FZJAVA)
 $(CLASS_FILES_TOOLS_FZJAVA): $(JAVA_FILES_TOOLS_FZJAVA) $(CLASS_FILES_TOOLS) $(CLASS_FILES_PARSER) $(CLASS_FILES_UTIL)
 	mkdir -p $(CLASSES_DIR)
 	$(JAVAC) -cp $(CLASSES_DIR) -d $(CLASSES_DIR) $(JAVA_FILES_TOOLS_FZJAVA)
 	touch $@
 
+.SILENT: $(CLASS_FILES_TOOLS_DOCS)
 $(CLASS_FILES_TOOLS_DOCS): $(JAVA_FILES_TOOLS_DOCS) $(CLASS_FILES_TOOLS) $(CLASS_FILES_PARSER) $(CLASS_FILES_UTIL)
 	mkdir -p $(CLASSES_DIR)
 	$(JAVAC) -cp $(CLASSES_DIR) -d $(CLASSES_DIR) $(JAVA_FILES_TOOLS_DOCS)
@@ -473,6 +495,7 @@ $(JARS_JFREE_SVG_JAR):
 	mkdir -p $(@D)
 	curl $(JFREE_SVG_URL) --output $@
 
+.SILENT: $(CLASS_FILES_MISC_LOGO)
 $(CLASS_FILES_MISC_LOGO): $(JAVA_FILES_MISC_LOGO) $(JARS_JFREE_SVG_JAR)
 	mkdir -p $(CLASSES_DIR)
 	$(JAVAC) -cp $(CLASSES_DIR):$(JARS_JFREE_SVG_JAR) -d $(CLASSES_DIR) $(JAVA_FILES_MISC_LOGO)
@@ -500,16 +523,19 @@ $(BUILD_DIR)/assets/logo_bleed_cropmark.svg: $(CLASS_FILES_MISC_LOGO)
 	rm -f $@.tmp.pdf
 	touch $@
 
+.SILENT: $(BUILD_DIR)/lib
 $(BUILD_DIR)/lib: $(FUZION_FILES_LIB)
 	rm -rf $@
 	mkdir -p $(@D)
 	cp -rf $(FZ_SRC_LIB) $@
 
+.SILENT: $(BUILD_DIR)/bin/fz
 $(BUILD_DIR)/bin/fz: $(FZ_SRC)/bin/fz $(CLASS_FILES_TOOLS) $(BUILD_DIR)/lib
 	mkdir -p $(@D)
 	cp -rf $(FZ_SRC)/bin/fz $@
 	chmod +x $@
 
+.SILENT: $(MOD_BASE)
 $(MOD_BASE): $(BUILD_DIR)/lib $(BUILD_DIR)/bin/fz
 	mkdir -p $(@D)
 	$(BUILD_DIR)/bin/fz -sourceDirs=$(BUILD_DIR)/lib -XloadBaseLib=off -saveLib=$@
@@ -518,15 +544,18 @@ $(MOD_BASE): $(BUILD_DIR)/lib $(BUILD_DIR)/bin/fz
 # keep make from deleting $(MOD_BASE) on ctrl-C:
 .PRECIOUS: $(MOD_BASE)
 
+.SILENT: $(MOD_TERMINAL)
 $(MOD_TERMINAL): $(MOD_BASE) $(BUILD_DIR)/bin/fz $(FZ_SRC)/modules/terminal/src/terminal.fz
 	mkdir -p $(@D)
 	$(BUILD_DIR)/bin/fz -sourceDirs=$(FZ_SRC)/modules/terminal/src -saveLib=$@
 
+.SILENT: $(BUILD_DIR)/bin/fzjava
 $(BUILD_DIR)/bin/fzjava: $(FZ_SRC)/bin/fzjava $(CLASS_FILES_TOOLS_FZJAVA)
 	mkdir -p $(@D)
 	cp -rf $(FZ_SRC)/bin/fzjava $@
 	chmod +x $@
 
+.SILENT: $(MOD_JAVA_BASE_FZ_FILES)
 $(MOD_JAVA_BASE_FZ_FILES): $(MOD_BASE) $(BUILD_DIR)/bin/fzjava
 	rm -rf $(@D)
 	mkdir -p $(@D)
@@ -534,6 +563,7 @@ $(MOD_JAVA_BASE_FZ_FILES): $(MOD_BASE) $(BUILD_DIR)/bin/fzjava
 	$(FUZION_BIN_BASH) -c "$(BUILD_DIR)/bin/fzjava java.base -to=$(@D) -verbose=0"
 	touch $@
 
+.SILENT: $(MOD_JAVA_XML_FZ_FILES)
 $(MOD_JAVA_XML_FZ_FILES): $(BUILD_DIR)/bin/fzjava
 	rm -rf $(@D)
 	mkdir -p $(@D)
@@ -541,6 +571,7 @@ $(MOD_JAVA_XML_FZ_FILES): $(BUILD_DIR)/bin/fzjava
 	$(FUZION_BIN_BASH) -c "$(BUILD_DIR)/bin/fzjava java.xml -to=$(@D) -modules=java.base -verbose=0"
 	touch $@
 
+.SILENT: $(MOD_JAVA_DATATRANSFER_FZ_FILES)
 $(MOD_JAVA_DATATRANSFER_FZ_FILES): $(BUILD_DIR)/bin/fzjava
 	rm -rf $(@D)
 	mkdir -p $(@D)
@@ -552,6 +583,7 @@ $(MOD_JAVA_DATATRANSFER_FZ_FILES): $(BUILD_DIR)/bin/fzjava
 	mv $(BUILD_DIR)/modules/java.datatransfer/Java/java/awt_pkg.fz  $(BUILD_DIR)/modules/java.datatransfer/
 	touch $@
 
+.SILENT: $(MOD_JAVA_DESKTOP_FZ_FILES)
 $(MOD_JAVA_DESKTOP_FZ_FILES): $(BUILD_DIR)/bin/fzjava
 	rm -rf $(@D)
 	mkdir -p $(@D)
@@ -567,261 +599,313 @@ $(MOD_JAVA_DESKTOP_FZ_FILES): $(BUILD_DIR)/bin/fzjava
 	mv $(BUILD_DIR)/modules/java.desktop/Java/sun/*.fz $(BUILD_DIR)/modules/java.desktop/
 	touch $@
 
+.SILENT: $(MOD_JAVA_COMPILER_FZ_FILES)
 $(MOD_JAVA_COMPILER_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE)
 	rm -rf $(@D)
 	mkdir -p $(@D)
 	$(FUZION_BIN_BASH) -c "$(BUILD_DIR)/bin/fzjava java.compiler -to=$(@D) -modules=java.base -verbose=0"
 	touch $@
+.SILENT: $(MOD_JAVA_INSTRUMENT_FZ_FILES)
 $(MOD_JAVA_INSTRUMENT_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE)
 	rm -rf $(@D)
 	mkdir -p $(@D)
 	$(FUZION_BIN_BASH) -c "$(BUILD_DIR)/bin/fzjava java.instrument -to=$(@D) -modules=java.base -verbose=0"
 	touch $@
+.SILENT: $(MOD_JAVA_LOGGING_FZ_FILES)
 $(MOD_JAVA_LOGGING_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE)
 	rm -rf $(@D)
 	mkdir -p $(@D)
 	$(FUZION_BIN_BASH) -c "$(BUILD_DIR)/bin/fzjava java.logging -to=$(@D) -modules=java.base -verbose=0"
 	touch $@
+.SILENT: $(MOD_JAVA_MANAGEMENT_FZ_FILES)
 $(MOD_JAVA_MANAGEMENT_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE)
 	rm -rf $(@D)
 	mkdir -p $(@D)
 	$(FUZION_BIN_BASH) -c "$(BUILD_DIR)/bin/fzjava java.management -to=$(@D) -modules=java.base -verbose=0"
 	touch $@
+.SILENT: $(MOD_JAVA_MANAGEMENT_RMI_FZ_FILES)
 $(MOD_JAVA_MANAGEMENT_RMI_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE) $(MOD_JAVA_MANAGEMENT) $(MOD_JAVA_RMI)
 	rm -rf $(@D)
 	mkdir -p $(@D)
 	$(FUZION_BIN_BASH) -c "$(BUILD_DIR)/bin/fzjava java.management.rmi -to=$(@D) -modules=java.base,java.management,java.rmi -verbose=0"
 	touch $@
+.SILENT: $(MOD_JAVA_NAMING_FZ_FILES)
 $(MOD_JAVA_NAMING_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE)
 	rm -rf $(@D)
 	mkdir -p $(@D)
 	$(FUZION_BIN_BASH) -c "$(BUILD_DIR)/bin/fzjava java.naming -to=$(@D) -modules=java.base -verbose=0"
 	touch $@
+.SILENT: $(MOD_JAVA_NET_HTTP_FZ_FILES)
 $(MOD_JAVA_NET_HTTP_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE)
 	rm -rf $(@D)
 	mkdir -p $(@D)
 	$(FUZION_BIN_BASH) -c "$(BUILD_DIR)/bin/fzjava java.net.http -to=$(@D) -modules=java.base -verbose=0"
 	touch $@
+.SILENT: $(MOD_JAVA_PREFS_FZ_FILES)
 $(MOD_JAVA_PREFS_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE)
 	rm -rf $(@D)
 	mkdir -p $(@D)
 	$(FUZION_BIN_BASH) -c "$(BUILD_DIR)/bin/fzjava java.prefs -to=$(@D) -modules=java.base -verbose=0"
 	touch $@
+.SILENT: $(MOD_JAVA_RMI_FZ_FILES)
 $(MOD_JAVA_RMI_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE)
 	rm -rf $(@D)
 	mkdir -p $(@D)
 	$(FUZION_BIN_BASH) -c "$(BUILD_DIR)/bin/fzjava java.rmi -to=$(@D) -modules=java.base -verbose=0"
 	touch $@
+.SILENT: $(MOD_JAVA_SCRIPTING_FZ_FILES)
 $(MOD_JAVA_SCRIPTING_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE)
 	rm -rf $(@D)
 	mkdir -p $(@D)
 	$(FUZION_BIN_BASH) -c "$(BUILD_DIR)/bin/fzjava java.scripting -to=$(@D) -modules=java.base -verbose=0"
 	touch $@
+.SILENT: $(MOD_JAVA_SE_FZ_FILES)
 $(MOD_JAVA_SE_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE) $(MOD_JAVA_SQL_ROWSET) $(MOD_JAVA_XML_CRYPTO) $(MOD_JAVA_MANAGEMENT_RMI) $(MOD_JAVA_SECURITY_JGSS) $(MOD_JAVA_SECURITY_SASL) $(MOD_JAVA_SCRIPTING) $(MOD_JAVA_DESKTOP) $(MOD_JAVA_COMPILER) $(MOD_JAVA_INSTRUMENT) $(MOD_JAVA_NET_HTTP) $(MOD_JAVA_PREFS)
 	rm -rf $(@D)
 	mkdir -p $(@D)
 	$(FUZION_BIN_BASH) -c "$(BUILD_DIR)/bin/fzjava java.se -to=$(@D) -modules=java.base,java.naming,java.transaction.xa,java.logging,java.scripting,java.xml,java.datatransfer,java.prefs,java.sql,java.desktop,java.compiler,java.instrument,java.rmi,java.management,java.net.http,java.sql.rowset,java.xml.crypto,java.management.rmi,java.security.jgss,java.security.sasl -verbose=0"
 	touch $@
+.SILENT: $(MOD_JAVA_SECURITY_JGSS_FZ_FILES)
 $(MOD_JAVA_SECURITY_JGSS_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE)
 	rm -rf $(@D)
 	mkdir -p $(@D)
 	$(FUZION_BIN_BASH) -c "$(BUILD_DIR)/bin/fzjava java.security.jgss -to=$(@D) -modules=java.base -verbose=0"
 	touch $@
+.SILENT: $(MOD_JAVA_SECURITY_SASL_FZ_FILES)
 $(MOD_JAVA_SECURITY_SASL_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE)
 	rm -rf $(@D)
 	mkdir -p $(@D)
 	$(FUZION_BIN_BASH) -c "$(BUILD_DIR)/bin/fzjava java.security.sasl -to=$(@D) -modules=java.base -verbose=0"
 	touch $@
+.SILENT: $(MOD_JAVA_SMARTCARDIO_FZ_FILES)
 $(MOD_JAVA_SMARTCARDIO_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE)
 	rm -rf $(@D)
 	mkdir -p $(@D)
 	$(FUZION_BIN_BASH) -c "$(BUILD_DIR)/bin/fzjava java.smartcardio -to=$(@D) -modules=java.base -verbose=0"
 	touch $@
+.SILENT: $(MOD_JAVA_SQL_FZ_FILES)
 $(MOD_JAVA_SQL_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE) $(MOD_JAVA_LOGGING) $(MOD_JAVA_XML) $(MOD_JAVA_TRANSACTION_XA)
 	rm -rf $(@D)
 	mkdir -p $(@D)
 	$(FUZION_BIN_BASH) -c "$(BUILD_DIR)/bin/fzjava java.sql -to=$(@D) -modules=java.base,java.logging,java.xml,java.transaction.xa -verbose=0"
 	touch $@
+.SILENT: $(MOD_JAVA_SQL_ROWSET_FZ_FILES)
 $(MOD_JAVA_SQL_ROWSET_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE) $(MOD_JAVA_SQL) $(MOD_JAVA_NAMING) $(MOD_JAVA_LOGGING) $(MOD_JAVA_XML) $(MOD_JAVA_TRANSACTION_XA)
 	rm -rf $(@D)
 	mkdir -p $(@D)
 	$(FUZION_BIN_BASH) -c "$(BUILD_DIR)/bin/fzjava java.sql.rowset -to=$(@D) -modules=java.base,java.logging,java.xml,java.transaction.xa,java.sql,java.naming -verbose=0"
 	touch $@
+.SILENT: $(MOD_JAVA_TRANSACTION_XA_FZ_FILES)
 $(MOD_JAVA_TRANSACTION_XA_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE)
 	rm -rf $(@D)
 	mkdir -p $(@D)
 	$(FUZION_BIN_BASH) -c "$(BUILD_DIR)/bin/fzjava java.transaction.xa -to=$(@D) -modules=java.base -verbose=0"
 	touch $@
+.SILENT: $(MOD_JAVA_XML_CRYPTO_FZ_FILES)
 $(MOD_JAVA_XML_CRYPTO_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE) $(MOD_JAVA_XML)
 	rm -rf $(@D)
 	mkdir -p $(@D)
 	$(FUZION_BIN_BASH) -c "$(BUILD_DIR)/bin/fzjava java.xml.crypto -to=$(@D) -modules=java.xml,java.base -verbose=0"
 	touch $@
+.SILENT: $(MOD_JDK_ACCESSIBILITY_FZ_FILES)
 $(MOD_JDK_ACCESSIBILITY_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE) $(MOD_JAVA_DESKTOP)
 	rm -rf $(@D)
 	mkdir -p $(@D)
 	$(FUZION_BIN_BASH) -c "$(BUILD_DIR)/bin/fzjava jdk.accessibility -to=$(@D) -modules=java.base,java.xml,java.datatransfer,java.desktop -verbose=0"
 	touch $@
+.SILENT: $(MOD_JDK_ATTACH_FZ_FILES)
 $(MOD_JDK_ATTACH_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE)
 	rm -rf $(@D)
 	mkdir -p $(@D)
 	$(FUZION_BIN_BASH) -c "$(BUILD_DIR)/bin/fzjava jdk.attach -to=$(@D) -modules=java.base -verbose=0"
 	touch $@
+.SILENT: $(MOD_JDK_CHARSETS_FZ_FILES)
 $(MOD_JDK_CHARSETS_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE)
 	rm -rf $(@D)
 	mkdir -p $(@D)
 	$(FUZION_BIN_BASH) -c "$(BUILD_DIR)/bin/fzjava jdk.charsets -to=$(@D) -modules=java.base -verbose=0"
 	touch $@
+.SILENT: $(MOD_JDK_COMPILER_FZ_FILES)
 $(MOD_JDK_COMPILER_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE) $(MOD_JAVA_COMPILER)
 	rm -rf $(@D)
 	mkdir -p $(@D)
 	$(FUZION_BIN_BASH) -c "$(BUILD_DIR)/bin/fzjava jdk.compiler -to=$(@D) -modules=java.base,java.compiler -verbose=0"
 	touch $@
+.SILENT: $(MOD_JDK_CRYPTO_CRYPTOKI_FZ_FILES)
 $(MOD_JDK_CRYPTO_CRYPTOKI_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE)
 	rm -rf $(@D)
 	mkdir -p $(@D)
 	$(FUZION_BIN_BASH) -c "$(BUILD_DIR)/bin/fzjava jdk.crypto.cryptoki -to=$(@D) -modules=java.base -verbose=0"
 	touch $@
+.SILENT: $(MOD_JDK_CRYPTO_EC_FZ_FILES)
 $(MOD_JDK_CRYPTO_EC_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE)
 	rm -rf $(@D)
 	mkdir -p $(@D)
 	$(FUZION_BIN_BASH) -c "$(BUILD_DIR)/bin/fzjava jdk.crypto.ec -to=$(@D) -modules=java.base -verbose=0"
 	touch $@
+.SILENT: $(MOD_JDK_DYNALINK_FZ_FILES)
 $(MOD_JDK_DYNALINK_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE)
 	rm -rf $(@D)
 	mkdir -p $(@D)
 	$(FUZION_BIN_BASH) -c "$(BUILD_DIR)/bin/fzjava jdk.dynalink -to=$(@D) -modules=java.base -verbose=0"
 	touch $@
+.SILENT: $(MOD_JDK_EDITPAD_FZ_FILES)
 $(MOD_JDK_EDITPAD_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE)
 	rm -rf $(@D)
 	mkdir -p $(@D)
 	$(FUZION_BIN_BASH) -c "$(BUILD_DIR)/bin/fzjava jdk.editpad -to=$(@D) -modules=java.base -verbose=0"
 	touch $@
+.SILENT: $(MOD_JDK_HTTPSERVER_FZ_FILES)
 $(MOD_JDK_HTTPSERVER_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE)
 	rm -rf $(@D)
 	mkdir -p $(@D)
 	$(FUZION_BIN_BASH) -c "$(BUILD_DIR)/bin/fzjava jdk.httpserver -to=$(@D) -modules=java.base -verbose=0"
 	touch $@
+.SILENT: $(MOD_JDK_JARTOOL_FZ_FILES)
 $(MOD_JDK_JARTOOL_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE)
 	rm -rf $(@D)
 	mkdir -p $(@D)
 	$(FUZION_BIN_BASH) -c "$(BUILD_DIR)/bin/fzjava jdk.jartool -to=$(@D) -modules=java.base -verbose=0"
 	touch $@
+.SILENT: $(MOD_JDK_JAVADOC_FZ_FILES)
 $(MOD_JDK_JAVADOC_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE) $(MOD_JDK_COMPILER)
 	rm -rf $(@D)
 	mkdir -p $(@D)
 	$(FUZION_BIN_BASH) -c "$(BUILD_DIR)/bin/fzjava jdk.javadoc -to=$(@D) -modules=java.base,java.compiler,jdk.compiler -verbose=0"
 	touch $@
+.SILENT: $(MOD_JDK_JCONSOLE_FZ_FILES)
 $(MOD_JDK_JCONSOLE_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE) $(MOD_JAVA_DESKTOP) $(MOD_JAVA_MANAGEMENT)
 	rm -rf $(@D)
 	mkdir -p $(@D)
 	$(FUZION_BIN_BASH) -c "$(BUILD_DIR)/bin/fzjava jdk.jconsole -to=$(@D) -modules=java.base,java.xml,java.datatransfer,java.desktop,java.management -verbose=0"
 	touch $@
+.SILENT: $(MOD_JDK_JDEPS_FZ_FILES)
 $(MOD_JDK_JDEPS_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE)
 	rm -rf $(@D)
 	mkdir -p $(@D)
 	$(FUZION_BIN_BASH) -c "$(BUILD_DIR)/bin/fzjava jdk.jdeps -to=$(@D) -modules=java.base -verbose=0"
 	touch $@
+.SILENT: $(MOD_JDK_JDI_FZ_FILES)
 $(MOD_JDK_JDI_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE)
 	rm -rf $(@D)
 	mkdir -p $(@D)
 	$(FUZION_BIN_BASH) -c "$(BUILD_DIR)/bin/fzjava jdk.jdi -to=$(@D) -modules=java.base -verbose=0"
 	touch $@
+.SILENT: $(MOD_JDK_JDWP_AGENT_FZ_FILES)
 $(MOD_JDK_JDWP_AGENT_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE)
 	rm -rf $(@D)
 	mkdir -p $(@D)
 	$(FUZION_BIN_BASH) -c "$(BUILD_DIR)/bin/fzjava jdk.jdwp.agent -to=$(@D) -modules=java.base -verbose=0"
 	touch $@
+.SILENT: $(MOD_JDK_JFR_FZ_FILES)
 $(MOD_JDK_JFR_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE)
 	rm -rf $(@D)
 	mkdir -p $(@D)
 	$(FUZION_BIN_BASH) -c "$(BUILD_DIR)/bin/fzjava jdk.jfr -to=$(@D) -modules=java.base -verbose=0"
 	touch $@
+.SILENT: $(MOD_JDK_JLINK_FZ_FILES)
 $(MOD_JDK_JLINK_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE)
 	rm -rf $(@D)
 	mkdir -p $(@D)
 	$(FUZION_BIN_BASH) -c "$(BUILD_DIR)/bin/fzjava jdk.jlink -to=$(@D) -modules=java.base -verbose=0"
 	touch $@
+.SILENT: $(MOD_JDK_JPACKAGE_FZ_FILES)
 $(MOD_JDK_JPACKAGE_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE)
 	rm -rf $(@D)
 	mkdir -p $(@D)
 	$(FUZION_BIN_BASH) -c "$(BUILD_DIR)/bin/fzjava jdk.jpackage -to=$(@D) -modules=java.base -verbose=0"
 	touch $@
+.SILENT: $(MOD_JDK_JSHELL_FZ_FILES)
 $(MOD_JDK_JSHELL_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE) $(MOD_JAVA_COMPILER) $(MOD_JAVA_PREFS) $(MOD_JDK_JDI)
 	rm -rf $(@D)
 	mkdir -p $(@D)
 	$(FUZION_BIN_BASH) -c "$(BUILD_DIR)/bin/fzjava jdk.jshell -to=$(@D) -modules=java.base,java.compiler,java.prefs,jdk.jdi -verbose=0"
 	touch $@
+.SILENT: $(MOD_JDK_JSOBJECT_FZ_FILES)
 $(MOD_JDK_JSOBJECT_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE)
 	rm -rf $(@D)
 	mkdir -p $(@D)
 	$(FUZION_BIN_BASH) -c "$(BUILD_DIR)/bin/fzjava jdk.jsobject -to=$(@D) -modules=java.base -verbose=0"
 	touch $@
+.SILENT: $(MOD_JDK_JSTATD_FZ_FILES)
 $(MOD_JDK_JSTATD_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE)
 	rm -rf $(@D)
 	mkdir -p $(@D)
 	$(FUZION_BIN_BASH) -c "$(BUILD_DIR)/bin/fzjava jdk.jstatd -to=$(@D) -modules=java.base -verbose=0"
 	touch $@
+.SILENT: $(MOD_JDK_LOCALEDATA_FZ_FILES)
 $(MOD_JDK_LOCALEDATA_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE)
 	rm -rf $(@D)
 	mkdir -p $(@D)
 	$(FUZION_BIN_BASH) -c "$(BUILD_DIR)/bin/fzjava jdk.localedata -to=$(@D) -modules=java.base -verbose=0"
 	touch $@
+.SILENT: $(MOD_JDK_MANAGEMENT_FZ_FILES)
 $(MOD_JDK_MANAGEMENT_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE) $(MOD_JAVA_MANAGEMENT)
 	rm -rf $(@D)
 	mkdir -p $(@D)
 	$(FUZION_BIN_BASH) -c "$(BUILD_DIR)/bin/fzjava jdk.management -to=$(@D) -modules=java.base,java.management -verbose=0"
 	touch $@
+.SILENT: $(MOD_JDK_MANAGEMENT_AGENT_FZ_FILES)
 $(MOD_JDK_MANAGEMENT_AGENT_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE)
 	rm -rf $(@D)
 	mkdir -p $(@D)
 	$(FUZION_BIN_BASH) -c "$(BUILD_DIR)/bin/fzjava jdk.management.agent -to=$(@D) -modules=java.base -verbose=0"
 	touch $@
+.SILENT: $(MOD_JDK_MANAGEMENT_JFR_FZ_FILES)
 $(MOD_JDK_MANAGEMENT_JFR_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE) $(MOD_JAVA_MANAGEMENT) $(MOD_JDK_JFR)
 	rm -rf $(@D)
 	mkdir -p $(@D)
 	$(FUZION_BIN_BASH) -c "$(BUILD_DIR)/bin/fzjava jdk.management.jfr -to=$(@D) -modules=java.base,java.management,jdk.jfr -verbose=0"
 	touch $@
+.SILENT: $(MOD_JDK_NAMING_DNS_FZ_FILES)
 $(MOD_JDK_NAMING_DNS_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE)
 	rm -rf $(@D)
 	mkdir -p $(@D)
 	$(FUZION_BIN_BASH) -c "$(BUILD_DIR)/bin/fzjava jdk.naming.dns -to=$(@D) -modules=java.base -verbose=0"
 	touch $@
+.SILENT: $(MOD_JDK_NAMING_RMI_FZ_FILES)
 $(MOD_JDK_NAMING_RMI_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE)
 	rm -rf $(@D)
 	mkdir -p $(@D)
 	$(FUZION_BIN_BASH) -c "$(BUILD_DIR)/bin/fzjava jdk.naming.rmi -to=$(@D) -modules=java.base -verbose=0"
 	touch $@
+.SILENT: $(MOD_JDK_NET_FZ_FILES)
 $(MOD_JDK_NET_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE)
 	rm -rf $(@D)
 	mkdir -p $(@D)
 	$(FUZION_BIN_BASH) -c "$(BUILD_DIR)/bin/fzjava jdk.net -to=$(@D) -modules=java.base -verbose=0"
 	touch $@
+.SILENT: $(MOD_JDK_NIO_MAPMODE_FZ_FILES)
 $(MOD_JDK_NIO_MAPMODE_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE)
 	rm -rf $(@D)
 	mkdir -p $(@D)
 	$(FUZION_BIN_BASH) -c "$(BUILD_DIR)/bin/fzjava jdk.nio.mapmode -to=$(@D) -modules=java.base -verbose=0"
 	touch $@
+.SILENT: $(MOD_JDK_SCTP_FZ_FILES)
 $(MOD_JDK_SCTP_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE)
 	rm -rf $(@D)
 	mkdir -p $(@D)
 	$(FUZION_BIN_BASH) -c "$(BUILD_DIR)/bin/fzjava jdk.sctp -to=$(@D) -modules=java.base -verbose=0"
 	touch $@
+.SILENT: $(MOD_JDK_SECURITY_AUTH_FZ_FILES)
 $(MOD_JDK_SECURITY_AUTH_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE) $(MOD_JAVA_NAMING)
 	rm -rf $(@D)
 	mkdir -p $(@D)
 	$(FUZION_BIN_BASH) -c "$(BUILD_DIR)/bin/fzjava jdk.security.auth -to=$(@D) -modules=java.base,java.naming -verbose=0"
 	touch $@
+.SILENT: $(MOD_JDK_SECURITY_JGSS_FZ_FILES)
 $(MOD_JDK_SECURITY_JGSS_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE) $(MOD_JAVA_SECURITY_JGSS)
 	rm -rf $(@D)
 	mkdir -p $(@D)
 	$(FUZION_BIN_BASH) -c "$(BUILD_DIR)/bin/fzjava jdk.security.jgss -to=$(@D) -modules=java.base,java.security.jgss -verbose=0"
 	touch $@
+.SILENT: $(MOD_JDK_XML_DOM_FZ_FILES)
 $(MOD_JDK_XML_DOM_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE) $(MOD_JAVA_XML)
 	rm -rf $(@D)
 	mkdir -p $(@D)
 	$(FUZION_BIN_BASH) -c "$(BUILD_DIR)/bin/fzjava jdk.xml.dom -to=$(@D) -modules=java.base,java.xml -verbose=0"
 	touch $@
+.SILENT: $(MOD_JDK_ZIPFS_FZ_FILES)
 $(MOD_JDK_ZIPFS_FZ_FILES): $(BUILD_DIR)/bin/fzjava $(MOD_JAVA_BASE)
 	rm -rf $(@D)
 	mkdir -p $(@D)
@@ -945,11 +1029,13 @@ $(MOD_JDK_XML_DOM): $(MOD_JAVA_BASE) $(MOD_JAVA_XML) $(MOD_JDK_XML_DOM_FZ_FILES)
 $(MOD_JDK_ZIPFS): $(MOD_JAVA_BASE) $(MOD_JDK_ZIPFS_FZ_FILES)
 	$(BUILD_DIR)/bin/fz -sourceDirs=$(MOD_JDK_ZIPFS_DIR) -modules=java.base -saveLib=$@
 
+.SILENT: $(BUILD_DIR)/tests
 $(BUILD_DIR)/tests: $(FZ_SRC)/tests
 	mkdir -p $(@D)
 	cp -rf $^ $@
 	chmod +x $@/*.sh
 
+.SILENT: $(BUILD_DIR)/examples
 $(BUILD_DIR)/examples: $(FZ_SRC)/examples
 	mkdir -p $(@D)
 	cp -rf $^ $@


### PR DESCRIPTION
```diff
diff --git a/tmp/before b/tmp/after
index e5274a8f..ee0c5f85 100644
--- a/tmp/before
+++ b/tmp/after
@@ -1,105 +1,26 @@
-mkdir -p build/generated/src/dev/flang/tools
-cat ./src/dev/flang/tools/Version.java.in \
-          | sed "s^@@VERSION@@^0.080dev^g" \
-          | sed "s^@@GIT_HASH@@^`cd .; echo -n \`git rev-parse HEAD\` \`git diff-index --quiet HEAD -- || echo with local changes\``^g" \
-          | sed "s^@@DATE@@^`date +%Y-%m-%d\ %H:%M:%S`^g"  \
-          | sed "s^@@BUILTBY@@^`echo -n sam@; hostname`^g" >build/generated/src/dev/flang/tools/Version.java
-mkdir -p ./build/classes
-javac -encoding UTF8 -source 17 -d ./build/classes ./src/dev/flang/util/ANY.java ./src/dev/flang/util/BiGraph.java ./src/dev/flang/util/Callable.java ./src/dev/flang/util/DataOut.java ./src/dev/flang/util/Errors.java ./src/dev/flang/util/FatalError.java ./src/dev/flang/util/FuzionConstants.java ./src/dev/flang/util/FuzionOptions.java ./src/dev/flang/util/Graph.java ./src/dev/flang/util/HasSourcePosition.java ./src/dev/flang/util/HexDump.java ./src/dev/flang/util/Intervals.java ./src/dev/flang/util/List.java ./src/dev/flang/util/Map2Int.java ./src/dev/flang/util/MapComparable2Int.java ./src/dev/flang/util/MapToN.java ./src/dev/flang/util/package-info.java ./src/dev/flang/util/Pair.java ./src/dev/flang/util/Profiler.java ./src/dev/flang/util/SourceDir.java ./src/dev/flang/util/SourceFile.java ./src/dev/flang/util/SourcePosition.java ./src/dev/flang/util/Terminal.java ./src/dev/flang/util/UnicodeData.java ./src/dev/flang/util/YesNo.java
 Note: Some input files use unchecked or unsafe operations.
 Note: Recompile with -Xlint:unchecked for details.
-touch build/classes/dev/flang/util/__marker_for_make__
-mkdir -p ./build/classes
-javac -encoding UTF8 -source 17 -cp ./build/classes -d ./build/classes ./src/dev/flang/ast/AbstractAssign.java ./src/dev/flang/ast/AbstractBlock.java ./src/dev/flang/ast/AbstractCall.java ./src/dev/flang/ast/AbstractCase.java ./src/dev/flang/ast/AbstractConstant.java ./src/dev/flang/ast/AbstractCurrent.java ./src/dev/flang/ast/AbstractFeature.java ./src/dev/flang/ast/AbstractMatch.java ./src/dev/flang/ast/AbstractType.java ./src/dev/flang/ast/Actual.java ./src/dev/flang/ast/Assign.java ./src/dev/flang/ast/AstErrors.java ./src/dev/flang/ast/Block.java ./src/dev/flang/ast/BoolConst.java ./src/dev/flang/ast/Box.java ./src/dev/flang/ast/Call.java ./src/dev/flang/ast/Case.java ./src/dev/flang/ast/Check.java ./src/dev/flang/ast/Cond.java ./src/dev/flang/ast/Constant.java ./src/dev/flang/ast/Consts.java ./src/dev/flang/ast/Contract.java ./src/dev/flang/ast/Current.java ./src/dev/flang/ast/Destructure.java ./src/dev/flang/ast/DotType.java ./src/dev/flang/ast/Env.java ./src/dev/flang/ast/Expr.java ./src/dev/flang/ast/ExprWithPos.java ./src/dev/flang/ast/Feature.java ./src/dev/flang/ast/FeatureName.java ./src/dev/flang/ast/FeaturesAndOuter.java ./src/dev/flang/ast/FeatureVisitor.java ./src/dev/flang/ast/FormalGenerics.java ./src/dev/flang/ast/Function.java ./src/dev/flang/ast/FunctionReturnType.java ./src/dev/flang/ast/Generic.java ./src/dev/flang/ast/If.java ./src/dev/flang/ast/Impl.java ./src/dev/flang/ast/IncompatibleResultsOnBranches.java ./src/dev/flang/ast/InlineArray.java ./src/dev/flang/ast/Loop.java ./src/dev/flang/ast/Match.java ./src/dev/flang/ast/Nop.java ./src/dev/flang/ast/NoType.java ./src/dev/flang/ast/NumLiteral.java ./src/dev/flang/ast/package-info.java ./src/dev/flang/ast/RefType.java ./src/dev/flang/ast/Resolution.java ./src/dev/flang/ast/ReturnType.java ./src/dev/flang/ast/SrcModule.java ./src/dev/flang/ast/StatementVisitor.java ./src/dev/flang/ast/Stmnt.java ./src/dev/flang/ast/StrConst.java ./src/dev/flang/ast/Tag.java ./src/dev/flang/ast/This.java ./src/dev/flang/ast/Type.java ./src/dev/flang/ast/Types.java ./src/dev/flang/ast/Unbox.java ./src/dev/flang/ast/Universe.java ./src/dev/flang/ast/ValueType.java ./src/dev/flang/ast/Visi.java
 Note: ./src/dev/flang/ast/Call.java uses unchecked or unsafe operations.
 Note: Recompile with -Xlint:unchecked for details.
-touch build/classes/dev/flang/ast/__marker_for_make__
-mkdir -p build
-./bin/ebnf.sh > build/fuzion.ebnf
-mkdir -p ./build/classes
-javac -encoding UTF8 -source 17 -cp ./build/classes -d ./build/classes ./src/dev/flang/parser/FList.java ./src/dev/flang/parser/Lexer.java ./src/dev/flang/parser/Operator.java ./src/dev/flang/parser/OpExpr.java ./src/dev/flang/parser/package-info.java ./src/dev/flang/parser/Parser.java
-touch build/classes/dev/flang/parser/__marker_for_make__
-mkdir -p ./build/classes
-javac -encoding UTF8 -source 17 -cp ./build/classes -d ./build/classes ./src/dev/flang/ir/IR.java
 Note: ./src/dev/flang/ir/IR.java uses unchecked or unsafe operations.
 Note: Recompile with -Xlint:unchecked for details.
-touch build/classes/dev/flang/ir/__marker_for_make__
-mkdir -p ./build/classes
-javac -encoding UTF8 -source 17 -cp ./build/classes -d ./build/classes ./src/dev/flang/mir/MIR.java ./src/dev/flang/mir/MirModule.java
 Note: ./src/dev/flang/mir/MIR.java uses unchecked or unsafe operations.
 Note: Recompile with -Xlint:unchecked for details.
-touch build/classes/dev/flang/mir/__marker_for_make__
-mkdir -p ./build/classes
-javac -encoding UTF8 -source 17 -cp ./build/classes -d ./build/classes ./src/dev/flang/fe/DFA.java ./src/dev/flang/fe/FeErrors.java ./src/dev/flang/fe/FixUps.java ./src/dev/flang/fe/FrontEnd.java ./src/dev/flang/fe/FrontEndOptions.java ./src/dev/flang/fe/GenericType.java ./src/dev/flang/fe/LibraryCall.java ./src/dev/flang/fe/LibraryFeature.java ./src/dev/flang/fe/LibraryModule.java ./src/dev/flang/fe/LibraryOut.java ./src/dev/flang/fe/LibraryType.java ./src/dev/flang/fe/Module.java ./src/dev/flang/fe/ModuleRef.java ./src/dev/flang/fe/NormalType.java ./src/dev/flang/fe/SourceModule.java
-touch build/classes/dev/flang/fe/__marker_for_make__
-mkdir -p ./build/classes
-javac -encoding UTF8 -source 17 -cp ./build/classes -d ./build/classes ./src/dev/flang/air/AirErrors.java ./src/dev/flang/air/AIR.java ./src/dev/flang/air/Clazzes.java ./src/dev/flang/air/Clazz.java
-touch build/classes/dev/flang/air/__marker_for_make__
-mkdir -p ./build/classes
-javac -encoding UTF8 -source 17 -cp ./build/classes -d ./build/classes ./src/dev/flang/me/MiddleEnd.java
-touch build/classes/dev/flang/me/__marker_for_make__
-mkdir -p ./build/classes
-javac -encoding UTF8 -source 17 -cp ./build/classes -d ./build/classes ./src/dev/flang/fuir/FUIR.java
 Note: ./src/dev/flang/fuir/FUIR.java uses unchecked or unsafe operations.
 Note: Recompile with -Xlint:unchecked for details.
-touch build/classes/dev/flang/fuir/__marker_for_make__
-mkdir -p ./build/classes
-javac -encoding UTF8 -source 17 -cp ./build/classes -d ./build/classes ./src/dev/flang/opt/Optimizer.java
-touch build/classes/dev/flang/opt/__marker_for_make__
-mkdir -p ./build/classes
-javac -encoding UTF8 -source 17 -cp ./build/classes -d ./build/classes ./src/dev/flang/fuir/analysis/AbstractInterpreter.java ./src/dev/flang/fuir/analysis/Escape.java ./src/dev/flang/fuir/analysis/TailCall.java
 Note: Some input files use unchecked or unsafe operations.
 Note: Recompile with -Xlint:unchecked for details.
-touch build/classes/dev/flang/fuir/analysis/__marker_for_make__
-mkdir -p ./build/classes
-javac -encoding UTF8 -source 17 -cp ./build/classes -d ./build/classes ./src/dev/flang/fuir/analysis/dfa/Call.java ./src/dev/flang/fuir/analysis/dfa/Context.java ./src/dev/flang/fuir/analysis/dfa/DFA.java ./src/dev/flang/fuir/analysis/dfa/Env.java ./src/dev/flang/fuir/analysis/dfa/Instance.java ./src/dev/flang/fuir/analysis/dfa/NumericValue.java ./src/dev/flang/fuir/analysis/dfa/RefValue.java ./src/dev/flang/fuir/analysis/dfa/Site.java ./src/dev/flang/fuir/analysis/dfa/SysArray.java ./src/dev/flang/fuir/analysis/dfa/TaggedValue.java ./src/dev/flang/fuir/analysis/dfa/Value.java ./src/dev/flang/fuir/analysis/dfa/ValueSet.java
 Note: Some input files use unchecked or unsafe operations.
 Note: Recompile with -Xlint:unchecked for details.
-touch build/classes/dev/flang/fuir/analysis/dfa/__marker_for_make__
-mkdir -p ./build/classes
-javac -encoding UTF8 -source 17 -cp ./build/classes -d ./build/classes ./src/dev/flang/be/c/CConstants.java ./src/dev/flang/be/c/CExpr.java ./src/dev/flang/be/c/CFile.java ./src/dev/flang/be/c/CIdent.java ./src/dev/flang/be/c/C.java ./src/dev/flang/be/c/CLocal.java ./src/dev/flang/be/c/CNames.java ./src/dev/flang/be/c/COptions.java ./src/dev/flang/be/c/CStmnt.java ./src/dev/flang/be/c/CString.java ./src/dev/flang/be/c/CTypes.java ./src/dev/flang/be/c/Intrinsics.java
 Note: ./src/dev/flang/be/c/C.java uses unchecked or unsafe operations.
 Note: Recompile with -Xlint:unchecked for details.
-touch build/classes/dev/flang/be/c/__marker_for_make__
-mkdir -p ./build/classes
-javac -encoding UTF8 -source 17 -cp ./build/classes -d ./build/classes ./src/dev/flang/fuir/cfg/CFG.java
-touch build/classes/dev/flang/fuir/cfg/__marker_for_make__
-mkdir -p ./build/classes
-javac -encoding UTF8 -source 17 -cp ./build/classes -d ./build/classes ./src/dev/flang/be/effects/Effects.java
-touch build/classes/dev/flang/be/effects/__marker_for_make__
-mkdir -p ./build/classes
-javac -encoding UTF8 -source 17 -cp ./build/classes -d ./build/classes ./src/dev/flang/be/interpreter/ArrayData.java ./src/dev/flang/be/interpreter/BackendCallable.java ./src/dev/flang/be/interpreter/boolValue.java ./src/dev/flang/be/interpreter/Callable.java ./src/dev/flang/be/interpreter/ChoiceIdAsRef.java ./src/dev/flang/be/interpreter/DynamicBinding.java ./src/dev/flang/be/interpreter/f32Value.java ./src/dev/flang/be/interpreter/f64Value.java ./src/dev/flang/be/interpreter/FuzionThread.java ./src/dev/flang/be/interpreter/i16Value.java ./src/dev/flang/be/interpreter/i32Value.java ./src/dev/flang/be/interpreter/i64Value.java ./src/dev/flang/be/interpreter/i8Value.java ./src/dev/flang/be/interpreter/Instance.java ./src/dev/flang/be/interpreter/Interpreter.java ./src/dev/flang/be/interpreter/Intrinsics.java ./src/dev/flang/be/interpreter/JavaInterface.java ./src/dev/flang/be/interpreter/JavaRef.java ./src/dev/flang/be/interpreter/Layout.java ./src/dev/flang/be/interpreter/LValue.java ./src/dev/flang/be/interpreter/u16Value.java ./src/dev/flang/be/interpreter/u32Value.java ./src/dev/flang/be/interpreter/u64Value.java ./src/dev/flang/be/interpreter/u8Value.java ./src/dev/flang/be/interpreter/Value.java ./src/dev/flang/be/interpreter/ValueWithClazz.java
-./src/dev/flang/be/interpreter/Instance.java:292: warning: [removal] isAssignableFrom(Clazz) in Clazz has been deprecated and marked for removal
-        if (!expected.isAssignableFrom(clazz()))
-                     ^
-./src/dev/flang/be/interpreter/Interpreter.java:446: warning: [removal] isAssignableFrom(Clazz) in Clazz has been deprecated and marked for removal
-                    matches = caseClazz.isAssignableFrom(subjectClazz);
-                                       ^
+Note: Some input files use or override a deprecated API that is marked for removal.
+Note: Recompile with -Xlint:removal for details.
 Note: ./src/dev/flang/be/interpreter/JavaInterface.java uses unchecked or unsafe operations.
 Note: Recompile with -Xlint:unchecked for details.
-2 warnings
-touch build/classes/dev/flang/be/interpreter/__marker_for_make__
-mkdir -p ./build/classes
-javac -encoding UTF8 -source 17 -cp ./build/classes -d ./build/classes ./src/dev/flang/tools/AceMode.java ./src/dev/flang/tools/CheckIntrinsics.java ./src/dev/flang/tools/FuzionHome.java ./src/dev/flang/tools/Fuzion.java ./src/dev/flang/tools/Latex.java ./src/dev/flang/tools/Pretty.java ./src/dev/flang/tools/Tool.java ./build/generated/src/dev/flang/tools/Version.java
-touch build/classes/dev/flang/tools/__marker_for_make__
-rm -rf build/lib
-mkdir -p build
-cp -rf ./lib build/lib
-mkdir -p build/bin
-cp -rf ./bin/fz build/bin/fz
-chmod +x build/bin/fz
-mkdir -p ./build/classes
-javac -encoding UTF8 -source 17 -cp ./build/classes -d ./build/classes ./src/dev/flang/tools/fzjava/FeatureWriter.java ./src/dev/flang/tools/fzjava/ForClass.java ./src/dev/flang/tools/fzjava/FZJava.java ./src/dev/flang/tools/fzjava/FZJavaOptions.java
 Note: ./src/dev/flang/tools/fzjava/ForClass.java uses unchecked or unsafe operations.
 Note: Recompile with -Xlint:unchecked for details.
-touch build/classes/dev/flang/tools/fzjava/__marker_for_make__
-mkdir -p build/bin
-cp -rf ./bin/fzjava build/bin/fzjava
-chmod +x build/bin/fzjava
-mkdir -p build/modules
-./build/bin/fz -sourceDirs=./build/lib -XloadBaseLib=off -saveLib=build/modules/base.fum
  + build/modules/base.fum
-./build/bin/fz -XXcheckIntrinsics
 
 [1;33mwarning 1[0m[1m: Interpreter backend does not implement intrinsic 'fuzion.sys.env_vars.set0'.[0m
 
@@ -107,13 +28,6 @@ mkdir -p build/modules
 [1;33mwarning 2[0m[1m: Interpreter backend does not implement intrinsic 'fuzion.sys.env_vars.unset0'.[0m
 
 2 warnings.
-mkdir -p build/modules
-./build/bin/fz -sourceDirs=./modules/terminal/src -saveLib=build/modules/terminal.fum
  + build/modules/terminal.fum
-mkdir -p build
-cp -rf tests build/tests
-chmod +x build/tests/*.sh
-mkdir -p build
-cp -rf examples build/examples
 cp README.md build/README.md
 cp release_notes.md build/release_notes.md
```