### PR TITLE
air: rename 'generics' as 'actualTypeParameters()'

### DIFF
--- a/src/dev/flang/air/Clazzes.java
+++ b/src/dev/flang/air/Clazzes.java
@@ -860,7 +860,7 @@ public class Clazzes extends ANY
     if(cf.isChoice())
     {
       outerClazz
-        .actualGenerics(c.generics())
+        .actualGenerics(c.actualTypeParameters())
         .stream()
         .forEach(ag ->
           {


### PR DESCRIPTION
This change was the result of a merge conflict.