### PR TITLE
lib: String.lteq was always true for strings with same prefix

### DIFF
--- a/lib/String.fz
+++ b/lib/String.fz
@@ -80,7 +80,7 @@ String ref : has_equality, has_hash, has_total_order is
       .zip b.utf8 (c,d)->(c,d)
       .filter (x ->
         (c, d) := x
-        !(a ≟ b))
+        !(c ≟ d))
       .mapSequence (x ->
         (c, d) := x
         c ≤ d)


### PR DESCRIPTION
Instead of single utf8 bytes, the whole strings were checked for equality.