### PR TITLE
air: Mark clazzes of constants as instantiated, fix #886, enhance #874

### DIFF
--- a/src/dev/flang/air/Clazz.java
+++ b/src/dev/flang/air/Clazz.java
@@ -39,6 +39,7 @@ import java.util.stream.Stream;
 import dev.flang.ast.AbstractAssign; // NYI: remove dependency!
 import dev.flang.ast.AbstractCall; // NYI: remove dependency!
 import dev.flang.ast.AbstractCase; // NYI: remove dependency!
+import dev.flang.ast.AbstractConstant; // NYI: remove dependency!
 import dev.flang.ast.AbstractFeature; // NYI: remove dependency!
 import dev.flang.ast.AbstractMatch; // NYI: remove dependency!
 import dev.flang.ast.AbstractType; // NYI: remove dependency!
@@ -1378,14 +1379,15 @@ public class Clazz extends ANY implements Comparable<Clazz>
           {
             public void action (Stmnt s)
             {
-              if      (s instanceof Unbox          u) { Clazzes.findClazzes(u, Clazz.this); }
-              else if (s instanceof AbstractAssign a) { Clazzes.findClazzes(a, Clazz.this); }
-              else if (s instanceof AbstractCall   c) { Clazzes.findClazzes(c, Clazz.this); }
-              else if (s instanceof If             i) { Clazzes.findClazzes(i, Clazz.this); }
-              else if (s instanceof InlineArray    i) { Clazzes.findClazzes(i, Clazz.this); }
-              else if (s instanceof Env            b) { Clazzes.findClazzes(b, Clazz.this); }
-              else if (s instanceof AbstractMatch  m) { Clazzes.findClazzes(m, Clazz.this); }
-              else if (s instanceof Tag            t) { Clazzes.findClazzes(t, Clazz.this); }
+              if      (s instanceof Unbox            u) { Clazzes.findClazzes(u, Clazz.this); }
+              else if (s instanceof AbstractAssign   a) { Clazzes.findClazzes(a, Clazz.this); }
+              else if (s instanceof AbstractCall     c) { Clazzes.findClazzes(c, Clazz.this); }
+              else if (s instanceof AbstractConstant c) { Clazzes.findClazzes(c, Clazz.this); }
+              else if (s instanceof If               i) { Clazzes.findClazzes(i, Clazz.this); }
+              else if (s instanceof InlineArray      i) { Clazzes.findClazzes(i, Clazz.this); }
+              else if (s instanceof Env              b) { Clazzes.findClazzes(b, Clazz.this); }
+              else if (s instanceof AbstractMatch    m) { Clazzes.findClazzes(m, Clazz.this); }
+              else if (s instanceof Tag              t) { Clazzes.findClazzes(t, Clazz.this); }
             }
             public void action(AbstractCase c)
             {

--- a/src/dev/flang/air/Clazzes.java
+++ b/src/dev/flang/air/Clazzes.java
@@ -920,6 +920,22 @@ public class Clazzes extends ANY
 
 
   /**
+   * Find actual clazzes used by a constant expression
+   *
+   * @param c the constant
+   *
+   * @param outerClazz the surrounding clazz
+   */
+  public static void findClazzes(AbstractConstant c, Clazz outerClazz)
+  {
+    if (PRECONDITIONS) require
+      (c != null, outerClazz != null);
+
+    clazz(c, outerClazz).instantiated(c.pos());
+  }
+
+
+  /**
    * Find all static clazzes for this case and store them in outerClazz.
    */
   public static void findClazzes(If i, Clazz outerClazz)


### PR DESCRIPTION
The example of #886 created constants of type `u8` without performing any calculations that produces an `u8`. Since the constants did falsely not mark clazz `u8` as instantiated, the middle end assumed there were no instances and hence no features could be called on `u8` resulting in this error when DFA analysed a call to `u8.infix <`.

Now, the presence of a constant ensures that the clazz of the constant is marked as instantiated.