### PR TITLE
ast: rename and clean up `Expr.type` and `Expr.typeForFeatureResultTypeInferencing`

### DIFF
--- a/src/dev/flang/ast/AbstractBlock.java
+++ b/src/dev/flang/ast/AbstractBlock.java
@@ -105,12 +105,14 @@ public abstract class AbstractBlock extends Expr
 
 
   /**
-   * type returns the type of this expression or Types.t_ERROR if the type is
-   * still unknown, i.e., before or during type resolution.
+   * typeIfKnown returns the type of this expression or null if the type is
+   * still unknown, i.e., before or during type resolution.  This is redefined
+   * by sub-classes of Expr, but it is usually not called directly. To obtain
+   * the type for type inference, inferredType() must be used.
    *
-   * @return this Expr's type or t_ERROR in case it is not known yet.
+   * @return this Expr's type or null if not known.
    */
-  public AbstractType type()
+  AbstractType typeIfKnown()
   {
     return Types.resolved.t_unit;
   }

--- a/src/dev/flang/ast/AbstractCurrent.java
+++ b/src/dev/flang/ast/AbstractCurrent.java
@@ -70,12 +70,14 @@ public abstract class AbstractCurrent extends Expr
 
 
   /**
-   * type returns the type of this expression or Types.t_ERROR if the type is
-   * still unknown, i.e., before or during type resolution.
+   * typeIfKnown returns the type of this expression or null if the type is
+   * still unknown, i.e., before or during type resolution.  This is redefined
+   * by sub-classes of Expr, but it is usually not called directly. To obtain
+   * the type for type inference, inferredType() must be used.
    *
-   * @return this Expr's type or t_ERROR in case it is not known yet.
+   * @return this Expr's type or null if not known.
    */
-  public AbstractType type()
+  AbstractType typeIfKnown()
   {
     return _type;
   }

--- a/src/dev/flang/ast/AbstractMatch.java
+++ b/src/dev/flang/ast/AbstractMatch.java
@@ -131,15 +131,15 @@ public abstract class AbstractMatch extends Expr
 
 
   /**
-   * Helper routine for typeForFeatureResultTypeInferencing to determine the type of this match statement
-   * on demand, i.e., as late as possible.
+   * Helper routine for typeIfKnown to determine the type of this match
+   * statement on demand, i.e., as late as possible.
    */
   private AbstractType typeFromCases()
   {
     AbstractType result = Types.resolved.t_void;
     for (var c: cases())
       {
-        var t = c.code().typeForFeatureResultTypeInferencing();
+        var t = c.code().inferredType();
         result = result == null || t == null ? null : result.union(t);
       }
     if (result == Types.t_UNDEFINED)
@@ -159,12 +159,14 @@ public abstract class AbstractMatch extends Expr
 
 
   /**
-   * type returns the type of this expression or Types.t_ERROR if the type is
-   * still unknown, i.e., before or during type resolution.
+   * typeIfKnown returns the type of this expression or null if the type is
+   * still unknown, i.e., before or during type resolution.  This is redefined
+   * by sub-classes of Expr, but it is usually not called directly. To obtain
+   * the type for type inference, inferredType() must be used.
    *
-   * @return this Expr's type or t_ERROR in case it is not known yet.
+   * @return this Expr's type or null if not known.
    */
-  public AbstractType type()
+  AbstractType typeIfKnown()
   {
     if (_type == null)
       {

--- a/src/dev/flang/ast/Block.java
+++ b/src/dev/flang/ast/Block.java
@@ -231,32 +231,19 @@ public class Block extends AbstractBlock
 
 
   /**
-   * type returns the type of this expression or Types.t_ERROR if the type is
-   * still unknown, i.e., before or during type resolution.
-   *
-   * @return this Expr's type or t_ERROR in case it is not known yet.
-   */
-  public AbstractType type()
-  {
-    Expr resExpr = resultExpression();
-    return resExpr == null
-      ? Types.resolved.t_unit
-      : resExpr.type();
-  }
-
-
-  /**
-   * typeForFeatureResultTypeInferencing returns the type of this expression or
-   * null if the type is still unknown, i.e., before or during type resolution.
+   * typeIfKnown returns the type of this expression or null if the type is
+   * still unknown, i.e., before or during type resolution.  This is redefined
+   * by sub-classes of Expr, but it is usually not called directly. To obtain
+   * the type for type inference, inferredType() must be used.
    *
    * @return this Expr's type or null if not known.
    */
-  AbstractType typeForFeatureResultTypeInferencing()
+  AbstractType typeIfKnown()
   {
     Expr resExpr = resultExpression();
     return resExpr == null
       ? Types.resolved.t_unit
-      : resExpr.typeForFeatureResultTypeInferencing();
+      : resExpr.inferredType();
   }
 
 

--- a/src/dev/flang/ast/BoolConst.java
+++ b/src/dev/flang/ast/BoolConst.java
@@ -92,12 +92,14 @@ public class BoolConst extends Constant
 
 
   /**
-   * type returns the type of this expression or Types.t_ERROR if the type is
-   * still unknown, i.e., before or during type resolution.
+   * typeIfKnown returns the type of this expression or null if the type is
+   * still unknown, i.e., before or during type resolution.  This is redefined
+   * by sub-classes of Expr, but it is usually not called directly. To obtain
+   * the type for type inference, inferredType() must be used.
    *
-   * @return this Expr's type or t_ERROR in case it is not known yet.
+   * @return this Expr's type or null if not known.
    */
-  public AbstractType type()
+  AbstractType typeIfKnown()
   {
     return Types.resolved.t_bool;
   }

--- a/src/dev/flang/ast/Box.java
+++ b/src/dev/flang/ast/Box.java
@@ -116,12 +116,14 @@ public class Box extends Expr
 
 
   /**
-   * type returns the type of this expression or Types.t_ERROR if the type is
-   * still unknown, i.e., before or during type resolution.
+   * typeIfKnown returns the type of this expression or null if the type is
+   * still unknown, i.e., before or during type resolution.  This is redefined
+   * by sub-classes of Expr, but it is usually not called directly. To obtain
+   * the type for type inference, inferredType() must be used.
    *
-   * @return this Expr's type or t_ERROR in case it is not known yet.
+   * @return this Expr's type or null if not known.
    */
-  public AbstractType type()
+  AbstractType typeIfKnown()
   {
     return _type;
   }

--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -1001,12 +1001,14 @@ public class Call extends AbstractCall
 
 
   /**
-   * typeForFeatureResultTypeInferencing returns the type of this expression or
-   * null if the type is still unknown, i.e., before or during type resolution.
+   * typeIfKnown returns the type of this expression or null if the type is
+   * still unknown, i.e., before or during type resolution.  This is redefined
+   * by sub-classes of Expr, but it is usually not called directly. To obtain
+   * the type for type inference, inferredType() must be used.
    *
    * @return this Expr's type or null if not known.
    */
-  AbstractType typeForFeatureResultTypeInferencing()
+  AbstractType typeIfKnown()
   {
     return _type;
   }
@@ -1544,7 +1546,7 @@ public class Call extends AbstractCall
                   {
                     count++;
                     Expr actual = resolveTypeForNextActual(aargs, res, outer);
-                    var actualType = actual.typeForFeatureResultTypeInferencing();
+                    var actualType = actual.inferredType();
                     if (actualType == null)
                       {
                         actualType = Types.t_ERROR;
@@ -1557,7 +1559,7 @@ public class Call extends AbstractCall
               {
                 count++;
                 Expr actual = resolveTypeForNextActual(aargs, res, outer);
-                var actualType = actual.typeForGenericsTypeInfereing();
+                var actualType = actual.inferredType();
                 if (actualType != null)
                   {
                     inferGeneric(res, t, actualType, actual.pos(), conflict, foundAt);
@@ -1636,7 +1638,7 @@ public class Call extends AbstractCall
           {
             for (var p: aft.inherits())
               {
-                var pt = p.typeForFeatureResultTypeInferencing();
+                var pt = p.inferredType();
                 if (pt != null)
                   {
                     var apt = actualType.actualType(pt);
@@ -1897,7 +1899,7 @@ public class Call extends AbstractCall
             // NYI: Need to check why this is needed, it does not make sense to
             // propagate the target's type to target. But if removed,
             // tests/reg_issue16_chainedBool/ fails with C backend:
-            _target = _target.propagateExpectedType(res, outer, _target.typeForFeatureResultTypeInferencing());
+            _target = _target.propagateExpectedType(res, outer, _target.inferredType());
           }
       }
   }

--- a/src/dev/flang/ast/Env.java
+++ b/src/dev/flang/ast/Env.java
@@ -81,12 +81,14 @@ public class Env extends ExprWithPos
 
 
   /**
-   * typeForFeatureResultTypeInferencing returns the type of this expression or
-   * null if the type is still unknown, i.e., before or during type resolution.
+   * typeIfKnown returns the type of this expression or null if the type is
+   * still unknown, i.e., before or during type resolution.  This is redefined
+   * by sub-classes of Expr, but it is usually not called directly. To obtain
+   * the type for type inference, inferredType() must be used.
    *
    * @return this Expr's type or null if not known.
    */
-  AbstractType typeForFeatureResultTypeInferencing()
+  AbstractType typeIfKnown()
   {
     return _type;
   }

--- a/src/dev/flang/ast/Expr.java
+++ b/src/dev/flang/ast/Expr.java
@@ -117,7 +117,7 @@ public abstract class Expr extends ANY implements Stmnt, HasSourcePosition
    */
   public AbstractType type()
   {
-    var result = typeForFeatureResultTypeInferencing();
+    var result = typeIfKnown();
     if (result == null)
       {
         result = Types.t_ERROR;
@@ -130,27 +130,31 @@ public abstract class Expr extends ANY implements Stmnt, HasSourcePosition
 
 
   /**
-   * typeForFeatureResultTypeInferencing returns the type of this expression or
-   * null if the type is still unknown, i.e., before or during type resolution.
+   * typeIfKnown returns the type of this expression or null if the type is
+   * still unknown, i.e., before or during type resolution.  This is redefined
+   * by sub-classes of Expr, but it is usually not called directly. To obtain
+   * the type for type inference, inferredType() must be used.
    *
    * @return this Expr's type or null if not known.
    */
-  AbstractType typeForFeatureResultTypeInferencing()
+  AbstractType typeIfKnown()
   {
     return type();
   }
 
 
   /**
-   * typeForGenericsTypeInfereing returns the type of this expression or null if
-   * the type is still unknown, i.e., before or during type resolution for
-   * generic type arguments.
+   * The type that is inferred from this Expr or null if unknown.
    *
-   * @return this Expr's type or null if not known.
+   * This is the value returned by typeIfKnown, but post-processed to
+   * replace `a.this.type` by `a` in case `a` is a ref feature.
+   *
+   * @return this Expr's inferred and post-processed type or null if not known.
    */
-  public AbstractType typeForGenericsTypeInfereing()
+  final AbstractType inferredType()
   {
-    return typeForFeatureResultTypeInferencing();
+    var result = typeIfKnown();
+    return result;
   }
 
 

--- a/src/dev/flang/ast/Feature.java
+++ b/src/dev/flang/ast/Feature.java
@@ -1345,7 +1345,7 @@ public class Feature extends AbstractFeature implements Stmnt
             _thisType = tt.resolve(res, this);
           }
 
-        if ((_impl._kind == Impl.Kind.FieldActual) && (_impl._initialValue.typeForFeatureResultTypeInferencing() == null))
+        if ((_impl._kind == Impl.Kind.FieldActual) && (_impl._initialValue.inferredType() == null))
           {
             _impl._initialValue.visit(new ResolveTypes(res),
                                      true /* NYI: impl_outerOfInitialValue not set yet */
@@ -2214,13 +2214,13 @@ public class Feature extends AbstractFeature implements Stmnt
       {
         if (CHECKS) check
           (!state().atLeast(State.TYPES_INFERENCED));
-        result = _impl._initialValue.typeForFeatureResultTypeInferencing();
+        result = _impl._initialValue.inferredType();
       }
     else if (_impl._kind == Impl.Kind.RoutineDef)
       {
         if (CHECKS) check
           (!state().atLeast(State.TYPES_INFERENCED));
-        result = _impl._code.typeForFeatureResultTypeInferencing();
+        result = _impl._code.inferredType();
       }
     else if (_returnType.isConstructorType())
       {

--- a/src/dev/flang/ast/Function.java
+++ b/src/dev/flang/ast/Function.java
@@ -490,13 +490,14 @@ public class Function extends ExprWithPos
 
 
   /**
-   * typeForGenericsTypeInfereing returns the type of this expression or null if
-   * the type is still unknown, i.e., before or during type resolution for
-   * generic type arguments.
+   * typeIfKnown returns the type of this expression or null if the type is
+   * still unknown, i.e., before or during type resolution.  This is redefined
+   * by sub-classes of Expr, but it is usually not called directly. To obtain
+   * the type for type inference, inferredType() must be used.
    *
    * @return this Expr's type or null if not known.
    */
-  public AbstractType typeForGenericsTypeInfereing()
+  AbstractType typeIfKnown()
   {
     // unlike type(), we do not produce an error but just return null here since
     // everything might eventually turn out fine in this case.

--- a/src/dev/flang/ast/If.java
+++ b/src/dev/flang/ast/If.java
@@ -180,7 +180,7 @@ public class If extends ExprWithPos
 
 
   /**
-   * Helper routine for typeForFeatureResultTypeInferencing to determine the
+   * Helper routine for typeIfKnown to determine the
    * type of this if statement on demand, i.e., as late as possible.
    */
   private AbstractType typeFromIfOrElse()
@@ -190,7 +190,7 @@ public class If extends ExprWithPos
     Iterator<Expr> it = branches();
     while (it.hasNext())
       {
-        var t = it.next().typeForFeatureResultTypeInferencing();
+        var t = it.next().inferredType();
         result = t == null ? Types.t_UNDEFINED : result.union(t);
       }
     if (result == Types.t_UNDEFINED)
@@ -205,12 +205,14 @@ public class If extends ExprWithPos
 
 
   /**
-   * type returns the type of this expression or Types.t_ERROR if the type is
-   * still unknown, i.e., before or during type resolution.
+   * typeIfKnown returns the type of this expression or null if the type is
+   * still unknown, i.e., before or during type resolution.  This is redefined
+   * by sub-classes of Expr, but it is usually not called directly. To obtain
+   * the type for type inference, inferredType() must be used.
    *
-   * @return this Expr's type or t_ERROR in case it is not known yet.
+   * @return this Expr's type or null if not known.
    */
-  public AbstractType type()
+  AbstractType typeIfKnown()
   {
     if (PRECONDITIONS) require
       (elseBlock != null || elseIf != null);

--- a/src/dev/flang/ast/InlineArray.java
+++ b/src/dev/flang/ast/InlineArray.java
@@ -94,19 +94,21 @@ public class InlineArray extends ExprWithPos
 
 
   /**
-   * type returns the type of this expression or Types.t_ERROR if the type is
-   * still unknown, i.e., before or during type resolution.
+   * typeIfKnown returns the type of this expression or null if the type is
+   * still unknown, i.e., before or during type resolution.  This is redefined
+   * by sub-classes of Expr, but it is usually not called directly. To obtain
+   * the type for type inference, inferredType() must be used.
    *
-   * @return this Expr's type or t_ERROR in case it is not known yet.
+   * @return this Expr's type or null if not known.
    */
-  public AbstractType type()
+  AbstractType typeIfKnown()
   {
     if (_type == null)
       {
         AbstractType t = Types.resolved.t_void;
         for (var e : _elements)
           {
-            var et = e.typeForFeatureResultTypeInferencing();
+            var et = e.inferredType();
             t =
               t  == null ? null :
               et == null ? null : t.union(et);

--- a/src/dev/flang/ast/NumLiteral.java
+++ b/src/dev/flang/ast/NumLiteral.java
@@ -350,12 +350,14 @@ public class NumLiteral extends Constant
   }
 
   /**
-   * type returns the type of this expression or Types.t_ERROR if the type is
-   * still unknown, i.e., before or during type resolution.
+   * typeIfKnown returns the type of this expression or null if the type is
+   * still unknown, i.e., before or during type resolution.  This is redefined
+   * by sub-classes of Expr, but it is usually not called directly. To obtain
+   * the type for type inference, inferredType() must be used.
    *
-   * @return this Expr's type or t_ERROR in case it is not known yet.
+   * @return this Expr's type or null if not known.
    */
-  public AbstractType type()
+  AbstractType typeIfKnown()
   {
     if (_type == null)
       {

--- a/src/dev/flang/ast/StrConst.java
+++ b/src/dev/flang/ast/StrConst.java
@@ -69,12 +69,14 @@ public class StrConst extends Constant
 
 
   /**
-   * type returns the type of this expression or Types.t_ERROR if the type is
-   * still unknown, i.e., before or during type resolution.
+   * typeIfKnown returns the type of this expression or null if the type is
+   * still unknown, i.e., before or during type resolution.  This is redefined
+   * by sub-classes of Expr, but it is usually not called directly. To obtain
+   * the type for type inference, inferredType() must be used.
    *
-   * @return this Expr's type or t_ERROR in case it is not known yet.
+   * @return this Expr's type or null if not known.
    */
-  public AbstractType type()
+  AbstractType typeIfKnown()
   {
     return Types.resolved.t_string;
   }

--- a/src/dev/flang/ast/Tag.java
+++ b/src/dev/flang/ast/Tag.java
@@ -108,12 +108,14 @@ public class Tag extends Expr
 
 
   /**
-   * type returns the type of this expression or Types.t_ERROR if the type is
-   * still unknown, i.e., before or during type resolution.
+   * typeIfKnown returns the type of this expression or null if the type is
+   * still unknown, i.e., before or during type resolution.  This is redefined
+   * by sub-classes of Expr, but it is usually not called directly. To obtain
+   * the type for type inference, inferredType() must be used.
    *
-   * @return this Expr's type or t_ERROR in case it is not known yet.
+   * @return this Expr's type or null if not known.
    */
-  public AbstractType type()
+  AbstractType typeIfKnown()
   {
     return _taggedType;
   }

--- a/src/dev/flang/ast/This.java
+++ b/src/dev/flang/ast/This.java
@@ -153,12 +153,14 @@ public class This extends ExprWithPos
 
 
   /**
-   * typeForFeatureResultTypeInferencing returns the type of this expression or
-   * null if the type is still unknown, i.e., before or during type resolution.
+   * typeIfKnown returns the type of this expression or null if the type is
+   * still unknown, i.e., before or during type resolution.  This is redefined
+   * by sub-classes of Expr, but it is usually not called directly. To obtain
+   * the type for type inference, inferredType() must be used.
    *
    * @return this Expr's type or null if not known.
    */
-  AbstractType typeForFeatureResultTypeInferencing()
+  AbstractType typeIfKnown()
   {
     return null;  // After type resolution, This is no longer part of the code.
   }

--- a/src/dev/flang/ast/Unbox.java
+++ b/src/dev/flang/ast/Unbox.java
@@ -119,12 +119,14 @@ public abstract class Unbox extends Expr
 
 
   /**
-   * type returns the type of this expression or Types.t_ERROR if the type is
-   * still unknown, i.e., before or during type resolution.
+   * typeIfKnown returns the type of this expression or null if the type is
+   * still unknown, i.e., before or during type resolution.  This is redefined
+   * by sub-classes of Expr, but it is usually not called directly. To obtain
+   * the type for type inference, inferredType() must be used.
    *
-   * @return this Expr's type or t_ERROR in case it is not known yet.
+   * @return this Expr's type or null if not known.
    */
-  public AbstractType type()
+  AbstractType typeIfKnown()
   {
     return _type;
   }

--- a/src/dev/flang/ast/Universe.java
+++ b/src/dev/flang/ast/Universe.java
@@ -65,12 +65,14 @@ public class Universe extends Expr
 
 
   /**
-   * type returns the type of this expression or Types.t_ERROR if the type is
-   * still unknown, i.e., before or during type resolution.
+   * typeIfKnown returns the type of this expression or null if the type is
+   * still unknown, i.e., before or during type resolution.  This is redefined
+   * by sub-classes of Expr, but it is usually not called directly. To obtain
+   * the type for type inference, inferredType() must be used.
    *
-   * @return this Expr's type or t_ERROR in case it is not known yet.
+   * @return this Expr's type or null if not known.
    */
-  public AbstractType type()
+  AbstractType typeIfKnown()
   {
     return Types.resolved.universe.thisType();
   }


### PR DESCRIPTION
The naming of these methods was confusing and their use was inconsistent.  This patch does

- split up `typeForFeatureResultTypeInferencing` into two methods: `typeIfKnown` and `inferredType`.

- `typeIfKnown` is used only in `Expr` instances created by the parser and gives the type of an expression or `null` if it is unkown.  This must be redefined by all parsed expressions, but it is usually not called, `inferredType` is used for this.

- `inferredType` provides the result of `typeIfKnown`, but it provides a means to post-process the type, which will become necessary for handling this.type.

- `Expr.type()` internally uses `typeIfKnown()`. Any `Expr` created from a library file must redefine `Expr.type` to give the type.

- `Expr.typeForGenericsTypeInfereing` (sic!) was removed, this could be replaced by `typeIfKnown` and `inferredType`, resp.