### PR TITLE
Makefile: actually replace build/tests directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -947,6 +947,7 @@ $(MOD_JDK_ZIPFS): $(MOD_JAVA_BASE) $(MOD_JDK_ZIPFS_FZ_FILES)
 
 $(BUILD_DIR)/tests: $(FZ_SRC)/tests
 	mkdir -p $(@D)
+	rm -rf $@
 	cp -rf $^ $@
 	chmod +x $@/*.sh
 


### PR DESCRIPTION
If `build/tests/` already existed when this target was run, `cp` would create a second folder `build/tests/tests` inside it. Now, the folder is completely removed first, so that any leftover files are removed and all tests get updated.