### PR TITLE
air: add expermimental code to eargerly replace 'a.this.type'

### DIFF
--- a/src/dev/flang/air/Clazz.java
+++ b/src/dev/flang/air/Clazz.java
@@ -652,6 +652,16 @@ public class Clazz extends ANY implements Comparable<Clazz>
 
 
   /**
+   * This is experimental: actualGenerics() could replace `a.this.type` by the
+   * actual outer type. This would avoid special handling in Clazzes.clazz(Expr
+   * e, Clazz outerClazz). However, this is currently disabled since it has the
+   * side-effect of marking some clazzes as instantiated that are actually not
+   * (in tests/reg_issues874ff), need to check why.
+   */
+  static final boolean NYI_UNDER_DEVELOPMENT_EAGERLY_REPLACE_THIS_TYPE = false;
+
+
+  /**
    * Convert the given generics to the actual generics of this class.
    *
    * @param generics a list of generic arguments that might itself consist of
@@ -662,6 +672,29 @@ public class Clazz extends ANY implements Comparable<Clazz>
    */
   public List<AbstractType> actualGenerics(List<AbstractType> generics)
   {
+    if (NYI_UNDER_DEVELOPMENT_EAGERLY_REPLACE_THIS_TYPE)
+      {
+        /**
+         * Replace any `a.this.type` actual generics by the actual outer clazz:
+         */
+        if (generics.stream().anyMatch(x->x.isThisType()))
+          {
+            var ng = new List<AbstractType>();
+            for (var g : generics)
+              {
+                if (g.isThisType())
+                  {
+                    var nc = findOuter(g.featureOfType(), SourcePosition.builtIn).typeClazz();
+                    System.out.println("replace "+g+" with "+nc+" in "+this);
+                    ng.add(nc._type);
+                  }
+                else
+                  {
+                    ng.add(g);
+                  }
+              }
+          }
+      }
     generics = this._type.replaceGenerics(generics);
     if (this._outer != null)
       {

--- a/src/dev/flang/air/Clazzes.java
+++ b/src/dev/flang/air/Clazzes.java
@@ -1089,10 +1089,10 @@ public class Clazzes extends ANY
                                       outerClazz.actualGenerics(c.actualTypeParameters()),
                                       c,
                                       false);
-            if (c.calledFeature() == Types.resolved.f_Types_get &&
+            if (!Clazz.NYI_UNDER_DEVELOPMENT_EAGERLY_REPLACE_THIS_TYPE &&
+                c.calledFeature() == Types.resolved.f_Types_get &&
                 c.actualTypeParameters().get(0).isThisType())
               {
-                // NYI: Check if this special handling could be done in inner.resultClazz() instead
                 result = outerClazz.findOuter(c.actualTypeParameters().get(0).featureOfType(), c).typeClazz();
               }
             else


### PR DESCRIPTION
This is experimental: Clazz.actualGenerics() could replace `a.this.type` by the actual outer type. This would avoid special handling in Clazzes.clazz(Expr e, Clazz outerClazz). However, this is currently disabled since it has the side-effect of marking some clazzes as instantiated that are actually not (in tests/reg_issues874ff), need to check why.