### PR TITLE
lib/tests: Add `local_mutate.mget` and suggested syntax for effect in signature

### DIFF
--- a/lib/local_mutate.fz
+++ b/lib/local_mutate.fz
@@ -31,6 +31,12 @@ local_mutate(# NYI: LM should be replaced by local_mutate.this.type
   : simpleEffect
 is
 
+  # short-hand to access effect type
+  #
+  # NYI: This does not work yet
+  #
+  # LM := local_mutate.this.type
+
   # an id used for runtime checks to verify that mutation made with the same effect
   # the mutable value was created with
   #
@@ -99,10 +105,21 @@ is
     # If this is open, check that the mutate effect this was created with is still
     # intalled in the current environment.
     #
-    get =>
+    # mget ! LM =>    -- NYI: effect syntax using '!' does not work yet
+    mget =>
       if open
         check_and_replace
       val
+
+
+    # read the current value of this mutable value after it was close for mutation.
+    #
+    get
+      pre
+        safety: !open
+     =>
+      val
+
 
     # update mutable field with new value
     #
@@ -111,9 +128,9 @@ is
     #
     put (
       # the new value to be stored with 'h'
-      to T)
+      to T) # ! LM  -- NYI: effect syntax using '!' does not work yet
     pre
-      open
+      safety: open
      =>
       check_and_replace
       set val := to
@@ -131,7 +148,7 @@ is
       f T->T
       )
      =>
-      put (f get)
+      put (f mget)
 
 
     # creates a copy of the mutable field

--- a/tests/local_mutate/test_local_mutate.fz
+++ b/tests/local_mutate/test_local_mutate.fz
@@ -55,7 +55,7 @@ test_local_mutate is
           s.update a->a+e
 
         # unwrap the sum value in s and return it
-        s.get
+        s.mget
 
       # run code within an instance of m
       #
@@ -66,7 +66,7 @@ test_local_mutate is
         for e in l do
           s.update a->a+e
 
-        say "inside m.use: s.get = {s.get}"
+        say "inside m.use: s.mget = {s.mget}"
         say "inside m.use: count = {count}")
 
       say "using m.run and count: {m.run ()->count (unit)->(-1)}"
@@ -242,10 +242,10 @@ test_local_mutate is
         match from.tail
           nil    => c
           t Cons => f := ring2 t
-                    l := f.prev
+                    l := f.p.mget
                     c.link f l
-                    f.link f.next c
-                    l.link c l.prev
+                    f.link f.n.mget c
+                    l.link c l.p.mget
         c
 
       ring3(from list T) cell T m is
@@ -253,7 +253,7 @@ test_local_mutate is
 
         for
           i in 1..10
-          e := r, e.next
+          e := r, e.n.mget
         do
           say "$i: {e.data}"
 
@@ -370,8 +370,8 @@ test_local_mutate is
       #
       merge(n mut_ring LM T) =>
         a := mut_ring.this
-        m := a.prev
-        z := n.prev
+        m := a.p.mget
+        z := n.n.mget
         a.p <- z
         z.n <- a
         m.n <- n

--- a/tests/local_mutate/test_local_mutate.fz.expected_out
+++ b/tests/local_mutate/test_local_mutate.fz.expected_out
@@ -1,4 +1,4 @@
-inside m.use: s.get = 81
+inside m.use: s.mget = 81
 inside m.use: count = 81
 using m.run and count: 81
 [0,8,11,15,47]


### PR DESCRIPTION
`mget` has to be used while a mutable value is still mutable, while `get` can only be used when it is closed.  `get` can easily be analysed statically not to require a local_mutate effect to be present.

Also added possible syntax to create alias for types.

Updated tests/local_mutate to use mget.