### PR TITLE
workflow, linux: add step build all java code

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -49,7 +49,10 @@ jobs:
       - name: check shell scripts
         run: make shellcheck
 
-      - name: build (no-java)
+      - name: build java code
+        run: make javac
+
+      - name: build (no java modules)
         run: make no-java
 
       - name: run tests


### PR DESCRIPTION
reason: docs code broke but was not unnoticed. This will prevent this in the future.