### PR TITLE
fuir: Use asStringWrapped for type parameters in FUIR.clazzBaseName, fix #1144

### DIFF
--- a/src/dev/flang/ast/AbstractType.java
+++ b/src/dev/flang/ast/AbstractType.java
@@ -1248,12 +1248,7 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
               + featureOfType().featureName().baseName();
         for (var g : generics())
           {
-            var gs = g.asString();
-            if (gs.indexOf(" ") >= 0)
-              {
-                gs = "(" + gs + ")";
-              }
-            result = result + " " + gs;
+            result = result + " " + g.asStringWrapped();
           }
         if (isThisType())
           {
@@ -1264,7 +1259,6 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
   }
 
 
-
   /**
    * wrap the result of toString in parentheses if necessary
    */
@@ -1273,6 +1267,17 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
     return toString().contains(" ")
            ? "(" + toString() + ")"
            : toString();
+  }
+
+
+  /**
+   * wrap the result of asString in parentheses if necessary
+   */
+  public String asStringWrapped()
+  {
+    var s = asString();
+    return s.contains(" ") ? "(" + s + ")"
+                           :       s      ;
   }
 
 

--- a/src/dev/flang/fuir/FUIR.java
+++ b/src/dev/flang/fuir/FUIR.java
@@ -504,7 +504,7 @@ public class FUIR extends IR
     var cc = clazz(cl);
     var res = cc.feature().featureName().baseName();
     res = res + cc._type.generics()
-      .toString(" ", " ", "", t -> t.toStringWrapped());
+      .toString(" ", " ", "", t -> t.asStringWrapped());
     return res;
   }
 


### PR DESCRIPTION
Added AbstractType.asStringWrapped as coutnerpart to toStringWrapped.

toString does not include `ref` in case of a `ref` type.