### PR TITLE
be/int: replace isAssignableFrom with isDirectlyAssignableFrom

### DIFF
--- a/src/dev/flang/air/Clazz.java
+++ b/src/dev/flang/air/Clazz.java
@@ -1181,20 +1181,6 @@ public class Clazz extends ANY implements Comparable<Clazz>
 
 
   /**
-   * Check if a value of clazz other can be assigned to a field of this clazz.
-   *
-   * @other the value to be assigned to a field of type this
-   *
-   * @return true iff other can be assigned to a field of type this.
-   */
-  @Deprecated(forRemoval = true) // NYI only isDirectlyAssignableFrom should be used after AST
-  public boolean isAssignableFrom(Clazz other)
-  {
-    return this._type.isAssignableFrom(other._type);
-  }
-
-
-  /**
    * Check if a value of clazz other can be assigned to a field of this clazz
    * without the need for tagging.
    *

--- a/src/dev/flang/be/interpreter/Instance.java
+++ b/src/dev/flang/be/interpreter/Instance.java
@@ -289,7 +289,7 @@ public class Instance extends ValueWithClazz
   {
     if (expected.isRef())
       {
-        if (!expected.isAssignableFrom(clazz()))
+        if (!expected.isDirectlyAssignableFrom(clazz()))
           {
             throw new Error("Dynamic runtime clazz "+clazz()+" does not match static "+expected);
           }

--- a/src/dev/flang/be/interpreter/Interpreter.java
+++ b/src/dev/flang/be/interpreter/Interpreter.java
@@ -443,7 +443,7 @@ public class Interpreter extends ANY
                 for (int i = 0; !matches && i < nt; i++)
                   {
                     Clazz caseClazz = staticClazz.getRuntimeClazz(c._runtimeClazzId + i);
-                    matches = caseClazz.isAssignableFrom(subjectClazz);
+                    matches = caseClazz.isDirectlyAssignableFrom(subjectClazz);
                   }
               }
             if (matches)


### PR DESCRIPTION
Since isAssignableFrom has been marked as deprecated and these are the only two places where it was used, we also remove the isAssignableFrom method in Clazz.