### PR TITLE
fuir: Check that Clazzes.error.get() is not part for the clazzes in FUIR

### DIFF
--- a/src/dev/flang/fuir/FUIR.java
+++ b/src/dev/flang/fuir/FUIR.java
@@ -266,7 +266,18 @@ public class FUIR extends IR
             if (CHECKS) check
               (Errors.count() > 0 || cl._type != Types.t_ERROR);
 
-            if (cl._type != Types.t_ADDRESS)     // NYI: would be better to not create this dummy clazz in the first place
+            if (cl._type == Types.t_ERROR)
+              {
+                if (CHECKS) check
+                  (Errors.count() > 0);
+
+                if (Errors.count() == 0)
+                  {
+                    Errors.error("Found error clazz in set of clazzes in the IR even though no earlier errors " +
+                                 "were reported.  This can only be the result of a severe bug.");
+                  }
+              }
+            else if (cl._type != Types.t_ADDRESS)     // NYI: would be better to not create this dummy clazz in the first place
               {
                 add(cl);
               }


### PR DESCRIPTION
This may only occur as a consequence of earlier errors and a bug that would result in a pre- or postcondition failure.

However, when pre/postconditios are disabled, generating C code for the error clazz is always confusing, so we better do not try to work with it at all.