### PR TITLE
parser/lib: Add syntax for effects in a feature declaration

### DIFF
--- a/lib/local_mutate.fz
+++ b/lib/local_mutate.fz
@@ -86,8 +86,7 @@ local_mutate : simpleEffect is
     # If this is open, check that the mutate effect this was created with is still
     # intalled in the current environment.
     #
-    # mget ! local_mutate.this.type =>    -- NYI: effect syntax using '!' does not work yet
-    mget =>
+    mget ! local_mutate.this.type =>
       if open
         check_and_replace
       val
@@ -109,7 +108,8 @@ local_mutate : simpleEffect is
     #
     put (
       # the new value to be stored with 'h'
-      to T) # ! local_mutate.this.type  -- NYI: effect syntax using '!' does not work yet
+      to T)
+      ! local_mutate.this.type
     pre
       safety: open
      =>

--- a/src/dev/flang/parser/Parser.java
+++ b/src/dev/flang/parser/Parser.java
@@ -265,6 +265,7 @@ routOrField : routine
             ;
 routine     : formArgsOpt
               returnType
+              effects
               inherits
               contract
               implRout
@@ -279,14 +280,16 @@ field       : returnType
     var name = n.get(i);
     var p2 = (i+1 < n.size()) ? fork() : null;
     var a = formArgsOpt();
-    ReturnType r = returnType();
+    var r = returnType();
+    var eff = effects();
     var hasType = r != NoType.INSTANCE;
     var inh = inherits();
     Contract c = contract(true);
     Impl p =
-      a  .isEmpty() &&
-      inh.isEmpty()    ? implFldOrRout(hasType)
-                       : implRout();
+      a  .isEmpty()    &&
+      eff == Type.NONE &&
+      inh.isEmpty()       ? implFldOrRout(hasType)
+                          : implRout();
     p = handleImplKindOf(pos, p, i == 0, l, inh);
     l.add(new Feature(pos, v,m,r,name,a,inh,c,p));
     return p2 == null
@@ -459,6 +462,7 @@ field       : returnType
         p = fork();
         p.skipType();
       }
+    p.skipEffects();
     return
       p.isInheritPrefix   () ||
       p.isContractPrefix  () ||
@@ -1154,6 +1158,40 @@ returnType  : type
           }
       }
     return result;
+  }
+
+
+
+  /**
+   * Parse effects
+   *
+effects     : EXCLAMATION typeList
+            |
+            ;
+EXCLAMATION : "!"
+            ;
+   */
+  List<AbstractType> effects()
+  {
+    var result = Type.NONE;
+    if (skip('!'))
+      {
+        var effects = typeList();
+      }
+    return result;
+  }
+
+
+  /**
+   * Check if the current position is an effects and if so, skip it
+   *
+   * @return true iff the next token(s) start a constructor return type,
+   * otherwise no functionReturnType was found and the parser/lexer is at an
+   * undefined position.
+   */
+  boolean skipEffects()
+  {
+    return skip('!') && skipTypeList();
   }
 
 


### PR DESCRIPTION
Use `! type1, type2, type2` after the feature result to describe the effects.

Currently, the effects are parsed, but irgnored otherwise.