### PR TITLE
fuir/analysis: Stop escape analysis on `void` value, fix #977

### DIFF
--- a/src/dev/flang/fuir/analysis/Escape.java
+++ b/src/dev/flang/fuir/analysis/Escape.java
@@ -53,6 +53,18 @@ public class Escape extends ANY
   /*----------------------------  constants  ----------------------------*/
 
 
+  /**
+   * property-controlled flag to enable debug output.
+   *
+   * To enable debugging, use fz with
+   *
+   *   FUZION_JAVA_OPTIONS=-Ddev.flang.fuir.analysis.Escape.DEBUG=true
+   */
+  static final boolean DEBUG =
+    System.getProperty("dev.flang.fuir.analysis.Escape.DEBUG",
+                       "false").equals("true");
+
+
 
   /*----------------------------  variables  ----------------------------*/
 
@@ -142,9 +154,14 @@ public class Escape extends ANY
    */
   private boolean doesCurEscape(int cl, Stack<Boolean> stack, int c)
   {
-    for (int i = 0; _fuir.withinCode(c, i); i = i + _fuir.codeSizeAt(c, i))
+    var gotVoid = false;
+    for (int i = 0; !gotVoid && _fuir.withinCode(c, i); i = i + _fuir.codeSizeAt(c, i))
       {
         var s = _fuir.codeAt(c, i);
+        if (DEBUG)
+          {
+            System.out.println("ESCAPE: process "+_fuir.clazzAsString(cl)+"."+c+"."+i+":\t"+_fuir.codeAtAsString(cl, c, i)+" stack is "+stack);
+          }
         switch (s)
           {
           case AdrOf:
@@ -248,6 +265,7 @@ public class Escape extends ANY
                             }
                         }
                     }
+                  gotVoid = _fuir.clazzIsVoidType(rt);
                   if (_fuir.hasData(rt))
                     {
                       stack.push(false);

--- a/tests/local_mutate/skip_c
+++ b/tests/local_mutate/skip_c
@@ -1,1 +1,0 @@
-C backend causes EmptyStackExeption here, need to fix


### PR DESCRIPTION
There is no point continuing after a call returned `void` since we cannot possible reach the code follwing this call, and the stack does not contain any value the following code may expect (since void is assignment compatible to every other type).

This fixes the empty stack exception since void left no value to be consumed.

Also added a DEBUG-mode to Escape analysis that can be enabled running `fz` with
```
  FUZION_JAVA_OPTIONS=-Ddev.flang.fuir.analysis.Escape.DEBUG=true
```
Also enabled tests/local_mutate to run with C backend since this should work now. 