### PR TITLE
windows: (re)-open stdout/err in binary mode

### DIFF
--- a/.github/workflows/windows_c.yml
+++ b/.github/workflows/windows_c.yml
@@ -1,0 +1,41 @@
+name: run c tests on windows
+
+on:
+  workflow_dispatch:
+
+jobs:
+  run_tests_c:
+    name: windows run c tests
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+      - uses: msys2/setup-msys2@v2
+        with:
+          update: true
+          path-type: minimal
+# NYI maybe use mingw64 here?
+          msystem: MSYS
+# git is used in Makefile: JAVA_FILE_TOOLS_VERSION
+          install: >-
+            make
+            git
+            mingw-w64-x86_64-clang
+            diffutils
+
+      - name: install choco packages
+        shell: powershell
+        run: choco install openjdk --version 17.0.0
+
+      - uses: actions/checkout@v2
+
+# NYI how can we set PATH???
+      - name: echo PATH
+        run: export PATH="/mingw64/bin/:/c/Program Files/OpenJDK/jdk-17/bin:$PATH" && echo "$PATH"
+
+      - name: echo versions
+        run:  export PATH="/mingw64/bin/:/c/Program Files/OpenJDK/jdk-17/bin:$PATH" && clang --version && javac --version
+
+      - name: run tests
+        run: export PATH="/mingw64/bin/:/c/Program Files/OpenJDK/jdk-17/bin:$PATH" && make run_tests_c

--- a/src/dev/flang/be/c/C.java
+++ b/src/dev/flang/be/c/C.java
@@ -602,6 +602,8 @@ public class C extends ANY
        "#include <pthread.h>\n"+
        "#include <errno.h>\n"+
        "#include <sys/stat.h>\n"+
+       // defines _O_BINARY
+       "#include <sys/fcntl.h>\n"+
        "\n");
     cf.print
       (CStmnt.decl("int", _names.GLOBAL_ARGC));
@@ -673,11 +675,11 @@ public class C extends ANY
 
     cf.println("int main(int argc, char **argv) { ");
 
+    // If we don't do the following stdout/err might be opened in text mode on windows.
+    // This would lead to automatic insertions of carriage returns.
     cf.println("#if _WIN32");
-    cf.println("#ifndef O_BINARY");
-    cf.println("#define O_BINARY 0");
-    cf.println(" _setmode( _fileno( stdout ), _O_BINARY );");
-    cf.println(" _setmode( _fileno( stderr ), _O_BINARY );");
+    cf.println(" _setmode( _fileno( stdout ), _O_BINARY ); // reopen stdout in binary mode");
+    cf.println(" _setmode( _fileno( stderr ), _O_BINARY ); // reopen stderr in binary mode");
     cf.println("#endif");
 
     if (_options._useBoehmGC)

--- a/src/dev/flang/be/c/C.java
+++ b/src/dev/flang/be/c/C.java
@@ -673,6 +673,11 @@ public class C extends ANY
 
     cf.println("int main(int argc, char **argv) { ");
 
+    cf.println("#if _WIN32");
+    cf.println(" _setmode( _fileno( stdout ), _O_BINARY );");
+    cf.println(" _setmode( _fileno( stderr ), _O_BINARY );");
+    cf.println("#endif");
+
     if (_options._useBoehmGC)
       {
         cf.println("GC_INIT(); /* Optional on Linux/X86 */");

--- a/src/dev/flang/be/c/C.java
+++ b/src/dev/flang/be/c/C.java
@@ -674,6 +674,8 @@ public class C extends ANY
     cf.println("int main(int argc, char **argv) { ");
 
     cf.println("#if _WIN32");
+    cf.println("#ifndef O_BINARY");
+    cf.println("#define O_BINARY 0");
     cf.println(" _setmode( _fileno( stdout ), _O_BINARY );");
     cf.println(" _setmode( _fileno( stderr ), _O_BINARY );");
     cf.println("#endif");


### PR DESCRIPTION
fixes #696

This then leaves two failing tests on windows:

```
 ./build/tests/envir_vars/: failed
./build/tests/fileio/: failed
make[1]: Entering directory '/d/a/fuzion/fuzion/build/tests/envir_vars'
../check_simple_example_c.sh "../../bin/fz " envir_vars.fz || exit 1
RUN envir_vars.fz 1,2d0
< setting FUZION_ENVIR_VARS_TEST_SET to world successful
< unsetting FUZION_ENVIR_VARS_TEST_SET successful
0a1,16
make: *** [Makefile:1014: run_tests_c] Error 1
> testbin.c:16441:7: error: call to undeclared function 'setenv'; ISO C99 and later do not support implicit function declarations [-Werror,-Wimplicit-function-declaration]
>   if (setenv((char*)arg0,(char*)arg1,1)==0)
>       ^
> testbin.c:16441:7: note: did you mean 'getenv'?
> D:/a/_temp/msys64/mingw64/include/stdlib.h:447:17: note: 'getenv' declared here
>   char *__cdecl getenv(const char *_VarName) __MINGW_ATTRIB_DEPRECATED_SEC_WARN;
>                 ^
> testbin.c:16450:7: error: call to undeclared function 'unsetenv'; ISO C99 and later do not support implicit function declarations [-Werror,-Wimplicit-function-declaration]
>   if (unsetenv((char*)arg0)==0)
>       ^
> 2 errors generated.
> 
> error 1: C backend: C compiler failed
> C compiler call 'clang -Wall -Werror -Wno-gnu-empty-struct -Wno-unused-variable -Wno-unused-label -Wno-unused-but-set-variable -Wno-unused-function -O3 -lm -lpthread -o testbin testbin.c' failed with exit code '1'
> 
> one error.
make[1]: Leaving directory '/d/a/fuzion/fuzion/build/tests/envir_vars'
make[1]: *** [../simple.mk:48: c] Error 1
make[1]: Entering directory '/d/a/fuzion/fuzion/build/tests/fileio'
FUZION_JAVA_STACK_SIZE=10m   ../check_simple_example_c.sh "../../bin/fz -unsafeIntrinsics=on" fileiotests.fz || exit 1
RUN fileiotests.fz 1,18d0
< testdir exists: false
< testdir was created
< testdir exists: true
< testdir/testfile exists: false
< testdir/testfile was created
< testdir/testfile exists: true
< testdir/testfile size is 16
< file content bytes: [72,101,108,108,111,32,119,111,114,108,100,32,240,159,140,141]
< file content is Hello world 🌍
< testdir/testfile was deleted
< testdir/testfile exists: false
< testdir exists: true
< newdir exists: false
< testdir is now: newdir
< newdir exists: true
< testdir exists: false
< newdir was deleted
< newdir exists: false
0a1,18
> testbin.c:20706:35: error: too many arguments to function call, expected 1, have 2
>   int result = mkdir((char *)arg0,S_IRWXU);
>                ~~~~~              ^~~~~~~
> D:/a/_temp/msys64/mingw64/include/sys/stat.h:149:18: note: expanded from macro 'S_IRWXU'
> #define S_IRWXU         _S_IRWXU
>                         ^~~~~~~~
> D:/a/_temp/msys64/mingw64/include/sys/stat.h:145:18: note: expanded from macro '_S_IRWXU'
> #define _S_IRWXU        (_S_IREAD | _S_IWRITE | _S_IEXEC)
>                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
> D:/a/_temp/msys64/mingw64/include/io.h:282:15: note: 'mkdir' declared here
>   int __cdecl mkdir (const char *) __MINGW_ATTRIB_DEPRECATED_MSVC2005;
>               ^
> 1 error generated.
> 
> error 1: C backend: C compiler failed
> C compiler call 'clang -Wall -Werror -Wno-gnu-empty-struct -Wno-unused-variable -Wno-unused-label -Wno-unused-but-set-variable -Wno-unused-function -O3 -lm -lpthread -o testbin testbin.c' failed with exit code '1'
> 
> one error.
```