### PR TITLE
parser: improve error when only type is missing in feature definition

### DIFF
--- a/src/dev/flang/parser/Parser.java
+++ b/src/dev/flang/parser/Parser.java
@@ -1049,12 +1049,8 @@ typeType    : "type"
                       }
                     result[0] = FormalOrActual.formal;
                   }
-                else if (!skipType())
-                  {
-                    result[0] = FormalOrActual.actual;
-                    return false;
-                  }
-                else if (skipDot())
+                // tolerate missing type here
+                else if ((skipType() || true) && skipDot())
                   {
                     if (!skip(Token.t_type))
                       {

--- a/tests/reg_issue952/Makefile
+++ b/tests/reg_issue952/Makefile
@@ -1,0 +1,27 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test Makefile
+#
+#  Author: Fridtjof Siebert (siebert@tokiwa.software)
+#
+# -----------------------------------------------------------------------
+
+override NAME = issue952
+include ../simple.mk

--- a/tests/reg_issue952/issue952.fz
+++ b/tests/reg_issue952/issue952.fz
@@ -1,0 +1,27 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test issue952
+#
+#  Author: Fridtjof Siebert (siebert@tokiwa.software)
+#
+# -----------------------------------------------------------------------
+
+issue952 is
+  a(b u64, f) is

--- a/tests/reg_issue952/issue952.fz.expected_err
+++ b/tests/reg_issue952/issue952.fz.expected_err
@@ -1,0 +1,7 @@
+
+[32m--CURDIR--/issue952.fz:27:13:[39m [1;31merror 1[0m[1m: Syntax error: expected identifier name, infix/prefix/postfix operator, 'ternary ? :', 'index' or 'set' name, found right parenthesis ')'[0m
+[34m  a(b u64, f) is
+[33m------------^[0m
+While parsing: name, parse stack: name (2 times), simpletype, onetype, type, formArgs, formArgsOpt, routOrField, feature, stmnt, stmnts, block, implRout, implFldOrRout, routOrField, feature, stmnt, stmnts, unit
+
+one error.


### PR DESCRIPTION
fixes #952 