### PR TITLE
parser: Remove rule for nameOrType from EBNF syntax

### DIFF
--- a/src/dev/flang/parser/Parser.java
+++ b/src/dev/flang/parser/Parser.java
@@ -1292,9 +1292,7 @@ callList    : call ( COMMA callList
   /**
    * Parse call
    *
-call        : nameOrType actuals callTail
-            ;
-nameOrType  : name
+call        : name actuals callTail
             ;
 actuals     : actualArgs
             | dot NUM_LITERAL


### PR DESCRIPTION
This rule exands to `name` only, so `nameOrType` can be replaced by `name`.