### PR TITLE
docs: fix comment html encoding

### DIFF
--- a/src/dev/flang/tools/docs/Html.java
+++ b/src/dev/flang/tools/docs/Html.java
@@ -224,7 +224,7 @@ public class Html
           + "'><summary>$1</summary><div class='fd-comment'>$2</div>$3</details>"
             .replace("$1",
               summary(af))
-            .replace("$2", htmlEncodeNbsp(Util.commentOf(af)))
+            .replace("$2", Util.commentOf(af))
             .replace("$3", redefines(af));
       })
       .collect(Collectors.joining(System.lineSeparator()));
@@ -242,7 +242,7 @@ public class Html
       .replace("$0", f.isUniverse() ? "API-Documentation": htmlEncodedBasename(f))
       .replace("$3", anchorTags(f))
       .replace("$1", f.isUniverse() ? "": summary(f))
-      .replace("$2", htmlEncodeNbsp(Util.commentOf(f)))
+      .replace("$2", Util.commentOf(f))
       .replace("$5", f.isUniverse() ? "": "d-none")
       .replace("$6", redefines(f));
   }

--- a/src/dev/flang/tools/docs/Util.java
+++ b/src/dev/flang/tools/docs/Util.java
@@ -61,7 +61,7 @@ public class Util
   }
 
   /**
-   * the comment belonging to this feature
+   * the comment belonging to this feature in HTML
    * @param af
    * @return
    */


### PR DESCRIPTION
Partially reverts a previous change of mine. At the time I did not realize that the comments where already HTML and did not need encoding anymore.