### PR TITLE
fe: Do not permit a routine `a` to return `a.this` as result, fix #1186

### DIFF
--- a/src/dev/flang/ast/Feature.java
+++ b/src/dev/flang/ast/Feature.java
@@ -1643,6 +1643,16 @@ public class Feature extends AbstractFeature implements Stmnt
           {
             t.checkChoice(_posOfReturnType);
           }
+        if (_resultType != null)
+          {
+            if (_resultType.isThisType() && _resultType.featureOfType() == this)
+              { // we are in the case of issue #1186: A routine returns itself:
+                //
+                //  a => a.this
+                AstErrors.routineCannotReturnItself(this);
+                _resultType = Types.t_ERROR;
+              }
+          }
 
         /**
          * Perform type inference from outside to the inside, i.e., propagate the


### PR DESCRIPTION
This avoid creating infinetely exploding instances since the instance of a routine contains the implicit result field (which is accessible in postconditions only).