### PR TITLE
parser/tests: Fix and unify parsing of ternary operator and inline match

### DIFF
--- a/src/dev/flang/parser/Lexer.java
+++ b/src/dev/flang/parser/Lexer.java
@@ -2735,7 +2735,7 @@ PIPE        : "|"
   private String tokenAsString()
   {
     if (PRECONDITIONS) require
-      (current() != Token.t_eof);
+      (currentNoLimit() != Token.t_eof);
 
     return asString(pos(), endPos());
   }

--- a/src/dev/flang/parser/Lexer.java
+++ b/src/dev/flang/parser/Lexer.java
@@ -195,6 +195,8 @@ public class Lexer extends SourceFile
     t_indentationLimit,  // token's indentation is not sufficient
     t_lineLimit,         // token is in next line while sameLine() parsing is enabled
     t_spaceLimit,        // token follows white space while endAtSpace is enabled
+    t_colonLimit,        // token is operator ":" while endAtColon is enabled
+    t_barLimit,          // token is operator "|" while endAtBar is enabled
     t_undefined;         // current token before first call to next()
 
     /**
@@ -471,6 +473,20 @@ public class Lexer extends SourceFile
 
 
   /**
+   * ':' operator restriction for current()/currentAtMinIndent(): if set,
+   * operator ":" will be replaced by t_colonLimit.
+   */
+  private boolean _endAtColon = false;
+
+
+  /**
+   * '|' operator restriction for current()/currentAtMinIndent(): if set,
+   * operator "|" will be replaced by t_barLimit.
+   */
+  private boolean _endAtBar = false;
+
+
+  /**
    * Has the raw token before current() been skipped because ignore(t) resulted
    * in true?
    */
@@ -509,6 +525,8 @@ public class Lexer extends SourceFile
     _minIndentStartPos = original._minIndentStartPos;
     _sameLine = original._sameLine;
     _endAtSpace = original._endAtSpace;
+    _endAtColon = original._endAtColon;
+    _endAtBar = original._endAtBar;
     _ignoredTokenBefore = original._ignoredTokenBefore;
     _stringLexer = original._stringLexer == null ? null : new StringLexer(original._stringLexer);
   }
@@ -648,6 +666,40 @@ public class Lexer extends SourceFile
 
 
   /**
+   * Restrict parsing until the next occurence of operator ":".  Operator ":"
+   * will be replaced by t_colonLimit.
+   *
+   * @param endAtColon true to enable, false to disable
+   *
+   * @return the previous endAtColon-restriction.
+   */
+  boolean endAtColon(boolean endAtColon)
+  {
+    var result = _endAtColon;
+    _endAtColon = endAtColon;
+
+    return result;
+  }
+
+
+  /**
+   * Restrict parsing until the next occurence of operator "|".  Operator "|"
+   * will be replaced by t_barLimit.
+   *
+   * @param endAtBar true to enable, false to disable
+   *
+   * @return the previous endAtBar-restriction
+   */
+  boolean endAtBar(boolean endAtBar)
+  {
+    var result = _endAtBar;
+    _endAtBar = endAtBar;
+
+    return result;
+  }
+
+
+  /**
    * Convenience method to temporarily reset limits set via sameLine() or
    * endAtSpace() while parsing.
    *
@@ -660,9 +712,13 @@ public class Lexer extends SourceFile
   {
     int oldLine = sameLine(-1);
     int oldEAS = endAtSpace(Integer.MAX_VALUE);
+    var oldEAC = endAtColon(false);
+    var oldEAB = endAtBar(false);
     V result = c.call();
     sameLine(oldLine);
     endAtSpace(oldEAS);
+    endAtColon(oldEAC);
+    endAtBar(oldEAB);
     return result;
   }
 
@@ -785,8 +841,12 @@ public class Lexer extends SourceFile
    *
    * @param spaceLimit the white space restriction (Integer.MAX_VALUE if none):
    * Any token after this position will be replaced by t_spaceLimit.
+   *
+   * @param endAtColon true to replace opeartor ":" by t_colonLimit.
+   *
+   * @param endAtBar true to replace opeartor "|" by t_barLimit.
    */
-  Token current(int minIndent, int sameLine, int endAtSpace)
+  Token current(int minIndent, int sameLine, int endAtSpace, boolean endAtColon, boolean endAtBar)
   {
     var t = _curToken;
     int l = _curLine;
@@ -796,7 +856,13 @@ public class Lexer extends SourceFile
       sameLine  >= 0 && l != sameLine                      ? Token.t_lineLimit        :
       p > endAtSpace && ignoredTokenBefore()               ? Token.t_spaceLimit       :
       p == _minIndentStartPos                              ? t                        :
-      minIndent >= 0 && codePointInLine(p, l) <= minIndent ? Token.t_indentationLimit
+      minIndent >= 0 && codePointInLine(p, l) <= minIndent ? Token.t_indentationLimit :
+      endAtColon                  &&
+      _curToken == Token.t_op     &&
+      tokenAsString().equals(":")                          ? Token.t_colonLimit       :
+      endAtBar                    &&
+      _curToken == Token.t_op     &&
+      tokenAsString().equals("|")                          ? Token.t_barLimit
                                                            : _curToken;
   }
 
@@ -807,7 +873,7 @@ public class Lexer extends SourceFile
    */
   public Token current()
   {
-    return current(_minIndent, _sameLine, _endAtSpace);
+    return current(_minIndent, _sameLine, _endAtSpace, _endAtColon, _endAtBar);
   }
 
 
@@ -817,7 +883,7 @@ public class Lexer extends SourceFile
    */
   Token currentAtMinIndent()
   {
-    return current(_minIndent - 1, _sameLine, _endAtSpace);
+    return current(_minIndent - 1, _sameLine, _endAtSpace, _endAtColon, _endAtBar);
   }
 
 
@@ -837,7 +903,7 @@ public class Lexer extends SourceFile
    */
   Token currentNoLimit()
   {
-    return current(-1, -1, Integer.MAX_VALUE);
+    return current(-1, -1, Integer.MAX_VALUE, false, false);
   }
 
 
@@ -1906,23 +1972,16 @@ HEX_TAIL    : "." HEX_DIGITS
   void syntaxError(int pos, String expected, String currentRule)
   {
     String detail = Parser.parserDetail(currentRule);
-    if (current() == Token.t_indentationLimit)
+    switch (current())
       {
-        Errors.indentationProblemEncountered(sourcePos(pos),
-                                             sourcePos(_minIndentStartPos),
-                                             detail);
-      }
-    else if (current() == Token.t_lineLimit)
-      {
-        Errors.lineBreakNotAllowedHere(sourcePos(lineEndPos(_sameLine)), detail);
-      }
-    else if (current() == Token.t_spaceLimit)
-      {
-        Errors.whiteSpaceNotAllowedHere(sourcePos(pos()), detail);
-      }
-    else
-      {
-        Errors.syntax(sourcePos(pos), expected, currentAsString(), detail);
+      case t_indentationLimit -> Errors.indentationProblemEncountered(sourcePos(pos),
+                                                                      sourcePos(_minIndentStartPos),
+                                                                      detail);
+      case t_lineLimit        -> Errors.lineBreakNotAllowedHere (sourcePos(lineEndPos(_sameLine)), detail);
+      case t_spaceLimit       -> Errors.whiteSpaceNotAllowedHere(sourcePos(pos()), detail);
+      case t_colonLimit       -> Errors.colonPartOfTernary      (sourcePos(pos()), detail);
+      case t_barLimit         -> Errors.barPartOfCase           (sourcePos(pos()), detail);
+      default                 -> Errors.syntax(sourcePos(pos), expected, currentAsString(), detail);
       }
   }
 

--- a/src/dev/flang/util/Errors.java
+++ b/src/dev/flang/util/Errors.java
@@ -641,6 +641,24 @@ public class Errors extends ANY
                 "To solve this, enclose the expression in parentheses '(' and ')'.");
   }
 
+  public static void colonPartOfTernary(SourcePosition pos, String detail)
+  {
+    syntaxError(pos,
+                "operator ':' is part of ternary ? : operator",
+                "This code is part of a ternary expression that must not contain operator ':'\n" +
+                detail + "\n" +
+                "To solve this, enclose the expression in parentheses '(' and ')'.");
+  }
+
+  public static void barPartOfCase(SourcePosition pos, String detail)
+  {
+    syntaxError(pos,
+                "operator '|' is part of match case",
+                "This code is part of a match case that must not contain operator '|'\n" +
+                detail + "\n" +
+                "To solve this, enclose the expression in parentheses '(' and ')' or braces '{' and '}'.");
+  }
+
   public static void expectedStringContinuation(SourcePosition pos, String token)
   {
     syntaxError(pos,

--- a/tests/ternary/Makefile
+++ b/tests/ternary/Makefile
@@ -1,0 +1,27 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test Makefile
+#
+#  Author: Fridtjof Siebert (siebert@tokiwa.software)
+#
+# -----------------------------------------------------------------------
+
+override NAME = test_ternary
+include ../simple.mk

--- a/tests/ternary/test_ternary.fz
+++ b/tests/ternary/test_ternary.fz
@@ -1,0 +1,82 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test ternary
+#
+#  Author: Fridtjof Siebert (siebert@tokiwa.software)
+#
+# -----------------------------------------------------------------------
+
+
+# test the syntax of ternary ? : and match using single lines, multi lines
+# and using expressions containing ':' and '|' operators.
+#
+test_ternary is
+
+  a is
+    ternary ? : (b, c Any) is say "a ? $b : $c"
+
+  # single line ternary ? :
+  _ := a ? { 3 } : { 4 }
+  _ := a ? ( 3 ) : ( 4 )
+  _ := a ?   3   :   4
+  a      ?   3   :   4
+
+  # multi-line ternary ? :
+  _ := (a ? 3
+          : 4)
+  a       ? 3
+          : 4
+
+  # ternary with mid-term containing ':'
+  _ :=  a ? (3 : ()->[4,5].asList) : nil
+  _ := (a ? (3 : ()->[4,5].asList)
+          : nil)
+  a ? say (3 : ()->[4,5].asList) : say nil
+  a ? say (3 : ()->[4,5].asList)
+    : say nil
+
+  x, y.
+  f(c x | y) =>
+
+    # single line ? | match
+    _ := c ? _ x => { f } | _ y => { g }
+    _ := c ? _ x => ( f ) | _ y => ( g )
+    _ := c ? _ x =>   f   | _ y =>   g
+    c      ? _ x =>   f   | _ y =>   g
+
+    # multi-line ? | match
+    _ := (c ? _ x => f
+            | _ y => g)
+    c       ? _ x => f
+            | _ y => g
+
+    # match with cases containing '|'
+    _ :=  c ? _ x => (3 | 4) | _ y => (5 | 8)
+    _ := (c ? _ x => (3 | 4)
+            | _ y => (5 | 8))
+    c ? _ x => say (3 | 4) | _ y => say (5 | 8)
+    c ? _ x => say (3 | 4)
+      | _ y => say (5 | 8)
+
+    f => say "found x"
+    g => say "found y"
+
+  f x
+  f y

--- a/tests/ternary/test_ternary.fz.expected_out
+++ b/tests/ternary/test_ternary.fz.expected_out
@@ -1,0 +1,30 @@
+a ? 3 : 4
+a ? 3 : 4
+a ? 3 : 4
+a ? 3 : 4
+a ? 3 : 4
+a ? 3 : 4
+a ? [3,4,5] : --nil--
+a ? [3,4,5] : --nil--
+[3,4,5]
+--nil--
+a ? unit : unit
+[3,4,5]
+--nil--
+a ? unit : unit
+found x
+found x
+found x
+found x
+found x
+found x
+7
+7
+found y
+found y
+found y
+found y
+found y
+found y
+13
+13


### PR DESCRIPTION
We can now write
```
  x := a ? b : c
```
or
```
  x := a ? b
         : c
```
or
```
  x := a ? TRUE => b | FALSE => c
```
or
```
  x := a ? TRUE  => b
         | FALSE => c
```
Added test for this syntax.