### PR TITLE
ast: Improve error created when arguments have equal names

### DIFF
--- a/src/dev/flang/ast/AbstractFeature.java
+++ b/src/dev/flang/ast/AbstractFeature.java
@@ -242,10 +242,11 @@ public abstract class AbstractFeature extends ANY implements Comparable<Abstract
   {
     var n = featureName().baseName();
     return
-      isUniverse()         ||
-      outer() == null      ||
-      outer().isUniverse()                        ? n
-                                                  : outer().qualifiedName() + "." + n;
+      !state().atLeast(Feature.State.FINDING_DECLARATIONS) ||
+      isUniverse()                                         ||
+      outer() == null                                      ||
+      outer().isUniverse()                                    ? n
+                                                              : outer().qualifiedName() + "." + n;
   }
 
 

--- a/src/dev/flang/ast/AstErrors.java
+++ b/src/dev/flang/ast/AstErrors.java
@@ -1579,15 +1579,23 @@ public class AstErrors extends ANY
       "Expected number given in base " + _base + " to fit into " + _type + " without loss of precision.");
   }
 
-  public static void argumentNamesNotDistinct(SourcePosition pos, Set<String> duplicateNames)
+  public static void argumentNamesNotDistinct(Feature f, Set<String> duplicateNames)
   {
-    error(pos,
-      "Names of arguments used in this feature must be distinct.",
+    int[] cnt = new int[1];
+    error(f.pos(),
+          "Names of arguments used in this feature must be distinct.",
           "The duplicate" + (duplicateNames.size() > 1 ? " names are " : " name is ")
           + duplicateNames
             .stream()
             .map(n -> sbn(n))
             .collect(Collectors.joining(", ")) + "\n"
+          + "Feature with equally named arguments: "+ s(f) + "\n"
+          + f.arguments()
+            .stream()
+            .map(a -> "Argument #" + (cnt[0]++) + ": " + sbn(a) +
+                 (duplicateNames.contains(a.featureName().baseName()) ? " is duplicate "
+                                                                      : " is ok"        ) + "\n")
+            .collect(Collectors.joining(""))
           + "To solve this, rename the arguments to have unique names."
         );
   }

--- a/src/dev/flang/ast/Feature.java
+++ b/src/dev/flang/ast/Feature.java
@@ -666,23 +666,6 @@ public class Feature extends AbstractFeature implements Stmnt
         n = FuzionConstants.UNDERSCORE_PREFIX + underscoreId++;
       }
     this._qname     = qname;
-
-    // check args for duplicate names
-    if (!a.stream()
-          .map(arg -> arg.featureName().baseName())
-          .filter(argName -> !argName.equals("_"))
-          .allMatch(new HashSet<>()::add))
-      {
-        var usedNames = new HashSet<>();
-        var duplicateNames = a.stream()
-              .map(arg -> arg.featureName().baseName())
-              .filter(argName -> !argName.equals("_"))
-              .filter(argName -> !usedNames.add(argName))
-              .collect(Collectors.toSet());
-        // NYI report pos of arguments not pos of feature
-        AstErrors.argumentNamesNotDistinct(pos, duplicateNames);
-      }
-
     this._arguments = a;
     this._featureName = FeatureName.get(n, arguments().size());
     this._inherits   = (i.isEmpty() &&
@@ -697,6 +680,22 @@ public class Feature extends AbstractFeature implements Stmnt
 
     this._contract = c == null ? Contract.EMPTY_CONTRACT : c;
     this._impl = p;
+
+    // check args for duplicate names
+    if (!a.stream()
+          .map(arg -> arg.featureName().baseName())
+          .filter(argName -> !argName.equals("_"))
+          .allMatch(new HashSet<>()::add))
+      {
+        var usedNames = new HashSet<>();
+        var duplicateNames = a.stream()
+              .map(arg -> arg.featureName().baseName())
+              .filter(argName -> !argName.equals("_"))
+              .filter(argName -> !usedNames.add(argName))
+              .collect(Collectors.toSet());
+        // NYI report pos of arguments not pos of feature
+        AstErrors.argumentNamesNotDistinct(this, duplicateNames);
+      }
   }
 
 

--- a/tests/reg_issue170_distinct_arg_names/issue170.fz.expected_err
+++ b/tests/reg_issue170_distinct_arg_names/issue170.fz.expected_err
@@ -3,6 +3,10 @@
 [34msay (a 3 4 5); a(b,b,b i32) => b+b+b
 [33m---------------^[0m
 The duplicate name is '[35mb[39m'
+Feature with equally named arguments: '[35ma[39m'
+Argument #0: '[35mb[39m' is duplicate 
+Argument #1: '[35mb[39m' is duplicate 
+Argument #2: '[35mb[39m' is duplicate 
 To solve this, rename the arguments to have unique names.
 
 
@@ -10,6 +14,11 @@ To solve this, rename the arguments to have unique names.
 [34msay (c 3 4 5 6); c(d,d,e,e i32) => d+d+e+e
 [33m-----------------^[0m
 The duplicate names are '[35md[39m', '[35me[39m'
+Feature with equally named arguments: '[35mc[39m'
+Argument #0: '[35md[39m' is duplicate 
+Argument #1: '[35md[39m' is duplicate 
+Argument #2: '[35me[39m' is duplicate 
+Argument #3: '[35me[39m' is duplicate 
 To solve this, rename the arguments to have unique names.
 
 2 errors.


### PR DESCRIPTION
This error was helpful when working on type features where I ran into a problem due to repeated arguments.  But I needed more information to understand the problem, so this patch.

Moved the check for this error to the end of the Feature constructor such that all fields in feature needed by the error are initialized.