### PR TITLE
ast: Make AbstractFeature.qualifiedName() robust for early calls, fix #461

### DIFF
--- a/lib/array.fz
+++ b/lib/array.fz
@@ -125,21 +125,7 @@ array(redef T type,
     pre
       debug: i >= 0
   is
-    if length <= i
-      nil
-    else
-      arrayCons i
-
-
-  # create a cons cell for a list of this array starting at the given
-  # index
-  #
-  arrayCons (i i32) : Cons T (list T)
-    pre
-      debug: 0 <= i < length
-  is
-    head => array.this[i]
-    tail => as_list i+1
+    slice i length
 
 
   # create a slice from this array's elements at index 'from' (included)

--- a/lib/effect.fz
+++ b/lib/effect.fz
@@ -128,7 +128,7 @@ effectMode is
     inst(f ()->unit).  # install and run 'f'. NYI: remove and use 'new' instead, see io.stdin.fz
 
 
-effect : effect (effectMode.inst code)
+code_effect : effect (effectMode.inst code)
 is
 
   # the code to be executed within this effect.  This is typically
@@ -153,5 +153,5 @@ is
 
   # install this simpleEffect and run code
   #
-  private use(code ()->unit) unit is
+  use(code ()->unit) unit is
     abortable (effect_call code)

--- a/lib/local_mutate.fz
+++ b/lib/local_mutate.fz
@@ -56,7 +56,7 @@ local_mutate : simpleEffect is
     #
     private check_and_replace is
       if my_id != local_mutate.this.type.env.id
-        panic "*** invalid local_mutate for ..local_mutate.this.type.." # NYI: add { }
+        panic "*** invalid local_mutate for {local_mutate.this.type}"
       local_mutate.this.type.env.replace
 
     # is this element open, i.e., can it be mutated?
@@ -87,7 +87,7 @@ local_mutate : simpleEffect is
     # NYI: remove as soon as inheriting mutable_element works
     private check_and_replace is
       if my_id != local_mutate.this.type.env.id
-        panic "*** invalid local_mutate for ..local_mutate.this.type.." # NYI: add { }
+        panic "*** invalid local_mutate for {local_mutate.this.type}"
       local_mutate.this.type.env.replace
 
     # NYI: remove as soon as inheriting mutable_element works

--- a/src/dev/flang/air/Clazz.java
+++ b/src/dev/flang/air/Clazz.java
@@ -2292,7 +2292,7 @@ public class Clazz extends ANY implements Comparable<Clazz>
                 if (CHECKS) check
                   (feature() == Types.resolved.f_Types_get);
 
-                gi = Types.intern(new Type((Type) gi, Type.RefOrVal.LikeUnderlyingFeature));
+                gi = gi.featureOfType().isThisRef() ? gi.asRef() : gi.asValue();
               }
             result[i] = actualClazz(gi);
           }

--- a/src/dev/flang/ast/AstErrors.java
+++ b/src/dev/flang/ast/AstErrors.java
@@ -893,23 +893,20 @@ public class AstErrors extends ANY
                          existing         != Types.f_ERROR &&
                          existing.outer() != Types.f_ERROR    ))
       {
-        // NYI: HACK: see #461: This is an ugly workaround that just ignores the
-        // fact that type features can be defined repeatedly.
-        if (f.isTypeFeature())
-          {
-            warning(pos,
-                    "Duplicate feature declaration (ignored since these are type features, see #461)",
-                    "Feature that was declared repeatedly: " + s(f) + "\n" +
-                    "originally declared at " + existing.pos().show() + "\n" +
-                    "To solve this, consider renaming one of these two features or changing its number of arguments");
-            return;
-          }
-
+        var of = f.isTypeFeature() ? f.typeFeatureOrigin() : f;
         error(pos,
               "Duplicate feature declaration",
-              "Feature that was declared repeatedly: " + s(f) + "\n" +
+              "Feature that was declared repeatedly: " + s(of) + "\n" +
               "originally declared at " + existing.pos().show() + "\n" +
-              "To solve this, consider renaming one of these two features or changing its number of arguments");
+              "To solve this, consider renaming one of these two features, e.g., as " + sbn(of.featureName().baseName() + "ʼ") +
+              " (using a unicode modifier letter apostrophe " + sbn("ʼ")+ " U+02BC) "+
+              (f.isTypeFeature()
+               ? ("or changing it into a routine by returning a " +
+                  sbn("unit") + " result, i.e.,  adding " + sbn("unit") + " before " + code("is") + " or using " + code("=>") +
+                  " instead of "+ code("is") + ".")
+               : ("or adding an additional argument (e.g. " + code("_ unit") +
+                  " for an ignored unit argument used only to disambiguate these two).")
+               ));
       }
   }
 
@@ -1467,10 +1464,13 @@ public class AstErrors extends ANY
 
   static void incompatibleActualGeneric(SourcePosition pos, Generic f, AbstractType g)
   {
-    error(pos,
-          "Incompatible type parameter",
-          "formal type parameter " + s(f) + " with constraint " + s(f.constraint()) + "\n"+
-          "actual type parameter " + s(g) + "\n");
+    if (g != Types.t_UNDEFINED || count() == 0)
+      {
+        error(pos,
+              "Incompatible type parameter",
+              "formal type parameter " + s(f) + " with constraint " + s(f.constraint()) + "\n"+
+              "actual type parameter " + s(g) + "\n");
+      }
   }
 
   static void destructuringForGeneric(SourcePosition pos, AbstractType t, List<String> names)

--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -1342,10 +1342,6 @@ public class Call extends AbstractCall
         if (g != null)
           {
             g.resolve(res, outer);
-            if (!g.isGenericArgument())
-              {
-                g.featureOfType().typeFeature(res);
-              }
           }
       }
 

--- a/src/dev/flang/ast/Feature.java
+++ b/src/dev/flang/ast/Feature.java
@@ -1419,6 +1419,10 @@ public class Feature extends AbstractFeature implements Stmnt
       {
         _state = State.RESOLVING_SUGAR1;
 
+        if (definesType())
+          {
+            typeFeature(res);
+          }
         visit(new FeatureVisitor()
           {
             public Expr action(Call c, AbstractFeature outer) { return c.resolveSyntacticSugar(res, outer); }
@@ -1864,10 +1868,10 @@ public class Feature extends AbstractFeature implements Stmnt
         _state = State.RESOLVING_SUGAR2;
 
         visit(new FeatureVisitor() {
-            public Stmnt action(Feature   f, AbstractFeature outer) { return new Nop(_pos);                         }
-            public Expr  action(Function  f, AbstractFeature outer) { return f.resolveSyntacticSugar2(res, outer); }
+            public Stmnt action(Feature     f, AbstractFeature outer) { return new Nop(_pos);                        }
+            public Expr  action(Function    f, AbstractFeature outer) { return f.resolveSyntacticSugar2(res, outer); }
             public Expr  action(InlineArray i, AbstractFeature outer) { return i.resolveSyntacticSugar2(res, outer); }
-            public void  action(Impl      i, AbstractFeature outer) {        i.resolveSyntacticSugar2(res, outer); }
+            public void  action(Impl        i, AbstractFeature outer) {        i.resolveSyntacticSugar2(res, outer); }
           });
 
         _state = State.RESOLVED_SUGAR2;

--- a/src/dev/flang/ast/Type.java
+++ b/src/dev/flang/ast/Type.java
@@ -399,11 +399,13 @@ public class Type extends AbstractType
 
 
   /**
-   * Create a ref or value type from a given value / ref type.
+   * Create a clone of original that uses orignalOuterFeature as context to
+   * look up features the type is built from.
    *
    * @param original the original value type
    *
-   * @param refOrVal must be RefOrVal.Ref or RefOrVal.Val
+   * @param origininalOuterFeature the original feature, which is not a type
+   * feature.
    */
   private Type(Type original, AbstractFeature originalOuterFeature)
   {
@@ -419,7 +421,10 @@ public class Type extends AbstractType
         this._generics = new List<>();
         for (var g : original._generics)
           {
-            this._generics.add(((Type)g).clone(originalOuterFeature));
+            var gc = (g instanceof Type gt)
+              ? gt.clone(originalOuterFeature)
+              : g;
+            this._generics.add(gc);
           }
       }
     this._outer             = (original._outer instanceof Type ot) ? ot.clone(originalOuterFeature) : original._outer;
@@ -450,6 +455,9 @@ public class Type extends AbstractType
    *
    * This is used for type features that use types from the original feature,
    * but needs to replace generics by the type feature's generics.
+   *
+   * @param origininalOuterFeature the original feature, which is not a type
+   * feature.
    */
   Type clone(AbstractFeature originalOuterFeature)
   {
@@ -1078,7 +1086,7 @@ public class Type extends AbstractType
           }
       }
 
-    ensure
+    if (POSTCONDITIONS) ensure
       (!result || Errors.count() > 0);
 
     return result;

--- a/src/dev/flang/fe/SourceModule.java
+++ b/src/dev/flang/fe/SourceModule.java
@@ -1115,7 +1115,7 @@ public class SourceModule extends Module implements SrcModule, MirModule
             var fs = lookupFeatures(o, name).values();
             for (var f : fs)
               {
-                if (f.isConstructor() || f.isChoice())
+                if (f.definesType())
                   {
                     type_fs.add(f);
                     result = f;


### PR DESCRIPTION
Disallow ambiguous types names even if they are not used as types: Constructors with the same name and number of formal arguments will cause an error now.

Fixed duplicate type names in the base lib (`array.arrayCons` and `effect`).

For all features that declare a type, the corresponding type feature is not created by default, independent of whether it is used or not. This avoids a lot of problems and workarounds when creating them on demand only. Disadvantage is that library files are slightly larger now.

`f.this.type` now work in a library module since the type features for all children of `f` will be created.

local_mutate now prints the actual `local_mutate.this.type` in `panic`-messages.

This fixes #461 without actually changing the format of the .fum file, but by adding all the type features. `base.fum` grows by about 10%, which is not great, but acceptable for now.  Many file size optimizations can stil be done.