### PR TITLE
fe: Remove the special handling for type lookup wrt outer

### DIFF
--- a/src/dev/flang/fe/SourceModule.java
+++ b/src/dev/flang/fe/SourceModule.java
@@ -499,7 +499,7 @@ public class SourceModule extends Module implements SrcModule, MirModule
          var q = inner._qname;
          var n = q.get(at);
          var o =
-           n != FuzionConstants.TYPE_NAME ? lookupType(inner.pos(), outer, n, true)
+           n != FuzionConstants.TYPE_NAME ? lookupType(inner.pos(), outer, n, at == 0)
                                           : outer.typeFeature(_res);
          if (at < q.size()-2)
            {
@@ -1086,35 +1086,12 @@ public class SourceModule extends Module implements SrcModule, MirModule
         var curOuter = outer;
         var type_fs = new List<AbstractFeature>();
         var nontype_fs = new List<AbstractFeature>();
-        if (false)  // NYI: Using this code does not work yet due to type
-                    // ambiguity for effectMode.abort. Type lookup currently
-                    // handled different than calls when several matches in
-                    // different outer levels are found: This produces an error
-                    // for calls, but currently does not produce for types
-                    // (where the innermost found type is used).
+        var fs = lookup(outer, name, null, traverseOuter);
+        for (var fo : fs)
           {
-            var fs = lookup(outer, name, null, traverseOuter);
-            for (var fo : fs)
-              {
-                var f = fo._feature;
-                (f.definesType() ? type_fs
-                                 : nontype_fs).add(f);
-              }
-          }
-        else
-          {
-            do
-              {
-                var fs = lookup(curOuter, name, null, false);
-                for (var fo : fs)
-                  {
-                    var f = fo._feature;
-                    (f.definesType() ? type_fs
-                     : nontype_fs).add(f);
-                  }
-                curOuter = curOuter.outer();
-              }
-            while (traverseOuter && type_fs.size() == 0 && curOuter != null);
+            var f = fo._feature;
+            (f.definesType() ? type_fs
+                             : nontype_fs).add(f);
           }
         if (type_fs.size() > 1)
           {

--- a/src/dev/flang/parser/Parser.java
+++ b/src/dev/flang/parser/Parser.java
@@ -401,7 +401,7 @@ field       : returnType
               {
                 list.add(f);
               }
-            g.add(new Type(f.pos(), f.featureName().baseName(), new List<>(), null));
+            g.add(new Type(f.pos(), f.featureName().baseName(), new List<>(), null, f, Type.RefOrVal.LikeUnderlyingFeature));
           }
       }
     else


### PR DESCRIPTION
Now, type lookup will cause an error when a matching type is found at different outer levels, just the same as a call lookup would cause an error in this case.

For this to work, the special syntax `a : choice of x, y, z` was changed to no longer require lookup of `x, y, z` such that this does not cause an error in case of a conflict (which occured for `effectMode.abort`).

Also, the type lookup in SeouceModule.setOUterANdAddInnerForQualifiedRec had to be fixed not to look for types in outer features unless we look for the first type in a qualified type `a.b.c`.