### PR TITLE
Support for type parameters in type features

### DIFF
--- a/src/dev/flang/ast/AbstractFeature.java
+++ b/src/dev/flang/ast/AbstractFeature.java
@@ -486,6 +486,8 @@ public abstract class AbstractFeature extends ANY implements Comparable<Abstract
    *
    * @param res Resolution instance used to resolve types in this call.
    *
+   * @param that the original feature that is used to lookup types.
+   *
    * @return instance of Call to be used for the parent call in typeFeature().
    */
   private Call typeCall(SourcePosition p, List<AbstractType> typeParameters, Resolution res, AbstractFeature that)
@@ -544,6 +546,8 @@ public abstract class AbstractFeature extends ANY implements Comparable<Abstract
    * by generics from 'this.typeFeature()'. Furthermore, resolution of
    * non-generic types used in 't' has to be performed relative to 'this' even
    * when the outer feature is 'this.typeFeature()'.
+   *
+   * @param t the type to be moved to the type feature.
    */
   public AbstractType rebaseTypeForTypeFeature(AbstractType t)
   {

--- a/src/dev/flang/ast/AbstractType.java
+++ b/src/dev/flang/ast/AbstractType.java
@@ -997,13 +997,15 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
        res != null || featureOfType().state().atLeast(Feature.State.RESOLVED));
 
     var result = this;
-    if (!featureOfType().isUniverse())
+    if (!featureOfType().isUniverse() && this != Types.t_ERROR)
       {
         var f = res == null ? featureOfType().typeFeature()
                             : featureOfType().typeFeature(res);
+        var g = new List<AbstractType>(this);
+        g.addAll(generics());
         result = Types.intern(new Type(f.pos(),
                                        f.featureName().baseName(),
-                                       new List<>(this),
+                                       g,
                                        outer().typeType(res),
                                        f,
                                        Type.RefOrVal.Value));

--- a/src/dev/flang/ast/Feature.java
+++ b/src/dev/flang/ast/Feature.java
@@ -2405,7 +2405,7 @@ public class Feature extends AbstractFeature implements Stmnt
   public AbstractFeature outerRef()
   {
     if (PRECONDITIONS) require
-      (_state.atLeast(State.RESOLVED_DECLARATIONS));
+      (isUniverse() || _state.atLeast(State.RESOLVED_DECLARATIONS));
 
     Feature result = _outerRef;
 

--- a/src/dev/flang/ast/Generic.java
+++ b/src/dev/flang/ast/Generic.java
@@ -114,7 +114,7 @@ public class Generic extends ANY
     if (PRECONDITIONS) require
       (feature().state().atLeast(Feature.State.RESOLVED_DECLARATIONS));
 
-    AbstractType result =_typeParameter.state().atLeast(Feature.State.RESOLVED_TYPES)
+    AbstractType result = _typeParameter.state().atLeast(Feature.State.RESOLVED_TYPES)
       ? _typeParameter.resultType()
       : ((Feature) _typeParameter).returnType().functionReturnType();
 

--- a/src/dev/flang/fe/LibraryFeature.java
+++ b/src/dev/flang/fe/LibraryFeature.java
@@ -243,7 +243,10 @@ public class LibraryFeature extends AbstractFeature
    */
   public int modifiers()
   {
-    return _libModule.featureIsFixed(_index) ? Consts.MODIFIER_FIXED : 0;
+    return
+      (_libModule.featureIsFixed       (_index)     ? Consts.MODIFIER_FIXED    : 0) |
+      (_libModule.featureRedefinesCount(_index) > 0 ? Consts.MODIFIER_REDEFINE : 0);
+
   }
 
 

--- a/src/dev/flang/fe/SourceModule.java
+++ b/src/dev/flang/fe/SourceModule.java
@@ -1192,7 +1192,7 @@ public class SourceModule extends Module implements SrcModule, MirModule
        original.outer().generics().list.get(0).typeParameter().featureName().baseName().equals(FuzionConstants.TYPE_FEATURE_THIS_TYPE) &&  /* NYI: ugly string comparison */
        !tr.isGenericArgument()                                                                                                         &&
        ((redefinition.modifiers() & Consts.MODIFIER_FIXED) != 0)                                                                       &&
-       tr.compareTo(redefinition.outer().typeFeatureOrigin().thisType()) == 0                                                             );
+       tr.compareTo(redefinition.outer().typeFeatureOrigin().thisTypeInTypeFeature()) == 0                                               );
   }
 
 

--- a/src/dev/flang/util/FuzionConstants.java
+++ b/src/dev/flang/util/FuzionConstants.java
@@ -95,7 +95,7 @@ public class FuzionConstants extends ANY
 
 
   /**
-   * Name of (dynamic) type features.
+   * Name of type features.
    */
   public static final String TYPE_NAME = INTERNAL_NAME_PREFIX + "type";
 

--- a/tests/type_feature/Makefile
+++ b/tests/type_feature/Makefile
@@ -1,0 +1,27 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test Makefile
+#
+#  Author: Fridtjof Siebert (siebert@tokiwa.software)
+#
+# -----------------------------------------------------------------------
+
+override NAME = test_type_feature
+include ../simple.mk

--- a/tests/type_feature/test_type_feature.fz
+++ b/tests/type_feature/test_type_feature.fz
@@ -1,0 +1,67 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test test_type_feature
+#
+#  Author: Fridtjof Siebert (siebert@tokiwa.software)
+#
+# -----------------------------------------------------------------------
+
+hasTypeArg is
+  type.showTypeArgs string is abstract
+
+ex(T, U type) : hasTypeArg, has_equality is
+  type.showTypeArgs => "T:$T U:$U"
+  fixed type.equality(a, b ex T U) bool is false
+
+ex2(T, U type: has_equality, a, b T, c U) : hasTypeArg, has_equality is
+  type.showTypeArgs => "T:$T U:$U"
+  fixed type.equality(a, b ex2 T U) bool is
+    (a.a ≟ b.a &&
+     a.b ≟ b.b &&
+     a.c ≟ b.c   )
+
+prefix !(X type: hasTypeArg, v X) string is X.showTypeArgs
+
+say !(ex i32 bool)
+say !(ex (array string) (array (array bool)))
+say !(ex bool (list f64))
+a := ex i32 bool
+b := ex i32 bool
+say (a ≟ b)
+c := ex2 12 34 true
+d := ex2 47 11 false
+e := ex2 12 34 true
+f := ex2 47 11 true
+say (c ≟ c)
+say (c ≟ d)
+say (c ≟ e)
+say (c ≟ f)
+say (d ≟ c)
+say (d ≟ d)
+say (d ≟ e)
+say (d ≟ f)
+say (e ≟ c)
+say (e ≟ d)
+say (e ≟ e)
+say (e ≟ f)
+say (f ≟ c)
+say (f ≟ d)
+say (f ≟ e)
+say (f ≟ f)

--- a/tests/type_feature/test_type_feature.fz.expected_out
+++ b/tests/type_feature/test_type_feature.fz.expected_out
@@ -1,0 +1,20 @@
+T:Type of 'i32' U:Type of 'bool'
+T:Type of 'array string' U:Type of 'array (array bool)'
+T:Type of 'bool' U:Type of 'list f64'
+false
+true
+false
+true
+false
+false
+true
+false
+false
+true
+false
+true
+false
+false
+false
+false
+true


### PR DESCRIPTION
Type features now have copies of the type parameters of their underlying
original features in addition to THIS#TYPE.  As an example, the type feature
option.type, where

  option(T type)

has one type parameters, has two:

  option.type(THIS#TYPE type, T type)

An the type of, e.g.

  option (list i32)

is

  option.type (option (list i32)) (list i32)

i.e., 'THIS#TYPE' is 'option (list i32)', while 'T' is 'list i32'

Special handling was needed for the case when actual type parameters are
inferred from actual arguments in a call. In this case, the type feature's does
not have the actual types ready when it is created, so a call-back is installed
to add this information when it becomes available.

Also, a special handling is needed for types that are cloned for use in type
features.  The clone will use its original context to look up features, but will
take the type feature to look up type parameters.

Also added a test case for type features with type parameters.