### PR TITLE
util/ast: Made List freezable, freeze generics list when used as key,…

### DIFF
--- a/src/dev/flang/ast/AbstractType.java
+++ b/src/dev/flang/ast/AbstractType.java
@@ -669,6 +669,7 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
         result = actualType_(f, actualGenerics);
         _actualType2CachedFor1 = f;
         _actualType2CachedFor2 = actualGenerics;
+        actualGenerics.freeze();
         _actualType2Cache = result;
       }
     return result;

--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -1033,20 +1033,7 @@ public class Call extends AbstractCall
    */
   public Expr visit(FeatureVisitor v, AbstractFeature outer)
   {
-    if (!_generics.isEmpty())
-      {
-        var i = _generics.listIterator();
-        while (i.hasNext())
-          {
-            var n = i.next();
-            if (CHECKS) check
-              (Errors.count() > 0 || n != null);
-            if (n != null)
-              {
-                i.set(n.visit(v, outer));
-              }
-          }
-      }
+    _generics = _generics.map(g -> g.visit(v, outer));
     if (v.doVisitActuals())
       {
         ListIterator<Expr> i = _actuals.listIterator(); // _actuals can change during resolveTypes, so create iterator early
@@ -1703,7 +1690,7 @@ public class Call extends AbstractCall
                 var rt = af.propagateExpectedType2(res, outer, at, true);
                 if (rt != null)
                   {
-                    _generics.set(ri, rt);
+                    _generics = _generics.setOrClone(ri, rt);
                   }
                 foundAt[ri] = (foundAt[ri] == null ? "" : foundAt[ri]) + rt + " found at " + pos.show() + "\n";
                 result = true;

--- a/src/dev/flang/ast/FormalGenerics.java
+++ b/src/dev/flang/ast/FormalGenerics.java
@@ -193,22 +193,9 @@ public class FormalGenerics extends ANY
    */
   public static void resolve(Resolution res, List<AbstractType> generics, AbstractFeature outer)
   {
-    if (!generics.isEmpty())
+    if (!(generics instanceof FormalGenerics.AsActuals))
       {
-        if (!(generics instanceof FormalGenerics.AsActuals))
-          {
-            ListIterator<AbstractType> i = generics.listIterator();
-            while (i.hasNext())
-              {
-                var t = i.next();
-                if (CHECKS) check
-                  (Errors.count() > 0 || t != null);
-                if (t != null)
-                  {
-                    i.set(t.resolve(res, outer));
-                  }
-              }
-          }
+        generics = generics.map(t -> t.resolve(res, outer));
       }
   }
 

--- a/src/dev/flang/ast/Types.java
+++ b/src/dev/flang/ast/Types.java
@@ -294,11 +294,7 @@ public class Types extends ANY
           {
             Types.intern(t.outer());
           }
-        var tg = t._generics.listIterator();
-        while (tg.hasNext())
-          {
-            tg.set(intern(tg.next()));
-          }
+        t._generics = t._generics.map(tt->intern(tt));
         Type existing = t._interned;
         if (existing == null)
           {


### PR DESCRIPTION
… fix #979

The bug that causes #979 was that AbstractType.actualType() used caching, while the key used for the cache was a list of generic parameters was modified afterwards, such that the cache contained a wrong result.

This patch adds methods to List to protect the List from modifications and also ways to clone a list on demand when seting one or mapping all elements.