### PR TITLE
ast: change result type of outer ref to be this.type, fix #904

### DIFF
--- a/src/dev/flang/ast/Expr.java
+++ b/src/dev/flang/ast/Expr.java
@@ -154,6 +154,10 @@ public abstract class Expr extends ANY implements Stmnt, HasSourcePosition
   final AbstractType inferredType()
   {
     var result = typeIfKnown();
+    if (result instanceof Type rt && rt.isThisType() && rt.featureOfType().isThisRef())
+      {
+        result = new Type(rt, Type.RefOrVal.LikeUnderlyingFeature);
+      }
     return result;
   }
 

--- a/src/dev/flang/ast/Feature.java
+++ b/src/dev/flang/ast/Feature.java
@@ -2234,6 +2234,10 @@ public class Feature extends AbstractFeature implements Stmnt
       {
         result = _returnType.functionReturnType();
       }
+    if (isOuterRef())
+      {
+        result = result.asThis();
+      }
 
     return result;
   }

--- a/src/dev/flang/ast/Unbox.java
+++ b/src/dev/flang/ast/Unbox.java
@@ -85,7 +85,7 @@ public abstract class Unbox extends Expr
   {
     if (PRECONDITIONS) require
       (adr != null,
-       adr.type().isRef() || adr instanceof AbstractCall c && c.calledFeature().isOuterRef(),
+       adr.type().isThisType() || adr.type().isRef(),
        !type.featureOfType().isThisRef()
        );
 
@@ -108,7 +108,7 @@ public abstract class Unbox extends Expr
 
     if (PRECONDITIONS) require
       (adr != null,
-       adr.type().isRef(),
+       adr.type().isThisType() || adr.type().isRef(),
        Errors.count() > 0 || type.featureOfType() == outer,
        !type.featureOfType().isThisRef()
        );


### PR DESCRIPTION
This also requires possibliy unboxing the value, so need to relax the precondition of Unbox.