### PR TITLE
ast: fix require condition failure when errors present

### DIFF
--- a/src/dev/flang/ast/InlineArray.java
+++ b/src/dev/flang/ast/InlineArray.java
@@ -267,7 +267,7 @@ public class InlineArray extends ExprWithPos
   public void checkTypes()
   {
     if (PRECONDITIONS) require
-      (_type != null);
+      (Errors.count() > 0 || _type != null);
 
     var elementType = elementType();
 


### PR DESCRIPTION
the example that triggered the require condition failure:
```
main =>
  counts := mapOf string u64 [] []
  stdin.
```