### PR TITLE
lib/searchablelist: add a variant of replace with a limit

### DIFF
--- a/lib/searchableSequence.fz
+++ b/lib/searchableSequence.fz
@@ -55,10 +55,16 @@ is
     (searchablelist asList).find l.asList
 
 
-  # replace all occurances of f by r
+  # replace all occurrences of f by r
   #
   replace (f, r Sequence A) =>
     (searchablelist asList).replace f.asList r.asList
+
+
+  # replace the first n occurrences of f by r
+  #
+  replace (f, r Sequence A, n u64) =>
+    (searchablelist asList).replace f.asList r.asList n
 
 
   # get the number of matches of l

--- a/lib/searchableSequence.fz
+++ b/lib/searchableSequence.fz
@@ -55,16 +55,16 @@ is
     (searchablelist asList).find l.asList
 
 
-  # replace all occurrences of f by r
+  # replace all occurrences of old by new
   #
-  replace (f, r Sequence A) =>
-    (searchablelist asList).replace f.asList r.asList
+  replace (old, new Sequence A) =>
+    (searchablelist asList).replace old.asList new.asList
 
 
-  # replace the first n occurrences of f by r
+  # replace the first n occurrences of old by new
   #
-  replace (f, r Sequence A, n u64) =>
-    (searchablelist asList).replace f.asList r.asList n
+  replace (old, new Sequence A, n u64) =>
+    (searchablelist asList).replace old.asList new.asList n
 
 
   # get the number of matches of l

--- a/lib/searchablelist.fz
+++ b/lib/searchablelist.fz
@@ -72,21 +72,31 @@ is
         c1 Cons => ((searchablelist c1.tail).find l) >>= n -> n + 1
 
 
-  # replace all occurances of f by r
+  # replace all occurrences of f by r
   #
-  replace (f, r list A) =>
+  replace (f, r list A) => replace f r nil from nil
 
-    # tail recursive helper
-    #
-    repl (h,       # the head part of from with f already replaced by r
-          t list A # the tail that still needs to be searched for f
-         ) list A
-    is
-      match (searchablelist t).find f
-        nil   => h ++ t
-        n i32 => repl h++(t.take n)++r (t.drop n+f.count)
 
-    repl nil from
+  # replace the first n occurrences of f by r
+  #
+  replace (f, r list A, n u64) => replace f r nil from n
+
+
+  # tail recursive helper for the replace features
+  #
+  private replace (f, r,
+                   h,        # the head part of from with f already replaced by r
+                   t list A, # the tail that still needs to be searched for f
+                   limit option u64
+                  ) list A
+  is
+    match (searchablelist t).find f
+      nil   => h ++ t
+      n i32 =>
+        if (limit.map (v -> v ≟ (u64 0))).get false
+          h ++ t
+        else
+          replace f r h++(t.take n)++r (t.drop n+f.count) (limit >>= (l -> l - 1))
 
 
   # get the number of matches of l

--- a/lib/searchablelist.fz
+++ b/lib/searchablelist.fz
@@ -72,31 +72,35 @@ is
         c1 Cons => ((searchablelist c1.tail).find l) >>= n -> n + 1
 
 
-  # replace all occurrences of f by r
+  # replace all occurrences of old by new
   #
-  replace (f, r list A) => replace f r nil from nil
+  replace (old, new list A) => replace old new nil from nil
 
 
-  # replace the first n occurrences of f by r
+  # replace the first n occurrences of old by new
   #
-  replace (f, r list A, n u64) => replace f r nil from n
+  replace (old, new list A, n u64) => replace old new nil from n
 
 
   # tail recursive helper for the replace features
   #
-  private replace (f, r,
-                   h,        # the head part of from with f already replaced by r
-                   t list A, # the tail that still needs to be searched for f
-                   limit option u64
-                  ) list A
+  private replace (old, new,
+                   already_replaced,        # the head part with old already replaced by new
+                   to_be_replaced list A,   # the tail that still needs to be searched for old
+                   limit option u64) list A
   is
-    match (searchablelist t).find f
-      nil   => h ++ t
+    match (searchablelist to_be_replaced).find old
+      nil   => already_replaced ++ to_be_replaced
       n i32 =>
+        # NYI: #637: perhaps make it possible to do
+        #     if limit ≟ option 0
+        # here.
         if (limit.map (v -> v ≟ (u64 0))).get false
-          h ++ t
+          already_replaced ++ to_be_replaced
         else
-          replace f r h++(t.take n)++r (t.drop n+f.count) (limit >>= (l -> l - 1))
+          a := already_replaced ++ (to_be_replaced.take n) ++ new
+          b := to_be_replaced.drop (n + old.count)
+          replace old new a b (limit >>= (l -> l - 1))
 
 
   # get the number of matches of l

--- a/lib/string.fz
+++ b/lib/string.fz
@@ -464,9 +464,13 @@ string ref : has_equality, hasHash string, ordered string, strings is
         s.find_last substring (skip + (found.get 0))
 
 
-  # replace all occurances of f within l by r
+  # replace all occurrences of f by r
   #
   replace (f, r string) => strings.fromBytes ((searchableSequence utf8).replace f.utf8 r.utf8)
+
+
+  # replace the first n occurrences of f by r
+  replace(f, r string, n u64) => strings.fromBytes ((searchableSequence utf8).replace f.utf8 r.utf8 n)
 
 
   # does this string contain the given 'substring'
@@ -474,7 +478,7 @@ string ref : has_equality, hasHash string, ordered string, strings is
   contains (substring string) => find(substring).exists
 
 
-  # count number of occurances of given 'substring' in this string
+  # count number of occurrences of given 'substring' in this string
   #
   count (substring string) =>
     (searchableSequence utf8).countMatches substring.utf8

--- a/lib/string.fz
+++ b/lib/string.fz
@@ -464,13 +464,13 @@ string ref : has_equality, hasHash string, ordered string, strings is
         s.find_last substring (skip + (found.get 0))
 
 
-  # replace all occurrences of f by r
+  # replace all occurrences of old by new
   #
-  replace (f, r string) => strings.fromBytes ((searchableSequence utf8).replace f.utf8 r.utf8)
+  replace (old, new string) => strings.fromBytes ((searchableSequence utf8).replace old.utf8 new.utf8)
 
 
-  # replace the first n occurrences of f by r
-  replace(f, r string, n u64) => strings.fromBytes ((searchableSequence utf8).replace f.utf8 r.utf8 n)
+  # replace the first n occurrences of old by new
+  replace(old, new string, n u64) => strings.fromBytes ((searchableSequence utf8).replace old.utf8 new.utf8 n)
 
 
   # does this string contain the given 'substring'


### PR DESCRIPTION
Given a limit, replace will only replace the first n occurrences of the sub-list to be replaced. Also, we add the same variants to the replace features of searchableSequence and string.