### PR TITLE
air/lib/tests: Support this.type.env to access effect in environment

### DIFF
--- a/lib/local_mutate.fz
+++ b/lib/local_mutate.fz
@@ -26,10 +26,7 @@
 # local_mutate -- an effect that permits creation of a local scope that permits
 # mutation
 #
-local_mutate(# NYI: LM should be replaced by local_mutate.this.type
-             LM type : local_mutate LM)
-  : simpleEffect
-is
+local_mutate : simpleEffect is
 
   # short-hand to access effect type
   #
@@ -58,9 +55,9 @@ is
     # check that this effect is intalled and replace it.
     #
     private check_and_replace is
-      if my_id != LM.env.id
-        panic "*** invalid local_mutate for type LM"
-      LM.env.replace
+      if my_id != local_mutate.this.type.env.id
+        panic "*** invalid local_mutate for ..local_mutate.this.type.." # NYI: add { }
+      local_mutate.this.type.env.replace
 
     # is this element open, i.e., can it be mutated?
     #
@@ -89,9 +86,9 @@ is
 
     # NYI: remove as soon as inheriting mutable_element works
     private check_and_replace is
-      if my_id != LM.env.id
-        panic "*** invalid local_mutate for type LM"
-      LM.env.replace
+      if my_id != local_mutate.this.type.env.id
+        panic "*** invalid local_mutate for ..local_mutate.this.type.." # NYI: add { }
+      local_mutate.this.type.env.replace
 
     # NYI: remove as soon as inheriting mutable_element works
     open => id != 0
@@ -105,7 +102,7 @@ is
     # If this is open, check that the mutate effect this was created with is still
     # intalled in the current environment.
     #
-    # mget ! LM =>    -- NYI: effect syntax using '!' does not work yet
+    # mget ! local_mutate.this.type =>    -- NYI: effect syntax using '!' does not work yet
     mget =>
       if open
         check_and_replace
@@ -128,7 +125,7 @@ is
     #
     put (
       # the new value to be stored with 'h'
-      to T) # ! LM  -- NYI: effect syntax using '!' does not work yet
+      to T) # ! local_mutate.this.type  -- NYI: effect syntax using '!' does not work yet
     pre
       safety: open
      =>

--- a/src/dev/flang/air/Clazz.java
+++ b/src/dev/flang/air/Clazz.java
@@ -328,7 +328,8 @@ public class Clazz extends ANY implements Comparable<Clazz>
        Errors.count() > 0 || actualType.featureOfType().outer() != null || outer == null,
        Errors.count() > 0 || (actualType != Types.t_ERROR     &&
                               actualType != Types.t_UNDEFINED   ),
-       outer == null || outer._type != Types.t_ADDRESS);
+       outer == null || outer._type != Types.t_ADDRESS,
+       !actualType.isThisType());
 
     if (actualType == Types.t_UNDEFINED)
       {
@@ -650,7 +651,8 @@ public class Clazz extends ANY implements Comparable<Clazz>
       (t != null,
        Errors.count() > 0 || !t.isOpenGeneric());
 
-    return Clazzes.clazz(actualType(t, -1));
+    return t.isThisType() ? findOuter(t.featureOfType(), t)
+                          : Clazzes.clazz(actualType(t, -1));
   }
 
 

--- a/tests/local_mutate/test_local_mutate.fz
+++ b/tests/local_mutate/test_local_mutate.fz
@@ -40,7 +40,7 @@ test_local_mutate is
 
       # define a local type `m` to identify the mutate effect:
       #
-      m : local_mutate m is
+      m : local_mutate is
 
       # count using a locally mutable variable:
       #
@@ -170,7 +170,7 @@ test_local_mutate is
       if c = 0
         []
       else
-        m : local_mutate m is
+        m : local_mutate is
 
         # wrap code into iqs (NYI: use m.go with inline code)
         iqs =>
@@ -220,7 +220,7 @@ test_local_mutate is
   #
   test_ring1 =>
 
-    cell(T type, LM type : local_mutate LM, data T) ref is
+    cell(T type, LM type : local_mutate, data T) ref is
       me cell T LM := cell.this
       n := LM.env.new me #  cell.this   -- NYI: cell.this causes crash!
       p := LM.env.new me
@@ -235,7 +235,7 @@ test_local_mutate is
       pre
         !from.is_empty
      =>
-      m : local_mutate m is
+      m : local_mutate is
 
       ring2(from list T) cell T m is   # NYI '=>' causes error cyclic type inference
         c := cell T m from.head.get
@@ -304,7 +304,7 @@ test_local_mutate is
     # add single cells, or `merge` to merge two rings into one larger ring.
     #
     mut_ring(# mutate effect to be used to create mutable variables
-             LM type : local_mutate LM,
+             LM type : local_mutate,
 
              # type of data stored in ring cells
              redef T type,
@@ -392,7 +392,7 @@ test_local_mutate is
         !from.is_empty
      =>
       # define mutate context to be used
-      m : local_mutate m is
+      m : local_mutate is
 
       # create ring, called with the env set to an instance of `m`.
       #


### PR DESCRIPTION
Using `a.this.type.env` automatically results in accessing the effect of a child of the effect `a`.

This change actually adds support for `this.type` to all uses of Clazz.actualClazz, but this seems to be only relevant to `this.type.env` for now.

Updated base lib's `local_mutate` to no longer use a type parameter, but use `local_mutate.this.type` instead.

Changed tests/local_mutate to no longer use these type parameters.