### PR TITLE
air/C: Uuse Type.asStringWrapped and FUIR.clazzAsStringNew, #1144

### DIFF
--- a/src/dev/flang/air/Clazz.java
+++ b/src/dev/flang/air/Clazz.java
@@ -1245,7 +1245,7 @@ public class Clazz extends ANY implements Comparable<Clazz>
             )
          + feature().featureName().baseName()
          + this._type.generics()
-             .toString(" ", " ", "", t -> t.toStringWrapped())
+         .toString(" ", " ", "", t -> t.asStringWrapped())
         );
   }
 

--- a/src/dev/flang/be/c/CTypes.java
+++ b/src/dev/flang/be/c/CTypes.java
@@ -273,7 +273,7 @@ public class CTypes extends ANY
     CStmnt result = CStmnt.EMPTY;
     if (needsTypeDeclaration(cl))
       {
-        var l = new List<CStmnt>(CStmnt.lineComment("for " + _fuir.clazzAsString(cl)));
+        var l = new List<CStmnt>(CStmnt.lineComment("for " + _fuir.clazzAsStringNew(cl)));
         var els = new List<CStmnt>();
         if (_fuir.clazzIsRef(cl))
           {


### PR DESCRIPTION
This results in better output and C code comments using '(' and including 'ref' for type parameters.