### PR TITLE
ast: Handle type passed as value argument Fix #961

### DIFF
--- a/src/dev/flang/ast/Actual.java
+++ b/src/dev/flang/ast/Actual.java
@@ -26,7 +26,7 @@ Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
 
 package dev.flang.ast;
 
-import dev.flang.util.ANY;
+import dev.flang.util.SourcePosition;
 
 
 /**
@@ -34,11 +34,17 @@ import dev.flang.util.ANY;
  *
  * @author Fridtjof Siebert (siebert@tokiwa.software)
  */
-public class Actual extends ANY
+public class Actual extends Expr
 {
 
 
   /*----------------------------  variables  ----------------------------*/
+
+
+  /**
+   * The sourcecode position of this expression, used for error messages.
+   */
+  private final SourcePosition _pos;
 
 
   /**
@@ -50,7 +56,7 @@ public class Actual extends ANY
   /**
    * This actual parsed as a value, Expr.NO_VALUE if it can only be parsed as a type.
    */
-  public final Expr _expr;
+  Expr _expr;
 
 
   /*-------------------------- constructors ---------------------------*/
@@ -61,12 +67,13 @@ public class Actual extends ANY
    *
    * t must be non-null or e must not be NO_VALUE.
    */
-  public Actual(AbstractType t, Expr e)
+  public Actual(SourcePosition pos, AbstractType t, Expr e)
   {
     if (PRECONDITIONS) require
       (t != null || e != Expr.NO_VALUE,
        e != null);
 
+    _pos = pos;
     _type = t;
     _expr = e;
   }
@@ -79,7 +86,7 @@ public class Actual extends ANY
    */
   public Actual(AbstractType t)
   {
-    this(t, Expr.NO_VALUE);
+    this(t.pos(), t, Expr.NO_VALUE);
 
     if (PRECONDITIONS) require
       (t != null);
@@ -92,11 +99,75 @@ public class Actual extends ANY
    */
   public Actual(Expr e)
   {
-    this(null, e);
+    this(e.pos(), null, e);
 
     if (PRECONDITIONS) require
       (e != Expr.NO_VALUE,
        e != null);
+  }
+
+
+
+  /*-----------------------------  methods  -----------------------------*/
+
+
+  /**
+   * The sourcecode position of this statment, used for error messages.
+   */
+  public SourcePosition pos()
+  {
+    return _pos;
+  }
+
+
+  /**
+   * visit all the features, expressions, statements within this feature.
+   *
+   * @param v the visitor instance that defines an action to be performed on
+   * visited objects.
+   *
+   * @param outer the feature surrounding this expression.
+   *
+   * @return this or an alternative Expr if the action performed during the
+   * visit replaces this by the alternative.
+   */
+  public Expr visit(FeatureVisitor v, AbstractFeature outer)
+  {
+    if (_expr != Expr.NO_VALUE)
+      {
+        _expr = _expr.visit(v, outer);
+      }
+    return this;
+  }
+
+
+  /**
+   * Obtain this actual as a Expr of the actual value argument. Produce an error
+   * if this does not contain an expression.
+   *
+   * @return an Expr that is not wrapped in an Actual,
+   */
+  public Expr expr(Call usedIn)
+  {
+    var e = _expr;
+    if (e == Expr.NO_VALUE)
+      {
+        AstErrors.actualTypeParameterUsedAsExpression(this, usedIn);
+        e =  Expr.ERROR_VALUE;
+      }
+
+    return e;
+  }
+
+
+  /**
+   * toString
+   *
+   * @return
+   */
+  public String toString()
+  {
+    return (_expr == Expr.NO_VALUE ? _type.toString() : _expr.toString());
   }
 
 }

--- a/src/dev/flang/ast/AstErrors.java
+++ b/src/dev/flang/ast/AstErrors.java
@@ -1601,6 +1601,45 @@ public class AstErrors extends ANY
           .collect(Collectors.joining(", "))
       );
   }
+
+  public static void actualTypeParameterUsedAsExpression(Actual a, Call usedIn)
+  {
+    var cf = usedIn != null ? usedIn._calledFeature : null;
+    String at = null;
+    if (cf != null)
+      {
+        var allUnknown = true;
+        String t = null;
+        var args = cf.arguments();
+        if (args != null)
+          {
+            for (var arg : args)
+              {
+                var argtype = "--still unkown--";
+                if (arg.state().atLeast(Feature.State.RESOLVED_TYPES))
+                  {
+                    allUnknown = false;
+                    argtype = s(arg.resultType());
+                  }
+                t = (t == null ? "" : t + " ") + argtype;
+              }
+          }
+        if (!allUnknown)
+          {
+            at = t;
+          }
+      }
+    error(a.pos(),
+          "Actual parameter in a call is a type, but the call expects an expression",
+          (usedIn != null ? "in call: "+ s(usedIn) + "\n" : "") +
+          (cf != null ? "call to " + s(cf) + "\n" : "" ) +
+          "actual type argument found: " + s(a._type) + "\n" +
+          (at != null ? "expected agument types: " + at + "\n" : "" ) +
+          "To solve this, check if the actual arguments match the expected formal arguments. Maybe add missing arguments or remove "+
+          "extra arguments.  If the arguments match, make sure that " + s(a._type) + " is parsable as an expression.");
+  }
+
+
 }
 
 /* end of file */

--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -236,7 +236,7 @@ public class Call extends AbstractCall
     var res = new List<Expr>();
     for (var a : la)
       {
-        res.add(a._expr);
+        res.add(a);
       }
     return res;
   }
@@ -679,11 +679,13 @@ public class Call extends AbstractCall
     if (_calledFeature == null)
       {
         var actualsResolved = false;
+        if (CHECKS) check
+          (Errors.count() > 0 || _name != Errors.ERROR_STRING);
         if (_name != Errors.ERROR_STRING)    // If call parsing failed, don't even try
           {
             var targetFeature = targetFeature(res, thiz);
             if (CHECKS) check
-              (Errors.count() > 0 || targetFeature != null);
+              (Errors.count() > 0 || targetFeature != null && targetFeature != Types.f_ERROR);
             if (targetFeature != null && targetFeature != Types.f_ERROR)
               {
                 var fo = calledFeatureCandidates(targetFeature, res, thiz);
@@ -1811,6 +1813,17 @@ public class Call extends AbstractCall
 
     if (CHECKS) check
       (Errors.count() > 0 || _calledFeature != null);
+
+    ListIterator<Expr> i = _actuals.listIterator();
+    while (i.hasNext())
+      {
+        Expr actl = i.next();
+        if (actl instanceof Actual aa)
+          {
+            actl = aa.expr(this);
+          }
+        i.set(actl);
+      }
 
     if (_calledFeature == null)
       {

--- a/src/dev/flang/ast/Expr.java
+++ b/src/dev/flang/ast/Expr.java
@@ -60,9 +60,26 @@ public abstract class Expr extends ANY implements Stmnt, HasSourcePosition
    */
   public static final Call NO_VALUE = new Call(SourcePosition.builtIn, Errors.ERROR_STRING)
     {
-      Expr box(AbstractType frmlT)
+      { _type = Types.t_ERROR; }
+    };
+
+
+  /**
+   * Dummy Expr value. Used in to represent error values.
+   */
+  public static final Expr ERROR_VALUE = new Expr()
+    {
+      public SourcePosition pos()
+      {
+        return SourcePosition.builtIn;
+      }
+      public Expr visit(FeatureVisitor v, AbstractFeature outer)
       {
         return this;
+      }
+      AbstractType typeIfKnown()
+      {
+        return Types.t_ERROR;
       }
     };
 

--- a/src/dev/flang/ast/Function.java
+++ b/src/dev/flang/ast/Function.java
@@ -555,7 +555,7 @@ public class Function extends ExprWithPos
             for (var f : calledFeature.arguments())
               {
                 String name = "a"+argnum;
-                actual_args.add(new Actual(null, new Call(pos(), null, name)));
+                actual_args.add(new Actual(new Call(pos(), null, name)));
                 formal_args.add(new Feature(pos(), Visi.LOCAL, 0, f.resultType(), name, Contract.EMPTY_CONTRACT));
                 argnum++;
               }

--- a/src/dev/flang/ast/InlineArray.java
+++ b/src/dev/flang/ast/InlineArray.java
@@ -301,8 +301,8 @@ public class InlineArray extends ExprWithPos
       {
         var et           = elementType();
         var eT           = new List<AbstractType>(et);
-        var args         = new List<Actual>(new Actual(et, Expr.NO_VALUE),
-                                            new Actual(null, new NumLiteral(_elements.size())));
+        var args         = new List<Actual>(new Actual(et),
+                                            new Actual(new NumLiteral(_elements.size())));
         var fuzion       = new Call(pos(), null, "fuzion"                     ).resolveTypes(res, outer);
         var sys          = new Call(pos(), fuzion, "sys"                      ).resolveTypes(res, outer);
         var sysArrayCall = new Call(pos(), sys , "internal_array", args).resolveTypes(res, outer);
@@ -319,8 +319,8 @@ public class InlineArray extends ExprWithPos
         for (var i = 0; i < _elements.size(); i++)
           {
             var e = _elements.get(i);
-            var setArgs         = new List<Actual>(new Actual(null, new NumLiteral(i)),
-                                                   new Actual(null, e));
+            var setArgs         = new List<Actual>(new Actual(new NumLiteral(i)),
+                                                   new Actual(e));
             var readSysArrayVar = new Call(e.pos(), null           , sysArrayName     ).resolveTypes(res, outer);
             var setElement      = new Call(e.pos(), readSysArrayVar,
                                            FuzionConstants.FEATURE_NAME_INDEX_ASSIGN,
@@ -331,11 +331,11 @@ public class InlineArray extends ExprWithPos
         var unit1           = new Call(pos(), null, "unit"                            ).resolveTypes(res, outer);
         var unit2           = new Call(pos(), null, "unit"                            ).resolveTypes(res, outer);
         var unit3           = new Call(pos(), null, "unit"                            ).resolveTypes(res, outer);
-        var sysArrArgs      = new List<Actual>(new Actual(et, Expr.NO_VALUE),
-                                               new Actual(null, readSysArrayVar),
-                                               new Actual(null, unit1),
-                                               new Actual(null, unit2),
-                                               new Actual(null, unit3));
+        var sysArrArgs      = new List<Actual>(new Actual(et),
+                                               new Actual(readSysArrayVar),
+                                               new Actual(unit1),
+                                               new Actual(unit2),
+                                               new Actual(unit3));
         var arrayCall       = new Call(pos(), null, "array"     , sysArrArgs).resolveTypes(res, outer);
         stmnts.add(arrayCall);
         result = new Block(pos(), stmnts);

--- a/src/dev/flang/ast/Loop.java
+++ b/src/dev/flang/ast/Loop.java
@@ -545,8 +545,8 @@ public class Loop extends ANY
                               null /* NYI outer */);
         arg._isIndexVarUpdatedByLoop = true;
         formalArguments.add(arg);
-        initialActuals .add(new Actual(null, ia));
-        nextActuals    .add(new Actual(null, na));
+        initialActuals .add(new Actual(ia));
+        nextActuals    .add(new Actual(na));
       }
   }
 

--- a/src/dev/flang/parser/OpExpr.java
+++ b/src/dev/flang/parser/OpExpr.java
@@ -195,7 +195,7 @@ public class OpExpr extends ANY
           {             // infix op:
             Expr e1 = expr(max-1);
             Expr e2 = expr(max+1);
-            Expr e = new Call(op.pos, e1, "infix "+op.text, new List<>(new Actual(null, e2)));
+            Expr e = new Call(op.pos, e1, "infix "+op.text, new List<>(new Actual(e2)));
             els.remove(max+1);
             els.remove(max);
             els.set(max-1, e);

--- a/src/dev/flang/parser/Parser.java
+++ b/src/dev/flang/parser/Parser.java
@@ -489,7 +489,7 @@ visiList    : visi ( COMMA visiList
       {
         if (skip(Token.t_export))
           {
-            List<List<String>> l = new List<>(visi());
+            var l = new List<List<String>>(visi());
             while (skipComma())
               {
                 l.add(visi());
@@ -841,7 +841,7 @@ featNames   : qual (COMMA featNames
    */
   List<List<String>> featNames()
   {
-    List<List<String>> result = new List<>(qual(true));
+    var result = new List<List<String>>(qual(true));
     while (skipComma())
       {
         result.add(qual(true));
@@ -1356,7 +1356,7 @@ indexTail   : ":=" exprInLine
         String n = FuzionConstants.FEATURE_NAME_INDEX;
         if (skip(":="))
           {
-            l.add(new Actual(null, exprInLine()));
+            l.add(new Actual(exprInLine()));
             n = FuzionConstants.FEATURE_NAME_INDEX_ASSIGN;
           }
         if (l.isEmpty())
@@ -1653,6 +1653,8 @@ actual   : expr | type
    */
   Actual actual()
   {
+    var pos = posObject();
+
     boolean hasType = fork().skipType();
     // instead of implementing 'isExpr()', which would be complex, we use
     // 'skipType' with second argument set to false to check if we can parse
@@ -1686,7 +1688,7 @@ actual   : expr | type
         t = type();
         e = Expr.NO_VALUE;
       }
-    return new Actual(t, e);
+    return new Actual(pos, t, e);
   }
 
 
@@ -1773,8 +1775,8 @@ expr        : opExpr
             matchOperator(":", "expr of the form >>a ? b : c<<");
             Expr g = expr();
             i.end();
-            result = new Call(pos, result, "ternary ? :", new List<>(new Actual(null, f),
-                                                                     new Actual(null, g)));
+            result = new Call(pos, result, "ternary ? :", new List<>(new Actual(f),
+                                                                     new Actual(g)));
           }
       }
     return result;
@@ -1857,7 +1859,7 @@ klammerLambd: LPAREN argNamesOpt RPAREN lambda
                        () -> {
                          do
                            {
-                             tupleElements.add(new Actual(null, expr()));
+                             tupleElements.add(new Actual(expr()));
                            }
                          while (skipComma());
                          return Void.TYPE;
@@ -1866,7 +1868,7 @@ klammerLambd: LPAREN argNamesOpt RPAREN lambda
 
     return
       isLambdaPrefix()          ? lambda(f.bracketTermWithNLs(PARENS, "argNamesOpt", () -> f.argNamesOpt())) :
-      tupleElements.size() == 1 ? tupleElements.get(0)._expr // a klammerexpr, not a tuple
+      tupleElements.size() == 1 ? tupleElements.get(0).expr(null)   // a klammerexpr, not a tuple
                                 : new Call(pos, null, "tuple", tupleElements);
   }
 
@@ -2149,7 +2151,7 @@ stringTermB : '}any chars&quot;'
    */
   Expr concatString(SourcePosition pos, Expr string1, Expr string2)
   {
-    return string1 == null ? string2 : new Call(pos, string1, "infix +", new List<>(new Actual(null, string2)));
+    return string1 == null ? string2 : new Call(pos, string1, "infix +", new List<>(new Actual(string2)));
   }
 
 


### PR DESCRIPTION
An Actual that cannot be parsed as Expr but only as Type would cause precondition and postconditions failures when passed to a non-type argument that requires a value.

This patch adds special handling an a better error message in this case.