### PR TITLE
lib: introduce 'normal' infix comparison operators like `<=`

### DIFF
--- a/lib/equals.fz
+++ b/lib/equals.fz
@@ -34,6 +34,16 @@ equals(T type : has_equality, a, b T) => T.equality a b
 infix ≟(T type : has_equality, a, b T) => equals T a b
 
 
+# infix = -- infix operation as short-hand for 'equals'
+#
+infix =(T type : has_equality, a, b T) => equals T a b
+
+
+# infix = -- infix operation as short-hand for 'equals'
+#
+infix !=(T type : has_equality, a, b T) => !equals T a b
+
+
 # lteq -- feature that compares two values using the lteq relation
 # defined in their type
 #
@@ -70,6 +80,41 @@ infix ⩻(T type : has_total_order, a, b T) bool is
 # result is = 0 if this = other
 #
 infix ⋄(T type : has_total_order, a, b T) i32 is
+  if      a ⩻ b then -1
+  else if a ⩼ b then +1
+  else                0
+
+
+# infix <= -- infix operation as short-hand for 'lteq'
+#
+infix <=(T type : has_partial_order, a, b T) => lteq T a b
+
+
+# does this come after other?
+#
+infix >=(T type : has_total_order, a, b T) bool is
+  lteq T b a
+
+
+# does this come strictly after other?
+#
+infix >(T type : has_total_order, a, b T) bool is
+  !(lteq T a b)
+
+
+# does this come strictly before other?
+#
+infix <(T type : has_total_order, a, b T) bool is
+  !(lteq T b a)
+
+
+# three-way comparison between this and other.
+#
+# result is < 0 if this < other
+# result is > 0 if this > other
+# result is = 0 if this = other
+#
+infix <>(T type : has_total_order, a, b T) i32 is
   if      a ⩻ b then -1
   else if a ⩼ b then +1
   else                0


### PR DESCRIPTION
Since the transition to type-features is mostly done now, we can go back to using the stablished operators.