### PR TITLE
ast: type inference failed for operator calls

### DIFF
--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -1609,7 +1609,12 @@ public class Call extends AbstractCall
                     inferGeneric(res, t, actualType, actual.pos(), conflict, foundAt);
                     checked[vai] = true;
                   }
+                // NYI cleanup/merge the two cases below
                 else if (actual instanceof Function af)
+                  {
+                    checked[vai] = inferGenericLambdaResult(res, outer, t, af, actual.pos(), conflict, foundAt);
+                  }
+                else if (actual instanceof Block b && b.resultExpression() instanceof Function af)
                   {
                     checked[vai] = inferGenericLambdaResult(res, outer, t, af, actual.pos(), conflict, foundAt);
                   }

--- a/src/dev/flang/ast/Function.java
+++ b/src/dev/flang/ast/Function.java
@@ -244,7 +244,7 @@ public class Function extends ExprWithPos
 
 
   /**
-   * Special version of propagateExpetedType(res, outer, t) tries to infer the
+   * Special version of propagateExpectedType(res, outer, t) tries to infer the
    * result type of a lambda.
    *
    * @param res this is called during type inference, res gives the resolution

--- a/src/dev/flang/parser/Parser.java
+++ b/src/dev/flang/parser/Parser.java
@@ -1914,7 +1914,12 @@ klammerLambd: LPAREN argNamesOpt RPAREN lambda
     else if (tupleElements.size() == 1)
       {
         var actual = tupleElements.get(0).expr(null);
-        return (actual instanceof Function)
+
+        // special handling for cases like:
+        // s9a i16 := -(32768)
+        // s9c i16 := -(-(-32768))
+        // s9a := i16 -(32768)
+        return (actual instanceof NumLiteral)
           ? actual
           : new Block(pos, posObject(), new List<>(actual));
       }

--- a/src/dev/flang/parser/Parser.java
+++ b/src/dev/flang/parser/Parser.java
@@ -1904,10 +1904,25 @@ klammerLambd: LPAREN argNamesOpt RPAREN lambda
                        },
                        () -> Void.TYPE);
 
-    return
-      isLambdaPrefix()          ? lambda(f.bracketTermWithNLs(PARENS, "argNamesOpt", () -> f.argNamesOpt())) :
-      tupleElements.size() == 1 ? tupleElements.get(0).expr(null)   // a klammerexpr, not a tuple
-                                : new Call(pos, null, "tuple", tupleElements);
+
+    // a lambda expression
+    if (isLambdaPrefix())
+      {
+        return lambda(f.bracketTermWithNLs(PARENS, "argNamesOpt", () -> f.argNamesOpt()));
+      }
+    // an expr wrapped in parentheses, not a tuple
+    else if (tupleElements.size() == 1)
+      {
+        var actual = tupleElements.get(0).expr(null);
+        return (actual instanceof Function)
+          ? actual
+          : new Block(pos, posObject(), new List<>(actual));
+      }
+    // a tuple
+    else
+      {
+        return new Call(pos, null, "tuple", tupleElements);
+      }
   }
 
 

--- a/tests/reg_issue1013_parentheses_ignored_in_operator_calls/Makefile
+++ b/tests/reg_issue1013_parentheses_ignored_in_operator_calls/Makefile
@@ -1,0 +1,27 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test Makefile
+#
+#  Author: Fridtjof Siebert (siebert@tokiwa.software)
+#
+# -----------------------------------------------------------------------
+
+override NAME = issue1013
+include ../simple.mk

--- a/tests/reg_issue1013_parentheses_ignored_in_operator_calls/issue1013.fz
+++ b/tests/reg_issue1013_parentheses_ignored_in_operator_calls/issue1013.fz
@@ -1,0 +1,29 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test issue1013
+#
+# -----------------------------------------------------------------------
+
+
+issue1013 is
+  for m in (i64 -1)..1 do
+    for n in (i64 -1)..1 do
+      x bool := ((m ≟ n) ≟ ((int m) ≟ (int n)))
+      say x

--- a/tests/reg_issue1013_parentheses_ignored_in_operator_calls/issue1013.fz.expected_out
+++ b/tests/reg_issue1013_parentheses_ignored_in_operator_calls/issue1013.fz.expected_out
@@ -1,0 +1,9 @@
+true
+true
+true
+true
+true
+true
+true
+true
+true


### PR DESCRIPTION
- reason was that parentheses were not represented in AST
- this resulted in Call.loadCalledFeature() to try and find (and erroneously succeed in this case) a chain booleans before trying to find the operator on outer.
- fixes  #1013 