### PR TITLE
ast: add a method to determine whether a feature is internal

### DIFF
--- a/src/dev/flang/ast/Feature.java
+++ b/src/dev/flang/ast/Feature.java
@@ -888,7 +888,7 @@ public class Feature extends AbstractFeature implements Stmnt
    */
   public boolean isArtificialField()
   {
-    return isField() && _featureName.baseName().startsWith(FuzionConstants.INTERNAL_NAME_PREFIX);
+    return isField() && _featureName.isInternal();
   }
 
 
@@ -944,7 +944,7 @@ public class Feature extends AbstractFeature implements Stmnt
   public boolean resultInternal()
   {
     return _impl._kind == Impl.Kind.RoutineDef &&
-      _featureName.baseName().startsWith(FuzionConstants.INTERNAL_NAME_PREFIX);
+      _featureName.isInternal();
   }
 
 

--- a/src/dev/flang/ast/FeatureName.java
+++ b/src/dev/flang/ast/FeatureName.java
@@ -33,6 +33,7 @@ import java.util.SortedMap;
 
 import dev.flang.util.ANY;
 import dev.flang.util.Errors;
+import dev.flang.util.FuzionConstants;
 
 
 /**
@@ -289,6 +290,16 @@ public class FeatureName extends ANY implements Comparable<FeatureName>
   {
     _all_.clear();
     _allBaseNames_.clear();
+  }
+
+
+  /**
+   * Returns true iff the name of the feature is an internal name, i.e. it starts with the
+   * internal name prefix.
+   */
+  public boolean isInternal()
+  {
+    return baseName().startsWith(FuzionConstants.INTERNAL_NAME_PREFIX);
   }
 
 

--- a/src/dev/flang/fe/LibraryOut.java
+++ b/src/dev/flang/fe/LibraryOut.java
@@ -465,7 +465,7 @@ class LibraryOut extends ANY
     var n = f.featureName();
     _data.writeShort(k);
     var bn = n.baseName();
-    if (_sourceModule._options._eraseInternalNamesInLib && bn.startsWith(FuzionConstants.INTERNAL_NAME_PREFIX))
+    if (_sourceModule._options._eraseInternalNamesInLib && n.isInternal())
       {
         bn = "";
       }

--- a/src/dev/flang/tools/docs/Docs.java
+++ b/src/dev/flang/tools/docs/Docs.java
@@ -229,7 +229,7 @@ public class Docs
       }
 
     return af.resultType().equals(Types.t_ADDRESS)
-      || af.featureName().baseName().contains(FuzionConstants.INTERNAL_NAME_PREFIX)
+      || af.featureName().isInternal()
       || af.featureName().isNameless()
       || (!ignoreVisibility && af.visibility() == Visi.INVISIBLE)
       || (!ignoreVisibility && af.visibility() == Visi.PRIVATE)

--- a/src/dev/flang/tools/docs/Docs.java
+++ b/src/dev/flang/tools/docs/Docs.java
@@ -223,6 +223,11 @@ public class Docs
   // but how to distinguish?
   private static boolean ignoreFeature(AbstractFeature af, boolean ignoreVisibility)
   {
+    if (af.isUniverse())
+      {
+        return false;
+      }
+
     return af.resultType().equals(Types.t_ADDRESS)
       || af.featureName().baseName().contains(FuzionConstants.INTERNAL_NAME_PREFIX)
       || af.featureName().isNameless()


### PR DESCRIPTION
Here, internal features are those generated by the Fuzion compiler, which use a name that is inaccessible from outside code, because it starts with the same character that starts a comment.