### PR TITLE
ast: freeze _generics array of interned Types

### DIFF
--- a/src/dev/flang/ast/Type.java
+++ b/src/dev/flang/ast/Type.java
@@ -738,14 +738,12 @@ public class Type extends AbstractType
       }
     if (!_generics.isEmpty() && !(_generics instanceof FormalGenerics.AsActuals))
       {
-        var i = _generics.listIterator();
-        while (i.hasNext())
+        var result = this;
+        var g = generics();
+        var ng = g.map(gt -> gt instanceof Type gtt ? gtt.visit(v, outerfeat) : gt);
+        if (ng != g)
           {
-            var gt = i.next();
-            var ng = (gt instanceof Type gtt ? gtt.visit(v, outerfeat) : gt);
-            if (CHECKS) check
-              (gt == ng || _interned == null);
-            i.set(ng);
+            result = new Type(this, ng, outer());
           }
       }
     return v.action(this, outerfeat);

--- a/src/dev/flang/ast/Types.java
+++ b/src/dev/flang/ast/Types.java
@@ -304,6 +304,7 @@ public class Types extends ANY
                 types.put(t,t);
                 existing = t;
               }
+            t._generics.freeze();
             t._interned = existing;
           }
         at = existing;


### PR DESCRIPTION
Also use List.map instead of ListIterator.set to make sure we properly a Type when its generics() array changes when visiting Types.

This generally should reduce problems due to mutation of Types and Lists of type parameters.