### PR TITLE
air: Make findOuter robust against not finding outer. fix #885, enhance #874

### DIFF
--- a/src/dev/flang/air/Clazz.java
+++ b/src/dev/flang/air/Clazz.java
@@ -2046,7 +2046,7 @@ public class Clazz extends ANY implements Comparable<Clazz>
      */
     var res = this;
     var i = feature();
-    while (i != o)
+    while (i != o && i.outerRef() != null)
       {
         res = res.lookup(i.outerRef(), pos).resultClazz();
         i = i.outer();


### PR DESCRIPTION
This may happen as a result of missing an implementation of a abstract feature, which will result in an error later.