### PR TITLE
test/local_mutate: use `go` instead of `use`, remove quicksort0, remove `me`

### DIFF
--- a/tests/local_mutate/test_local_mutate.fz
+++ b/tests/local_mutate/test_local_mutate.fz
@@ -59,19 +59,17 @@ test_local_mutate is
 
       # run code within an instance of m
       #
-      m.use (()->
-
+      m.go (()->
         s := m.env.new 0
 
         for e in l do
           s.update a->a+e
 
-        say "inside m.use: s.mget = {s.mget}"
-        say "inside m.use: count = {count}")
+        say "inside m.go: s.mget = {s.mget}"
+        say "inside m.go: count = {count}"
+        )
 
-      say "using m.run and count: {m.run ()->count (unit)->(-1)}"
-
-#       say (m.go i32 ()->count)     # NY: m.go does not work yet
+      say "using m.go and count: {m.go ()->count}"
 
       count2 =>
         s := m.env.new 0
@@ -85,80 +83,30 @@ test_local_mutate is
 
       # NYI: move this into negative test
       if envir.args.count == 3
-        s := (m.run ()->count2 (unit)->nil).get
+        s := m.go ()->count2
         say s        # *** will cause an error, requires m to be installed
 
-/* NYI: check this, causes error:
-
+/*
+      # NYI: move this into negative test
       if envir.args.count == 4
-        s := m.run ()->count2 (unit)->nil
-        m.use (() ->
-          s <- -12    # *** will cause an error, m has changed!
-          say s)
+        s := m.go ()->count2
+        m.go ()->
+          s.get <- -12    # *** will cause an error, m has changed!
+          say s
 */
 
       # NYI: move this into negative test
-      if envir.args.count == 4
+      if envir.args.count == 5
         q =>
-          s1 := m.run ()->count2 (unit)->nil
-          m.use (() ->
+          s1 := m.go ()->count2
+          m.go ()->
             s1.get <- -12    # *** will cause an error, m has changed!
-            say s1)
+            say s1
         q
 
     sum l
 
   test_sum
-
-
-  # quicksort using old marray, just for reference
-  #
-  # NYI: remove this case, this does not use mutate effect!
-  #
-  test_quicksort0 =>
-
-    quicksort(T type: ordered T, data Sequence T) array T is
-      c := data.count
-      if c = 0
-        []
-      else
-        arr := (marrays T).new c data[0]
-        for i in arr.indices do
-          arr[i] := data[i]
-
-        swap(i,j i32) =>
-          t := arr[i]
-          arr[i] := arr[j]
-          arr[j] := t
-
-        partition(l, r, pivot i32) =>
-          pv := arr[pivot]
-          swap pivot r
-          for
-            a := l, a + (sw ? 0 : 1)
-            b := r, b - (sw ? 1 : 0)
-            sw := arr[a] > pv
-          while a < b
-            if sw
-              swap a b-1
-          else
-            swap b r
-            b
-
-        qs(l, r i32) unit is # =>  does not work
-          if l < r
-            pi := partition l r (l + r)/2
-            qs l pi-1
-            qs pi+1 r
-
-        qs 0 c-1
-        arr.as_array
-
-    say (quicksort [0, 8, 15, 47, 11])
-    say (quicksort 0..10)
-    say (quicksort (10..0 : -1))
-
-  test_quicksort0
 
 
   # quicksort using array created via local mutate effect
@@ -172,7 +120,8 @@ test_local_mutate is
       else
         m : local_mutate is
 
-        # wrap code into iqs (NYI: use m.go with inline code)
+        # execute code with mutate effect `m`:
+        # m.go (()->    -- NYI: use go with inline code when #1002 is fixed
         iqs =>
           swap(i,j i32) =>
             t := arr[i]
@@ -206,7 +155,7 @@ test_local_mutate is
           qs 0 c-1
           arr.as_array
 
-        m.run ()->iqs (unit)->(panic "*** unexpected abort ***")
+        m.go ()->iqs
 
     say (quicksort [0, 8, 15, 47, 11])
     for i in -1..10 do
@@ -221,10 +170,9 @@ test_local_mutate is
   test_ring1 =>
 
     cell(T type, LM type : local_mutate, data T) ref is
-      me cell T LM := cell.this
-      n := LM.env.new me #  cell.this   -- NYI: cell.this causes crash!
-      p := LM.env.new me
-      link(ne, pr ref cell T LM) is
+      n := LM.env.new (cell T LM) cell.this
+      p := LM.env.new (cell T LM) cell.this
+      link(ne, pr cell T LM) is
         n <- ne
         p <- pr
 
@@ -263,7 +211,7 @@ test_local_mutate is
           cur.p.close
         r
 
-      r := m.run ()->(ring3 from.as_list) (unit)->(panic "*** unexpected abort ***")
+      r := m.go ()->(ring3 from.as_list)
       say "left local_mutate environment m"
       for
         i in 1..10
@@ -402,8 +350,7 @@ test_local_mutate is
         c.freeze
         c
 
-      # NYI: use m.go, not m.run()
-      r := m.run ()->(create_ring2 from.as_list) (unit)->(panic "*** unexpected abort ***")
+      r := m.go ()->(create_ring2 from.as_list)
       say "left local_mutate environment m"
       say r
       for

--- a/tests/local_mutate/test_local_mutate.fz.expected_out
+++ b/tests/local_mutate/test_local_mutate.fz.expected_out
@@ -1,9 +1,6 @@
-inside m.use: s.mget = 81
-inside m.use: count = 81
-using m.run and count: 81
-[0,8,11,15,47]
-[0,1,2,3,4,5,6,7,8,9,10]
-[0,1,2,3,4,5,6,7,8,9,10]
+inside m.go: s.mget = 81
+inside m.go: count = 81
+using m.go and count: 81
 [0,8,11,15,47]
 []
 []


### PR DESCRIPTION
`go` works now including returning a result. Also the crash when using `cell.this` is gone.

quicksort0 did not use local_mutate effect.