### PR TITLE
air: Made code more robust against earlier errors

### DIFF
--- a/src/dev/flang/air/Clazz.java
+++ b/src/dev/flang/air/Clazz.java
@@ -1998,7 +1998,13 @@ public class Clazz extends ANY implements Comparable<Clazz>
             return Clazzes.error.get();
           }
       }
-    return _outer.actualGenerics()[f.typeParameterIndex()];
+
+    var ix = f.typeParameterIndex();
+    var oag = _outer.actualGenerics();
+    if (CHECKS) check
+      (ix >= 0 && ix < oag.length || Errors.count() > 0);
+
+    return ix < 0 || ix >= oag.length ? Clazzes.error.get() : oag[ix];
   }
 
 

--- a/src/dev/flang/air/Clazzes.java
+++ b/src/dev/flang/air/Clazzes.java
@@ -183,7 +183,15 @@ public class Clazzes extends ANY
   public static final OnDemandClazz string      = new OnDemandClazz(() -> Types.resolved.t_string           );
   public static final OnDemandClazz conststring = new OnDemandClazz(() -> Types.resolved.t_conststring      , true /* needed? */);
   public static final OnDemandClazz c_unit      = new OnDemandClazz(() -> Types.resolved.t_unit             );
-  public static final OnDemandClazz error       = new OnDemandClazz(() -> Types.t_ERROR                     );
+  public static final OnDemandClazz error       = new OnDemandClazz(() -> Types.t_ERROR                     )
+    {
+      public Clazz get()
+      {
+        if (CHECKS) check
+          (Errors.count() > 0);
+        return super.get();
+      }
+    };
   public static Clazz constStringInternalArray;  // field conststring.internalArray
   public static Clazz fuzionSysArray_u8;         // result clazz of conststring.internalArray
   public static Clazz fuzionSysArray_u8_data;    // field fuzion.sys.array<u8>.data


### PR DESCRIPTION
Added check()s that illegal type parameter index only occurs if errors where reported and made sure that error clazz is touched only in case of previous errors.