### PR TITLE
be/c: fix compilation with dfa=off by allowing infinite recursions

### DIFF
--- a/src/dev/flang/be/c/C.java
+++ b/src/dev/flang/be/c/C.java
@@ -551,6 +551,8 @@ public class C extends ANY
           "-Wno-unused-label",
           "-Wno-unused-but-set-variable",
           "-Wno-unused-function",
+          // allow infinite recursion
+          "-Wno-infinite-recursion",
           "-O3");
       }
     if(_options._useBoehmGC)


### PR DESCRIPTION
error was: 
> ex.c:39792:1: error: all paths through this function will call itself [-Werror,-Winfinite-recursion]
> {
> ^
> 1 error generated.
> 
> error 1: C backend: C compiler failed
> C compiler call 'clang -Wall -Werror -Wno-gnu-empty-struct -Wno-unused-variable -Wno-unused-label -Wno-unused-but-set-variable -Wno-unused-function -O3 -lm -lpthread -o ex ex.c' failed with exit code '1'
> 
> one error.
> 