### PR TITLE
fe/air: Don't lookup internal features that were added late, fix #978

### DIFF
--- a/src/dev/flang/air/Clazz.java
+++ b/src/dev/flang/air/Clazz.java
@@ -335,6 +335,9 @@ public class Clazz extends ANY implements Comparable<Clazz>
         actualType = Types.t_ERROR;
       }
 
+    if (CHECKS) check
+      (Errors.count() > 0 || actualType != Types.t_ERROR);
+
     this._type = actualType;
     this._select = select;
     /* NYI: Handling of outer in Clazz is not done properly yet. There are two
@@ -981,7 +984,7 @@ public class Clazz extends ANY implements Comparable<Clazz>
               }
           }
       }
-    return _module.lookupFeature(feature(), fn);
+    return _module.lookupFeature(feature(), fn, f);
   }
 
 

--- a/src/dev/flang/ast/AbstractAssign.java
+++ b/src/dev/flang/ast/AbstractAssign.java
@@ -238,7 +238,7 @@ public abstract class AbstractAssign extends ANY implements Stmnt, HasSourcePosi
           }
 
         if (CHECKS) check
-          (res._module.lookupFeature(this._target.type().featureOfType(), f.featureName()) == f || Errors.count() > 0);
+          (res._module.lookupFeature(this._target.type().featureOfType(), f.featureName(), f) == f || Errors.count() > 0);
       }
   }
 

--- a/src/dev/flang/ast/Feature.java
+++ b/src/dev/flang/ast/Feature.java
@@ -320,6 +320,18 @@ public class Feature extends AbstractFeature implements Stmnt
   }
 
 
+  /**
+   * Flag used by dev.flang.fe.SourceModule to mark Features that were added to
+   * their outer feature late.  Features that were added late will not be seen
+   * via heirs.
+   *
+   * This is used for adding internal features like wrappers for lambdas.
+   *
+   * This is a fix for #978 but it might need to be removed when fixing #932.
+   */
+  public boolean _addedLate = false;
+
+
   /*--------------------------  constructors  ---------------------------*/
 
 

--- a/src/dev/flang/ast/SrcModule.java
+++ b/src/dev/flang/ast/SrcModule.java
@@ -65,7 +65,7 @@ public interface SrcModule
 
 
   SortedMap<FeatureName, AbstractFeature> declaredOrInheritedFeatures(AbstractFeature outer);
-  AbstractFeature lookupFeature(AbstractFeature outer, FeatureName name);
+  AbstractFeature lookupFeature(AbstractFeature outer, FeatureName name, AbstractFeature original);
   void findDeclaredOrInheritedFeatures(Feature outer);
   SortedMap<FeatureName, AbstractFeature> lookupFeatures(AbstractFeature outer, String name);
   FeaturesAndOuter lookupNoTarget(AbstractFeature thiz, String name, Call call, AbstractAssign assign, Destructure destructure);

--- a/src/dev/flang/fe/SourceModule.java
+++ b/src/dev/flang/fe/SourceModule.java
@@ -800,6 +800,15 @@ public class SourceModule extends Module implements SrcModule, MirModule
       {
         f.redefines().add(existing);
       }
+    if (f     instanceof Feature ff &&
+        outer instanceof Feature of && of.state().atLeast(Feature.State.RESOLVED_DECLARATIONS))
+      {
+        ff._addedLate = true;
+      }
+    if (f instanceof Feature ff && ff.state().atLeast(Feature.State.RESOLVED_DECLARATIONS))
+      {
+        ff._addedLate = true;
+      }
     doi.put(fn, f);
   }
 
@@ -937,12 +946,20 @@ public class SourceModule extends Module implements SrcModule, MirModule
    *
    * @param outer the declaring or inheriting feature
    */
-  public AbstractFeature lookupFeature(AbstractFeature outer, FeatureName name)
+  public AbstractFeature lookupFeature(AbstractFeature outer, FeatureName name, AbstractFeature original)
   {
     if (PRECONDITIONS) require
       (!(outer instanceof Feature of) || of.state().atLeast(Feature.State.LOADING));
 
-    return declaredOrInheritedFeatures(outer).get(name);
+    /* Was feature f added to the declared features of its outer features late,
+     * i.e., after the RESOLVING_DECLARATIONS phase?  These late features are
+     * currently not added to the sets of declared or inherited features by
+     * children of their outer clazz.
+     *
+     * This is a fix for #978 but it might need to be removed when fixing #932.
+     */
+    return original instanceof Feature of && of._addedLate ? original
+                                                           : declaredOrInheritedFeatures(outer).get(name);
   }
 
 

--- a/src/dev/flang/fe/SourceModule.java
+++ b/src/dev/flang/fe/SourceModule.java
@@ -951,6 +951,8 @@ public class SourceModule extends Module implements SrcModule, MirModule
     if (PRECONDITIONS) require
       (!(outer instanceof Feature of) || of.state().atLeast(Feature.State.LOADING));
 
+    var result = declaredOrInheritedFeatures(outer).get(name);
+
     /* Was feature f added to the declared features of its outer features late,
      * i.e., after the RESOLVING_DECLARATIONS phase?  These late features are
      * currently not added to the sets of declared or inherited features by
@@ -958,8 +960,8 @@ public class SourceModule extends Module implements SrcModule, MirModule
      *
      * This is a fix for #978 but it might need to be removed when fixing #932.
      */
-    return original instanceof Feature of && of._addedLate ? original
-                                                           : declaredOrInheritedFeatures(outer).get(name);
+    return result == null && original instanceof Feature of && of._addedLate ? original
+                                                                             : result;
   }
 
 


### PR DESCRIPTION
Internal features added for, e.g., lambda expressions do not show up in the set of declared or inherited features of the children of their outer features.  This is why a lookup would fail and we avoid this here.

This fix might need to be revisted when working on #932, for now this is just a workaround.