### PR TITLE
lib/ast/tests: cleanup and add tests of type inference using this, fix #874

### DIFF
--- a/lib/String.fz
+++ b/lib/String.fz
@@ -27,10 +27,10 @@
 #
 String ref : has_equality, hasHash String, ordered String, Strings is
 
-  redef orderedThis => String.this
+  redef orderedThis String is String.this
 
   # converting a string to a string is just returning string.this
-  redef asString => String.this
+  redef asString String is String.this
 
   # any concrete string must implement utf8
   utf8 Sequence u8 is abstract
@@ -526,7 +526,7 @@ String ref : has_equality, hasHash String, ordered String, Strings is
       !s.isEmpty
     is
     match (find s)
-      nil => [String.this].asList
+      nil => [asString].asList
       idx i32 => ref : Cons String (list String)
                    head => substring 0 idx
                    tail =>
@@ -624,7 +624,7 @@ String ref : has_equality, hasHash String, ordered String, Strings is
   #
   cut(sep String) tuple String String bool is
     match find sep
-      nil => (String.this, "", false)
+      nil => (asString, "", false)
       i i32 =>
         l := byteLength
         sepl := sep.byteLength

--- a/src/dev/flang/ast/AbstractBlock.java
+++ b/src/dev/flang/ast/AbstractBlock.java
@@ -107,8 +107,7 @@ public abstract class AbstractBlock extends Expr
   /**
    * typeIfKnown returns the type of this expression or null if the type is
    * still unknown, i.e., before or during type resolution.  This is redefined
-   * by sub-classes of Expr, but it is usually not called directly. To obtain
-   * the type for type inference, inferredType() must be used.
+   * by sub-classes of Expr to provide type information.
    *
    * @return this Expr's type or null if not known.
    */

--- a/src/dev/flang/ast/AbstractCurrent.java
+++ b/src/dev/flang/ast/AbstractCurrent.java
@@ -72,8 +72,7 @@ public abstract class AbstractCurrent extends Expr
   /**
    * typeIfKnown returns the type of this expression or null if the type is
    * still unknown, i.e., before or during type resolution.  This is redefined
-   * by sub-classes of Expr, but it is usually not called directly. To obtain
-   * the type for type inference, inferredType() must be used.
+   * by sub-classes of Expr to provide type information.
    *
    * @return this Expr's type or null if not known.
    */

--- a/src/dev/flang/ast/AbstractMatch.java
+++ b/src/dev/flang/ast/AbstractMatch.java
@@ -139,7 +139,7 @@ public abstract class AbstractMatch extends Expr
     AbstractType result = Types.resolved.t_void;
     for (var c: cases())
       {
-        var t = c.code().inferredType();
+        var t = c.code().typeIfKnown();
         result = result == null || t == null ? null : result.union(t);
       }
     if (result == Types.t_UNDEFINED)
@@ -161,8 +161,7 @@ public abstract class AbstractMatch extends Expr
   /**
    * typeIfKnown returns the type of this expression or null if the type is
    * still unknown, i.e., before or during type resolution.  This is redefined
-   * by sub-classes of Expr, but it is usually not called directly. To obtain
-   * the type for type inference, inferredType() must be used.
+   * by sub-classes of Expr to provide type information.
    *
    * @return this Expr's type or null if not known.
    */

--- a/src/dev/flang/ast/Block.java
+++ b/src/dev/flang/ast/Block.java
@@ -233,8 +233,7 @@ public class Block extends AbstractBlock
   /**
    * typeIfKnown returns the type of this expression or null if the type is
    * still unknown, i.e., before or during type resolution.  This is redefined
-   * by sub-classes of Expr, but it is usually not called directly. To obtain
-   * the type for type inference, inferredType() must be used.
+   * by sub-classes of Expr to provide type information.
    *
    * @return this Expr's type or null if not known.
    */
@@ -243,7 +242,7 @@ public class Block extends AbstractBlock
     Expr resExpr = resultExpression();
     return resExpr == null
       ? Types.resolved.t_unit
-      : resExpr.inferredType();
+      : resExpr.typeIfKnown();
   }
 
 

--- a/src/dev/flang/ast/BoolConst.java
+++ b/src/dev/flang/ast/BoolConst.java
@@ -94,8 +94,7 @@ public class BoolConst extends Constant
   /**
    * typeIfKnown returns the type of this expression or null if the type is
    * still unknown, i.e., before or during type resolution.  This is redefined
-   * by sub-classes of Expr, but it is usually not called directly. To obtain
-   * the type for type inference, inferredType() must be used.
+   * by sub-classes of Expr to provide type information.
    *
    * @return this Expr's type or null if not known.
    */

--- a/src/dev/flang/ast/Box.java
+++ b/src/dev/flang/ast/Box.java
@@ -118,8 +118,7 @@ public class Box extends Expr
   /**
    * typeIfKnown returns the type of this expression or null if the type is
    * still unknown, i.e., before or during type resolution.  This is redefined
-   * by sub-classes of Expr, but it is usually not called directly. To obtain
-   * the type for type inference, inferredType() must be used.
+   * by sub-classes of Expr to provide type information.
    *
    * @return this Expr's type or null if not known.
    */

--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -1003,8 +1003,7 @@ public class Call extends AbstractCall
   /**
    * typeIfKnown returns the type of this expression or null if the type is
    * still unknown, i.e., before or during type resolution.  This is redefined
-   * by sub-classes of Expr, but it is usually not called directly. To obtain
-   * the type for type inference, inferredType() must be used.
+   * by sub-classes of Expr to provide type information.
    *
    * @return this Expr's type or null if not known.
    */
@@ -1546,7 +1545,7 @@ public class Call extends AbstractCall
                   {
                     count++;
                     Expr actual = resolveTypeForNextActual(aargs, res, outer);
-                    var actualType = actual.inferredType();
+                    var actualType = actual.typeIfKnown();
                     if (actualType == null)
                       {
                         actualType = Types.t_ERROR;
@@ -1559,7 +1558,7 @@ public class Call extends AbstractCall
               {
                 count++;
                 Expr actual = resolveTypeForNextActual(aargs, res, outer);
-                var actualType = actual.inferredType();
+                var actualType = actual.typeIfKnown();
                 if (actualType != null)
                   {
                     inferGeneric(res, t, actualType, actual.pos(), conflict, foundAt);
@@ -1638,7 +1637,7 @@ public class Call extends AbstractCall
           {
             for (var p: aft.inherits())
               {
-                var pt = p.inferredType();
+                var pt = p.typeIfKnown();
                 if (pt != null)
                   {
                     var apt = actualType.actualType(pt);
@@ -1899,7 +1898,7 @@ public class Call extends AbstractCall
             // NYI: Need to check why this is needed, it does not make sense to
             // propagate the target's type to target. But if removed,
             // tests/reg_issue16_chainedBool/ fails with C backend:
-            _target = _target.propagateExpectedType(res, outer, _target.inferredType());
+            _target = _target.propagateExpectedType(res, outer, _target.typeIfKnown());
           }
       }
   }

--- a/src/dev/flang/ast/Env.java
+++ b/src/dev/flang/ast/Env.java
@@ -83,8 +83,7 @@ public class Env extends ExprWithPos
   /**
    * typeIfKnown returns the type of this expression or null if the type is
    * still unknown, i.e., before or during type resolution.  This is redefined
-   * by sub-classes of Expr, but it is usually not called directly. To obtain
-   * the type for type inference, inferredType() must be used.
+   * by sub-classes of Expr to provide type information.
    *
    * @return this Expr's type or null if not known.
    */

--- a/src/dev/flang/ast/Expr.java
+++ b/src/dev/flang/ast/Expr.java
@@ -132,33 +132,13 @@ public abstract class Expr extends ANY implements Stmnt, HasSourcePosition
   /**
    * typeIfKnown returns the type of this expression or null if the type is
    * still unknown, i.e., before or during type resolution.  This is redefined
-   * by sub-classes of Expr, but it is usually not called directly. To obtain
-   * the type for type inference, inferredType() must be used.
+   * by sub-classes of Expr to provide type information.
    *
    * @return this Expr's type or null if not known.
    */
   AbstractType typeIfKnown()
   {
     return type();
-  }
-
-
-  /**
-   * The type that is inferred from this Expr or null if unknown.
-   *
-   * This is the value returned by typeIfKnown, but post-processed to
-   * replace `a.this.type` by `a` in case `a` is a ref feature.
-   *
-   * @return this Expr's inferred and post-processed type or null if not known.
-   */
-  final AbstractType inferredType()
-  {
-    var result = typeIfKnown();
-    if (result instanceof Type rt && rt.isThisType() && rt.featureOfType().isThisRef())
-      {
-        result = new Type(rt, Type.RefOrVal.LikeUnderlyingFeature);
-      }
-    return result;
   }
 
 

--- a/src/dev/flang/ast/Feature.java
+++ b/src/dev/flang/ast/Feature.java
@@ -1345,7 +1345,7 @@ public class Feature extends AbstractFeature implements Stmnt
             _thisType = tt.resolve(res, this);
           }
 
-        if ((_impl._kind == Impl.Kind.FieldActual) && (_impl._initialValue.inferredType() == null))
+        if ((_impl._kind == Impl.Kind.FieldActual) && (_impl._initialValue.typeIfKnown() == null))
           {
             _impl._initialValue.visit(new ResolveTypes(res),
                                      true /* NYI: impl_outerOfInitialValue not set yet */
@@ -2214,13 +2214,13 @@ public class Feature extends AbstractFeature implements Stmnt
       {
         if (CHECKS) check
           (!state().atLeast(State.TYPES_INFERENCED));
-        result = _impl._initialValue.inferredType();
+        result = _impl._initialValue.typeIfKnown();
       }
     else if (_impl._kind == Impl.Kind.RoutineDef)
       {
         if (CHECKS) check
           (!state().atLeast(State.TYPES_INFERENCED));
-        result = _impl._code.inferredType();
+        result = _impl._code.typeIfKnown();
       }
     else if (_returnType.isConstructorType())
       {

--- a/src/dev/flang/ast/Function.java
+++ b/src/dev/flang/ast/Function.java
@@ -492,8 +492,7 @@ public class Function extends ExprWithPos
   /**
    * typeIfKnown returns the type of this expression or null if the type is
    * still unknown, i.e., before or during type resolution.  This is redefined
-   * by sub-classes of Expr, but it is usually not called directly. To obtain
-   * the type for type inference, inferredType() must be used.
+   * by sub-classes of Expr to provide type information.
    *
    * @return this Expr's type or null if not known.
    */

--- a/src/dev/flang/ast/If.java
+++ b/src/dev/flang/ast/If.java
@@ -190,7 +190,7 @@ public class If extends ExprWithPos
     Iterator<Expr> it = branches();
     while (it.hasNext())
       {
-        var t = it.next().inferredType();
+        var t = it.next().typeIfKnown();
         result = t == null ? Types.t_UNDEFINED : result.union(t);
       }
     if (result == Types.t_UNDEFINED)
@@ -207,8 +207,7 @@ public class If extends ExprWithPos
   /**
    * typeIfKnown returns the type of this expression or null if the type is
    * still unknown, i.e., before or during type resolution.  This is redefined
-   * by sub-classes of Expr, but it is usually not called directly. To obtain
-   * the type for type inference, inferredType() must be used.
+   * by sub-classes of Expr to provide type information.
    *
    * @return this Expr's type or null if not known.
    */

--- a/src/dev/flang/ast/InlineArray.java
+++ b/src/dev/flang/ast/InlineArray.java
@@ -96,8 +96,7 @@ public class InlineArray extends ExprWithPos
   /**
    * typeIfKnown returns the type of this expression or null if the type is
    * still unknown, i.e., before or during type resolution.  This is redefined
-   * by sub-classes of Expr, but it is usually not called directly. To obtain
-   * the type for type inference, inferredType() must be used.
+   * by sub-classes of Expr to provide type information.
    *
    * @return this Expr's type or null if not known.
    */
@@ -108,7 +107,7 @@ public class InlineArray extends ExprWithPos
         AbstractType t = Types.resolved.t_void;
         for (var e : _elements)
           {
-            var et = e.inferredType();
+            var et = e.typeIfKnown();
             t =
               t  == null ? null :
               et == null ? null : t.union(et);

--- a/src/dev/flang/ast/NumLiteral.java
+++ b/src/dev/flang/ast/NumLiteral.java
@@ -352,8 +352,7 @@ public class NumLiteral extends Constant
   /**
    * typeIfKnown returns the type of this expression or null if the type is
    * still unknown, i.e., before or during type resolution.  This is redefined
-   * by sub-classes of Expr, but it is usually not called directly. To obtain
-   * the type for type inference, inferredType() must be used.
+   * by sub-classes of Expr to provide type information.
    *
    * @return this Expr's type or null if not known.
    */

--- a/src/dev/flang/ast/StrConst.java
+++ b/src/dev/flang/ast/StrConst.java
@@ -71,8 +71,7 @@ public class StrConst extends Constant
   /**
    * typeIfKnown returns the type of this expression or null if the type is
    * still unknown, i.e., before or during type resolution.  This is redefined
-   * by sub-classes of Expr, but it is usually not called directly. To obtain
-   * the type for type inference, inferredType() must be used.
+   * by sub-classes of Expr to provide type information.
    *
    * @return this Expr's type or null if not known.
    */

--- a/src/dev/flang/ast/Tag.java
+++ b/src/dev/flang/ast/Tag.java
@@ -110,8 +110,7 @@ public class Tag extends Expr
   /**
    * typeIfKnown returns the type of this expression or null if the type is
    * still unknown, i.e., before or during type resolution.  This is redefined
-   * by sub-classes of Expr, but it is usually not called directly. To obtain
-   * the type for type inference, inferredType() must be used.
+   * by sub-classes of Expr to provide type information.
    *
    * @return this Expr's type or null if not known.
    */

--- a/src/dev/flang/ast/This.java
+++ b/src/dev/flang/ast/This.java
@@ -155,8 +155,7 @@ public class This extends ExprWithPos
   /**
    * typeIfKnown returns the type of this expression or null if the type is
    * still unknown, i.e., before or during type resolution.  This is redefined
-   * by sub-classes of Expr, but it is usually not called directly. To obtain
-   * the type for type inference, inferredType() must be used.
+   * by sub-classes of Expr to provide type information.
    *
    * @return this Expr's type or null if not known.
    */

--- a/src/dev/flang/ast/Unbox.java
+++ b/src/dev/flang/ast/Unbox.java
@@ -121,8 +121,7 @@ public abstract class Unbox extends Expr
   /**
    * typeIfKnown returns the type of this expression or null if the type is
    * still unknown, i.e., before or during type resolution.  This is redefined
-   * by sub-classes of Expr, but it is usually not called directly. To obtain
-   * the type for type inference, inferredType() must be used.
+   * by sub-classes of Expr to provide type information.
    *
    * @return this Expr's type or null if not known.
    */

--- a/src/dev/flang/ast/Universe.java
+++ b/src/dev/flang/ast/Universe.java
@@ -67,8 +67,7 @@ public class Universe extends Expr
   /**
    * typeIfKnown returns the type of this expression or null if the type is
    * still unknown, i.e., before or during type resolution.  This is redefined
-   * by sub-classes of Expr, but it is usually not called directly. To obtain
-   * the type for type inference, inferredType() must be used.
+   * by sub-classes of Expr to provide type information.
    *
    * @return this Expr's type or null if not known.
    */

--- a/tests/reg_issue874ff/Makefile
+++ b/tests/reg_issue874ff/Makefile
@@ -1,0 +1,27 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test Makefile
+#
+#  Author: Fridtjof Siebert (siebert@tokiwa.software)
+#
+# -----------------------------------------------------------------------
+
+override NAME = issue874
+include ../simple.mk

--- a/tests/reg_issue874ff/issue874.fz
+++ b/tests/reg_issue874ff/issue874.fz
@@ -1,0 +1,268 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test issue874
+#
+#  Author: Fridtjof Siebert (siebert@tokiwa.software)
+#
+# -----------------------------------------------------------------------
+
+
+# all the tests are directly declared in the universe
+
+# first example from #874 assigning n.this to a field
+#
+test_this1 is
+
+  n is
+    m => 3
+    l =>
+      for
+        x := n.this
+        y := x.m
+      while false
+
+  i : n.
+
+  _ := i.l
+
+test_this1
+
+
+# second example from #874 assigning n.this to a field
+#
+test_this2 is
+
+  n is
+    m => 3
+    l =>
+      for
+        x := n.this
+        y := x.m
+      while false
+
+  i : n.
+
+  _ := n.l
+
+test_this2
+
+
+# third example from #874 and #885
+#
+test_this3 is
+
+  num is
+
+    type.zero num.this.type is abstract
+    type.one  num.this.type is abstract
+    lessThan(other num.this.type) bool is abstract
+    minus(other num.this.type) num.this.type is abstract
+
+    to_u32_loop =>
+      for
+        x := num.this, x.minus num.this.type.one
+        u := u32 0, u+1
+      while num.this.type.zero.lessThan x
+
+    redef asString => "num.this.type {to_u32_loop} 'asString'"
+
+  intM5(v u8) : num is
+    fixed type.zero => test_this3.intM5 0
+    fixed type.one => test_this3.intM5 1
+    fixed lessThan(other intM5) => v < other.v
+    fixed plus(other intM5) => intM5 (v + other.v)%5
+    fixed minus(other intM5) => intM5 (v - other.v)%5
+
+y := test_this3.intM5 1
+say (y.plus y)
+
+# fourth example from #874 and #886
+#
+test_this4 is
+
+  num is
+
+    type.zero num.this.type is abstract
+    type.one  num.this.type is abstract
+    lessThan(other num.this.type) bool is abstract
+    minus(other num.this.type) num.this.type is abstract
+
+    to_u32_loop =>
+      for
+        x := num.this, x.minus num.this.type.one
+        u := u32 0, u+1
+      while num.this.type.zero.lessThan x
+      else
+        u
+
+    redef asString => "num.this.type {to_u32_loop} 'asString'"
+
+
+  intM5(v u8) : num is
+    fixed type.zero => test_this4.intM5 0
+    fixed type.one => test_this4.intM5 1
+    fixed lessThan(other intM5) => v < other.v
+    fixed plus(other intM5) => intM5 (v + other.v)%5
+    fixed minus(other intM5) => intM5 (v - other.v)%5
+
+y := test_this4.intM5 1
+say (y.plus y)
+
+
+
+# example from #891
+#
+test_cov is
+
+  n is
+
+    p (other n.this.type) n.this.type is abstract
+
+    f =>
+      x := n.this
+      y := x.p n.this
+
+    redef asString => "{f}"
+
+  i(isZero bool) : n is
+    fixed p(other i) => other
+
+say (test_cov.i false)
+
+
+# example from #891 change such that is caused pop on empty stack
+#
+test_cov_DFA_pop is
+
+  n is
+    r =>
+      x := n.this
+      x.asString
+
+  i : n is
+
+  _ := i.r
+  o ref n := i
+  _ := o.r
+
+test_cov_DFA_pop
+
+
+# exmple from #891, but declaring n as ref
+#
+test_cov2 is
+
+  n ref is
+
+    p (other n.this.type) n.this.type is abstract
+
+    f =>
+      x := n.this
+      y := x.p n.this
+
+    redef asString => "{f}"
+
+  i(isZero bool) : n is
+    fixed p(other i) => other
+
+s := (test_cov2.i false).asString
+say s
+
+
+# exmple from #891, but declaring n as ref and simplified
+#
+test_cov2a0 is
+
+  n ref is
+
+    p (other n.this.type) n.this.type is abstract
+
+    f =>
+      x := n.this
+      y := x.p n.this
+
+  i(isZero bool) : n is
+    fixed p(other i) => other
+
+_ := (test_cov2a0.i false).f
+
+
+
+# example form #904
+#
+test_cov3 is
+  a ref is
+
+    f (o a.this.type) unit is
+    g => f a.this
+
+  b : a is
+
+  _ := b
+
+_ := test_cov3
+
+
+# example form #904, modified to call g
+#
+test_cov3a is
+  a ref is
+
+    f (o a.this.type) unit is
+    g => f a.this
+
+  b : a is
+  b.g
+
+_ := test_cov3a
+
+
+# exmple form #905
+#
+test_cov4 is
+  a ref is
+
+  #  x := ""
+  #  say x
+    f (o a.this.type) unit is
+    f a.this
+
+  b : a is
+
+  _ := b
+
+_ := test_cov4
+
+
+# exmple form #905 with a and b containing data, so not unit types
+#
+test_cov4a is
+  a ref is
+
+    x := ""
+    say x
+    f (o a.this.type) unit is
+    f a.this
+
+  b : a is
+
+  _ := b
+
+_ := test_cov4a

--- a/tests/reg_issue874ff/issue874.fz.expected_out
+++ b/tests/reg_issue874ff/issue874.fz.expected_out
@@ -1,0 +1,5 @@
+num.this.type 2 'asString'
+num.this.type 2 'asString'
+unit
+unit
+


### PR DESCRIPTION
Removed post-processing of type for type inference, this turned out not to work in all cases in the new test added in this patch.  Expr.inferredType() has been removed, Expr.typeIfKnown can be used directly instead.

Whenever type inference is used with `this`, the type is now the corresponding `this.type`. This required changes in `String.fz` that used `String.this` for type inference resulting in a type incompatible with `String`.

Added tests/reg_issue874ff that contains a collection of test cases related to type inference and this.type.