### PR TITLE
fe: Remove fallback for modules to load source files instead of .fum

### DIFF
--- a/src/dev/flang/fe/FrontEnd.java
+++ b/src/dev/flang/fe/FrontEnd.java
@@ -168,19 +168,9 @@ public class FrontEnd extends ANY
       {
         _baseModule = null;
       }
-    for (int i = 0; i < options._modules.size(); i++)
-      {
-        var m = _options._modules.get(i);
-        var loaded = loadModule(m, true);
-        if (loaded != null)
-          {
-            lms.add(loaded);
-          }
-        else if (Errors.count() == 0)
-          { // NYI: Fallback if module file does not exists use source files instead. Remove this.
-            sourceDirs[sourcePaths.length + i] = new SourceDir(options._fuzionHome.resolve(Path.of("modules")).resolve(Path.of(m)));
-          }
-      }
+    lms.addAll(options._modules.stream().map(mn -> loadModule(mn))
+                                        .filter(m -> m != null)
+                                        .toList());
     var dependsOn = lms.toArray(LibraryModule[]::new);
     if (options._loadSources)
       {
@@ -266,36 +256,22 @@ public class FrontEnd extends ANY
    */
   LibraryModule loadModule(String m)
   {
-    return loadModule(m, false);
-  }
-  LibraryModule loadModule(String m,
-                           boolean ignoreNotFound // NYI: remove when module support is stable
-                           )
-  {
     var result = _modules.get(m);
-    if (result != null)
-      {
-        return result;
-      }
-    else
+    if (result == null)
       {
         var p = modulePath(m);
         if (p != null)
           {
-            return module(m, p);
-          }
-        else if (ignoreNotFound)
-          {
-            return null;
+            result = module(m, p);
           }
         else
           {
             Errors.error("Module file '"+(m + ".fum")+"' for module '"+m+"' not found, "+
                          "module directories checked are '" + baseModuleDir() + "' and " +
                          _options._moduleDirs.toString("'","', '", "'") + ".");
-            return null;
           }
       }
+    return result;
   }
 
 


### PR DESCRIPTION
This fallback is no longer needed since modules are sufficiently stable.