### PR TITLE
lib/be: Add intrinsic `fuzion.sys.misc.unique_id`, use it in mutate effect

### DIFF
--- a/lib/fuzion/sys/misc.fz
+++ b/lib/fuzion/sys/misc.fz
@@ -1,0 +1,40 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion standard library feature fuzion.sys.misc
+#
+#  Author: Fridtjof Siebert (siebert@tokiwa.software)
+#
+# -----------------------------------------------------------------------
+
+# fuzion.sys.misc -- miscellaneous system intrinsics
+#
+private misc is
+
+
+  # intrinsic to get a unique id > 0
+  #
+  # this can be used to add a unique identifier to compare instances.
+  #
+  # sine there are 2^64-1 possible values, you can safely assume that these are
+  # in fact unique.  Assuming one unique id is consumed every nanosecond, it
+  # would take more than 500 years before we run out of values
+  # (2^64/10^9/3600/24/365.25).
+  #
+  private unique_id u64 is intrinsic

--- a/lib/mutate.fz
+++ b/lib/mutate.fz
@@ -64,7 +64,7 @@ mutate : simpleEffect is
   # an id used for runtime checks to verify that mutation made with the same effect
   # the mutable value was created with
   #
-  id := time.nano.read   # NYI: replace by intrinsic that produces a unique id
+  id := fuzion.sys.misc.unique_id
 
   # 0 is used to indicate this is closed
   #

--- a/src/dev/flang/be/c/Intrinsics.java
+++ b/src/dev/flang/be/c/Intrinsics.java
@@ -635,7 +635,10 @@ public class Intrinsics extends ANY
      put("fuzion.sys.misc.unique_id",(c,cl,outer,in) ->
          {
            var last_id= new CIdent("last_id");
-           return CStmnt.seq(CStmnt.decl("static "+c._types.scalar(FUIR.SpecialClazzes.c_u64),last_id),
+           return CStmnt.seq(CStmnt.decl("static",
+                                         c._types.scalar(FUIR.SpecialClazzes.c_u64),
+                                         last_id,
+                                         CExpr.uint64const(0)),
                              last_id.assign(last_id.add(CExpr.uint64const(1))),
                              last_id.ret());
          });

--- a/src/dev/flang/be/c/Intrinsics.java
+++ b/src/dev/flang/be/c/Intrinsics.java
@@ -632,6 +632,13 @@ public class Intrinsics extends ANY
                                        c._names.FZ_TRUE.ret()),
                             c._names.FZ_FALSE.ret());
         });
+     put("fuzion.sys.misc.unique_id",(c,cl,outer,in) ->
+         {
+           var last_id= new CIdent("last_id");
+           return CStmnt.seq(CStmnt.decl("static "+c._types.scalar(FUIR.SpecialClazzes.c_u64),last_id),
+                             last_id.assign(last_id.add(CExpr.uint64const(1))),
+                             last_id.ret());
+         });
      put("fuzion.sys.thread.spawn0", (c,cl,outer,in) ->
         {
           var oc = c._fuir.clazzActualGeneric(cl, 0);

--- a/src/dev/flang/be/interpreter/Intrinsics.java
+++ b/src/dev/flang/be/interpreter/Intrinsics.java
@@ -137,6 +137,12 @@ public class Intrinsics extends ANY
   private static long _maxFileDescriptor_  = 3;
 
 
+  /**
+   * the last unique identifier returned by `fuzion.sys.misc.unique_id`.
+   */
+  private static long _last_unique_id_ = 0;
+
+
   /*-------------------------  static methods  --------------------------*/
 
 
@@ -766,6 +772,7 @@ public class Intrinsics extends ANY
         });
     put("fuzion.sys.env_vars.has0", (interpreter, innerClazz) -> args -> new boolValue(System.getenv(utf8ByteArrayDataToString(args.get(1))) != null));
     put("fuzion.sys.env_vars.get0", (interpreter, innerClazz) -> args -> Interpreter.value(System.getenv(utf8ByteArrayDataToString(args.get(1)))));
+    put("fuzion.sys.misc.unique_id",(interpreter, innerClazz) -> args -> new u64Value(++_last_unique_id_));
     put("fuzion.sys.thread.spawn0", (interpreter, innerClazz) -> args ->
         {
           var call = Types.resolved.f_function_call;

--- a/src/dev/flang/fuir/analysis/dfa/DFA.java
+++ b/src/dev/flang/fuir/analysis/dfa/DFA.java
@@ -1178,6 +1178,7 @@ public class DFA extends ANY
     put("fuzion.sys.env_vars.get0"       , cl -> cl._dfa.newConstString(null, cl) );
     put("fuzion.sys.env_vars.set0"       , cl -> cl._dfa._bool );
     put("fuzion.sys.env_vars.unset0"     , cl -> cl._dfa._bool );
+    put("fuzion.sys.misc.unique_id"      , cl -> new NumericValue(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc)) );
     put("fuzion.sys.thread.spawn0"       , cl ->
         {
           var oc = cl._dfa._fuir.clazzActualGeneric(cl._cc, 0);

--- a/src/dev/flang/fuir/cfg/CFG.java
+++ b/src/dev/flang/fuir/cfg/CFG.java
@@ -447,6 +447,7 @@ public class CFG extends ANY
     put("fuzion.sys.env_vars.get0"       , (cfg, cl) -> { } );
     put("fuzion.sys.env_vars.set0"       , (cfg, cl) -> { } );
     put("fuzion.sys.env_vars.unset0"     , (cfg, cl) -> { } );
+    put("fuzion.sys.misc.unique_id"      , (cfg, cl) -> { } );
     put("fuzion.sys.thread.spawn0"       , (cfg, cl) -> { } );
     put("fuzion.std.nano_sleep"          , (cfg, cl) -> { } );
     put("fuzion.std.nano_time"           , (cfg, cl) -> { } );


### PR DESCRIPTION
This intrinsic enables adding a unique number to identify instances.  This is used to make sure the mutable variables are mutated with exactly the same effect they were created with.