### PR TITLE
lib/fe: remove TYPE_STATIC

### DIFF
--- a/lib/Type.fz
+++ b/lib/Type.fz
@@ -46,16 +46,6 @@ Type ref is
   redef asString => "Type of '$name'"
 
 
-# Type_STATIC -- direct parent feature of all type features
-#
-# type features 'f.type' are declared implicitly for every feature f.
-# Type features do not contain state, they are unit types.
-#
-# All type features inherit directly from this feature.
-#
-Type_STATIC(STATIC_THIS_TYPE type) is
-
-
 # Types -- features related to Type but not requiring an instance of Type
 #
 Types is

--- a/src/dev/flang/ast/AbstractType.java
+++ b/src/dev/flang/ast/AbstractType.java
@@ -967,8 +967,7 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
 
   /**
    * For a given type t, get the type of t's type feature. E.g., for t==string,
-   * this will return the type of string.type, which is 'string.#type_STATIC
-   * string'
+   * this will return the type of string.type, which is 'string.#type string'
    *
    * @param res Resolution instance used to resolve the type feature that might
    * need to be created.
@@ -1014,12 +1013,12 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
       {
         var tf = tt.featureOfType();
         if (dependsOnGenerics() &&
-            tf.isStaticTypeFeature() &&
+            tf.isTypeFeature() &&
             target instanceof AbstractCall tc && tc.calledFeature().isTypeParameter())
           {
             if (isGenericArgument())
               {
-                if (genericArgument().typeParameter() == tf.typeFeaturesNonStaticParent().arguments().get(0))
+                if (genericArgument().typeParameter() == tf.arguments().get(0))
                   { // a call of the form 'T.f x' where 'f' is declared as 'abc.type.f(arg THIS_TYPE)', so replace 'THIS_TYPE' by 'T'.
                     // NYI: replace THIS_TYPE recursively in frmlT, e.g., in case formT is 'Option THIS_TYPE'.
                     result = new Type(tc.pos(), new Generic(tc.calledFeature()));

--- a/src/dev/flang/ast/Box.java
+++ b/src/dev/flang/ast/Box.java
@@ -81,7 +81,7 @@ public class Box extends Expr
        frmlT.isGenericArgument() || !value.type().isRef() || value.isCallToOuterRef());
 
     this._value = value;
-    var t = value.type();
+    var t = Types.intern(value.type());
     this._type = frmlT.isGenericArgument() ? t : t.asRef();
   }
 

--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -1173,13 +1173,6 @@ public class Call extends AbstractCall
 
     var declF = _calledFeature.outer();
     var heirF = targetTypeOrConstraint(res).featureOfType();
-    if (target() instanceof Call tc              &&
-        tc.calledFeature().isTypeParameter()     &&
-        heirF.isStaticTypeFeature()              &&
-        calledFeature().outer().isTypeFeature()     )
-      {  // divert calls T.f with a type parameter as target to the non-static type if needed.
-        heirF = heirF.typeFeaturesNonStaticParent();
-      }
     if (declF != heirF)
       {
         var a = _calledFeature.handDown(res, new AbstractType[] { frmlT }, heirF);
@@ -1426,17 +1419,14 @@ public class Call extends AbstractCall
         // result type depends on a generic that can be replaced by an actual
         // generic given in the call?
         var gt = _generics.get(0);
-        if (gt.isGenericArgument())
+        if (!gt.isGenericArgument())
           {
-            _type = t.resolve(res, tt.featureOfType());
+            gt = gt.typeType(res);
           }
-        else
+        _type = gt.resolve(res, tt.featureOfType());
+        if (_type == null)
           {
-            _type = gt.featureOfType().typeFeature(res).resultTypeIfPresent(res, _generics);
-            if (_type == null)
-              {
-                throw new Error("NYI (see #283): resolveTypes for .type: resultType not present at "+pos().show());
-              }
+            throw new Error("NYI (see #283): resolveTypes for .type: resultType not present at "+pos().show());
           }
       }
     else

--- a/src/dev/flang/ast/SrcModule.java
+++ b/src/dev/flang/ast/SrcModule.java
@@ -72,8 +72,8 @@ public interface SrcModule
   void checkTypes(Feature f);
   AbstractFeature lookupFeatureForType(SourcePosition pos, String name, AbstractFeature o);
 
-  AbstractFeature addTypeFeature(AbstractFeature outerType,
-                                 Feature         innerType);
+  void addTypeFeature(AbstractFeature outerType,
+                      Feature         innerType);
 
   /*----------------------  methods needed by AIR  ----------------------*/
 

--- a/src/dev/flang/fe/Module.java
+++ b/src/dev/flang/fe/Module.java
@@ -215,8 +215,7 @@ public abstract class Module extends ANY
                 if (CHECKS) check
                   (cf != outer);
 
-                if ((f.modifiers() & Consts.MODIFIER_FIXED) == 0 ||
-                    outer.isStaticTypeFeature())
+                if ((f.modifiers() & Consts.MODIFIER_FIXED) == 0)
                   {
                     var newfn = cf.handDown(null, f, fn, p, outer);
                     addInheritedFeature(set, outer, p, newfn, f);

--- a/src/dev/flang/fe/SourceModule.java
+++ b/src/dev/flang/fe/SourceModule.java
@@ -500,7 +500,7 @@ public class SourceModule extends Module implements SrcModule, MirModule
          var n = q.get(at);
          var o =
            n != FuzionConstants.TYPE_NAME ? lookupFeatureForType(inner.pos(), n, outer)
-                                          : outer.nonStaticTypeFeature(_res);
+                                          : outer.typeFeature(_res);
          if (at < q.size()-2)
            {
              setOuterAndAddInnerForQualifiedRec(inner, at+1, o);
@@ -615,20 +615,15 @@ public class SourceModule extends Module implements SrcModule, MirModule
    *
    * @param outerType the static outer type of universe.
    *
-   * @param typeFeature the new (static or non-static) type feature declared
-   * within nonStaticOuterType.
+   * @param typeFeature the new type feature declared within outerType.
    */
-  public AbstractFeature addTypeFeature(AbstractFeature outerType,
-                                        Feature typeFeature)
+  public void addTypeFeature(AbstractFeature outerType,
+                             Feature typeFeature)
   {
-    var nonStaticOuterType = outerType.isUniverse() ? outerType : outerType.typeFeaturesNonStaticParent();
-    var result = typeFeature;
-    findDeclarations(typeFeature, nonStaticOuterType);
-    addDeclared(false, nonStaticOuterType, typeFeature);
+    findDeclarations(typeFeature, outerType);
     addDeclared(true,  outerType, typeFeature);
     typeFeature.scheduleForResolution(_res);
     resolveDeclarations(typeFeature);
-    return result;
   }
 
 

--- a/src/dev/flang/util/FuzionConstants.java
+++ b/src/dev/flang/util/FuzionConstants.java
@@ -101,12 +101,6 @@ public class FuzionConstants extends ANY
 
 
   /**
-   * Name of static type features.
-   */
-  public static final String TYPE_STATIC_NAME = INTERNAL_NAME_PREFIX + "type_STATIC";
-
-
-  /**
    * Name of type parameter for type features.  This type parameter will be set
    * to the actual static type.
    */


### PR DESCRIPTION
Fix 'fixed' features, the inheritance structure of type features can be simplified since 'fixed' no longer need to be part of the static type feature, there is no need for these any more.

This avoids a lot of special handling for static vs. nonStatic type features.