### PR TITLE
lib/internal_array separate allocation of memory from `internal_array`.

### DIFF
--- a/lib/array.fz
+++ b/lib/array.fz
@@ -225,7 +225,7 @@ is
 # private:
   indices => 0..length-1
 
-  internal := fuzion.sys.internal_array T length
+  internal := fuzion.sys.internal_array_init T length
   for x in indices do
     internal[x] := init x
 

--- a/lib/array2.fz
+++ b/lib/array2.fz
@@ -32,7 +32,7 @@
 array2(redef T type,
        length0, length1 i32,
        init2 (i32, i32) -> T)
- : array T (fuzion.sys.internal_array T length0*length1) unit unit unit
+ : array T (fuzion.sys.internal_array_init T length0*length1) unit unit unit
   pre
     safety: length0 ≥ 0,
     safety: length1 ≥ 0,

--- a/lib/array3.fz
+++ b/lib/array3.fz
@@ -32,7 +32,7 @@
 array3(redef T type,
        length0, length1, length2 i32,
        init3 (i32, i32, i32) -> T)
- : array T (fuzion.sys.internal_array T length0*length1*length2) unit unit unit
+ : array T (fuzion.sys.internal_array_init T length0*length1*length2) unit unit unit
   pre
     safety: length0 ≥ 0,
     safety: length1 ≥ 0,

--- a/lib/conststring.fz
+++ b/lib/conststring.fz
@@ -28,7 +28,7 @@
 # conststring cannot be called directly, instances are created implicitly by the
 # backend.
 #
-conststring (cannot_be_called void) ref : String, array u8 (fuzion.sys.internal_array u8 -1) unit unit unit is
+conststring (cannot_be_called void) ref : String, array u8 (fuzion.sys.internal_array_init u8 -1) unit unit unit is
 
   redef utf8 Sequence u8 is conststring.this
 

--- a/lib/fuzion/sys/internal_array.fz
+++ b/lib/fuzion/sys/internal_array.fz
@@ -23,19 +23,23 @@
 #
 # -----------------------------------------------------------------------
 
-# fuzion.sys.internal_array -- one-dimensional low-level array
+# helper to allocate memory for an internal_array.
+# returns an internal_array.
 #
-internal_array(T type, length i32) is
+internal_array_init(T type, private length i32) =>
 
-# private:
+  private alloc(X type, l i32) Any is intrinsic
 
-  data := alloc T length
+  internal_array T (alloc T length) length
 
-  alloc(X type, l i32) Any is intrinsic
-  get  (X type, d Any, i i32) X is intrinsic
-  setel(X type, d Any, i i32, o X) unit is intrinsic
 
-# public:
+
+# fuzion.sys.internal_array_init -- one-dimensional low-level array
+internal_array(T type, data Any, private length i32) is
+
+  private get  (X type, d Any, i i32) X is intrinsic
+  private setel(X type, d Any, i i32, o X) unit is intrinsic
+
 
   indices => 0..length-1
 

--- a/lib/marray.fz
+++ b/lib/marray.fz
@@ -88,7 +88,7 @@ is
   is
     d := if (data.length ⩼ length) data
       else
-        newData := fuzion.sys.internal_array T (8.max data.length*2)
+        newData := fuzion.sys.internal_array_init T (8.max data.length*2)
         for i in indices do
           newData[i] := data[i]
         newData
@@ -156,7 +156,7 @@ is
    ) marray T
 
   is
-    data := fuzion.sys.internal_array T length
+    data := fuzion.sys.internal_array_init T length
 
     for x in data.indices do
       data[x] := init

--- a/lib/ps_map.fz
+++ b/lib/ps_map.fz
@@ -166,7 +166,7 @@ O(n log n).
         join (fill - sz - 2*(fill - ole - sz) - 2*sz) dest 2*sz
 
     if (nsize & size) ≟ 0
-      set ndata := fuzion.sys.internal_array (tuple PK V) (data.length * 2 + (nsize+1) / 2)
+      set ndata := fuzion.sys.internal_array_init (tuple PK V) (data.length * 2 + (nsize+1) / 2)
       set nfill := 0
     ndata[nfill] := kv
     join fill-1 nfill 1
@@ -220,7 +220,7 @@ O(n log n).
   # create sorted array of all keys in this map
   #
   asKeyArray array PK is
-    r := fuzion.sys.internal_array PK size
+    r := fuzion.sys.internal_array_init PK size
 
     # join arrays data[ole..ole+sz-1] and r[dest..dest+rsz-1] to r[dest..dest+sz+rsz-1]
     #
@@ -368,7 +368,7 @@ ps_maps(PK type : has_total_order, V type) is
   #
   # This feature creates an empty instance of ps_map.
   #
-  empty => ps_map (fuzion.sys.internal_array (tuple PK V) 0) 0 0
+  empty => ps_map (fuzion.sys.internal_array_init (tuple PK V) 0) 0 0
 
 
 # ps_map -- routine to initialize a partially sorted map from two Sequences

--- a/lib/stream.fz
+++ b/lib/stream.fz
@@ -72,7 +72,7 @@ stream(redef T type) ref : Sequence T is
   #
   redef take (n i32) =>
     for
-      a := marray 0 (fuzion.sys.internal_array T 0), a.add x
+      a := marray 0 (fuzion.sys.internal_array_init T 0), a.add x
       i in (1..n)
     while has_next
       x := next
@@ -179,7 +179,7 @@ stream(redef T type) ref : Sequence T is
   #
   redef as_array array T is
     for
-      a := marray 0 (fuzion.sys.internal_array T 0), a.add x
+      a := marray 0 (fuzion.sys.internal_array_init T 0), a.add x
     while has_next
       x := next
     else

--- a/src/dev/flang/ast/InlineArray.java
+++ b/src/dev/flang/ast/InlineArray.java
@@ -305,7 +305,7 @@ public class InlineArray extends ExprWithPos
                                             new Actual(new NumLiteral(_elements.size())));
         var fuzion       = new Call(pos(), null, "fuzion"                     ).resolveTypes(res, outer);
         var sys          = new Call(pos(), fuzion, "sys"                      ).resolveTypes(res, outer);
-        var sysArrayCall = new Call(pos(), sys , "internal_array", args).resolveTypes(res, outer);
+        var sysArrayCall = new Call(pos(), sys , "internal_array_init", args).resolveTypes(res, outer);
         var fuzionT      = new Type(pos(), "fuzion", Type.NONE, null);
         var sysT         = new Type(pos(), "sys"   , Type.NONE, fuzionT);
         var sysArrayT    = new Type(pos(), "internal_array", eT, sysT);

--- a/src/dev/flang/be/c/Intrinsics.java
+++ b/src/dev/flang/be/c/Intrinsics.java
@@ -582,7 +582,7 @@ public class Intrinsics extends ANY
                             res.castTo(c._types.clazz(rc)).ret());
         });
 
-    put("fuzion.sys.internal_array.alloc", (c,cl,outer,in) ->
+    put("fuzion.sys.internal_array_init.alloc", (c,cl,outer,in) ->
         {
           var gc = c._fuir.clazzActualGeneric(cl, 0);
           return CExpr.call(c.malloc(),

--- a/src/dev/flang/be/interpreter/Intrinsics.java
+++ b/src/dev/flang/be/interpreter/Intrinsics.java
@@ -708,7 +708,7 @@ public class Intrinsics extends ANY
           Clazz resultClazz = innerClazz.resultClazz();
           return JavaInterface.javaObjectToInstance(jb, resultClazz);
         });
-    put("fuzion.sys.internal_array.alloc", (interpreter, innerClazz) -> args ->
+    put("fuzion.sys.internal_array_init.alloc", (interpreter, innerClazz) -> args ->
         {
           return fuzionSysArrayAlloc(/* size */ args.get(1).i32Value(),
                                      /* type */ innerClazz._outer);

--- a/src/dev/flang/fuir/analysis/dfa/DFA.java
+++ b/src/dev/flang/fuir/analysis/dfa/DFA.java
@@ -1145,7 +1145,7 @@ public class DFA extends ANY
 
     put("Any.hashCode"                   , cl -> new NumericValue(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc)) );
     put("Any.as_string"                  , cl -> cl._dfa.newConstString(null, cl) );
-    put("fuzion.sys.internal_array.alloc", cl -> { return new SysArray(cl._dfa, new byte[0]); } ); // NYI: get length from args
+    put("fuzion.sys.internal_array_init.alloc", cl -> { return new SysArray(cl._dfa, new byte[0]); } ); // NYI: get length from args
     put("fuzion.sys.internal_array.setel", cl ->
         {
           var array = cl._args.get(0);

--- a/src/dev/flang/fuir/cfg/CFG.java
+++ b/src/dev/flang/fuir/cfg/CFG.java
@@ -440,7 +440,7 @@ public class CFG extends ANY
 
     put("Any.hashCode"                   , (cfg, cl) -> { } );
     put("Any.as_string"                  , (cfg, cl) -> { } );
-    put("fuzion.sys.internal_array.alloc", (cfg, cl) -> { } );
+    put("fuzion.sys.internal_array_init.alloc", (cfg, cl) -> { } );
     put("fuzion.sys.internal_array.setel", (cfg, cl) -> { } );
     put("fuzion.sys.internal_array.get"  , (cfg, cl) -> { } );
     put("fuzion.sys.env_vars.has0"       , (cfg, cl) -> { } );


### PR DESCRIPTION
This is in preparation of being able to create a slice of an `internal_array`.