### PR TITLE
docs: add option to show features with limited visibility

### DIFF
--- a/src/dev/flang/ast/FeatureName.java
+++ b/src/dev/flang/ast/FeatureName.java
@@ -263,15 +263,18 @@ public class FeatureName extends ANY implements Comparable<FeatureName>
     return _argCount;
   }
 
+
   public String argCountAndIdString()
   {
     return " (" + Errors.argumentsString(_argCount) + (_id > 0 ? "," + _id : "") + ")";
   }
 
+
   public String toString()
   {
     return _baseName + argCountAndIdString();
   }
+
 
   public boolean equalsExceptId(FeatureName o)
   {
@@ -286,6 +289,16 @@ public class FeatureName extends ANY implements Comparable<FeatureName>
   {
     _all_.clear();
     _allBaseNames_.clear();
+  }
+
+
+  /**
+   * Returns true if this FeatureName is unspecified, i.e. an "@"-name would be generated
+   * by baseName above.
+   */
+  public boolean isNameless()
+  {
+    return _baseNameId < 0;
   }
 
 }

--- a/src/dev/flang/tools/docs/Docs.java
+++ b/src/dev/flang/tools/docs/Docs.java
@@ -222,10 +222,14 @@ public class Docs
   // but how to distinguish?
   private static boolean ignoreFeature(AbstractFeature af)
   {
-    return af.visibility() == Visi.INVISIBLE
+    return af.resultType().equals(Types.t_ADDRESS)
+      || af.featureName().baseName().contains(FuzionConstants.INTERNAL_NAME_PREFIX)
+      || af.featureName().baseName().startsWith("@")
+      || af.visibility() == Visi.INVISIBLE
       || af.visibility() == Visi.PRIVATE
       || af.isTypeFeature()
       || Util.isArgument(af)
+      || af.featureName().baseName().equals(FuzionConstants.RESULT_NAME)
       || isDummyFeature(af);
   }
 

--- a/src/dev/flang/tools/docs/Docs.java
+++ b/src/dev/flang/tools/docs/Docs.java
@@ -158,13 +158,14 @@ public class Docs
 
     if (Stream.of(args).anyMatch(arg -> arg.equals("-styles")))
       {
-        return new DocsOptions(null, false, true);
+        return new DocsOptions(null, false, true, false);
       }
 
     var destination = parseDestination(args);
 
     var bare = Stream.of(args).anyMatch(arg -> arg.equals("-bare"));
-    return new DocsOptions(destination, bare, false);
+    var ignoreVisibility = Stream.of(args).anyMatch(arg -> arg.equals("-ignoreVisibility"));
+    return new DocsOptions(destination, bare, false, ignoreVisibility);
   }
 
 
@@ -220,13 +221,13 @@ public class Docs
    */
   // NYI we want to ignore most but not all fields
   // but how to distinguish?
-  private static boolean ignoreFeature(AbstractFeature af)
+  private static boolean ignoreFeature(AbstractFeature af, boolean ignoreVisibility)
   {
     return af.resultType().equals(Types.t_ADDRESS)
       || af.featureName().baseName().contains(FuzionConstants.INTERNAL_NAME_PREFIX)
       || af.featureName().baseName().startsWith("@")
-      || af.visibility() == Visi.INVISIBLE
-      || af.visibility() == Visi.PRIVATE
+      || (!ignoreVisibility && af.visibility() == Visi.INVISIBLE)
+      || (!ignoreVisibility && af.visibility() == Visi.PRIVATE)
       || af.isTypeFeature()
       || Util.isArgument(af)
       || af.featureName().baseName().equals(FuzionConstants.RESULT_NAME)
@@ -271,12 +272,12 @@ public class Docs
     var mapOfDeclaredFeatures = new HashMap<AbstractFeature, SortedSet<AbstractFeature>>();
 
     breadthFirstTraverse(feature -> {
-      if (ignoreFeature(feature))
+      if (ignoreFeature(feature, config.ignoreVisibility()))
         {
           return;
         }
       var s = declaredFeatures(feature)
-        .filter(af -> !ignoreFeature(af))
+        .filter(af -> !ignoreFeature(af, config.ignoreVisibility()))
         .collect(Collectors.toCollection(
           () -> new TreeSet<>(byFeatureName)));
       mapOfDeclaredFeatures.put(feature, s);

--- a/src/dev/flang/tools/docs/Docs.java
+++ b/src/dev/flang/tools/docs/Docs.java
@@ -225,7 +225,7 @@ public class Docs
   {
     return af.resultType().equals(Types.t_ADDRESS)
       || af.featureName().baseName().contains(FuzionConstants.INTERNAL_NAME_PREFIX)
-      || af.featureName().baseName().startsWith("@")
+      || af.featureName().isNameless()
       || (!ignoreVisibility && af.visibility() == Visi.INVISIBLE)
       || (!ignoreVisibility && af.visibility() == Visi.PRIVATE)
       || af.isTypeFeature()

--- a/src/dev/flang/tools/docs/DocsOptions.java
+++ b/src/dev/flang/tools/docs/DocsOptions.java
@@ -31,10 +31,15 @@ import java.nio.file.Path;
 /**
  * api doc specific options
  */
-public record DocsOptions(Path destination, boolean bare, boolean printCSSStyles)
+public record DocsOptions(Path destination, boolean bare, boolean printCSSStyles, boolean ignoreVisibility)
 {
 
   static final String baseApiDir = "/api/std";
+
+  public boolean ignoreVisibility()
+  {
+    return ignoreVisibility;
+  }
 
   public String docsRoot()
   {

--- a/src/dev/flang/tools/docs/Html.java
+++ b/src/dev/flang/tools/docs/Html.java
@@ -39,6 +39,7 @@ import java.util.stream.Stream;
 
 import dev.flang.ast.AbstractFeature;
 import dev.flang.ast.AbstractType;
+import dev.flang.ast.Visi;
 
 public class Html
 {
@@ -221,7 +222,8 @@ public class Html
       .map(af -> {
         // NYI summary tag must not contain div
         return "<details id='" + htmlID(af)
-          + "'><summary>$1</summary><div class='fd-comment'>$2</div>$3</details>"
+          + "'$0><summary>$1</summary><div class='fd-comment'>$2</div>$3</details>"
+            .replace("$0", (config.ignoreVisibility() && (af.visibility() == Visi.PRIVATE)) ? "class='fd-private' hidden" : "")
             .replace("$1",
               summary(af))
             .replace("$2", Util.commentOf(af))
@@ -558,12 +560,16 @@ public class Html
             <div class="container">
               <section>$0</section>
               <section>$1</section>
+              $3
             </div>
           </div>
         """
         .replace("$0", headingSection(af))
         .replace("$1", mainSection(mapOfDeclaredFeatures.get(af)))
-        .replace("$2", navigation);
+        .replace("$2", navigation)
+        .replace("$3", config.ignoreVisibility() ? """
+          <button onclick="for (let element of document.getElementsByClassName('fd-private')) { element.hidden = !element.hidden; }">Toggle hidden features</button>
+        """ : "");
     return config.bare() ? bareHtml: fullHtml(af, bareHtml);
   }
 


### PR DESCRIPTION
If the docs are built using the new `-ignoreVisibility` option, they will include features whose visibility is limited in the again. However, this documentation is hidden by default and can be toggled by pressing a button. This is intended to be used to generate developer docs.

Fixes #974