### PR TITLE
move entry back to ordered_map.entry

### DIFF
--- a/lib/ordered_map.fz
+++ b/lib/ordered_map.fz
@@ -42,9 +42,24 @@ ordered_map(OK type : has_total_order,
 is
 
 
+  # entry represents the pair of key and value at the given
+  # index i of the ordered map.
+  #
+  entry(i i32) : has_total_order is
+
+
+    key => ks[i]
+    val => vs[i]
+
+
+    # total order over entries.
+    #
+    fixed type.lteq(a, b entry.this.type) => a.key ≤ b.key
+
+
   # a sorted array of entries of this map
   #
-  sortedEntries := sorted_array_of (ks.indices.mapSequence (entry OK V) (i -> entry ordered_map.this i)).as_array
+  sortedEntries := sorted_array_of (ks.indices.mapSequence (i -> entry i)).as_array
 
 
   # number of entries in this map
@@ -103,20 +118,3 @@ ordered_maps (OK type : has_total_order, V type) is
   empty => (ordered_map
             ((Sequence OK).type.empty).as_array
             ((Sequence V).type.empty).as_array)
-
-
-# entry is an index in ks/vs
-#
-entry(OK type : has_total_order,
-      V type,
-      om ref ordered_map OK V,
-      i i32) : has_total_order is
-
-
-  key => om.ks[i]
-  val => om.vs[i]
-
-
-  # total order over entries.
-  #
-  fixed type.lteq(a, b entry OK V) => a.om.ks[a.i] ≤ b.om.ks[b.i]


### PR DESCRIPTION
Remove the hack using a ref to the ordered_map.

Closes #1044.