### PR TITLE
fe: Freeze LibraryCall.actualTypeParameters(), fix #1098

### DIFF
--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -115,6 +115,7 @@ public class Call extends AbstractCall
               }
           }
       }
+    // res.freeze();  -- NYI: res.freeze not possible here since Function.propagateExpectedType2 performs gs.set
     return res;
   }
 
@@ -1705,7 +1706,7 @@ public class Call extends AbstractCall
                 conflict[i] = true;
                 nt = Types.t_ERROR;
               }
-            _generics.set(i, nt);  // NYI: use setOrClone?
+            _generics = _generics.setOrClone(i, nt);
             foundAt [i] = (foundAt[i] == null ? "" : foundAt[i]) + actualType + " found at " + pos.show() + "\n";
           }
       }

--- a/src/dev/flang/ast/Function.java
+++ b/src/dev/flang/ast/Function.java
@@ -334,7 +334,7 @@ public class Function extends ExprWithPos
                 res.resolveDeclarations(_wrapper);
                 res.resolveTypes(f);
                 result = f.resultType();
-                gs.set(0, result);   // NYI: hack to set inferred result type
+                gs.set(0, result);   // NYI: hack to set inferred result type, this prevents performing freeze in Call.actualTypeParameters.
               }
 
             _call = new Call(pos(), new Current(pos(), outer.thisType()), _wrapper).resolveTypes(res, outer);

--- a/src/dev/flang/fe/LibraryCall.java
+++ b/src/dev/flang/fe/LibraryCall.java
@@ -107,6 +107,7 @@ public abstract class LibraryCall extends AbstractCall
     Collections.reverse(actuals);
     _actuals = actuals;
     _generics = g;
+    g.freeze();
     Expr target = null;
     var feat = lib.callCalledFeature(index);
     var f = lib.libraryFeature(feat);
@@ -144,7 +145,7 @@ public abstract class LibraryCall extends AbstractCall
       {
         i.set(i.next().visit(v, outer));
       }
-    var j = actuals().listIterator(); // _actuals can change during resolveTypes, so create iterator early
+    var j = actuals().listIterator();
     while (j.hasNext())
       {
         j.set(j.next().visit(v, outer));


### PR DESCRIPTION
Without freezing this list, a call to Clazz.actualGenerics() with these generics will result in some of the generics being replaced, so a second call with different actual generics will not use the correct actual generics.

This problem did not manifest for dev.flang.ast.Call since the front end calls AbstractType.actualType on Call.actualTypeParameters, which freezes this list, while the list in LibraryCall was not frozen.

This patch also adds a NYI-comment where Call.actualTypeParameters should freeze the list with a reference why this is not possible yet (due to a hacky way to obtain the result type from a lambda).

Also added one more use of List.setOrClone, just to be safe and removed a wrong comment in LibraryCall (refering to resolveTyps, while resolution is fully done for Libraraycall).