### PR TITLE
ast: Avoid redundant errors reported in #1051

### DIFF
--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -1537,6 +1537,7 @@ public class Call extends AbstractCall
         else if (conflict[i])
           {
             AstErrors.incompatibleTypesDuringTypeInference(pos(), g, foundAt[i]);
+            _generics.set(i, Types.t_ERROR);
           }
       }
 


### PR DESCRIPTION
If type inference resulted in incompatible types, we better set the inferred type to `t_ERROR` to avoid reporting any further problems related to this type.

This reduces the number of errors produced by the example of #1051 from 4 to 2.