### PR TITLE
parser/lib/tests: New syntax for type parameter constraints: `T type : C`

### DIFF
--- a/lib/Sequence.fz
+++ b/lib/Sequence.fz
@@ -320,7 +320,7 @@ Sequence(T type) ref is
 
 
   # sort this Sequence using total order defined for 'f a[i]'
-  sortBy(O (ordered O).type, f T->O) => sort (a, b -> f a <= f b)
+  sortBy(O type : ordered O, f T->O) => sort (a, b -> f a <= f b)
 
 
   # create a new list from the result of applying 'f' to the
@@ -388,7 +388,7 @@ Sequence(T type) ref is
   # adds an index to every element
   # in the sequence starting at start_idx
   #
-  indexed(I (hasInterval I).type, start_idx I) list (tuple I T) is
+  indexed(I type : hasInterval I, start_idx I) list (tuple I T) is
     zip (start_idx..) (a,b -> (b, a))
 
 
@@ -397,7 +397,7 @@ Sequence(T type) ref is
   #
   # f determines the key of an element
   #
-  group_by(K (hasHash K).type, f T -> K) map K (Sequence T) is
+  group_by(K type : hasHash K, f T -> K) map K (Sequence T) is
     # NYI It should be possible to choose the map implementation that is used.
     res := CTrie K (Sequence T)
     for_each (x ->
@@ -443,9 +443,9 @@ Sequences is
   # of the list, 1 if it comes directly after head, etc. nil if x is not
   # in the list.
   #
-  indexIn(A (hasEquals A).type, l Sequence A, x A) => (searchableSequence A l).indexOf x
+  indexIn(A type : hasEquals A, l Sequence A, x A) => (searchableSequence A l).indexOf x
 
 
   # get the index of x within this Sequence or nil if it does not exist
   #
-  find(A (hasEquals A).type, l Sequence A, x Sequence A) => (searchableSequence A l).find x
+  find(A type : hasEquals A, l Sequence A, x Sequence A) => (searchableSequence A l).find x

--- a/lib/Set.fz
+++ b/lib/Set.fz
@@ -25,7 +25,7 @@
 
 # Set -- an abstract set of values V
 #
-Set(E (hasEquals E).type) ref : Sequence E is
+Set(E type : hasEquals E) ref : Sequence E is
 
   # number of entries in this set.  May be undefined, i.e., a range of
   # floating point numbers or an infinite set.

--- a/lib/comparable_sequence.fz
+++ b/lib/comparable_sequence.fz
@@ -25,7 +25,7 @@
 
 # comparable_sequence -- a Sequence that inherits from hasEquals
 #
-comparable_sequence(A (hasEquals A).type, from Sequence A) : Sequence A, hasEquals (comparable_sequence A)
+comparable_sequence(A type : hasEquals A, from Sequence A) : Sequence A, hasEquals (comparable_sequence A)
 is
 
   # create a list from this Sequence.
@@ -43,7 +43,7 @@ is
       (0..(from.count - 1)) ∀ (i -> fa[i] = oa[i])
 
   # NYI: #637:
-  # comparable_sequence(A (hasEquals A).type, a, b comparable_sequence A) bool is
+  # comparable_sequence(A type : hasEquals A, a, b comparable_sequence A) bool is
   #   aa := a.asArray
   #   ba := b.asArray
   #   if aa.count ≟ ba.count

--- a/lib/complex.fz
+++ b/lib/complex.fz
@@ -28,7 +28,7 @@
 # complex provides complex numbers based on a numeric type (e.g. f64, i32).
 # A complex number consists of a real and an imaginary part.
 #
-complex (C (numeric C).type,
+complex (C type : numeric C,
          real,    # real part
          imag C   # imaginary part
          ) : numeric (complex C), complexes C
@@ -62,7 +62,7 @@ is
   redef infix != (b complex C) => a.real != b.real || a.imag != b.imag
 
   # NYI: #637:
-  # fixed type.equality(C (numeric C).type, a, b complex C)
+  # fixed type.equality(C type : numeric C, a, b complex C)
   #   a.real = b.real && a.imag = b.imag
 
   # NYI: total order ignoring imag
@@ -98,7 +98,7 @@ is
 # to https://www.wordhippo.com/what-is/the-plural-of/complex.html, so we
 # use complexes.
 #
-complexes(E (numeric E).type) : numerics (complex E) is
+complexes(E type : numeric E) : numerics (complex E) is
 
   redef name => "complex"
 
@@ -123,4 +123,4 @@ complexes(E (numeric E).type) : numerics (complex E) is
 # does not define a type (which would cause a name clash with complex with two
 # arguments).
 #
-complex(E (numeric E).type) => complexes E
+complex(E type : numeric E) => complexes E

--- a/lib/ctrie.fz
+++ b/lib/ctrie.fz
@@ -54,7 +54,7 @@
 
 # a tomb node
 # "a T-node is the last value assigned to an I-node"
-private TNode(CTK (hasHash CTK).type, CTV type, sn SNode CTK CTV) is
+private TNode(CTK type : hasHash CTK, CTV type, sn SNode CTK CTV) is
   redef asString => "TNode($sn)"
 
   asList => sn.asList
@@ -62,14 +62,14 @@ private TNode(CTK (hasHash CTK).type, CTV type, sn SNode CTK CTV) is
 
 # a singleton node
 # the node type containing actual data
-private SNode(CTK (hasHash CTK).type, CTV type, k CTK, v CTV) is
+private SNode(CTK type : hasHash CTK, CTV type, k CTK, v CTV) is
   redef asString => "SNode($k, $v)"
 
   asList => [(k,v)].asList
 
 
 # an indirection or a singleton node
-private Branch(CTK (hasHash CTK).type, CTV type) : choice (INode CTK CTV) (SNode CTK CTV) is
+private Branch(CTK type : hasHash CTK, CTV type) : choice (INode CTK CTV) (SNode CTK CTV) is
   redef asString =>
     match Branch.this
       iNode INode => "$iNode"
@@ -83,7 +83,7 @@ private Branch(CTK (hasHash CTK).type, CTV type) : choice (INode CTK CTV) (SNode
 
 # a container node
 # consists of a bitmap of filled spaces and an array of child nodes
-private CNode(CTK (hasHash CTK).type, CTV type, bmp u32, array array (Branch CTK CTV)) is
+private CNode(CTK type : hasHash CTK, CTV type, bmp u32, array array (Branch CTK CTV)) is
 
   # update a child node and return a new cnode
   updated(pos u32, node Branch CTK CTV) =>
@@ -118,7 +118,7 @@ private CNode(CTK (hasHash CTK).type, CTV type, bmp u32, array array (Branch CTK
 
 
 # a container, T or linked list node
-private MainNode(CTK (hasHash CTK).type, CTV type, data choice (CNode CTK CTV) (TNode CTK CTV) (LNode CTK CTV), gen i32) ref : hasEquals (MainNode CTK CTV) is
+private MainNode(CTK type : hasHash CTK, CTV type, data choice (CNode CTK CTV) (TNode CTK CTV) (LNode CTK CTV), gen i32) ref : hasEquals (MainNode CTK CTV) is
 
   # a previous node that gets set during a generational aware compare and set
   prev := mut (choice (FNode CTK CTV) (MainNode CTK CTV) nil) nil
@@ -155,10 +155,10 @@ private MainNode(CTK (hasHash CTK).type, CTV type, data choice (CNode CTK CTV) (
 
 
 # a failed node where the previous indirection node contains a main node
-private FNode(CTK (hasHash CTK).type, CTV type, prev MainNode CTK CTV) is
+private FNode(CTK type : hasHash CTK, CTV type, prev MainNode CTK CTV) is
 
 # an indirection node
-private INode(CTK (hasHash CTK).type, CTV type, data mutate.new (MainNode CTK CTV)) ref : hasEquals (INode CTK CTV) is
+private INode(CTK type : hasHash CTK, CTV type, data mutate.new (MainNode CTK CTV)) ref : hasEquals (INode CTK CTV) is
 
   # compare and update
   private CAS(old_n, new_n MainNode CTK CTV) bool is
@@ -230,7 +230,7 @@ private INode(CTK (hasHash CTK).type, CTV type, data mutate.new (MainNode CTK CT
 
 # a linked list node
 # NYI instead of Sequence we should use something like the original implementation ListMap(Scala).
-private LNode(CTK (hasHash CTK).type, CTV type, from Sequence (SNode CTK CTV)) : Sequence (SNode CTK CTV)
+private LNode(CTK type : hasHash CTK, CTV type, from Sequence (SNode CTK CTV)) : Sequence (SNode CTK CTV)
 pre from ∀ (sn -> (from.filter (snn -> sn.k.hash = snn.k.hash)).count = 1)
 is
   redef asList => from.asList
@@ -239,11 +239,11 @@ private RESTART is
 private OK is
 
 
-private RDCSS_Descriptor(CTK (hasHash CTK).type, CTV type, ov INode CTK CTV, exp MainNode CTK CTV, nv INode CTK CTV) is
+private RDCSS_Descriptor(CTK type : hasHash CTK, CTV type, ov INode CTK CTV, exp MainNode CTK CTV, nv INode CTK CTV) is
 
 # the ctrie
 # NYI marking ctrie as ref see issue https://github.com/tokiwa-software/fuzion/issues/304
-private CTrie(CTK (hasHash CTK).type, CTV type, root mutate.new (choice (INode CTK CTV) (RDCSS_Descriptor CTK CTV)), read_only bool) ref : map CTK CTV
+private CTrie(CTK type : hasHash CTK, CTV type, root mutate.new (choice (INode CTK CTV) (RDCSS_Descriptor CTK CTV)), read_only bool) ref : map CTK CTV
 is
 
   private CAS_ROOT(ov, nv choice (INode CTK CTV) (RDCSS_Descriptor CTK CTV)) =>
@@ -567,7 +567,7 @@ is
       .asList
 
 # initialize a new ctrie
-CTrie(CTK (hasHash CTK).type, CTV type) =>
+CTrie(CTK type : hasHash CTK, CTV type) =>
   # NYI better type inference could make this tmp unecessary
   tmp choice (INode CTK CTV) (RDCSS_Descriptor CTK CTV) := INode (mut (MainNode (CNode CTK CTV 0 []) 0))
   CTrie CTK CTV (mut tmp) false

--- a/lib/effect.fz
+++ b/lib/effect.fz
@@ -59,7 +59,7 @@ is
   #
   # NYI: uses type parameter T only to simplify C backend
   #
-  private abortable(T (Function unit).type, f T) unit is intrinsic
+  private abortable(T type : Function unit, f T) unit is intrinsic
 
   # replace effect in the current context by this and abort current execution
   private abort void is intrinsic

--- a/lib/equals.fz
+++ b/lib/equals.fz
@@ -26,9 +26,9 @@
 # equals -- feature that compares two values using the equality relation
 # defined in their type
 #
-equals(T has_equality.type, a, b T) => T.equality a b
+equals(T type : has_equality, a, b T) => T.equality a b
 
 
 # infix ≟ -- infix operation as short-hand for 'equals'
 #
-infix ≟(T has_equality.type, a, b T) => equals T a b
+infix ≟(T type : has_equality, a, b T) => equals T a b

--- a/lib/float.fz
+++ b/lib/float.fz
@@ -29,7 +29,7 @@
 # float is the abstract parent of concrete floating point features such as
 # f32 or f64.
 #
-float(redef F (float F).type) : numeric F, floats F is
+float(redef F type : float F) : numeric F, floats F is
 
 
   # preconditions for basic operations: true if the operation's result is
@@ -86,7 +86,7 @@ float(redef F (float F).type) : numeric F, floats F is
 # floats -- unit type defining features related to float but not requiring
 # an instance
 #
-floats(F (float F).type) : numerics F is
+floats(F type : float F) : numerics F is
 
   # number of bytes required to store this value
   #

--- a/lib/floatSequence.fz
+++ b/lib/floatSequence.fz
@@ -31,7 +31,7 @@
 
 # floatSequence -- a Sequence whose elements inherit from float
 #
-floatSequence(F (float F).type, redef from Sequence F) : numericSequence F from is
+floatSequence(F type : float F, redef from Sequence F) : numericSequence F from is
 
   # create a list from this Sequence.
   #
@@ -53,4 +53,3 @@ floatSequence(F (float F).type, redef from Sequence F) : numericSequence F from 
   euclidean_norm F is
     # NYI #500: sqrt,two and sum should be accessed via type
     first.sqrt ((mapSequence (x)->x**first.two).fold first.sum)
-

--- a/lib/fraction.fz
+++ b/lib/fraction.fz
@@ -35,7 +35,7 @@
 # there are currently no checks or preconditions for overflows in the numerator
 # or the denominator.
 #
-fraction(B (integer B).type,
+fraction(B type : integer B,
          num,    # numerator
          den B   # denominatior
         ) : numeric (fraction B)
@@ -85,7 +85,7 @@ is
   redef infix >= (b fraction B) =>  (a - b).num.sign >= 0
 
   # NYI: #637:
-  # fixed fraction.type.equality(B (integer B).type, a, b fraction B) =>
+  # fixed fraction.type.equality(B type : integer B, a, b fraction B) =>
   #   (a - b).num.isZero
 
   redef asString => "" + num + "⁄" + den

--- a/lib/fuzion/sys/thread.fz
+++ b/lib/fuzion/sys/thread.fz
@@ -37,4 +37,4 @@ private thread is
 
     spawn0 doCall
 
-  private spawn0(T (()->unit).type, code T) unit is intrinsic
+  private spawn0(T type : ()->unit, code T) unit is intrinsic

--- a/lib/hasEquals.fz
+++ b/lib/hasEquals.fz
@@ -31,7 +31,7 @@
 # NYI: the compiler should check that features inheriting from this are
 # actually immutable.
 #
-hasEquals(HE (hasEquals HE).type) is
+hasEquals(HE type : hasEquals HE) is
 
   # equality check for immutable values
   #

--- a/lib/hasHash.fz
+++ b/lib/hasHash.fz
@@ -28,7 +28,7 @@
 # NYI: the compiler should check that features inheriting from this are
 # actually immutable.
 #
-hasHash(redef HE (hasEquals HE).type) : hasEquals HE
+hasHash(redef HE type : hasEquals HE) : hasEquals HE
 
 /* NYI: quantor intrinsics not supported yet:
 

--- a/lib/hasInterval.fz
+++ b/lib/hasInterval.fz
@@ -25,7 +25,7 @@
 
 # hasInterval -- feature for integers that can define an interval
 #
-hasInterval(H (hasInterval H).type) : integer H is
+hasInterval(H type : hasInterval H) : integer H is
   max  H is abstract
 /*
   zero T is abstract

--- a/lib/hashMap.fz
+++ b/lib/hashMap.fz
@@ -25,7 +25,7 @@
 
 # hashMap -- an immutable hash map from keys HK to values V
 #
-hashMap(HK (hasHash HK).type,
+hashMap(HK type : hasHash HK,
         redef V type,
         ks array HK,
         vs array V) : map HK V
@@ -125,7 +125,7 @@ is
 #
 # NYI: move to hashMap.type
 #
-hashMaps(HK (hasHash HK).type, V type) is
+hashMaps(HK type : hasHash HK, V type) is
 
 
   # empty -- convenience routine to create an empty instance of hashMap

--- a/lib/integer.fz
+++ b/lib/integer.fz
@@ -29,7 +29,7 @@
 # from numeric plus a devision remainder operation %, bitwise logical operations,
 # shift operations and gcd. Also, integers can be used to build fractions.
 #
-integer(I (integer I).type) : numeric I is
+integer(I type : integer I) : numeric I is
 
   # division remainder
   redef infix % (other I) I

--- a/lib/mapOf.fz
+++ b/lib/mapOf.fz
@@ -28,7 +28,7 @@
 #
 # This feature creates an instance of a map.
 #
-mapOf(K (ordered K).type, V type, ks array K, vs array V) map K V is orderedMap ks vs
+mapOf(K type : ordered K, V type, ks array K, vs array V) map K V is orderedMap ks vs
 
 
 # mapOf -- routine to initialize a map from an array of key value tuples
@@ -37,5 +37,5 @@ mapOf(K (ordered K).type, V type, ks array K, vs array V) map K V is orderedMap 
 #
 # example: mapOf [(key1, value1), (key2, value2)]
 #
-mapOf(K (ordered K).type, V type, kvs array (tuple K V)) map K V is
+mapOf(K type : ordered K, V type, kvs array (tuple K V)) map K V is
   orderedMap (kvs.map (kv -> kv.values.0)) (kvs.map (kv -> kv.values.1))

--- a/lib/matrix.fz
+++ b/lib/matrix.fz
@@ -27,7 +27,7 @@
 #
 # matrix provides matrix operations based on an arbitray numeric type
 #
-matrix(redef M (numeric M).type, e array2 M) : numeric (matrix M), matrices M
+matrix(redef M type : numeric M, e array2 M) : numeric (matrix M), matrices M
 is
 
 # private:
@@ -72,7 +72,7 @@ is
       true
 
   # NYI: #637:
-  # fixed matrix.type.equality(M (numeric M).type, a, b matrix M) =>
+  # fixed matrix.type.equality(M type : numeric M, a, b matrix M) =>
   #   for
   #     x in a.e
   #     y in a.e
@@ -107,7 +107,7 @@ is
 # matrices is a unit type defining features related to matrix but not
 # requiring an instance.
 #
-matrices(M numeric M.type) : numerics (matrix M) is
+matrices(M type : numeric M) : numerics (matrix M) is
 
   redef name => "matrix"
 

--- a/lib/monad.fz
+++ b/lib/monad.fz
@@ -34,7 +34,7 @@
 # applied to generic types.
 #
 #
-monad (A type, MA (monad A MA).type) is
+monad (A type, MA type : monad A MA) is
 
 
   # monadic operator within the same monad
@@ -60,7 +60,7 @@ monad (A type, MA (monad A MA).type) is
   # NYI: useless since redefinition currently not supported for
   # feature with generics.
   #
-  join(MMA (monad MA (monad A MA)).type, a MMA) MA is abstract
+  join(MMA type : monad MA (monad A MA), a MMA) MA is abstract
 
 
   # NYI: fmap:
@@ -70,7 +70,7 @@ monad (A type, MA (monad A MA).type) is
 
 # type related to monad declaring features not requiring an instance of monad
 #
-monads(A type, MA (monad A MA).type) is
+monads(A type, MA type : monad A MA) is
 
 
   # return function

--- a/lib/numOption.fz
+++ b/lib/numOption.fz
@@ -29,7 +29,7 @@
 # value: nil.  Any operation on nil will result in nil for a
 # numeric result or false for a boolean result.
 #
-numOption(T (numeric T).type) :
+numOption(T type : numeric T) :
   choice T nil,
   monad T (numOption T)
 is
@@ -76,7 +76,7 @@ is
   #
   # Same as non-generic >>=, but also maps to a different type B.
   #
-  bind(B (numeric T).type, f T -> numOption B) numOption B is
+  bind(B type : numeric T, f T -> numOption B) numOption B is
     numOption.this ? v T => f v
                    | nil => nil
 
@@ -141,12 +141,12 @@ is
 #
 #   o numOption TypeOfX := x
 #
-numOption(T (numeric T).type, o numOption T) => o
+numOption(T type : numeric T, o numOption T) => o
 
 
 # type related to numOption declaring features not requiring an instance of numOption
 #
-numOptions(T (numeric T).type) : monads T (numOption T) is
+numOptions(T type : numeric T) : monads T (numOption T) is
 
 
   # return function

--- a/lib/numeric.fz
+++ b/lib/numeric.fz
@@ -25,7 +25,7 @@
 
 # numeric -- parent of all numeric features
 #
-numeric(redef T (numeric T).type) : hasHash T, ordered T, numerics T is
+numeric(redef T type : numeric T) : hasHash T, ordered T, numerics T is
 
   # get numeric.this value of type T.  This is used for a generic implemention
   # of some features (e.g. prefix -, abs
@@ -208,7 +208,7 @@ numeric(redef T (numeric T).type) : hasHash T, ordered T, numerics T is
 # numerics -- unit type defining features related to numeric but not
 # requiring an instance
 #
-numerics(T (numeric T).type) is
+numerics(T type : numeric T) is
 
   # name of this numeric type, e.g., "u64"
   #

--- a/lib/numericSequence.fz
+++ b/lib/numericSequence.fz
@@ -25,7 +25,7 @@
 
 # numericSequence -- a Sequence whose elements inherit from numeric
 #
-numericSequence(N (numeric N).type, from Sequence N) : Sequence N, hasEquals (numericSequence N)  is
+numericSequence(N type : numeric N, from Sequence N) : Sequence N, hasEquals (numericSequence N)  is
 
   # create a list from this Sequence.
   #

--- a/lib/onewayMonad.fz
+++ b/lib/onewayMonad.fz
@@ -33,7 +33,7 @@ onewayMonad(
 
   redef A type,
 
-  OMA (onewayMonad A OMA).type,
+  OMA type : onewayMonad A OMA,
 
   # action to be performed, may include code to run while this effect is installed.
   #
@@ -42,4 +42,4 @@ onewayMonad(
 is
 
 onewayMonads(redef A type,
-             OMA (onewayMonad A OMA).type) : monads A OMA is
+             OMA type : onewayMonad A OMA) : monads A OMA is

--- a/lib/ordered.fz
+++ b/lib/ordered.fz
@@ -31,7 +31,7 @@
 # NYI: the compiler should check that features inheriting from this are
 # actually immutable.
 #
-ordered(O (ordered O).type) : partiallyOrdered O
+ordered(O type : ordered O) : partiallyOrdered O
 
 /* NYI: quantor intrinsics not supported yet:
 

--- a/lib/orderedMap.fz
+++ b/lib/orderedMap.fz
@@ -32,7 +32,7 @@
 # performance of creation of the map is in O(n log n) where n is
 # keys.length.
 #
-orderedMap(OK ordered OK .type,
+orderedMap(OK type : ordered OK,
            redef V type,
            ks array OK,
            vs array V) : map OK V
@@ -102,7 +102,7 @@ is
 #
 # NYI: move to orderedMap.type
 #
-orderedMaps (OK ordered OK .type, V type) is
+orderedMaps (OK type : ordered OK, V type) is
 
 
   # create an empty instance of orderedMap

--- a/lib/partiallyOrdered.fz
+++ b/lib/partiallyOrdered.fz
@@ -32,7 +32,7 @@
 # NYI: the compiler should check that features inheriting from this are
 # actually immutable.
 #
-partiallyOrdered(P (partiallyOrdered P).type) : has_equality, hasEquals P
+partiallyOrdered(P type : partiallyOrdered P) : has_equality, hasEquals P
 
 /* NYI: quantor intrinsics not supported yet:
 

--- a/lib/psMap.fz
+++ b/lib/psMap.fz
@@ -48,7 +48,7 @@
 psMap
   (
    # key type
-   PK (ordered PK).type,
+   PK type : ordered PK,
 
    # value type
    redef V type,
@@ -362,7 +362,7 @@ O(n log n).
 #
 # NYI: move to psMap.type
 #
-psMaps(PK (ordered PK).type, V type) is
+psMaps(PK type : ordered PK, V type) is
 
   # empty -- an empty partially sorted map
   #
@@ -376,7 +376,7 @@ psMaps(PK (ordered PK).type, V type) is
 # This feature creates a pre-initialized instance of psMap.
 #
 psMap(
-    PK (ordered PK).type,
+    PK type : ordered PK,
     V type,
     # list of keys in the map
     ks Sequence PK,

--- a/lib/psSet.fz
+++ b/lib/psSet.fz
@@ -35,7 +35,7 @@
 # O(m*n log² n) for adding an element m times.
 #
 psSet
-  (K (ordered K).type,
+  (K type : ordered K,
    psm ref psMap K unit,  # NYI: #167: 'ref' due to lack of 'like this'
    dummy unit    # just to distinguish this from routine psSet(vs Sequence K)
   )
@@ -136,7 +136,7 @@ has     -- NYI: 'has' keyword not supported yet, so the following require an ins
 #
 # NYI: move to psSet.type
 #
-psSets(K (ordered K).type) is
+psSets(K type : ordered K) is
 
   # psSet -- a partially sorted set based on psMap
   #
@@ -149,4 +149,4 @@ psSets(K (ordered K).type) is
 #
 # This feature creates a pre-initialized instance of psSet.
 #
-psSet(K (ordered K).type, vs Sequence K) => (psSets K).empty.addAll vs
+psSet(K type : ordered K, vs Sequence K) => (psSets K).empty.addAll vs

--- a/lib/searchableSequence.fz
+++ b/lib/searchableSequence.fz
@@ -29,7 +29,7 @@
 # type 'list', so it is more flexible.
 #
 #
-searchableSequence(A (hasEquals A).type, from Sequence A) : Sequence A
+searchableSequence(A type : hasEquals A, from Sequence A) : Sequence A
 is
 
   # create a list from this Sequence.

--- a/lib/searchablelist.fz
+++ b/lib/searchablelist.fz
@@ -29,7 +29,7 @@
 # type 'Sequence', so it is more efficient.
 #
 #
-searchablelist(A (hasEquals A).type, from list A) : Sequence A
+searchablelist(A type : hasEquals A, from list A) : Sequence A
 /* : list A -- NYI: we might allow inherting from a choice to get a choice
                     with more restrictions on the type arguments
 

--- a/lib/setOf.fz
+++ b/lib/setOf.fz
@@ -27,7 +27,7 @@
 #
 # This feature creates an instance of a Set.
 #
-setOf(K (ordered K).type, vs Sequence K) Set K is psSet vs
+setOf(K type : ordered K, vs Sequence K) Set K is psSet vs
 
 
 # set_of -- routine to initialize a set from a Sequence of hashable elements
@@ -35,7 +35,7 @@ setOf(K (ordered K).type, vs Sequence K) Set K is psSet vs
 # This feature creates an instance of a Set.
 #
 # NYI name clash with feature above
-set_of(K (hasHash K).type, vs (CTrie K unit) | (Sequence K)) Set K is
+set_of(K type : hasHash K, vs (CTrie K unit) | (Sequence K)) Set K is
 
   private map := CTrie K unit
   match vs

--- a/lib/sortedArray.fz
+++ b/lib/sortedArray.fz
@@ -193,7 +193,7 @@ is
 #
 sortedArrayOf
   (
-  T (ordered T).type,
+  T type : ordered T,
   # orginal, unsorted Sequence
   from Sequence T
   ) sortedArray T

--- a/lib/string.fz
+++ b/lib/string.fz
@@ -181,7 +181,7 @@ string ref : has_equality, hasHash string, ordered string, strings is
   #
   parse_integer(
     # the integer type
-    T (integer T).type,
+    T type : integer T,
 
     # base gives the base of the integer, must be between 2 and 36, inclusive.
     base T
@@ -203,7 +203,7 @@ string ref : has_equality, hasHash string, ordered string, strings is
   #
   private parse_integer(
     # the integer type
-    T (integer T).type,
+    T type : integer T,
 
     # base gives the base, between 2 and 36
     base T,

--- a/lib/sum.fz
+++ b/lib/sum.fz
@@ -31,7 +31,7 @@
 #   say (sum l)     # '6'
 #
 #
-sum(T (numeric T).type, l Sequence T)
+sum(T type : numeric T, l Sequence T)
   pre
     debug: !l.isEmpty   # sum does not work (yet) for empty Sequence
   =>
@@ -56,8 +56,8 @@ sum(T (numeric T).type, l Sequence T)
 #
 sum0(
   # the numeric type we are summing, unit value
-  U (numerics T).type,
-  T (numeric T).type,
+  U type : numerics T,
+  T type : numeric T,
   n U,
   l Sequence T
   )

--- a/lib/wrappingInteger.fz
+++ b/lib/wrappingInteger.fz
@@ -28,7 +28,7 @@
 # wrappingInteger is the abstract ancestor of integer numbers that have min and
 # max values and operations with wrap-around semantics.
 #
-wrappingInteger(redef W (wrappingInteger W).type) : integer W, wrappingIntegers W is
+wrappingInteger(redef W type : wrappingInteger W) : integer W, wrappingIntegers W is
 
   # overflow checking
 
@@ -197,7 +197,7 @@ wrappingInteger(redef W (wrappingInteger W).type) : integer W, wrappingIntegers 
 # wrappingIntegers -- unit type defining features related to wrappingInteger
 # but not requiring an instance
 #
-wrappingIntegers(W (wrappingInteger W).type) : numerics W is
+wrappingIntegers(W type : wrappingInteger W) : numerics W is
 
   min W is abstract
   max W is abstract

--- a/src/dev/flang/parser/Parser.java
+++ b/src/dev/flang/parser/Parser.java
@@ -898,9 +898,9 @@ argument    : visibility
               argType
               contract
             ;
-argType     : typeType
-            | type
-            | type dot typeType
+argType     : type
+            | typeType
+            | typeType COLON type
             ;
    */
   List<Feature> formArgs()
@@ -918,14 +918,14 @@ argType     : typeType
                                     Impl i;
                                     if (current() == Token.t_type)
                                       {
-                                        t = new Type("Object");
-                                        i =  typeType();
+                                        i = typeType();
+                                        t = skipColon() ? type()
+                                                        : new Type("Object");
                                       }
                                     else
                                       {
+                                        i = Impl.FIELD;
                                         t = type();
-                                        i = skipDot() ? typeType()
-                                                      : Impl.FIELD;
                                       }
                                     Contract c = contract();
                                     for (String s : n)
@@ -979,14 +979,14 @@ typeType    : "type"
                     if (skip(Token.t_type))
                       {
                         splitSkip("...");
+                        if (skipColon())
+                          {
+                            result = skipType();
+                          }
                       }
                     else
                       {
                         result = skipType();
-                        if (result && skipDot() && skip(Token.t_type))
-                          {
-                            splitSkip("...");
-                          }
                       }
                   }
                 if (result)
@@ -1040,10 +1040,11 @@ typeType    : "type"
                 if (skip(Token.t_type))
                   {
                     splitSkip("...");
-                  }
-                else if (fork().skipDotType())
-                  {
-                    skipDotType();
+                    if (skipColon())
+                      {
+                        skipType();
+                      }
+                    result[0] = FormalOrActual.formal;
                   }
                 else if (!skipType())
                   {

--- a/tests/basicIntegers/basicIntegers.fz
+++ b/tests/basicIntegers/basicIntegers.fz
@@ -29,7 +29,7 @@
 #
 basicIntegers =>
 
-  test(T (wrappingInteger T).type, a, b T) unit is
+  test(T type : wrappingInteger T, a, b T) unit is
     say "{a.name}: $a +° $b = {a +° b}"
     say "{a.name}: $a -° $b = {a -° b}"
     say "{a.name}: $a *° $b = {a *° b}"

--- a/tests/covariance/test_covariance.fz
+++ b/tests/covariance/test_covariance.fz
@@ -103,7 +103,7 @@ test_covariance is
 
 run_test_covariance =>
 
-  test(N test_covariance.num.type, x, y N) =>
+  test(N type : test_covariance.num, x, y N) =>
     say x
     say y
     # NYI: all of the following do not work yet:

--- a/tests/floating_point_math/floating_point_math.fz
+++ b/tests/floating_point_math/floating_point_math.fz
@@ -36,7 +36,7 @@ floating_point_math is
       "FAILED: "
     say (s + msg)
 
-  generic_tests(T (float T).type, a T) is
+  generic_tests(T type : float T, a T) is
 
     # isNaN
     chck (a.isNaN a.NaN)                                                   "{a.name}: isNaN NaN"

--- a/tests/floating_point_numbers/floating_point_numbers.fz
+++ b/tests/floating_point_numbers/floating_point_numbers.fz
@@ -36,7 +36,7 @@ floating_point_numbers is
       "FAILED: "
     say (s + msg)
 
-  generic_tests(T (float T).type, a T) is
+  generic_tests(T type: float T, a T) is
 
     zero := a.zero
     one := a.one

--- a/tests/outerNormalization/outerNormalization.fz
+++ b/tests/outerNormalization/outerNormalization.fz
@@ -100,7 +100,7 @@ outerNormalization is
   # simpler features j/n
   #
   testNormalize is
-    n(T (n T).type) is
+    n(T type : n T) is
       a T is abstract
       b T is a
 

--- a/tests/reg_issue309_check_constraints_of_types/issue309.fz
+++ b/tests/reg_issue309_check_constraints_of_types/issue309.fz
@@ -30,5 +30,5 @@ issue309 is
 
   b(T type) Set T is abstract  // 2. should flag an error: Incompatible type parameter
 
-  c(T (hasEquals T).type) is
+  c(T type : hasEquals T) is
   d c a is abstract            // 3. should flag an error: Incompatible type parameter

--- a/tests/reg_issue698_np_excep_in_choice_with_call_to_outer_ref/issue698.fz
+++ b/tests/reg_issue698_np_excep_in_choice_with_call_to_outer_ref/issue698.fz
@@ -5,7 +5,7 @@ ex_tree is
     left B is abstract
     right C is abstract
 
-  tree(A (ordered A).type) : choice nil (Node A (tree A) (tree A)) is
+  tree(A type : ordered A) : choice nil (Node A (tree A) (tree A)) is
 
     size i32 is
       tree.this ? nil    => 0
@@ -19,7 +19,7 @@ ex_tree is
         right tree A is right
 
   trees is
-    empty(A (ordered A).type) tree A is
+    empty(A type : ordered A) tree A is
       nil
 
   x := (trees.empty i32).smart 42 nil nil

--- a/tests/reg_issue698_np_excep_in_choice_with_call_to_outer_ref/issue698.fz.expected_err
+++ b/tests/reg_issue698_np_excep_in_choice_with_call_to_outer_ref/issue698.fz.expected_err
@@ -1,6 +1,6 @@
 
 [32m--CURDIR--/issue698.fz:8:3:[39m [1;31merror 1[0m[1m: Choice type must not access fields of surrounding scope.[0m
-[34m  tree(A (ordered A).type) : choice nil (Node A (tree A) (tree A)) is
+[34m  tree(A type : ordered A) : choice nil (Node A (tree A) (tree A)) is
 [33m--^[0m
 A closure cannot be built for a choice type. Forbidden accesses occur at 
 [32m--CURDIR--/issue698.fz:15:7:[39m

--- a/tests/reg_issue7_genericConstraint/checkGenericConstraint.fz
+++ b/tests/reg_issue7_genericConstraint/checkGenericConstraint.fz
@@ -34,7 +34,7 @@ checkGenericConstraint is
   H is
     h i32 is abstract
 
-  hm (T H.type, x T) is
+  hm (T type : H, x T) is
     x.h
     unit
 


### PR DESCRIPTION
Previously, the syntax for a type parameter `T` with constraint `C` was `T C.type`. The new syntax is in-line with the inheritance syntax, which makes sense here since the legal type parameters must inherit from the constraint.

Updated the syntax in the base lib and tests.

Fix #777.