### PR TITLE
ast/tests: Fix #1158: type inferred from type parameter and type of type

### DIFF
--- a/src/dev/flang/ast/AbstractFeature.java
+++ b/src/dev/flang/ast/AbstractFeature.java
@@ -795,11 +795,13 @@ public abstract class AbstractFeature extends ANY implements Comparable<Abstract
   public AbstractFeature typeFeature()
   {
     if (PRECONDITIONS) require
-      (hasTypeFeature());
+      (isTypeFeature() || hasTypeFeature());
 
     if (_typeFeature == null)
       {
-        _typeFeature = this == Types.f_ERROR ? this : existingTypeFeature();
+        _typeFeature = this == Types.f_ERROR ? this :
+                       isTypeFeature()       ? Types.resolved.f_Type
+                                             : existingTypeFeature();
       }
     var result = _typeFeature;
 

--- a/src/dev/flang/ast/AbstractType.java
+++ b/src/dev/flang/ast/AbstractType.java
@@ -1000,10 +1000,15 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
        res != null || featureOfType().state().atLeast(Feature.State.RESOLVED));
 
     var result = this;
-    if (!featureOfType().isUniverse() && this != Types.t_ERROR)
+    var fot = featureOfType();
+    if (fot.isTypeFeature())
       {
-        var f = res == null ? featureOfType().typeFeature()
-                            : featureOfType().typeFeature(res);
+        result = Types.resolved.f_Type.thisType();
+      }
+    else if (!fot.isUniverse() && this != Types.t_ERROR)
+      {
+        var f = res == null ? fot.typeFeature()
+                            : fot.typeFeature(res);
         var g = new List<AbstractType>(this);
         g.addAll(generics());
         result = Types.intern(new Type(f.pos(),

--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -1695,6 +1695,10 @@ public class Call extends AbstractCall
     if (actualType != null)
       {
         actualType = actualType.replace_type_parameters_of_type_feature_origin(outer);
+        if (!actualType.isGenericArgument() && actualType.featureOfType().isTypeFeature())
+          {
+            actualType = Types.resolved.f_Type.thisType();
+          }
       }
     return actualType;
   }

--- a/src/dev/flang/ast/Feature.java
+++ b/src/dev/flang/ast/Feature.java
@@ -2139,7 +2139,6 @@ public class Feature extends AbstractFeature implements Stmnt
   }
 
 
-
   /**
    * resultTypeRaw returns the result type of this feature using the
    * formal generic argument.
@@ -2163,18 +2162,22 @@ public class Feature extends AbstractFeature implements Stmnt
       {
         result = (outer() instanceof Feature of) ? of.resultTypeRaw() : outer().resultType();
       }
-    else if (_impl._kind == Impl.Kind.FieldDef ||
-             _impl._kind == Impl.Kind.FieldActual)
+    else if (_impl._kind == Impl.Kind.FieldDef    ||
+             _impl._kind == Impl.Kind.FieldActual ||
+             _impl._kind == Impl.Kind.RoutineDef)
       {
         if (CHECKS) check
           (!state().atLeast(State.TYPES_INFERENCED));
-        result = _impl._initialValue.typeIfKnown();
-      }
-    else if (_impl._kind == Impl.Kind.RoutineDef)
-      {
-        if (CHECKS) check
-          (!state().atLeast(State.TYPES_INFERENCED));
-        result = _impl._code.typeIfKnown();
+        var from = _impl._kind == Impl.Kind.RoutineDef ? _impl._code
+                                                       : _impl._initialValue;
+        result = from.typeIfKnown();
+        if (!(from instanceof Call c && c.calledFeature() == Types.resolved.f_Types_get) &&
+            result != null &&
+            !result.isGenericArgument() &&
+            result.featureOfType().isTypeFeature())
+          {
+            result = Types.resolved.f_Type.thisType();
+          }
       }
     else if (_returnType.isConstructorType())
       {

--- a/tests/reg_issue1158_type_of_type_parameters/Makefile
+++ b/tests/reg_issue1158_type_of_type_parameters/Makefile
@@ -1,0 +1,27 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test Makefile
+#
+#  Author: Fridtjof Siebert (siebert@tokiwa.software)
+#
+# -----------------------------------------------------------------------
+
+override NAME = test_type_of
+include ../positive.mk

--- a/tests/reg_issue1158_type_of_type_parameters/test_type_of.fz
+++ b/tests/reg_issue1158_type_of_type_parameters/test_type_of.fz
@@ -66,7 +66,7 @@ test_type_of is
   chck_cmp $(type_of2 (type_of2 (option 42))) "Type of 'Type'"
   chck_cmp $(type_of2 (option i32).type     ) "Type of 'Type'"
 
-  type_of3 314.0                  "Type of 'f64' 314.0"
+  type_of3 3140000000             "Type of 'i64' 3140000000"
   type_of3 (option 42)            "Type of 'option i32' 42"
   type_of3 (type_of2 (option 42)) "Type of 'Type' Type of 'option i32'"
   type_of3 (option i32).type      "Type of 'Type' Type of 'option i32'"

--- a/tests/reg_issue1158_type_of_type_parameters/test_type_of.fz
+++ b/tests/reg_issue1158_type_of_type_parameters/test_type_of.fz
@@ -1,0 +1,85 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test test_type_of
+#
+#  Author: Fridtjof Siebert (siebert@tokiwa.software)
+#
+# -----------------------------------------------------------------------
+
+test_type_of is
+
+  exit_code := mut 0
+
+  chck(b bool, msg String) =>
+    s := if b
+      "PASSED: "
+    else
+      exit_code <- 1
+      "FAILED: "
+    say (s + msg)
+
+  chck_cmp(s1, s2 String) =>
+    chck s1=s2 "$s1 = $s2"
+
+
+  # type_of using explicit result type
+  #
+  type_of1(T type, _ T) Type is T
+
+
+  # type_of using inferred result type
+  #
+  type_of2(T type, _ T) => T
+
+
+  # type_of using field with inferred  type
+  #
+  type_of3(T type, v T, s String) =>
+    x := T
+    chck_cmp "$x $v" s
+
+
+  chck_cmp $(type_of1 3.14                  ) "Type of 'f64'"
+  chck_cmp $(type_of1 (option 42)           ) "Type of 'option i32'"
+  chck_cmp $(type_of1 (type_of1 (option 42))) "Type of 'Type'"
+  chck_cmp $(type_of1 (option i32).type     ) "Type of 'Type'"
+
+  chck_cmp $(type_of2 3.14                  ) "Type of 'f64'"
+  chck_cmp $(type_of2 (option 42)           ) "Type of 'option i32'"
+  chck_cmp $(type_of2 (type_of2 (option 42))) "Type of 'Type'"
+  chck_cmp $(type_of2 (option i32).type     ) "Type of 'Type'"
+
+  type_of3 314.0                  "Type of 'f64' 314.0"
+  type_of3 (option 42)            "Type of 'option i32' 42"
+  type_of3 (type_of2 (option 42)) "Type of 'Type' Type of 'option i32'"
+  type_of3 (option i32).type      "Type of 'Type' Type of 'option i32'"
+
+  chck_cmp $(Types.get f64         ) "Type of 'f64'"
+  chck_cmp $(Types.get (option i32)) "Type of 'option i32'"
+
+  t(T type) => T
+  chck_cmp $(t f64         ) "Type of 'f64'"
+  chck_cmp $(t (option i32)) "Type of 'option i32'"
+
+  u(T type, s String) => chck_cmp $T s
+  u f64          "Type of 'f64'"
+  u (option i32) "Type of 'option i32'"
+
+  exit exit_code

--- a/tests/reg_issue1158_type_of_type_parameters/test_type_of.fz
+++ b/tests/reg_issue1158_type_of_type_parameters/test_type_of.fz
@@ -82,4 +82,4 @@ test_type_of is
   u f64          "Type of 'f64'"
   u (option i32) "Type of 'option i32'"
 
-  exit exit_code
+  exit exit_code.get


### PR DESCRIPTION
It is not possible to obtain the type of a type feature. This type is always the base library feature Type, so we cannot run into an endless sequence of type-of-type-of-type...

Also, for routines and fields whose result type is inferred from a type parameter, the type is set to the base library feature 'Type'.

The usage of base lib's 'Type' in these cases results in boxing of type values, which allows them to be passed on (while type values themselves are unit type values and their surrounding feature get specialized for a specific value).

Also added a test checking type values returned by routines or assigned to fields.