### PR TITLE
fuir: Add comment to make it easier to enable debugging the abstract …

### DIFF
--- a/src/dev/flang/fuir/analysis/AbstractInterpreter.java
+++ b/src/dev/flang/fuir/analysis/AbstractInterpreter.java
@@ -195,6 +195,10 @@ public class AbstractInterpreter<VALUE, RESULT> extends ANY
 
   /**
    * property-controlled flag to enable debug output.
+   *
+   * To enable debugging, use fz with
+   *
+   *   FUZION_JAVA_OPTIONS=-Ddev.flang.fuir.analysis.AbstractInterpreter.DEBUG=true
    */
   static final boolean DEBUG =
     System.getProperty("dev.flang.fuir.analysis.AbstractInterpreter.DEBUG",


### PR DESCRIPTION
…interpreter

Debugging requires setting a Java property with a lengthy name via FUZION_JAVA_OPTIONS. So I added this for easy copy-and-pasting.