### PR TITLE
ast: cleanup and fix related to handling of `this.type` in type features, #1007

### DIFF
--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -1205,7 +1205,29 @@ public class Call extends AbstractCall
               }
             else
               {
-                frmlT = frmlT.replace_THIS_TYPE(target());
+                var target = target();
+                if (target instanceof AbstractCall tc && tc.calledFeature().isTypeParameter())
+                  {
+                    /*
+                     * Special handling for calling type feature with formal argument types that
+                     * are `this.type` of the original feature:
+                     *
+                     * example:
+                     *
+                     *   has_equality is
+                     *
+                     *     type.equality(a, b has_equality.this.type) bool is abstract
+                     *
+                     *   equals(T type : has_equality, x, y T) => T.equality x y
+                     *
+                     * For the call `T.equality x y`, we must replace the the formal argument type
+                     * for `a` (and `b`) by `T`.
+                     */
+                    frmlT = frmlT.replace_type_parameter_used_for_this_type_in_type_feature
+                      (target.type().featureOfType(),
+                       tc);
+                  }
+
                 frmlT = targetTypeOrConstraint(res).actualType(frmlT);
                 frmlT = frmlT.actualType(_calledFeature, _generics);
                 frmlT = Types.intern(frmlT);


### PR DESCRIPTION
Split up AbstractType.replace_THIS_TYPE into a part done inline in Call.java and the rest renamed as `replace_type_parameter_used_for_this_Type_in_type_feature` using `applyToGenericsAndOunter`.

Fixed bug in `remove_type_parameter_used_for_this_type_in_type_feature`, forgot to assign `applyToGenericsAndOuter` to result.