### PR TITLE
workflow linux: disable parallel test runs

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -53,4 +53,4 @@ jobs:
         run: make
 
       - name: run tests
-        run: make run_tests_parallel
+        run: make run_tests


### PR DESCRIPTION
exit codes are not properly handled in parallel test execution.