### PR TITLE
lib/ast: Add `Any.dynamic_type`, fix #1167

### DIFF
--- a/lib/Any.fz
+++ b/lib/Any.fz
@@ -28,5 +28,25 @@
 Any ref is
 
   hashCode i32 is intrinsic
+
+  # create a String from this instance.  Unless redefined, `a.as_string` will
+  # create `"instance[T]"` where `T` is the dynamic type of `a`
+  #
   as_string String is intrinsic
+
+
+  # convenience prefix operator to create a string from a value.
+  #
+  # This permits usage of `$` as a prefix operator in a similar way both
+  # inside and outside of constant strings: $x and "$x" will produce the
+  # same string.
+  #
   prefix $ => Any.this.as_string
+
+
+  # Get the dynamic type of this instance.  For value instances `x`, this is
+  # equal to `type_of x`, but for `x` with a  `ref` type `x.dynamic_type` gives
+  # the actual runtime type, while `type_of x` results in the static
+  # compile-time type.
+  #
+  dynamic_type => Any.this.type

--- a/src/dev/flang/ast/AbstractType.java
+++ b/src/dev/flang/ast/AbstractType.java
@@ -1001,22 +1001,26 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
 
     var result = this;
     var fot = featureOfType();
-    if (fot.isTypeFeature())
+    if (!fot.isUniverse() && this != Types.t_ERROR)
       {
-        result = Types.resolved.f_Type.thisType();
-      }
-    else if (!fot.isUniverse() && this != Types.t_ERROR)
-      {
-        var f = res == null ? fot.typeFeature()
-                            : fot.typeFeature(res);
-        var g = new List<AbstractType>(this);
-        g.addAll(generics());
-        result = Types.intern(new Type(f.pos(),
-                                       f.featureName().baseName(),
-                                       g,
-                                       outer().typeType(res),
-                                       f,
-                                       Type.RefOrVal.Value));
+        var f = fot.isTypeFeature() ? null
+              : res == null         ? fot.typeFeature()
+                                    : fot.typeFeature(res);
+        if (f == null)  // NYI: This is the case for fot.isTypeFeature(), but also for some internal features linke #anonymous. Neeed to check why.
+          {
+            result = Types.resolved.f_Type.thisType();
+          }
+        else
+          {
+            var g = new List<AbstractType>(this);
+            g.addAll(generics());
+            result = Types.intern(new Type(f.pos(),
+                                           f.featureName().baseName(),
+                                           g,
+                                           outer().typeType(res),
+                                           f,
+                                           Type.RefOrVal.Value));
+          }
       }
     return result;
   }


### PR DESCRIPTION
Workaround for a NullPointerException when determining the type of type as produced by the example of #1167.

Added `Any.dynamic_type` to obtain the dynamic type of an instance (which was not possible without the previous workaround).

Also added some documentation for `Any.as_string` ans `Any.prefix $`.