### PR TITLE
ast: enhance precondition in typeFeature to exclude universe

### DIFF
--- a/src/dev/flang/ast/AbstractFeature.java
+++ b/src/dev/flang/ast/AbstractFeature.java
@@ -520,7 +520,8 @@ public abstract class AbstractFeature extends ANY implements Comparable<Abstract
   {
     if (PRECONDITIONS) require
       (state().atLeast(Feature.State.FINDING_DECLARATIONS),
-       res != null);
+       res != null,
+       !isUniverse());
 
     if (_typeFeature == null)
       {
@@ -569,7 +570,9 @@ public abstract class AbstractFeature extends ANY implements Comparable<Abstract
    */
   private AbstractFeature existingOrNewTypeFeature(Resolution res, String name, List<AbstractCall> inh)
   {
-    var outerType = outer() == null || outer().isUniverse() ? universe() : outer().typeFeature(res);
+    if (PRECONDITIONS) require
+      (!isUniverse());
+    var outerType = outer().isUniverse() ? universe() : outer().typeFeature(res);
     var result = res._module.declaredOrInheritedFeatures(outerType).get(FeatureName.get(name, 0));
     if (result == null)
       {


### PR DESCRIPTION
I was investigating #824 a NP-Exception because outer() is null. The relevant code has meanwhile already been changed but
 I stumbled upon `outer() == null || outer().isUniverse()` in `existingOrNewTypeFeature()`. The `outer() == null` seems wrong or unnecessary since further down `outer().isUniverse()` is used without any null check.
