### PR TITLE
lib: Add `codepoint.type.equality` and `codepoint.type.lteq`

### DIFF
--- a/lib/codepoint.fz
+++ b/lib/codepoint.fz
@@ -121,3 +121,17 @@ is
       4
     else
       error "first byte is not the start of utf-8 character."
+
+
+  # compare two codepoints for equality
+  #
+  # result is true iff the codepoints have the same value
+  #
+  fixed type.equality(a, b codepoint) => a.val = b.val
+
+
+  # compare two codepoints
+  #
+  # This defines a total order over strings that is unrelated to alphabetic order.
+  #
+  fixed type.lteq(a, b codepoint) => a.val <= b.val


### PR DESCRIPTION
This fixes idiom 159 and provides a much more efficient handling of codepoints in an ordered data structure.