### PR TITLE
dfa: Fix joining numeric value with ValueSet, #1121

### DIFF
--- a/src/dev/flang/fuir/analysis/dfa/NumericValue.java
+++ b/src/dev/flang/fuir/analysis/dfa/NumericValue.java
@@ -216,6 +216,10 @@ public class NumericValue extends Value implements Comparable<NumericValue>
             return super.joinInstances(v);
           }
       }
+    else if (v instanceof ValueSet)
+      {
+        return v.join(this);
+      }
     else
       {
         return super.joinInstances(v);


### PR DESCRIPTION
joinInstance in numeric value was missing the case that we join with a whole set of numeric values.

This avoids the bug in #1121, but it reveals new problems in the C backend.