### PR TITLE
air: Fix feature result types that refer to actual outer clazzs via 'this.type'

### DIFF
--- a/src/dev/flang/air/Clazz.java
+++ b/src/dev/flang/air/Clazz.java
@@ -2031,6 +2031,31 @@ public class Clazz extends ANY implements Comparable<Clazz>
 
 
   /**
+   * Find outer clazz of this corresponding to feature `o`.
+   *
+   * @param o the outer feature whose clazz we are searching for.
+   *
+   * @param pos a position for error messages.
+   *
+   * @return the outer clazz of this corresponding feature `o`.
+   */
+  Clazz findOuter(AbstractFeature o, HasSourcePosition pos)
+  {
+    /* starting with feature(), follow outer references
+     * until we find o.
+     */
+    var res = this;
+    var i = feature();
+    while (i != o)
+      {
+        res = res.lookup(i.outerRef(), pos).resultClazz();
+        i = i.outer();
+      }
+    return res;
+  }
+
+
+  /**
    * Determine the clazz of the result of calling this clazz.
    *
    * @return the result clazz.
@@ -2065,7 +2090,13 @@ public class Clazz extends ANY implements Comparable<Clazz>
       {
         var ft = f.resultType();
         var t = _outer.actualType(ft, _select);
-        if (!t.dependsOnGenerics())
+
+        if (ft.isThisType())
+          {
+            // Find outer feature corresponding to ft:
+            return _outer.findOuter(ft.featureOfType(), feature());
+          }
+        else if (!t.dependsOnGenerics())
           {
             /* We have this situation:
 

--- a/src/dev/flang/air/Clazzes.java
+++ b/src/dev/flang/air/Clazzes.java
@@ -1076,19 +1076,8 @@ public class Clazzes extends ANY
             if (c.calledFeature() == Types.resolved.f_Types_get &&
                 c.actualTypeParameters().get(0).isThisType())
               {
-                /* starting with outerClazz.feature(), follow outer references
-                 * until we find the call's type parameter. The type of that outer ref's result
-                 * is the type whose type clazz is our result.
-                 */
-                var res = outerClazz;
-                var o = c.actualTypeParameters().get(0).featureOfType();
-                var i = outerClazz.feature();
-                while (i != o)
-                  {
-                    res = res.lookup(i.outerRef(), c).resultClazz();
-                    i = i.outer();
-                  }
-                result = res.typeClazz();
+                // NYI: Check if this special handling could be done in inner.resultClazz() instead
+                result = outerClazz.findOuter(c.actualTypeParameters().get(0).featureOfType(), c).typeClazz();
               }
             else
               {


### PR DESCRIPTION
This fixes the first example in #874.