### PR TITLE
lib/uint: fix right shift for case shift>32

### DIFF
--- a/lib/uint.fz
+++ b/lib/uint.fz
@@ -60,9 +60,8 @@ is
     if other = zero
       thiz
     else if other >= uint 32
-      (uint (data
-        .reverse
-        .drop (other.as_i32 / 32)) unit) >> (other % (uint 32))
+      discard := other.as_i32 / 32
+      (uint (data.take data.count-discard) unit) >> (other % (uint 32))
     else
       shift := other.as_u32
       (l,_) := data


### PR DESCRIPTION
In case of a shift greater than 32 some u32 where dropped from the reversed sequence. It was missing to re-reverse the sequence after dropping some u32s.