### PR TITLE
air/ast: Improve error for missing implementation of abstract feature

### DIFF
--- a/src/dev/flang/air/AirErrors.java
+++ b/src/dev/flang/air/AirErrors.java
@@ -94,7 +94,7 @@ public class AirErrors extends AstErrors
       foundFixed                  ? "fixed"             : Errors.ERROR_STRING;
     for (var af : abstractFeature)
       {
-        abs.append(abs.length() == 0 ? "" : ", ").append(af.featureName().baseName());
+        abs.append(abs.length() == 0 ? "" : ", ").append(s(af));
         var afKind = af.isAbstract() ? "abstract" : "fixed";
         abstracts.append((abstracts.length() == 0 ? "inherits or declares" : "and") + " " + afKind + " feature " +
                          s(af) + " declared at " + af.pos().show() + "\n" +
@@ -102,7 +102,7 @@ public class AirErrors extends AstErrors
       }
     abstracts.append("without providing an implementation\n");
     error(featureThatDoesNotImplementAbstract.pos(),
-          "Used " + kind + " " + (abstractFeature.size() > 1 ? "features " + abs + " are" : "feature " + abs + " is") + " not implemented",
+          "Used " + kind + " " + (abstractFeature.size() > 1 ? "features " + abs + " are" : "feature " + abs + " is") + " not implemented by "+s(featureThatDoesNotImplementAbstract),
           "Feature " + s(featureThatDoesNotImplementAbstract) + " " +
           "instantiated at " + instantiatedAt.pos().show() + "\n" +
           abstracts);

--- a/src/dev/flang/ast/AstErrors.java
+++ b/src/dev/flang/ast/AstErrors.java
@@ -902,7 +902,7 @@ public class AstErrors extends ANY
               " (using a unicode modifier letter apostrophe " + sbn("ʼ")+ " U+02BC) "+
               (f.isTypeFeature()
                ? ("or changing it into a routine by returning a " +
-                  sbn("unit") + " result, i.e.,  adding " + sbn("unit") + " before " + code("is") + " or using " + code("=>") +
+                  sbn("unit") + " result, i.e., adding " + sbn("unit") + " before " + code("is") + " or using " + code("=>") +
                   " instead of "+ code("is") + ".")
                : ("or adding an additional argument (e.g. " + code("_ unit") +
                   " for an ignored unit argument used only to disambiguate these two).")


### PR DESCRIPTION
In the first line of the error, highlight the missing feature and add the feature that should provide an implementation.

Also fixed a double space after a comma in another error message.