### PR TITLE
air: Remove field Clazz._typeType, this information is available now

### DIFF
--- a/src/dev/flang/air/Clazz.java
+++ b/src/dev/flang/air/Clazz.java
@@ -1983,37 +1983,14 @@ public class Clazz extends ANY implements Comparable<Clazz>
 
 
   /**
-   * For a type clazz such as 'i32.type', this will set the type this clazz
-   * represents.
-   *
-   * NYI: This is currently set in Clazzes.findClasses() when processing
-   * TypeParameters.  It would be nicer (less error prone etc.) to have this
-   * information available directly when this instance of Clazz is created.
-   *
-   * Maybe if we added a type parameter to feature 'Type' or to all instances
-   * inheriting from 'Type', we could have this information available directly.
-   */
-  AbstractType _typeType = null;
-
-
-  /**
    * For a type clazz such as 'i32.type' return its name, such as 'i32'.
    */
   public String typeName()
   {
-    if (isRef()) // the type was boxed, so get the name from the original value type
-      {
-        return asValue().typeName();
-      }
-    else if (_typeType == null)
-      {
-        Errors.error("*** internal error: type name is not set for '" + this + "'");
-        return "** UNDEF **";
-      }
-    else
-      {
-        return _typeType.asString();
-      }
+    if (PRECONDITIONS) require
+      (feature().isTypeFeature());
+
+    return _type.generics().get(0).asString();
   }
 
 

--- a/src/dev/flang/air/Clazzes.java
+++ b/src/dev/flang/air/Clazzes.java
@@ -906,7 +906,6 @@ public class Clazzes extends ANY
         if (f.kind() == AbstractFeature.Kind.TypeParameter)
           {
             var tpc = innerClazz.resultClazz();
-            tpc._typeType = innerClazz.typeParameterActualType()._type;
             do
               {
                 addUsedFeature(tpc.feature(), c.pos());


### PR DESCRIPTION
This field was just an ugly workaround to obtain the name of a type, this is available through the type's first type parameter (THIS#TYPE) now.