### PR TITLE
lib/array: move array initialization to type feature new

### DIFF
--- a/lib/Sequence.fz
+++ b/lib/Sequence.fz
@@ -116,7 +116,7 @@ Sequence(T type) ref is
   #
   as_array array T is
     s := as_stream
-    array T count i->s.next
+    (array T).type.new count i->s.next
 
 
   # create a stream and call 'for_each f' on it

--- a/lib/array.fz
+++ b/lib/array.fz
@@ -25,21 +25,14 @@
 
 # array -- one-dimensional immutable array
 #
-# This is the result type of array(type, i32, i32 -> T) which creates an
-# initalized immutable array
-#
-# NYI: This uses three dummy unit-type args (i.e. total of 5 args or 4 value
-# args) to avoid name clashes with routine array(T,length,init) (i.e., 3 args
-# or  2 value args).  These unit-type args can go if the routine would be
-# moved to 'array.type.new' or 'arrays.new'
+# This creates a one-dimensional immutable array based on an internal representation,
+# and should not be used for initializing arrays. Use the array.type.new type feature
+# to create an initialized immutable array given a type, the length of the array, and
+# a mapping of indices to values.
 #
 array(redef T type,
-      internalArray fuzion.sys.internal_array T,
-      _ unit,
-      _ unit,
-      _ unit) : Sequence T is
+      internalArray fuzion.sys.internal_array T) : Sequence T is
 
-# public:
 
   length => internalArray.length
 
@@ -79,7 +72,7 @@ array(redef T type,
     # NYI: This is very inefficent since it copies the whole array.  Should
     # better use a persistent array implementation such as persistent hash array
     # mapped trie.
-    array T length.max(i+1) (ix -> if (ix ≟ i) v else array.this[ix])
+    (array T).type.new length.max(i+1) (ix -> if (ix ≟ i) v else array.this[ix])
 
   # create a new array with element i set to v. Grow the array in case i >= length.
   # New array elements at indices array.this.length..i-1 will be set to z.
@@ -93,7 +86,7 @@ array(redef T type,
     # NYI: This is very inefficent since it copies the whole array.  Should
     # better use a persistent array implementation such as persistent hash array
     # mapped trie.
-    array T length.max(i+1) (ix -> if (ix ≟ i) v else if (ix ≥ length) z else array.this[ix])
+    (array T).type.new length.max(i+1) (ix -> if (ix ≟ i) v else if (ix ≥ length) z else array.this[ix])
 
 
   # apply f to all elements in this array
@@ -146,14 +139,14 @@ array(redef T type,
   # map the array to a new array applying function f to all elements
   #
   map(B type, f T -> B) array B is
-    array B array.this.length (i -> f array.this[i])
+    (array B).type.new array.this.length (i -> f array.this[i])
 
 
   # variant of map which additionally passes the index to
   # the mapping function f
   #
   map_indexed(B type, f (T, i32) -> B) array B is
-    array B array.this.length (i -> f array.this[i] i)
+    (array B).type.new array.this.length (i -> f array.this[i] i)
 
 
   # fold the elements of this array using the given monoid.
@@ -180,7 +173,7 @@ array(redef T type,
   # reverse the order of the elements in this array
   #
   reverse array T is
-    array T array.this.length (i -> array.this[array.this.length-1-i])
+    (array T).type.new array.this.length (i -> array.this[array.this.length-1-i])
 
 
   # get a list of tuples indices and elements in this array
@@ -209,24 +202,22 @@ array(redef T type,
   # collect the contents of this Sequence into an array
   #
   redef as_array array T is
-    array T internalArray unit unit unit
+    array T internalArray
 
 
-# array -- create initialized one-dimensional immutable array
-#
-# NYI: move this to 'arrays.new' or similar to avoid overloading
-# with 'array(T,internalArray,_,_,_)'.
-#
-array(T type, length i32, init i32 -> T) array T
-  pre
-    safety: length ≥ 0
-is
+  # create initialized one-dimensional immutable array
+  #
+  # takes the length of the array to be created and a feature init
+  # that maps indices to values.
+  #
+  type.new(length i32, init i32 -> T) array T
+    pre
+      safety: length ≥ 0
+  is
+    indices => 0..length-1
 
-# private:
-  indices => 0..length-1
+    internal := fuzion.sys.internal_array T length
+    for x in indices do
+      internal[x] := init x
 
-  internal := fuzion.sys.internal_array T length
-  for x in indices do
-    internal[x] := init x
-
-  array T internal unit unit unit
+    array T internal

--- a/lib/array2.fz
+++ b/lib/array2.fz
@@ -32,7 +32,7 @@
 array2(redef T type,
        length0, length1 i32,
        init2 (i32, i32) -> T)
- : array T (fuzion.sys.internal_array T length0*length1) unit unit unit
+ : array T (fuzion.sys.internal_array T length0*length1)
   pre
     safety: length0 ≥ 0,
     safety: length1 ≥ 0,

--- a/lib/array3.fz
+++ b/lib/array3.fz
@@ -32,7 +32,7 @@
 array3(redef T type,
        length0, length1, length2 i32,
        init3 (i32, i32, i32) -> T)
- : array T (fuzion.sys.internal_array T length0*length1*length2) unit unit unit
+ : array T (fuzion.sys.internal_array T length0*length1*length2)
   pre
     safety: length0 ≥ 0,
     safety: length1 ≥ 0,

--- a/lib/bitset.fz
+++ b/lib/bitset.fz
@@ -50,7 +50,7 @@ is
     else
       match bitset.this
         _ nil   => bit
-        x u64   => array bool bit.max(x).as_i32+1 (i -> i.as_u64 ≟ bit || i.as_u64 ≟ x)
+        x u64   => (array bool).type.new bit.max(x).as_i32+1 (i -> i.as_u64 ≟ bit || i.as_u64 ≟ x)
         a array => a.put bit.as_i32 true false
 
   # union of two bitsets
@@ -64,7 +64,7 @@ is
           _ nil   => bitset.this
           x u64   => bitset.this.put x
           b array =>
-            array bool a.length.max(b.length) (i -> (has i.as_u64) || (other.has i.as_u64))
+            (array bool).type.new a.length.max(b.length) (i -> (has i.as_u64) || (other.has i.as_u64))
 
   # get the highest bit in this bitset
   #

--- a/lib/conststring.fz
+++ b/lib/conststring.fz
@@ -28,7 +28,7 @@
 # conststring cannot be called directly, instances are created implicitly by the
 # backend.
 #
-conststring (cannot_be_called void) ref : String, array u8 (fuzion.sys.internal_array u8 -1) unit unit unit is
+conststring (cannot_be_called void) ref : String, array u8 (fuzion.sys.internal_array u8 -1) is
 
   redef utf8 Sequence u8 is conststring.this
 

--- a/lib/fuzion/sys/args.fz
+++ b/lib/fuzion/sys/args.fz
@@ -37,4 +37,4 @@ private args =>
     is intrinsic
 
   # return the arguments in an array
-  array String count (i -> get i)
+  (array String).type.new count (i -> get i)

--- a/lib/fuzion/sys/fileio.fz
+++ b/lib/fuzion/sys/fileio.fz
@@ -34,7 +34,7 @@ public fileio is
   # has been reached.
   #
   read(fd i64, n u64) outcome (array u8) is
-    buf := array n.as_i32 i->(u8 0)
+    buf := (array u8).type.new n.as_i32 i->0
     res := read fd buf.internalArray.data buf.length
 
     if res ⩻ i64 0
@@ -62,7 +62,7 @@ public fileio is
   private get_file_size(
                         # the (relative or absolute) file name, using platform specific path separators
                         path String) outcome i64 is
-    md := array 4 i->(i64 0)
+    md := (array i64).type.new 4 i->0
     match stats (fuzion.sys.c_string path) md.internalArray.data
       TRUE => md[0]
       FALSE => error "error getting file size"
@@ -196,7 +196,7 @@ public fileio is
               path String,
               # a flag to speicify the open method (Read: 0, Write: 1, Append: 2)
               flag i8) outcome i64 is
-    open_results := array 2 i->(i64 0) # open_results[file descriptor, error number]
+    open_results := (array i64).type.new 2 i->0 # open_results[file descriptor, error number]
     open (fuzion.sys.c_string path) open_results.internalArray.data flag
     if open_results[1] ≟ i64 0
       open_results[0]
@@ -247,7 +247,7 @@ public fileio is
               fd i64,
               # the offset to seek from the beginning of this file
               offset i64) outcome i64 is
-    arr := array 2 (i -> i64 0)
+    arr := (array i64).type.new 2 i->0
     seek fd offset arr.internalArray.data
     if arr[1] ≟ i64 0
       arr[0]
@@ -275,7 +275,7 @@ public fileio is
   public file_position(
                        # file descriptor
                        fd i64) outcome i64 is
-    arr := array 2 (i -> i64 0)
+    arr := (array i64).type.new 2 i->0
     file_position fd arr.internalArray.data
     if arr[1] ≟ i64 0
       arr[0]

--- a/lib/handles.fz
+++ b/lib/handles.fz
@@ -87,7 +87,7 @@ is
   post
     result.hasLast
   is
-    na := array T count+1 (i -> if (i ⩻ count) ar[i] else w)
+    na := (array T).type.new count+1 (i -> if (i ⩻ count) ar[i] else w)
     handles T X v na mode
 
 
@@ -177,12 +177,12 @@ is
 # short-hand for creating and installing an empty set of handles of given type.
 #
 handles(T type, rr ()->unit) =>
-  handles T unit unit (array T 0 x->do) (effectMode.inst rr)
+  handles T unit unit ((array T).type.new 0 x->do) (effectMode.inst rr)
   unit
 
 # short-hand for creating an empty set of handles of given type.
 #
-handles_(T type) => handles T unit unit (array T 0 x->do) effectMode.plain
+handles_(T type) => handles T unit unit ((array T).type.new 0 x->do) effectMode.plain
 
 
 # short-hand for accessing handles monad for given type in current environment
@@ -226,7 +226,7 @@ handles_type(T type) is
   # install default instance of handles
   #
   installDefault unit is
-    handles T unit unit (array T 0 x->do) effectMode.default
+    handles T unit unit ((array T).type.new 0 x->do) effectMode.default
     unit
 
 

--- a/lib/io/file/stat.fz
+++ b/lib/io/file/stat.fz
@@ -51,7 +51,7 @@ private stat(
   stats(
         # the (relative or absolute) file name, using platform specific path separators
         path String) outcome meta_data is
-    data := array 4 i->(i64 0) # data will contain: [size, time of last modification in seconds, regular file? 1 : 0, dir? 1 : 0]
+    data := (array i64).type.new 4 i->0 # data will contain: [size, time of last modification in seconds, regular file? 1 : 0, dir? 1 : 0]
     if (ps.stats (fuzion.sys.c_string path) data.internalArray.data)
       replace
       meta_data data[0] data[1] (data[2] ≟ i64 1) (data[3] ≟ i64 1)
@@ -67,7 +67,7 @@ private stat(
   lstats(
          # the (relative or absolute) file name, using platform specific path separators
          path String) outcome meta_data is # NYI : not sure whether to use meta_data or introduce a new feature for lstats metadata
-    data := array 4 i->(i64 0) # data will contain: [size, time of last modification in seconds, regular file? 1 : 0, dir? 1 : 0]
+    data := (array i64).type.new 4 i->0 # data will contain: [size, time of last modification in seconds, regular file? 1 : 0, dir? 1 : 0]
     if (ps.stats (fuzion.sys.c_string path) data.internalArray.data)
       replace
       meta_data data[0] data[1] (data[2] ≟ i64 1) (data[3] ≟ i64 1)

--- a/lib/marray.fz
+++ b/lib/marray.fz
@@ -104,7 +104,7 @@ is
   # create immutable array from this
   #
   redef as_array =>
-    array T length (i -> marray.this[i])
+    (array T).type.new length (i -> marray.this[i])
 
 
   # create a list from this marray
@@ -119,7 +119,7 @@ is
   # map the array to a new array applying function f to all elements
   #
   map(B type, f T -> B) array B is
-    array B marray.this.length (i -> f marray.this[i])
+    (array B).type.new marray.this.length (i -> f marray.this[i])
 
 
   # fold the elements of this array using the given monoid.

--- a/lib/ordered_map.fz
+++ b/lib/ordered_map.fz
@@ -90,7 +90,7 @@ is
           (ks++[k]).as_array
           (vs++[v]).as_array)
       V =>
-        va := array size (i -> if ks[i] ≟ k then v else vs[i])
+        va := (array V).type.new size (i -> if ks[i] ≟ k then v else vs[i])
         (ordered_map ks va)
 
 

--- a/lib/ps_map.fz
+++ b/lib/ps_map.fz
@@ -154,7 +154,7 @@ O(n log n).
       if (size & sz) ≟ 0
         ps_map ndata nsize dest+sz
       else
-        tmp := array (tuple PK V) sz (i -> ndata[dest+i])
+        tmp := (array (tuple PK V)).type.new sz (i -> ndata[dest+i])
         for
           i1 := 0, if (use1) i1+1 else i1
           i2 := 0, if (use1) i2   else i2+1
@@ -227,7 +227,7 @@ O(n log n).
     join (ole i32, sz i32, rsz i32, skip i32) unit is
       if sz ≤ size
         if (size & sz) != 0
-          tmp := array PK rsz (i -> r[i])
+          tmp := (array PK).type.new rsz (i -> r[i])
           for
             i1 := 0, if (use1) i1+1 else i1
             i2 := 0, if (use1) i2   else i2+1
@@ -242,7 +242,7 @@ O(n log n).
 
     if size != 0
       join fill-1 1 0 0
-    array r unit unit unit
+    array r
 
 
   # get an array of all key/value pairs in this map

--- a/lib/sorted_array.fz
+++ b/lib/sorted_array.fz
@@ -56,7 +56,7 @@ sorted_array
 
   )
 
-  : array T (sort from.as_array 1).internalArray unit unit unit
+  : array T (sort from.as_array 1).internalArray
 
 is
 
@@ -89,7 +89,7 @@ is
       # of array.
       h1 := 0;
 
-      na := array T a.length (i ->
+      na := (array T).type.new a.length (i ->
         # index in current pair of heaps
         hi := i & (heap_size*2-1)
         # reset h1 in case we start new pair of heaps

--- a/lib/time/now.fz
+++ b/lib/time/now.fz
@@ -70,6 +70,6 @@ now =>
 # the system is giving us.
 #
 private default_now ()->time.date_time is () ->
-  a := array i32 6 i->0
+  a := (array i32).type.new 6 i->0
   fuzion.std.date_time a.internalArray.data
   time.date_time a[0] a[1] a[2] a[3] a[4] a[5]

--- a/lib/uint.fz
+++ b/lib/uint.fz
@@ -181,7 +181,7 @@ is
   # return an array of length n
   # initialized with u32 zeros.
   private zeros(n i32) =>
-    array n (_ -> u32 0)
+    (array u32).type.new n (_ -> u32 0)
 
 
   # NYI make faster: https://en.wikipedia.org/wiki/Multiplication_algorithm#Computational_complexity_of_multiplication

--- a/src/dev/flang/ast/InlineArray.java
+++ b/src/dev/flang/ast/InlineArray.java
@@ -329,14 +329,8 @@ public class InlineArray extends ExprWithPos
             stmnts.add(setElement);
           }
         var readSysArrayVar = new Call(pos(), null, sysArrayName                      ).resolveTypes(res, outer);
-        var unit1           = new Call(pos(), null, "unit"                            ).resolveTypes(res, outer);
-        var unit2           = new Call(pos(), null, "unit"                            ).resolveTypes(res, outer);
-        var unit3           = new Call(pos(), null, "unit"                            ).resolveTypes(res, outer);
         var sysArrArgs      = new List<Actual>(new Actual(et),
-                                               new Actual(readSysArrayVar),
-                                               new Actual(unit1),
-                                               new Actual(unit2),
-                                               new Actual(unit3));
+                                               new Actual(readSysArrayVar));
         var arrayCall       = new Call(pos(), null, "array"     , sysArrArgs).resolveTypes(res, outer);
         stmnts.add(arrayCall);
         result = new Block(pos(), stmnts);

--- a/src/dev/flang/ast/Types.java
+++ b/src/dev/flang/ast/Types.java
@@ -215,7 +215,7 @@ public class Types extends ANY
       f_function      = universe.get(mod, FUNCTION_NAME);
       f_function_call = f_function.get(mod, "call");
       f_safety        = universe.get(mod, "safety");
-      f_array         = universe.get(mod, "array", 5);
+      f_array         = universe.get(mod, "array", 2);
       f_array_internalArray = f_array.get(mod, "internalArray");
       f_fuzion                     = universe.get(mod, "fuzion");
       f_fuzion_sys                 = f_fuzion.get(mod, "sys");

--- a/tests/loop/looptest.fz
+++ b/tests/loop/looptest.fz
@@ -41,7 +41,7 @@ looptest is
   #
   # so we put '-2*i' in parentheses:
   #
-  a := array i32 100 (i -> if (i % 23 ≟ 0) (-2*i) else i*i)
+  a := (array i32).type.new 100 (i -> if (i % 23 ≟ 0) (-2*i) else i*i)
 
   say "testLoop0: plain while loop"
   testLoop0(data array i32, isWhatWeWant (i32) -> bool) is

--- a/tests/reg_issue119/issue119.fz
+++ b/tests/reg_issue119/issue119.fz
@@ -33,4 +33,4 @@
 
 issue119 is
   a := [0]
-  a := array i32 0 (i -> a[i])
+  a := (array i32).type.new 0 (i -> a[i])


### PR DESCRIPTION
Move the three-argument feature array(T type, length i32, init i32 -> T) to the type feature array.type.new(length i32, init i32 -> T). This resolves name clashes with the array feature which takes a type and an internal array representation, and up until now used three dummy unit arguments to avoid name clashes.