### PR TITLE
lib/tests: Add new base lib feature type_of to determine compile-time type

### DIFF
--- a/lib/Type.fz
+++ b/lib/Type.fz
@@ -58,3 +58,43 @@ Types is
   # 'Types.get x'.
   #
   get(T type) => T
+
+
+# universe feature to determine the compile-time type of an expression.
+#
+# This is to be called without an actual type passed to `T`, but `T` should be
+# inferred from the actual value argument `_`.
+#
+# The value arugment is evaluated and ignored.
+#
+# The result is the type of the value argument boxed into a ref value and returned
+# as a value of type `Type`.
+#
+# examples:
+#
+#   `type_of "bla"` is `String`
+#   `type_of (panic "***")` will terminate
+#
+type_of(T type, _ T) => T
+
+
+# universe feature to determine the compile-time type of an expression.
+#
+# This is to be called without an actual type passed to `T`, but `T` should be
+# inferred from the result type of the actual value argument `_`.
+#
+# The function passed as value arugment is ignored, it is not called.
+#
+# The result is the result type of the value argument boxed into a ref value and
+# returned as a value of type `Type`.
+#
+# examples:
+#
+#   `type_of_lazy ()->"bla"` is Type of `String`
+#   `type_of_lazy ()->(panic "***")` is Type of `void`.
+#
+# NYI: Fuzion should have better syntax sugar for lazy value arguments such that
+# we do not need the `()->` prefix to create a lambda.  Then, `type_of` could
+# have a lazy argument and `type_of_lazy` could be removed.
+#
+type_of_lazy(T type, _ ()->T) => T

--- a/tests/reg_issue1158_type_of_type_parameters/test_type_of.fz
+++ b/tests/reg_issue1158_type_of_type_parameters/test_type_of.fz
@@ -82,4 +82,19 @@ test_type_of is
   u f64          "Type of 'f64'"
   u (option i32) "Type of 'option i32'"
 
+  # additional tests using base lib's `type_of`:
+  chck_cmp $(type_of 3.14                  ) "Type of 'f64'"
+  chck_cmp $(type_of (option 42)           ) "Type of 'option i32'"
+  chck_cmp $(type_of (type_of (option 42))) "Type of 'Type'"
+  chck_cmp $(type_of (option i32).type     ) "Type of 'Type'"
+  chck_cmp $(type_of "bal"                 ) "Type of 'String'"
+
+  # additional tests using base lib's `type_of` with lazy argument:
+  chck_cmp $(type_of_lazy ()->3.14                          ) "Type of 'f64'"
+  chck_cmp $(type_of_lazy ()->(option 42)                   ) "Type of 'option i32'"
+  chck_cmp $(type_of_lazy ()->(type_of_lazy ()->(option 42))) "Type of 'Type'"
+  chck_cmp $(type_of_lazy ()->((option i32).type)           ) "Type of 'Type'"
+  chck_cmp $(type_of_lazy ()->"bal"                         ) "Type of 'String'"
+  chck_cmp $(type_of_lazy ()->(panic "***")                 ) "Type of 'void'"
+
   exit exit_code.get


### PR DESCRIPTION
`type_of expr` determines the compile-time type of `expr` after evaluating `expr`.

`type_of_lazy ()->expr` determines the compile-time type of `expr` without evaluating `expr`.

Once syntax sugar for lambdas used as lazy values was improved, `type_of` could itself be made lazy and `type_of_lazy` could be removed`.

Also added tests for type_of to test/reg_issue1158_type_of_type_parameters.