### PR TITLE
fe: Check version number of fum file dependencies, fix #1048

### DIFF
--- a/src/dev/flang/fe/FeErrors.java
+++ b/src/dev/flang/fe/FeErrors.java
@@ -26,6 +26,9 @@ Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
 
 package dev.flang.fe;
 
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
 import dev.flang.ast.AbstractFeature;
 import dev.flang.ast.AstErrors;
 
@@ -103,6 +106,30 @@ public class FeErrors extends AstErrors
           "there are no calls to features that end up reading this field before it is "+
           "initialized.\n");
   }
+
+
+  static String versionString(byte[] v)
+  {
+    return
+      v == null     ? "-- null --" :
+      v.length == 0 ? "-- empty version --"
+                    : IntStream.range(0, v.length)
+                        .map(j -> v[j] & 0xff)
+                        .mapToObj(x -> Integer.toHexString(0x100 + x).substring(1))
+                        .collect(Collectors.joining());
+  }
+
+  static void incompatibleModuleVersion(LibraryModule user,
+                                        LibraryModule m,
+                                        byte[] expected_version,
+                                        byte[] found_version)
+  {
+    error("Incompatible module version encountered",
+          "Module " + user + " referencec mobule " + m + "\n" +
+          "Expected version: " + versionString(expected_version) + "\n" +
+          "Actual version  : " + versionString(found_version));
+  }
+
 
 }
 

--- a/src/dev/flang/fe/LibraryModule.java
+++ b/src/dev/flang/fe/LibraryModule.java
@@ -31,6 +31,7 @@ import java.nio.file.Path;
 import java.nio.ByteBuffer;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Map;
 import java.util.SortedMap;
 import java.util.TreeMap;
@@ -47,6 +48,7 @@ import dev.flang.ir.IR;
 
 import dev.flang.mir.MIR;
 
+import dev.flang.util.Errors;
 import dev.flang.util.FuzionConstants;
 import dev.flang.util.HexDump;
 import dev.flang.util.List;
@@ -190,7 +192,13 @@ public class LibraryModule extends Module
       {
         var n = moduleRefName(p);
         var v = moduleRefVersion(p);
-        var mr = new ModuleRef(moduleOffset, n, v, fe.loadModule(n));
+        var m = fe.loadModule(n);
+        var mv = m.version();
+        if (!Arrays.equals(v, mv))
+          {
+            FeErrors.incompatibleModuleVersion(this, m, v, mv);
+          }
+        var mr = new ModuleRef(moduleOffset, n, v, m);
         _modules[i] = mr;
         moduleOffset = moduleOffset + mr.size();
         p = moduleRefNextPos(p);


### PR DESCRIPTION
Any .fum file now checks the version of all the .fum files it depends on. An error is produced in case a version does not match.