### PR TITLE
ast: Make Cal.toString() more robust

### DIFF
--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -978,7 +978,9 @@ public class Call extends AbstractCall
             (_target instanceof This t && t.toString().equals(FuzionConstants.UNIVERSE_NAME + ".this"))
             ? ""
             : _target.toString() + ".")
-      + (_name != null ? _name : _calledFeature.featureName().baseName())
+      + (_name          != null ? _name :
+         _calledFeature != null ? _calledFeature.featureName().baseName()
+                                : "--ANONYMOUS--" )
       + (_generics.isEmpty() ? "" : "<" + _generics + ">")
       + (_actuals.isEmpty() ? "" : "(" + _actuals +")")
       + (_select < 0        ? "" : "." + _select);


### PR DESCRIPTION
For calls created for lambdas, there might be a time when _name and _calledFeature are both null, so toString() should deal with this.