### PR TITLE
ast: box expr passed to a ref thisType, fix #904

### DIFF
--- a/src/dev/flang/ast/Box.java
+++ b/src/dev/flang/ast/Box.java
@@ -82,7 +82,7 @@ public class Box extends Expr
 
     this._value = value;
     var t = Types.intern(value.type());
-    this._type = frmlT.isGenericArgument() ? t : t.asRef();
+    this._type = needsBoxingForGenericOrThis(frmlT) ? t : t.asRef();
   }
 
 

--- a/src/dev/flang/ast/Expr.java
+++ b/src/dev/flang/ast/Expr.java
@@ -404,13 +404,28 @@ public abstract class Expr extends ANY implements Stmnt, HasSourcePosition
 
 
   /**
+   * Is boxing needed when we assign to frmlT since frmlT is generic (so it
+   * could be a ref) or frmlT is this type and the underlying feature is by
+   * default a ref?
+   *
+   * @param frmlT the formal type we are assigning to.
+   */
+  boolean needsBoxingForGenericOrThis(AbstractType frmlT)
+  {
+    return
+      frmlT.isGenericArgument() ||
+      frmlT.isThisType() && frmlT.featureOfType().isThisRef();
+  }
+
+
+  /**
    * Is boxing needed when we assign to frmlT?
    * @param frmlT the formal type we are assigning to.
    */
   private boolean needsBoxing(AbstractType frmlT)
   {
     var t = type();
-    if (frmlT.isGenericArgument())
+    if (needsBoxingForGenericOrThis(frmlT))
       {
         return true;
       }


### PR DESCRIPTION
A thisType whose underlying feature is a ref is always treated like a ref type, so value types in heirs are boxed.