### PR TITLE
air: Add caching for type clazz

### DIFF
--- a/src/dev/flang/air/Clazz.java
+++ b/src/dev/flang/air/Clazz.java
@@ -1942,10 +1942,20 @@ public class Clazz extends ANY implements Comparable<Clazz>
    */
   Clazz typeClazz()
   {
-    return feature().isUniverse() ? this
-                                  : Clazzes.create(_type.typeType(),
-                                                   _outer.typeClazz());
+    if (_typeClazz == null)
+      {
+        _typeClazz = feature().isUniverse() ? this
+                                            : Clazzes.create(_type.typeType(),
+                                                             _outer.typeClazz());
+      }
+    return _typeClazz;
   }
+
+
+  /**
+   * cached result of typeClazz()
+   */
+  private Clazz _typeClazz = null;
 
 
   /**


### PR DESCRIPTION
This is not only about performance, but it the following patches it will be essential to use the already created type clazzes when they are accessed later since creation of clazzes during later phases is not allowed.