### PR TITLE
Create error if call lookup is ambiguous, fix #1089

### DIFF
--- a/lib/String.fz
+++ b/lib/String.fz
@@ -57,8 +57,8 @@ String ref : has_equality, has_hash, has_total_order is
     n ≥ 0
   is
     redef utf8 Sequence u8 is
-      utf8 := String.this.utf8
-      utf8.cycle.take (utf8.count * n)
+      bytes := String.this.utf8
+      bytes.cycle.take (bytes.count * n)  # NYI: this does not work for infinite Strings.
 
 
   # equality: compare two strings byte-by-byte
@@ -569,7 +569,7 @@ String ref : has_equality, has_hash, has_total_order is
         n u32 => n ⩼ (u32 0)
     is
       match (find s)
-        nil => [as_string].as_list
+        nil => String.this.as_string : ()->nil
         idx i32 =>
           ref : Cons String (list String)
             head => substring 0 (if split_after then idx + s.byte_length else idx)
@@ -675,7 +675,7 @@ String ref : has_equality, has_hash, has_total_order is
   #
   cut(sep String) tuple String String bool is
     match find sep
-      nil => (as_string, "", false)
+      nil => (String.this.as_string, "", false)
       i i32 =>
         l := byte_length
         sepl := sep.byte_length

--- a/lib/ctrie.fz
+++ b/lib/ctrie.fz
@@ -199,12 +199,12 @@ private Indirection_Node(CTK type : has_hash, CTV type, data mutate.new (Main_No
       * => (gcas_commit m ct)
 
   # generation aware compare and set
-  gcas(o Main_Node CTK CTV, n Main_Node CTK CTV, ct ref CTrie CTK CTV) choice restart ok is
+  gcas(o Main_Node CTK CTV, n Main_Node CTK CTV, ct ref CTrie CTK CTV) choice restart ctrie_ok is
     n.cas_prev o nil
     if(cas o n)
       gcas_commit n ct
       match n.prev.get
-        nil => ok
+        nil => ctrie_ok
         * => restart
     else
       restart
@@ -248,7 +248,7 @@ is
 private restart is
 
 # unit type to indicate success
-private ok is
+private ctrie_ok is
 
 
 # descriptor for double-compare-single-swap operation
@@ -395,7 +395,7 @@ is
                       ncn := cn.updated pos tn.sn
                       match (p.gcas m (contract ncn lev gen) CTrie.this)
                         restart => clean_parent p i hash lev gen
-                        ok =>
+                        ctrie_ok =>
                     * =>
               * =>
         * =>
@@ -456,7 +456,7 @@ is
                 lookup sin k (lev + width) i gen
               else
                 match i.gcas m (Main_Node (cn.renewed gen CTrie.this) gen) CTrie.this
-                  ok => lookup i k lev parent gen
+                  ctrie_ok => lookup i k lev parent gen
                   restart => restart
             sn singleton_node =>
               if sn.k ≟ k
@@ -483,13 +483,13 @@ is
     match add r k v 0 nil r.data.get.gen
       r restart =>
         add k v
-      ok =>
+      ctrie_ok =>
         unit
 
 
   # try adding an element to the ctrie
   # may fail and result in a restart
-  private add(i Indirection_Node CTK CTV, k CTK, v CTV, lev u32, parent option (Indirection_Node CTK CTV), gen i32) choice restart ok is
+  private add(i Indirection_Node CTK CTV, k CTK, v CTV, lev u32, parent option (Indirection_Node CTK CTV), gen i32) choice restart ctrie_ok is
     m := i.gcas_read CTrie.this
     match m.data
       cn container_node CTK CTV =>
@@ -504,7 +504,7 @@ is
                 add sin k v (lev+width) i gen
               else
                 match (i.gcas m (Main_Node (cn.renewed gen CTrie.this) gen) CTrie.this)
-                  ok => add i k v lev parent gen
+                  ctrie_ok => add i k v lev parent gen
                   restart => restart
             sn singleton_node =>
               if !(sn.k ≟ k)
@@ -546,7 +546,7 @@ is
                 remove sin k (lev + width) i gen
               else
                 match (i.gcas m (Main_Node (cn.renewed gen CTrie.this) gen) CTrie.this)
-                  ok => remove i k lev parent gen
+                  ctrie_ok => remove i k lev parent gen
                   restart => restart
             sn singleton_node =>
               if !(sn.k ≟ k)
@@ -555,7 +555,7 @@ is
                 ncn  := cn.removed pos flag
                 cntr := contract ncn lev gen
                 match (i.gcas m cntr CTrie.this)
-                  ok => sn.v
+                  ctrie_ok => sn.v
                   restart => restart
           match res
             v CTV =>
@@ -571,7 +571,7 @@ is
         fln := list_node ln.filter(sn -> !(sn.k ≟ k))
         nln Main_Node CTK CTV := if fln.count ≟ 1 then Main_Node (tomb_node fln.first) i.data.get.gen else Main_Node fln i.data.get.gen
         match (i.gcas m nln CTrie.this)
-          ok => find ln k
+          ctrie_ok => find ln k
           restart => restart
 
 

--- a/lib/envir/vars.fz
+++ b/lib/envir/vars.fz
@@ -45,7 +45,7 @@ is
   # If set, get the environment variable corresponding to v.
   # Otherwise, return default
   #
-  get(v String, default String) => (get v).get default
+  get(v String, default String) => (get v).get get.this.default
 
   # Set the environment variable corresponding to n to have the
   # value v.

--- a/lib/float_sequence.fz
+++ b/lib/float_sequence.fz
@@ -40,11 +40,8 @@ float_sequence(F type : float F, redef from Sequence F) : numeric_sequence F fro
 
   # the standard deviation of the sequence
   # https://en.wikipedia.org/wiki/Standard_deviation
-  std_dev option F is
-    match variance
-      nil => nil
-      variance F =>
-        first.sqrt variance
+  std_dev =>
+    variance.map (x -> first.sqrt x)
 
 
   # the euclidean norm of this sequence

--- a/lib/fuzion/std.fz
+++ b/lib/fuzion/std.fz
@@ -36,7 +36,7 @@ fuzion.std is
   #
   panic(msg String) void is
     fuzion.sys.err.println "*** panic: $msg"
-    exit 1
+    std.this.exit 1
 
   # no guarantee can be given for precision nor resolution
   nano_time u64 is intrinsic

--- a/lib/hasInterval.fz
+++ b/lib/hasInterval.fz
@@ -104,7 +104,7 @@ hasInterval(H type : hasInterval H) : integer H is
 
       # use map implementation from Sequence:
       #
-      map(B type, f H -> B)  => mapSequence f
+      map(B type, f H -> B)  => infix : .this.mapSequence f
 
 
     # create a list from this interval

--- a/lib/integer.fz
+++ b/lib/integer.fz
@@ -146,13 +146,13 @@ integer(I type : integer I) : numeric I is
     n := integer.this.as_string base
 
     # split n into sign and digits
-    (sign, digits) := if (integer.this.sign ⩻ 0) ("-", String.type.from_bytes (n.utf8.drop 1)) else ("", n)
+    (sgn, digits) := if (integer.this.sign ⩻ 0) ("-", String.type.from_bytes (n.utf8.drop 1)) else ("", n)
 
     # create required additional zeros
     zeros := "0" * 0.max (len - n.byte_length)
 
     # put it all together
-    sign + zeros + digits
+    sgn + zeros + digits
 
 
   # create binary representation

--- a/lib/numeric_sequence.fz
+++ b/lib/numeric_sequence.fz
@@ -34,9 +34,9 @@ numeric_sequence(N type : numeric N, redef from Sequence N) : searchable_sequenc
     if is_empty
       nil
     else
-      count := (mapSequence N (_ -> first.one)).fold first.sum
+      cnt := (mapSequence N (_ -> first.one)).fold first.sum
       sum := fold first.sum
-      sum / count
+      sum / cnt
 
 
   # the variance of the sequence
@@ -45,9 +45,9 @@ numeric_sequence(N type : numeric N, redef from Sequence N) : searchable_sequenc
     match average
       nil => nil
       avg N =>
-        count := (mapSequence N (_ -> first.one)).fold first.sum
+        cnt := (mapSequence N (_ -> first.one)).fold first.sum
         sum := (mapSequence N (x -> (x - avg)**first.two)).fold first.sum
-        sum / count
+        sum / cnt
 
 
   # minimum value in the sequence

--- a/lib/time/nano.fz
+++ b/lib/time/nano.fz
@@ -72,7 +72,7 @@ nano(p Nano_Time_Provider, rr ()->unit) =>
 # short-hand for accessing time.nano effect in current environment
 #
 nano =>
-  nanos.installDefault
+  nano_type.installDefault
   nano.env
 
 
@@ -99,7 +99,7 @@ defaultNanoTime : Nano_Time_Provider is
 # unit type feature defining features related to time.nano but not requiring an
 # instance.
 #
-nanos is
+nano_type is
 
   # install default effect time using defaultTime
   installDefault unit is

--- a/lib/uint.fz
+++ b/lib/uint.fz
@@ -150,9 +150,9 @@ is
 
         (bits, rest, carry_over) := r
 
-        sum := t.as_u64 + rest.first.as_u64 + carry_over
+        s := t.as_u64 + rest.first.as_u64 + carry_over
 
-        ([sum.low32bits] ++ bits, (rest.drop 1), (sum>>32))
+        ([s.low32bits] ++ bits, (rest.drop 1), (s>>32))
       )
 
     uint d unit

--- a/src/dev/flang/ast/AbstractType.java
+++ b/src/dev/flang/ast/AbstractType.java
@@ -1129,7 +1129,7 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
   public AbstractType replace_type_parameters_of_type_feature_origin(AbstractFeature f)
   {
     var t = this;
-    if (!f.isUniverse())
+    if (!f.isUniverse() && f != Types.f_ERROR)
       {
         t = t.replace_type_parameters_of_type_feature_origin(f.outer());
         if (f.isTypeFeature())

--- a/src/dev/flang/ast/Assign.java
+++ b/src/dev/flang/ast/Assign.java
@@ -173,17 +173,23 @@ public class Assign extends AbstractAssign
     var f = _assignedField;
     if (f == null)
       {
-        var fo = res._module.lookupNoTarget(outer, _name, null, destructure == null ? this : null, destructure);
-        if (CHECKS) check
-          (Errors.count() > 0 || fo.features.size() <= 1);
-        f = fo.filter(pos(), FeatureName.get(_name, 0), __ -> false);
-        if (f == null)
+        var fo = FeatureAndOuter.filter(res._module.lookup(outer,
+                                                           _name,
+                                                           destructure == null ? this : destructure,
+                                                           true),
+                                        pos(), "assignment", FeatureName.get(_name, 0), __ -> false);
+        if (fo != null)
+          {
+            _target = fo.target(pos(), res, outer);
+            f = fo._feature;
+          }
+        else
           {
             AstErrors.assignmentTargetNotFound(this, outer);
+            _target = Expr.NO_VALUE;
             f = Types.f_ERROR;
           }
         _assignedField = f;
-        _target        = fo.target(pos(), res, outer);
       }
     if      (f == Types.f_ERROR          ) { if (CHECKS) check
                                                (Errors.count() > 0);

--- a/src/dev/flang/ast/Feature.java
+++ b/src/dev/flang/ast/Feature.java
@@ -1931,14 +1931,7 @@ public class Feature extends AbstractFeature implements Stmnt
    *
    * @param name the name of the feature
    *
-   * @param call the call we are trying to resolve, or null when not resolving a
-   * call.
-   *
-   * @param assign the assign we are trying to resolve, or null when not resolving an
-   * assign
-   *
-   * @param destructure the destructure we are trying to resolve, or null when not
-   * resolving a destructure.
+   * @param use the call, assign or destructure we are trying to resolve
    *
    * @param inner the inner feature that contains call or assign, null if
    * call/assign is part of current feature's code.
@@ -1946,13 +1939,13 @@ public class Feature extends AbstractFeature implements Stmnt
    * @return in case we found a feature visible in the call's or assign's scope,
    * this is the feature.
    */
-  public Feature findFieldDefInScope(String name, Call call, AbstractAssign assign, Destructure destructure, AbstractFeature inner)
+  public Feature findFieldDefInScope(String name, Stmnt use, AbstractFeature inner)
   {
     if (PRECONDITIONS) require
       (name != null,
-       call != null && assign == null && destructure == null ||
-       call == null && assign != null && destructure == null ||
-       call == null && assign == null && destructure != null,
+       use instanceof Call ||
+       use instanceof AbstractAssign ||
+       use instanceof Destructure,
        inner == null || inner.outer() == this);
 
     // curres[0]: currently visible field with name name
@@ -1986,7 +1979,7 @@ public class Feature extends AbstractFeature implements Stmnt
 
         public Call action(Call c, AbstractFeature outer)
         {
-          if (c == call)
+          if (c == use)
             { // Found the call, so we got the result!
               found();
             }
@@ -2004,14 +1997,14 @@ public class Feature extends AbstractFeature implements Stmnt
         }
         public void action(AbstractAssign a, AbstractFeature outer)
         {
-          if (a == assign)
+          if (a == use)
             { // Found the assign, so we got the result!
               found();
             }
         }
         public Stmnt action(Destructure d, AbstractFeature outer)
         {
-          if (d == destructure)
+          if (d == use)
             { // Found the assign, so we got the result!
               found();
             }

--- a/src/dev/flang/ast/FeatureAndOuter.java
+++ b/src/dev/flang/ast/FeatureAndOuter.java
@@ -20,38 +20,60 @@ Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
  *
  * Tokiwa Software GmbH, Germany
  *
- * Source of class FeaturesAndOuter
+ * Source of class FeatureAndOuter
  *
  *---------------------------------------------------------------------*/
 
 package dev.flang.ast;
-
-import java.util.SortedMap;
-import java.util.function.Predicate;
 
 import dev.flang.util.ANY;
 import dev.flang.util.Errors;
 import dev.flang.util.List;
 import dev.flang.util.SourcePosition;
 
+import java.util.function.Predicate;
 
 /**
- * FeaturesAndOuter is a set of features combined with an outer feature that
- * were found in outer and are candidates for the target of a call.
+ * FeatureAndOuter is a pair of an AbstractFeature f and an outer
+ * Feature where it was found.  f might be inherited by outer, i.e.,
+ * f.outer() == outer might not hold.
  *
  * @author Fridtjof Siebert (siebert@tokiwa.software)
  */
-public class FeaturesAndOuter extends ANY
+public class FeatureAndOuter extends ANY
 {
 
-  public SortedMap<FeatureName, AbstractFeature> features;
+  /**
+   * The feature containeed in this instance.
+   */
+  public final AbstractFeature _feature;
 
-  public AbstractFeature outer;
+
+  /**
+   * The feature where _feature was found.  This might be _feature.outer(), but
+   * it may as well be a heir of that.
+   */
+  public final AbstractFeature _outer;
+
+
+  /**
+   * Constructor for given feature and outer.
+   *
+   * @param f the feature
+   *
+   * @param o the outer feature f was found in.
+   */
+  public FeatureAndOuter(AbstractFeature f,
+                         AbstractFeature o)
+  {
+    this._feature = f;
+    this._outer = o;
+  }
 
 
   /**
    * For an access (call to or assignment to field), create an expression to
-   * get the outer instance that contains the accessed feature(s).
+   * get the outer instance that contains the accessed feature.
    *
    * @param pos source code position of the access
    *
@@ -61,7 +83,7 @@ public class FeaturesAndOuter extends ANY
    */
   Expr target(SourcePosition pos, Resolution res, AbstractFeature cur)
   {
-    var t = new This(pos, cur, outer);
+    var t = new This(pos, cur, _outer);
     Expr result = t;
     if (cur.state() != Feature.State.RESOLVING_INHERITANCE)
       {
@@ -73,47 +95,65 @@ public class FeaturesAndOuter extends ANY
 
 
   /**
-   * Filter the features to find an exact match for name or a candidate.
+   * Filter the features in given list to find an exact match for name or
+   * a candidate.
    *
    * If one feature f matches exactly or there is exactly one for which
    * isCandidate.test(f) holds, return that candidate. Otherwise, return null
    * if no candidate was found, or create an error and return Types.f_ERROR if
    * several candidates were found.
    *
+   * @param l the list to filter
+   *
    * @param pos source position of the access, for error reporting.
+   *
+   * @param operation "call" or "assignment", to be used in error messages
    *
    * @param name the name to search for an exact match
    *
    * @param isCandidate predicate to decide if a feature is a candidate even
    * if its name is not an exact match.
+   *
+   * @return if exaclty one match was found, that match, null if no match was
+   * found, an instance of FeatureAndOuter consisting of Types.f_ERROR for
+   * feature and outer in case of several matches. An error is reported in this
+   * case.
    */
-  AbstractFeature filter(SourcePosition pos, FeatureName name, Predicate<AbstractFeature> isCandidate)
+  static FeatureAndOuter filter(List<FeatureAndOuter> l,
+                                SourcePosition pos,
+                                String operation,
+                                FeatureName name,
+                                Predicate<AbstractFeature> isCandidate)
   {
     var match = false;
-    var found = new List<AbstractFeature>();
-    for (var f : features.entrySet())
+    var found = new List<FeatureAndOuter>();
+    for (var fo : l)
       {
-        var ff = f.getValue();
-        var fn = f.getKey();
-        if (ff.isChoice() && !ff.isBaseChoice())
+        var f = fo._feature;
+        var fn = f.featureName();
+        if (f.isChoice() && !f.isBaseChoice())
           {
             /* suppress call to choice type (e.g. bool : choice TRUE FALSE),
-               expect for (inheritance) calls to 'choice' */
+               except for (inheritance) calls to 'choice' */
           }
         else if (fn.equalsExceptId(name))  /* an exact match, so use it: */
           {
             if (CHECKS) check
-              (Errors.count() > 0 || !match || fn.argCount() == 0);
+              (Errors.count() > 0 ||
+               !match ||
+               fn.argCount() == 0 /* we might have several exact matches for fields */ ||
+               found.get(0)._outer != fo._outer /* we might have several exact matches at different outer levels */
+               );
             if (!match)
               {
                 found = new List<>();
                 match = true;
               }
-            found.add(ff);
+            found.add(fo);
           }
-        else if (!match && isCandidate.test(ff))
+        else if (!match && isCandidate.test(f))
           { /* no exact match, but we have a candidate to check later: */
-            found.add(ff);
+            found.add(fo);
           }
       }
     return switch (found.size())
@@ -121,10 +161,10 @@ public class FeaturesAndOuter extends ANY
       case 0 -> null;
       case 1 -> found.get(0);
       default ->
-      {
-        AstErrors.ambiguousCallTargets(pos, name, found);
-        yield Types.f_ERROR;
-      }
+        {
+          AstErrors.ambiguousTargets(pos, operation, name, found);
+          yield new FeatureAndOuter(Types.f_ERROR, Types.f_ERROR);
+        }
       };
   }
 

--- a/src/dev/flang/ast/SrcModule.java
+++ b/src/dev/flang/ast/SrcModule.java
@@ -30,6 +30,7 @@ import java.util.Collection;
 import java.util.Set;
 import java.util.SortedMap;
 
+import dev.flang.util.List;
 import dev.flang.util.SourcePosition;
 
 
@@ -67,10 +68,9 @@ public interface SrcModule
   SortedMap<FeatureName, AbstractFeature> declaredOrInheritedFeatures(AbstractFeature outer);
   AbstractFeature lookupFeature(AbstractFeature outer, FeatureName name, AbstractFeature original);
   void findDeclaredOrInheritedFeatures(Feature outer);
-  SortedMap<FeatureName, AbstractFeature> lookupFeatures(AbstractFeature outer, String name);
-  FeaturesAndOuter lookupNoTarget(AbstractFeature thiz, String name, Call call, AbstractAssign assign, Destructure destructure);
+  List<FeatureAndOuter> lookup(AbstractFeature thiz, String name, Stmnt use, boolean traverseOuter);
   void checkTypes(Feature f);
-  AbstractFeature lookupFeatureForType(SourcePosition pos, String name, AbstractFeature o);
+  AbstractFeature lookupType(SourcePosition pos, AbstractFeature outer, String name, boolean traverseOuter);
 
   void addTypeFeature(AbstractFeature outerType,
                       Feature         innerType);

--- a/src/dev/flang/ast/Type.java
+++ b/src/dev/flang/ast/Type.java
@@ -950,7 +950,7 @@ public class Type extends AbstractType
           }
         if (feature == null)
           {
-            feature = res._module.lookupFeatureForType(pos2BeRemoved(), name, of);
+            feature = res._module.lookupType(pos2BeRemoved(), of, name, _outer == null);
           }
       }
     if (POSTCONDITIONS) ensure

--- a/tests/choice_mix/choice_mix.fz
+++ b/tests/choice_mix/choice_mix.fz
@@ -297,20 +297,20 @@ choice_mix is
   alternatives1
 
   alternatives2 unit is // use pipe for choice argument type
-    Nil is
-    MyRef (a,b,c i32) ref is
+    Nil2 is
+    MyRef2 (a,b,c i32) ref is
 
-    test(p i32 | bool | String | Nil | MyRef) unit is
+    test(p i32 | bool | String | Nil2 | MyRef2) unit is
       match p
         i i32    => say "i32:    $i"
         b bool   => say "bool:   $b"
         s String => say "string: $s"
-        n Nil    => say "Nil:    $n"
-        m MyRef  => say "MyRef:  $m"
+        n Nil2   => say "Nil:    $n"
+        m MyRef2 => say "MyRef:  $m"
 
     test 3
     test true
     test "string"
-    test Nil
-    test (MyRef 3 4 5)
+    test Nil2
+    test (MyRef2 3 4 5)
   alternatives2

--- a/tests/covariance/test_covariance.fz
+++ b/tests/covariance/test_covariance.fz
@@ -217,8 +217,8 @@ test_this_type =>
   chck $z       "abcz"
   chck $Z       "vwxZ"
 
-  chck(s, t String) =>
-    say (if s ≟ t then "PASS: $s = $t" else "*** FAIL ***: $s /= $t")
+  chck(s1, s2 String) =>
+    say (if s1 ≟ s2 then "PASS: $s1 = $s2" else "*** FAIL ***: $s1 /= $s2")
 
 # This test creates nested features with inner type features that use outer features'
 # this.type in their signature.

--- a/tests/functions/functions.fz
+++ b/tests/functions/functions.fz
@@ -26,24 +26,24 @@
 functions is
 
     y(f ()->i32){}
-    x0(f Function i32 Any i32) is
+    x0(f0 Function i32 Any i32) is
       say "here 1x0---------------"
-      r1 i32 := f.call "hallo" 3
+      r1 i32 := f0.call "hallo" 3
       say "here 2x0---------------"
       r2 i32 := 42
-      //r2 := f "welt" 5
+      //r2 := f0 "welt" 5
       say "here 3x0---------------"
       say "$r1  $r2"
       say "here 1x0 done---------------"
 
-    x(f (Any, i32) -> i32) is
+    x(f0 (Any, i32) -> i32) is
       say "here 1x---------------"
-      r1 i32 := f.call "hallo" 3
-      g (Any, i32) -> i32 := f;
+      r1 i32 := f0.call "hallo" 3
+      g (Any, i32) -> i32 := f0;
       r2 i32 := g.call "welt"  4
-      // i32 r3 := f     ("hola",5);
+      // i32 r3 := f0    ("hola",5);
       // i32 r4 := g     ("mundo",5);
-      // r5 := f("Konnichiwa sekai!",7);
+      // r5 := f0("Konnichiwa sekai!",7);
       say "$r1  $r2"
 
     say "here 1a---------------"

--- a/tests/inheritance/inheritance.fz
+++ b/tests/inheritance/inheritance.fz
@@ -85,13 +85,13 @@ inheritance is
   // mixing value and ref types along the inheritance chain:
   mixValAndRef is
     // simple test: value type inheriting form ref type:
-    A ref is
+    AA ref is
       x := 3
       p => print
       print =>
         say x
-    B : A is
-    b := B
+    BB : AA is
+    b := BB
     b.p // all type info is static in this call
 
     c := 1000
@@ -100,9 +100,9 @@ inheritance is
     // nested features with a ref (P, Q, R, S) and a value (Pv, Qv, Rv, Sv)
     // variant and calls to features of the corresponding outer features.
     P ref is
-      id := count
+      pid := count
       p => print
-      print => say id
+      print => say pid
       Q ref is
         q => yak "q"; p
         R ref is
@@ -202,23 +202,23 @@ inheritance is
   cnt := 0
   Z
   Z ref is
-    B ref : Z is
+    BB ref : Z is
     if cnt ⩻ 10
       set cnt := cnt + 1
-      _ := B
+      _ := BB
 
   /* more complex inheritcane of outer feateature, with one more level of nesting: */
   tricky_Inheritance is
     cnt := 0
-    Z
-    Z ref is
-        say "tricky_Inheritance.Z: $cnt"
-        B ref is
-          q ref : Z is
-            say "tricky_Inheritance.Z.B.q: $cnt"
+    ZZ
+    ZZ ref is
+        say "tricky_Inheritance.ZZ: $cnt"
+        BB ref is
+          q ref : ZZ is
+            say "tricky_Inheritance.ZZ.B.q: $cnt"
         if cnt ⩻ 10
           set cnt := cnt + 1
-          _ := B.q
+          _ := BB.q
     unit
   tricky_Inheritance
 
@@ -233,25 +233,25 @@ inheritance is
 
     cnt_A_y := 0
     cnt_C_y := 0
-    A is
+    AA is
       x is rx := y
       y i32 is
         set cnt_A_y := cnt_A_y + 1
         say "inherit.A.y"
         0
 
-      C ref : A is
+      CC ref : AA is
         redefine y i32 is
           set cnt_C_y := cnt_C_y + 1
           say "inherit.C.y"
           1
-      D(i i32) is
+      DD(i i32) is
         say i
         chck i≟1 "call to y in arguments must be performed on heir instance"
 
-      B ref : x, C, D y is
+      BB ref : x, CC, DD BB.this.y is
 
-    A.B
+    AA.BB
     chck cnt_A_y≟1 "inherits calls to x must be performed in outer feature A"
     chck cnt_C_y≟1 "C.y must be called exactly once as argument to parent D(y)"
   call_inherited_from_parent_args
@@ -267,38 +267,38 @@ inheritance is
 
     cnt_A_y := 0
     cnt_C_y := 0
-    A ref is
+    AA ref is
       x is rx := y
       y i32 is
         set cnt_A_y := cnt_A_y + 1
         say "inherit.A.y"
         0
 
-      C ref : A is
+      CC ref : AA is
         redefine y i32 is
           set cnt_C_y := cnt_C_y + 1
           say "inherit.C.y"
           1
-      D(i i32) is
+      DD(i i32) is
         say i
         chck i≟1 "call to y in arguments must be performed on heir instance"
 
-      B ref : x, C, D y is
+      BB ref : x, CC, DD BB.this.y is
 
-    A.B
+    AA.BB
     chck cnt_A_y≟1 "inherits calls to x must be performed in outer feature A"
     chck cnt_C_y≟1 "C.y must be called exactly once as argument to parent D(y)"
   call_inherited_from_parent_args2
 
   /* check dynamic binding on call to A.x if ref feature B inherits from value feature A */
   check_dyn_binding_when_inheriting_value is
-    A is
+    AA is
       a => x
       x => say "A.x: FAILED."; exit_code <- 1
-    B ref : A is
+    BB ref : AA is
       a
       redefine x unit is say "B.x: PASSED."
-    B
+    BB
     unit
   check_dyn_binding_when_inheriting_value
 
@@ -313,25 +313,25 @@ inheritance is
 
     cnt_A_y := 0
     cnt_C_y := 0
-    A is
+    AA is
       x is rx := y
       y i32 is
         set cnt_A_y := cnt_A_y + 1
         say "inherit.A.y"
         0
 
-      C ref : A is
+      CC ref : AA is
         redefine y i32 is
           set cnt_C_y := cnt_C_y + 1
           say "inherit.C.y"
           1
-      D(i i32) is
+      DD(i i32) is
         say i
         chck i≟1 "call to y in arguments must be performed on heir instance"
 
-      B ref : x, C, D y is
+      BB ref : x, CC, DD BB.this.y is
 
-    A.B
+    AA.BB
     chck cnt_A_y≟1 "inherits calls to x must be performed in outer feature A"
     chck cnt_C_y≟1 "C.y must be called exactly once via x as argument to parent D(x)"
   call_inherited_from_parent_args3
@@ -344,36 +344,36 @@ inheritance is
     Ecnt := 0
     Fcnt := 0
 
-    A ref is
+    AA ref is
       set Acnt := Acnt + 1
-      B ref is
+      BB ref is
         set Bcnt := Bcnt + 1
-        C ref is
+        CC ref is
           set Ccnt := Ccnt + 1
-          D ref is
+          DD ref is
             set Dcnt := Dcnt + 1
-            E ref is
+            EE ref is
               set Ecnt := Ecnt + 1
-              F ref is
+              FF ref is
                 set Fcnt := Fcnt + 1
-                F3 ref : F is
-              E3 ref : E is
-            D3 ref : D is
-          C3 ref : C is
-        B3 ref : B is
-      A3 ref : A is
-    A1 ref : A is
-    B1 ref : A1.B is
-    C1 ref : B1.C is
-    D1 ref : C1.D is
-    E1 ref : D1.E is
-    F1 ref : E1.F is
-    A2 ref : A.A3 is
-    B2 ref : A2.B.B3 is
-    C2 ref : B2.C.C3 is
-    D2 ref : C2.D.D3 is
-    E2 ref : D2.E.E3 is
-    F2 ref : E2.F.F3 is
+                F3 ref : FF is
+              E3 ref : EE is
+            D3 ref : DD is
+          C3 ref : CC is
+        B3 ref : BB is
+      A3 ref : AA is
+    A1 ref : AA is
+    B1 ref : A1.BB is
+    C1 ref : B1.CC is
+    D1 ref : C1.DD is
+    E1 ref : D1.EE is
+    F1 ref : E1.FF is
+    A2 ref : AA.A3 is
+    B2 ref : A2.BB.B3 is
+    C2 ref : B2.CC.C3 is
+    D2 ref : C2.DD.D3 is
+    E2 ref : D2.EE.E3 is
+    F2 ref : E2.FF.F3 is
     A1
     B1
     C1

--- a/tests/inheritance_for_value_types/inheritance_for_value_types.fz
+++ b/tests/inheritance_for_value_types/inheritance_for_value_types.fz
@@ -36,8 +36,8 @@ inheritance_for_value_types is
 
   exit_code := mut 0
 
-  chck (msg String, b bool) unit is
-    if b
+  chck (msg String, b0 bool) unit is
+    if b0
       say "PASSED: $msg"
     else
       say "FAILED: $msg"

--- a/tests/nested_choice/nested_choice.fz
+++ b/tests/nested_choice/nested_choice.fz
@@ -51,10 +51,10 @@ nested_choice =>
       tripel_nested_choice : choice i32 bool_or_u64 is
         redef as_string =>
           match tripel_nested_choice.this
-            i32 i32 => $i32
+            i i32 => $i
             b1 bool_or_u64 =>
               match b1
-                u64 u64 => $u64
+                u u64 => $u
                 b2 bool => $b2
 
 
@@ -169,7 +169,7 @@ nested_choice =>
           choice choice nil String =>
             match choice
               nil nil => "inner nil"
-              String String => String
+              str String => str
           nil nil => "outer nil"
 
     a my_choice := nil
@@ -184,7 +184,7 @@ nested_choice =>
           choice choice nil String =>
             match choice
               nil nil => "inner nil"
-              String String => String
+              str String => str
           choice choice nil unit =>
             match choice
               nil nil => "inner nil"

--- a/tests/reg_issue176_using_inner_field_of_boxed_outer/issue176.fz
+++ b/tests/reg_issue176_using_inner_field_of_boxed_outer/issue176.fz
@@ -35,4 +35,4 @@ issue176 is
 
   match v.o
     e v.e => say e.i
-    nil nil => say nil
+    nil   => say nil

--- a/tests/reg_issue580_match_cases_involvin_generics/issue580.fz
+++ b/tests/reg_issue580_match_cases_involvin_generics/issue580.fz
@@ -25,14 +25,14 @@
 
 
 issue580 is
-  abort(T type, a T) is
+  abort0(T type, a T) is
 
-  a(T type, b T | abort T) is
+  a(T type, b T | abort0 T) is
     match b
       T => say "t"
-      abort => say "i"
+      abort0 => say "i"
 
   a 2
-  a i32 (abort 2)
+  a i32 (abort0 2)
 
   unit

--- a/tests/reg_issue698_np_excep_in_choice_with_call_to_outer_ref/issue698.fz
+++ b/tests/reg_issue698_np_excep_in_choice_with_call_to_outer_ref/issue698.fz
@@ -13,10 +13,10 @@ ex_tree is
 
     private smart (datum A, left, right tree A) tree A is
       ref : Node A (tree A) (tree A)
-        datum A is datum
-        count i32 is (1 + left.size + right.size)
-        left tree A is left
-        right tree A is right
+        datum A is smart.this.datum
+        count i32 is (1 + smart.this.left.size + smart.this.right.size)
+        left tree A is smart.this.left
+        right tree A is smart.this.right
 
   trees is
     empty(A type : has_total_order) tree A is

--- a/tests/reg_issue874ff/issue874.fz
+++ b/tests/reg_issue874ff/issue874.fz
@@ -287,22 +287,22 @@ test_return_this
 
 # second example from #923
 #
-a is
-  x a.this.type is
-    a.this
+aaa is
+  x aaa.this.type is
+    aaa.this
   redef as_string => "a"
 
-b : a is
+bbb : aaa is
   redef as_string => "b"
 
-say a.x
-say b.x
+say aaa.x
+say bbb.x
 
 
 # extended second example from #923, using nested child and nested parent
 #
 q is
-  b : a is
+  b : aaa is
     redef as_string => "q.b"
 
 r is

--- a/tests/valWithDynOuter/valWithDynOuter.fz
+++ b/tests/valWithDynOuter/valWithDynOuter.fz
@@ -31,11 +31,11 @@ valWithDynOuter is
 
   exit_code := mut 0
 
-  chck(s, expected String) =>
-    if s ≟ expected
-      say "PASSED: $s"
+  chck(str, expected String) =>
+    if str ≟ expected
+      say "PASSED: $str"
     else
-      say "FAILED: $s /= $expected"
+      say "FAILED: $str /= $expected"
       exit_code <- 1
 
   # test if e.y produces expected as result
@@ -45,13 +45,13 @@ valWithDynOuter is
   # by different other outer types producing
   #
   test(e v.e, expected String) =>
-    s := e.y
-    chck s expected
+    str := e.y
+    chck str expected
 
   test_mut(e v.e, expected String) =>
     e.mut
-    s := e.y
-    chck s expected
+    str := e.y
+    chck str expected
 
   v (f String) is
     a => "v"

--- a/tests/visibility/visibility.fz
+++ b/tests/visibility/visibility.fz
@@ -217,14 +217,14 @@ visibility is
       chck (x ≟ "Outer!") "outer x"
       b is
         x => "Inner!"
-        chck (x ≟ "Inner!") "inner x"
+        # chck (x ≟ "Inner!") "inner x"      -- causes an error, `x` is ambiguous
         chck (a.this.x ≟ "Outer!") "a.this.x"
         chck (b.this.x ≟ "Inner!") "b.this.x"
 
         c is
-          chck (x ≟ "Inner Inner!") "inner inner x"
+          # chck (x ≟ "Inner Inner!") "inner inner x"     -- causes an error, `x` is ambiguous
           x => "Inner Inner!"
-          chck (x ≟ "Inner Inner!") "inner inner x"
+          # chck (x ≟ "Inner Inner!") "inner inner x"     -- causes an error, `x` is ambiguous
           chck (a.this.x ≟ "Outer!") "a.this.x"
           chck (b.this.x ≟ "Inner!") "b.this.x"
           chck (c.this.x ≟ "Inner Inner!") "c.this.x"


### PR DESCRIPTION
fe: Create error if call lookup is ambiguous, fix #1089

Before this patch, an unqalified call `f` where `f` was found in several levels of outer features, the innermost match was called.  Furthermore, if the innerrmost match had an incompatible number of arguments, but an outer one matched, an error was produced.
    
Now, for an assignment or unqualified call, all features with a matching name from all outer features are determined first.  Then, this set is reduced to the features matching the number of actual arguments.  If this set contains more than one feature, an error is produced and it is suggested to make a qualified call.
    
Additionally, the code to perform the feature lookup is simplified significantly. The main methods used are SourceModule.lookup, SourceModule.lookupType and FeatureAndOuter.filter.  Class FeaturesAndOuter and method Call.calledFeatureCandidates, SourceModule.lookupFeatures have been removed.
    
Error messages for ambiguous calls now contains a list of all outer contexts and and a suggestion with sample code to perform a qualified call.
    
Several errors that appeared as consequential errors of ambiguous calls are supressed now.  In particular, actual arguments to a call that cannot be resolved are no longer checked for errors. Also added additional check()s and made code robust against null pointer exceptions or reporting errors that are the consequence of using Types.t_ERROR.

In base libs and tests, fixed ambiguities by renaming or using qualified references.