### PR TITLE
lib/fe/air/tests: 'a.this.type' to get actual type of outer feature a

### DIFF
--- a/lib/Type.fz
+++ b/lib/Type.fz
@@ -53,7 +53,25 @@ Types is
   # Get the Type instance corresponding to a given type
   #
   # The result of 'Types.get x' is the same as 'x.type'.
+  #
   # Internally, Fuzion's front end implements 'x.type' using
   # 'Types.get x'.
   #
   get(T type) => T
+
+
+  # Get the Type instance corresponding to a given outer type.
+  #
+  # This is used for expressions like 'numeric.this.type' where the actual type
+  # depends on what specialized child for numeric we are currently in.
+  #
+  # Internally, Fuzion's front end implements 'x.this.type' within feature
+  # 'x.y.z' using 'Types.getOuterType x x.y.z'.
+  #
+  # This feature is treated specially the Fuzion IR which replaces a call by
+  # a no-op and specializing the subsequent code for the actual outer clazz.
+  #
+  # The parameters O and I could be replaced by an integer indicating the
+  # number of levels to go
+  #
+  private getOuterType(O type) => O

--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -1352,7 +1352,8 @@ public class Call extends AbstractCall
           }
         _type = tptype;
       }
-    else if (_calledFeature == Types.resolved.f_Types_get)
+    else if (_calledFeature == Types.resolved.f_Types_get          ||
+             _calledFeature == Types.resolved.f_Types_getOuterType    )
       { // NYI (see #282): special handling could maybe be avoided? Maybe make
         // this special handling the normal handlng for all features whose
         // result type depends on a generic that can be replaced by an actual

--- a/src/dev/flang/ast/DotType.java
+++ b/src/dev/flang/ast/DotType.java
@@ -110,10 +110,12 @@ public class DotType extends Expr
    */
   public Call resolveTypes(Resolution res, AbstractFeature outer)
   {
-    AbstractType t = _lhs;
-    var tc = new Call(pos(), new Universe(), "Types");
+    var tc = new Call(_pos, new Universe(), "Types");
     tc.resolveTypes(res, outer);
-    return new Call(_pos, tc, "get", new List<>(new Actual(_lhs))).resolveTypes(res, outer);
+    return new Call(_pos,
+                    tc,
+                    _lhs.isThisType() ? "getOuterType" : "get",
+                    new List<>(new Actual(_lhs))).resolveTypes(res, outer);
   }
 
 

--- a/src/dev/flang/ast/Types.java
+++ b/src/dev/flang/ast/Types.java
@@ -166,6 +166,7 @@ public class Types extends ANY
     public final AbstractFeature f_Type;
     public final AbstractFeature f_Types;
     public final AbstractFeature f_Types_get;
+    public final AbstractFeature f_Types_getOuterType;
     public static interface CreateType
     {
       AbstractType type(String name, boolean isRef);
@@ -224,6 +225,7 @@ public class Types extends ANY
       f_Type                       = universe.get(mod, "Type");
       f_Types                      = universe.get(mod, "Types");
       f_Types_get                  = f_Types.get(mod, "get");
+      f_Types_getOuterType         = f_Types.get(mod, "getOuterType");
       resolved = this;
       t_ADDRESS  .resolveArtificialType(universe.get(mod, "Object"));
       t_UNDEFINED.resolveArtificialType(universe);

--- a/src/dev/flang/fuir/FUIR.java
+++ b/src/dev/flang/fuir/FUIR.java
@@ -1037,7 +1037,7 @@ hw25 is
           {
           case Abstract, Choice -> false;
           case Intrinsic, Routine, Field ->
-            (cc.isInstantiated() || cc.feature().isOuterRef())
+            (cc.isInstantiated() || cc.feature().isOuterRef() || cc.feature().isTypeFeature())
             && cc != Clazzes.conststring.getIfCreated()
             && !cc.isAbsurd()
             // NYI: this should not depend on string comparison!

--- a/src/dev/flang/me/MiddleEnd.java
+++ b/src/dev/flang/me/MiddleEnd.java
@@ -252,6 +252,13 @@ public class MiddleEnd extends ANY
           {
             markUsed(rf, usedAt);
           }
+        if (f.hasTypeFeature())
+          { // NYI: This might mark too many type features. It shold be
+            // sufficient to mark all type features of types passed as type
+            // parameters and of all features that whose ancestors use this.type
+            // (i.e., Types.getOuterType) to access the current type instance.
+            markUsed(f.typeFeature(), false, usedAt);
+          }
       }
   }
 

--- a/tests/covariance/test_covariance.fz
+++ b/tests/covariance/test_covariance.fz
@@ -35,13 +35,6 @@ test_covariance is
 
     # special values
     #
-    # NYI: remove these, should be type.zero/type.one
-    #
-    z num.this.type is abstract
-    o num.this.type is abstract
-
-    # special values
-    #
     type.zero THIS_TYPE is abstract  # NYI: THIS_TYPE -> num.this.type
     type.one  THIS_TYPE is abstract  # NYI: THIS_TYPE -> num.this.type
 
@@ -55,18 +48,21 @@ test_covariance is
     to_u32_loop =>
       555555
 /* NYI: crashes:
-      if num.type.zero.lessThan num.this
-        (minus num.type.one).to_u32_loop + 1
+   to_u32_loop =>
+      for
+        x := num.this, x.minus num.this.type.one
+        u := u32 0, u+1
+      while num.this.type.zero.lessThan num.this
       else
-        0
-
+        u
 */
 
     # convert this to corresponding values as an 'u32'
     #
     to_u32 u32 is
-      if z.lessThan num.this
-        (minus o).to_u32 + 1
+      t := num.this.type
+      if t.zero.lessThan num.this
+        (minus t.one).to_u32 + 1
       else
         0
 
@@ -105,7 +101,7 @@ test_covariance is
     fixed minus(other intM5) => intM5 (v - other.v)%5
     redef valueString => "$v mod 5"
 
-run =>
+run_test_covariance =>
 
   test(N test_covariance.num.type, x, y N) =>
     say x
@@ -153,4 +149,80 @@ run =>
   say z
   test x y
 
-run
+
+# This test creates nested features with accesses to the outer features' this.type
+# values.  Then, it creates new features by inheriting from the outer features and
+# redefining type features.
+#
+# It will then be tested that the corresponding type features respect the nesting
+# and inheritance relation.
+#
+test_this_type =>
+
+  a is
+    type.s => "a"
+    redef asString => "{a.this.type.s}"
+    b is
+      type.s => "b"
+      redef asString => "{a.this.type.s}{b.this.type.s}"
+      c is
+        type.s => "c"
+        d is
+          type.s => "d"
+          redef asString => "{a.this.type.s}{b.this.type.s}{c.this.type.s}{d.this.type.s}"
+
+  k : a is
+    redef type.s => "k"
+
+  l : a.b is
+    redef type.s => "l"
+
+  p : a is
+    redef type.s => "p"
+  q : a is
+    redef type.s => "q"
+    r : b is
+      redef type.s => "r"
+  s : a is
+    redef type.s => "s"
+    t : b is
+      redef type.s => "t"
+      u : c is
+        redef type.s => "u"
+  v : a is
+    redef type.s => "v"
+    w : b is
+      redef type.s => "w"
+      x : c is
+        redef type.s => "x"
+        y : d is
+          redef type.s => "y"
+
+  z : a.b.c.d is
+    redef type.s => "z"
+
+  Z : v.w.x.y is
+    redef type.s => "Z"
+
+  chck $a       "a"
+  chck $k       "k"
+  chck $a.b     "ab"
+  chck $l       "al"
+  chck $a.b.c.d "abcd"
+  chck $p.b.c.d "pbcd"
+  chck $q.r.c.d "qrcd"
+  chck $s.b.c.d "sbcd"
+  chck $s.t.c.d "stcd"
+  chck $s.t.u.d "stud"
+  chck $v.b.c.d "vbcd"
+  chck $v.w.c.d "vwcd"
+  chck $v.w.x.d "vwxd"
+  chck $v.w.x.y "vwxy"
+  chck $z       "abcz"
+  chck $Z       "vwxZ"
+
+  chck(s, t string) =>
+    say (if s = t then "PASS: $s = $t" else "*** FAIL ***: $s /= $t")
+
+run_test_covariance
+test_this_type

--- a/tests/covariance/test_covariance.fz.expected_out
+++ b/tests/covariance/test_covariance.fz.expected_out
@@ -18,3 +18,19 @@ num.this.type 4 555555 '4 mod 5'
 num.this.type 3 555555 '3 mod 5'
 num.this.type 0 555555 '0 mod 5'
 num.this.type 1 555555 '1 mod 5'
+PASS: a = a
+PASS: k = k
+PASS: ab = ab
+PASS: al = al
+PASS: abcd = abcd
+PASS: pbcd = pbcd
+PASS: qrcd = qrcd
+PASS: sbcd = sbcd
+PASS: stcd = stcd
+PASS: stud = stud
+PASS: vbcd = vbcd
+PASS: vwcd = vwcd
+PASS: vwxd = vwxd
+PASS: vwxy = vwxy
+PASS: abcz = abcz
+PASS: vwxZ = vwxZ


### PR DESCRIPTION
This enables accessing the actual type of an outer 'this' instance and allows calling features redefined for a specific type.

This is expected to make the generic parameter in features like 'numeric' obsolete, this parameter can be replaced by 'numeric.this.type'.

Extended tests/covariance with test cases that check different levels of outer this.types being accessed and redefined.