### PR TITLE
fe: LibraryModule fix NP-Exception, in case of missing fum-file

### DIFF
--- a/src/dev/flang/fe/LibraryModule.java
+++ b/src/dev/flang/fe/LibraryModule.java
@@ -32,18 +32,13 @@ import java.nio.ByteBuffer;
 
 import java.util.ArrayList;
 import java.util.Map;
-import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
-import java.util.TreeSet;
 
 import dev.flang.ast.AbstractFeature;
 import dev.flang.ast.AbstractType;
-import dev.flang.ast.Env;
 import dev.flang.ast.Expr;
-import dev.flang.ast.Feature;
 import dev.flang.ast.FeatureName;
-import dev.flang.ast.FormalGenerics;
 import dev.flang.ast.Generic;
 import dev.flang.ast.Type;
 import dev.flang.ast.Types;
@@ -55,7 +50,6 @@ import dev.flang.mir.MIR;
 import dev.flang.util.FuzionConstants;
 import dev.flang.util.HexDump;
 import dev.flang.util.List;
-import dev.flang.util.SourceDir;
 import dev.flang.util.SourceFile;
 import dev.flang.util.SourcePosition;
 
@@ -300,9 +294,9 @@ public class LibraryModule extends Module
    *
    * @param offset the offset in data()
    *
-   * @return the LibraryFeature declared at offset in this module.
+   * @return the feature declared at offset in this module.
    */
-  LibraryFeature libraryFeature(int offset)
+  AbstractFeature libraryFeature(int offset)
   {
     if (offset >= 0 && offset <= _data.limit())
       {
@@ -320,7 +314,9 @@ public class LibraryModule extends Module
         if (CHECKS) check
           (mr != null);
 
-        return mr._module.libraryFeature(offset - mr._offset);
+        return mr._module != null
+                ? mr._module.libraryFeature(offset - mr._offset)
+                : Types.f_ERROR;
       }
   }
 

--- a/src/dev/flang/fe/ModuleRef.java
+++ b/src/dev/flang/fe/ModuleRef.java
@@ -88,11 +88,13 @@ public class ModuleRef extends ANY
 
 
   /**
-   * Size of the data wiritten to this madule's .tum riles.
+   * Size of the data written to this module's .fum files.
    */
   int size()
   {
-    return _module._data.limit();
+    return _module != null
+      ? _module._data.limit()
+      : 0;
   }
 
 


### PR DESCRIPTION
Stacktrace:
```
dev.flang.fe.LibraryModule.libraryFeature(LibraryModule.java:323)
dev.flang.fe.LibraryModule.type(LibraryModule.java:447)
dev.flang.fe.LibraryFeature.resultType(LibraryFeature.java:464)
dev.flang.shared.FeatureTool.IsInternal(FeatureTool.java:236)
dev.flang.shared.CallTool.lambda$static$0(CallTool.java:54)
```