### PR TITLE
air: Replace `this.type` early during creation of clazzes. fix #949

### DIFF
--- a/src/dev/flang/air/Clazz.java
+++ b/src/dev/flang/air/Clazz.java
@@ -657,16 +657,6 @@ public class Clazz extends ANY implements Comparable<Clazz>
 
 
   /**
-   * This is experimental: actualGenerics() could replace `a.this.type` by the
-   * actual outer type. This would avoid special handling in Clazzes.clazz(Expr
-   * e, Clazz outerClazz). However, this is currently disabled since it has the
-   * side-effect of marking some clazzes as instantiated that are actually not
-   * (in tests/reg_issues874ff), need to check why.
-   */
-  static final boolean NYI_UNDER_DEVELOPMENT_EAGERLY_REPLACE_THIS_TYPE = false;
-
-
-  /**
    * Convert the given generics to the actual generics of this class.
    *
    * @param generics a list of generic arguments that might itself consist of
@@ -677,35 +667,20 @@ public class Clazz extends ANY implements Comparable<Clazz>
    */
   public List<AbstractType> actualGenerics(List<AbstractType> generics)
   {
-    if (NYI_UNDER_DEVELOPMENT_EAGERLY_REPLACE_THIS_TYPE)
+    var result = this._type.replaceGenerics(generics);
+
+    // Replace any `a.this.type` actual generics by the actual outer clazz:
+    if (result.stream().anyMatch(x->x.isThisType()))
       {
-        /**
-         * Replace any `a.this.type` actual generics by the actual outer clazz:
-         */
-        if (generics.stream().anyMatch(x->x.isThisType()))
-          {
-            var ng = new List<AbstractType>();
-            for (var g : generics)
-              {
-                if (g.isThisType())
-                  {
-                    var nc = findOuter(g.featureOfType(), SourcePosition.builtIn).typeClazz();
-                    System.out.println("replace "+g+" with "+nc+" in "+this);
-                    ng.add(nc._type);
-                  }
-                else
-                  {
-                    ng.add(g);
-                  }
-              }
-          }
+        result = result.map(g -> g.isThisType() ? findOuter(g.featureOfType(), SourcePosition.builtIn)._type
+                                                : g);
       }
-    generics = this._type.replaceGenerics(generics);
+
     if (this._outer != null)
       {
-        generics = this._outer.actualGenerics(generics);
+        result = this._outer.actualGenerics(result);
       }
-    return generics;
+    return result;
   }
 
 

--- a/src/dev/flang/air/Clazzes.java
+++ b/src/dev/flang/air/Clazzes.java
@@ -304,7 +304,8 @@ public class Clazzes extends ANY
   {
     if (PRECONDITIONS) require
       (actualType == Types.intern(actualType),
-       Errors.count() > 0 || !actualType.dependsOnGenerics());
+       Errors.count() > 0 || !actualType.dependsOnGenerics(),
+       Errors.count() > 0 || !actualType.containsThisType());
 
     Clazz result = null;
     Clazz o = outer;
@@ -1088,16 +1089,7 @@ public class Clazzes extends ANY
                                       outerClazz.actualGenerics(c.actualTypeParameters()),
                                       c,
                                       false);
-            if (!Clazz.NYI_UNDER_DEVELOPMENT_EAGERLY_REPLACE_THIS_TYPE &&
-                c.calledFeature() == Types.resolved.f_Types_get &&
-                c.actualTypeParameters().get(0).isThisType())
-              {
-                result = outerClazz.findOuter(c.actualTypeParameters().get(0).featureOfType(), c).typeClazz();
-              }
-            else
-              {
-                result = inner.resultClazz();
-              }
+            result = inner.resultClazz();
           }
         else
           {

--- a/src/dev/flang/ast/AbstractType.java
+++ b/src/dev/flang/ast/AbstractType.java
@@ -1136,6 +1136,21 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
   }
 
 
+  /**
+   * Check if for this or any type parameters of this, isThisType is true.  This
+   * must not be the case for any clazzes in FUIR since clazzes require concrete
+   * types.
+   *
+   * @return true if an `this.type` where found
+   */
+  public boolean containsThisType()
+  {
+    return
+      isThisType() ||
+      !isGenericArgument() && generics().stream().anyMatch(g -> g.containsThisType());
+  }
+
+
   public abstract AbstractFeature featureOfType();
   public abstract AbstractType asRef();
   public abstract AbstractType asValue();


### PR DESCRIPTION
Avoid special handling for the result of `Types.get` for this type.