### PR TITLE
util: Add `#` prefix before `THIS_TYPE` type parameter of type features

### DIFF
--- a/src/dev/flang/util/FuzionConstants.java
+++ b/src/dev/flang/util/FuzionConstants.java
@@ -102,9 +102,10 @@ public class FuzionConstants extends ANY
 
   /**
    * Name of type parameter for type features.  This type parameter will be set
-   * to the actual static type.
+   * to the actual corresponding type, i.e., including the type's type
+   * parameters.
    */
-  public static final String TYPE_FEATURE_THIS_TYPE = "THIS_TYPE";
+  public static final String TYPE_FEATURE_THIS_TYPE = INTERNAL_NAME_PREFIX + "THIS_TYPE";
 
 
   /**

--- a/src/dev/flang/util/FuzionConstants.java
+++ b/src/dev/flang/util/FuzionConstants.java
@@ -104,8 +104,12 @@ public class FuzionConstants extends ANY
    * Name of type parameter for type features.  This type parameter will be set
    * to the actual corresponding type, i.e., including the type's type
    * parameters.
+   *
+   * NOTE: Here, the INTERNAL_NAME_PREFIX is not used as a prefix since feature
+   * names with this prefix will be removed from .fum files which results in
+   * this not being found in redefinitions.
    */
-  public static final String TYPE_FEATURE_THIS_TYPE = INTERNAL_NAME_PREFIX + "THIS_TYPE";
+  public static final String TYPE_FEATURE_THIS_TYPE = "THIS" + INTERNAL_NAME_PREFIX + "TYPE";
 
 
   /**


### PR DESCRIPTION
`THIS_TYPE` has been replaced by `abc.this.type` and is no longer used in any example or library code.  So it can be renamed to an internal name to avoid name conflicts.