### PR TITLE
lib/fe/air: repalces Types.getOuterType by Types.get

### DIFF
--- a/lib/Type.fz
+++ b/lib/Type.fz
@@ -58,20 +58,3 @@ Types is
   # 'Types.get x'.
   #
   get(T type) => T
-
-
-  # Get the Type instance corresponding to a given outer type.
-  #
-  # This is used for expressions like 'numeric.this.type' where the actual type
-  # depends on what specialized child for numeric we are currently in.
-  #
-  # Internally, Fuzion's front end implements 'x.this.type' within feature
-  # 'x.y.z' using 'Types.getOuterType x x.y.z'.
-  #
-  # This feature is treated specially the Fuzion IR which replaces a call by
-  # a no-op and specializing the subsequent code for the actual outer clazz.
-  #
-  # The parameters O and I could be replaced by an integer indicating the
-  # number of levels to go
-  #
-  private getOuterType(O type) => O

--- a/src/dev/flang/air/Clazz.java
+++ b/src/dev/flang/air/Clazz.java
@@ -1997,16 +1997,13 @@ public class Clazz extends ANY implements Comparable<Clazz>
       {
         return typeParameterActualType().typeClazz();
       }
-    else if (f  == Types.resolved.f_Types_get                                   ||
-             of == Types.resolved.f_Types_get          && f == of.resultField() ||
-             f  == Types.resolved.f_Types_getOuterType                          ||
-             of == Types.resolved.f_Types_getOuterType && f == of.resultField()    )
+    else if (f  == Types.resolved.f_Types_get                          ||
+             of == Types.resolved.f_Types_get && f == of.resultField()   )
       // NYI (see #282): Would be nice if this would not need special handlng but would
       // work in general for any feature with type parameters that returns one
       // of this type parameters as its result using '=>'.
       {
-        var ag = ((f == Types.resolved.f_Types_get          ||
-                   f == Types.resolved.f_Types_getOuterType    ) ? this : _outer).actualGenerics();
+        var ag = (f == Types.resolved.f_Types_get ? this : _outer).actualGenerics();
         return ag[0].typeClazz();
       }
     else
@@ -2181,13 +2178,13 @@ public class Clazz extends ANY implements Comparable<Clazz>
             var gi = gs.get(i);
             if (gi.isThisType())
               {
-                // Only calls to Types.getOuterType may have generic parameters
-                // gi with gi.isThisType().  Calls to Types.getOuterType will
-                // essentially become NOPs anyway. Here we replace the
-                // this.types by their underlying type to avoid problems
-                // creating clazzes form this.types.
+                // Only calls to Types.get may have generic parameters gi with
+                // gi.isThisType().  Calls to Types.get will essentially become
+                // NOPs anyway. Here we replace the this.types by their
+                // underlying type to avoid problems creating clazzes form
+                // this.types.
                 if (CHECKS) check
-                  (feature() == Types.resolved.f_Types_getOuterType);
+                  (feature() == Types.resolved.f_Types_get);
 
                 gi = Types.intern(new Type((Type) gi, Type.RefOrVal.LikeUnderlyingFeature));
               }

--- a/src/dev/flang/air/Clazzes.java
+++ b/src/dev/flang/air/Clazzes.java
@@ -1065,7 +1065,8 @@ public class Clazzes extends ANY
                                       outerClazz.actualGenerics(c.actualTypeParameters()),
                                       c,
                                       false);
-            if (c.calledFeature() == Types.resolved.f_Types_getOuterType)
+            if (c.calledFeature() == Types.resolved.f_Types_get &&
+                c.actualTypeParameters().get(0).isThisType())
               {
                 /* starting with outerClazz.feature(), follow outer references
                  * until we find the call's type parameter. The type of that outer ref's result

--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -1352,8 +1352,7 @@ public class Call extends AbstractCall
           }
         _type = tptype;
       }
-    else if (_calledFeature == Types.resolved.f_Types_get          ||
-             _calledFeature == Types.resolved.f_Types_getOuterType    )
+    else if (_calledFeature == Types.resolved.f_Types_get)
       { // NYI (see #282): special handling could maybe be avoided? Maybe make
         // this special handling the normal handlng for all features whose
         // result type depends on a generic that can be replaced by an actual

--- a/src/dev/flang/ast/DotType.java
+++ b/src/dev/flang/ast/DotType.java
@@ -114,7 +114,7 @@ public class DotType extends Expr
     tc.resolveTypes(res, outer);
     return new Call(_pos,
                     tc,
-                    _lhs.isThisType() ? "getOuterType" : "get",
+                    "get",
                     new List<>(new Actual(_lhs))).resolveTypes(res, outer);
   }
 

--- a/src/dev/flang/ast/Types.java
+++ b/src/dev/flang/ast/Types.java
@@ -166,7 +166,6 @@ public class Types extends ANY
     public final AbstractFeature f_Type;
     public final AbstractFeature f_Types;
     public final AbstractFeature f_Types_get;
-    public final AbstractFeature f_Types_getOuterType;
     public static interface CreateType
     {
       AbstractType type(String name, boolean isRef);
@@ -225,7 +224,6 @@ public class Types extends ANY
       f_Type                       = universe.get(mod, "Type");
       f_Types                      = universe.get(mod, "Types");
       f_Types_get                  = f_Types.get(mod, "get");
-      f_Types_getOuterType         = f_Types.get(mod, "getOuterType");
       resolved = this;
       t_ADDRESS  .resolveArtificialType(universe.get(mod, "Object"));
       t_UNDEFINED.resolveArtificialType(universe);

--- a/src/dev/flang/me/MiddleEnd.java
+++ b/src/dev/flang/me/MiddleEnd.java
@@ -256,7 +256,7 @@ public class MiddleEnd extends ANY
           { // NYI: This might mark too many type features. It shold be
             // sufficient to mark all type features of types passed as type
             // parameters and of all features that whose ancestors use this.type
-            // (i.e., Types.getOuterType) to access the current type instance.
+            // (i.e., Types.get) to access the current type instance.
             markUsed(f.typeFeature(), false, usedAt);
           }
       }


### PR DESCRIPTION
These two features are redundant, the only difference is that getOuterType was always called with a this.type. We can hence simplify the code and use only Types.get.