### PR TITLE
rename `has_equality` as `equatable`

### DIFF
--- a/lib/Sequence.fz
+++ b/lib/Sequence.fz
@@ -442,7 +442,7 @@ Sequence(T type) ref is
     # equality
     #
     redef infix == (a, b Sequence T) =>
-      fuzion.std.panic "NYI: Sequences.concatMonoid.infix ==, requires T : has_equality"
+      fuzion.std.panic "NYI: Sequences.concatMonoid.infix ==, requires T : equatable"
 
     # identity element
     #
@@ -459,9 +459,9 @@ Sequences is
   # of the list, 1 if it comes directly after head, etc. nil if x is not
   # in the list.
   #
-  index_in(A type : has_equality, l Sequence A, x A) => (searchable_sequence A l).index_of x
+  index_in(A type : equatable, l Sequence A, x A) => (searchable_sequence A l).index_of x
 
 
   # get the index of x within this Sequence or nil if it does not exist
   #
-  find(A type : has_equality, l Sequence A, x Sequence A) => (searchable_sequence A l).find x
+  find(A type : equatable, l Sequence A, x Sequence A) => (searchable_sequence A l).find x

--- a/lib/Set.fz
+++ b/lib/Set.fz
@@ -25,7 +25,7 @@
 
 # Set -- an abstract set of values V
 #
-Set(E type : has_equality) ref : Sequence E is
+Set(E type : equatable) ref : Sequence E is
 
 
   # is this sequence known to be finite?  For infinite sequences, features like

--- a/lib/String.fz
+++ b/lib/String.fz
@@ -25,7 +25,7 @@
 
 # string -- immutable sequences of utf8 encoded unicode characters
 #
-String ref : has_equality, has_hash, has_total_order is
+String ref : equatable, has_hash, has_total_order is
 
   # converting a string to a string is just returning string.this
   redef as_string String is String.this

--- a/lib/bitset.fz
+++ b/lib/bitset.fz
@@ -28,7 +28,7 @@
 bitset : choice nil          # empty bitset
                 u64          # unit bitset
                 (array bool) # general
-       , has_equality
+       , equatable
 is
 
   # test if the given bit is part of this bitset

--- a/lib/bool.fz
+++ b/lib/bool.fz
@@ -36,7 +36,7 @@
 # value of type 'bool'.
 #
 #
-bool : choice FALSE TRUE, has_equality is
+bool : choice FALSE TRUE, equatable is
 
   # not
   prefix ! bool is
@@ -63,7 +63,7 @@ bool : choice FALSE TRUE, has_equality is
   # ('true <=> false <=> false' evaluates to 'true')
   infix <=> (other bool) => if bool.this other else !other
 
-  # equality check implementation for inherited has_equality
+  # equality check implementation for inherited equatable
   #
   fixed type.equality(a, b bool) =>
     if a

--- a/lib/ctrie.fz
+++ b/lib/ctrie.fz
@@ -118,7 +118,7 @@ private container_node(CTK type : has_hash, CTV type, bmp u32, array array (bran
 
 
 # a container, tomb or linked list node
-private Main_Node(CTK type : has_hash, CTV type, data choice (container_node CTK CTV) (tomb_node CTK CTV) (list_node CTK CTV), gen i32) ref : has_equality is
+private Main_Node(CTK type : has_hash, CTV type, data choice (container_node CTK CTV) (tomb_node CTK CTV) (list_node CTK CTV), gen i32) ref : equatable is
 
   # a previous node that gets set during a generational aware compare and set
   prev := mut (choice (failed_node CTK CTV) (Main_Node CTK CTV) nil) nil
@@ -159,7 +159,7 @@ private Main_Node(CTK type : has_hash, CTV type, data choice (container_node CTK
 private failed_node(CTK type : has_hash, CTV type, prev Main_Node CTK CTV) is
 
 # an indirection node
-private Indirection_Node(CTK type : has_hash, CTV type, data mutate.new (Main_Node CTK CTV)) ref : has_equality is
+private Indirection_Node(CTK type : has_hash, CTV type, data mutate.new (Main_Node CTK CTV)) ref : equatable is
 
   # compare and update
   private cas(old_n, new_n Main_Node CTK CTV) bool is

--- a/lib/equals.fz
+++ b/lib/equals.fz
@@ -26,22 +26,22 @@
 # equals -- feature that compares two values using the equality relation
 # defined in their type
 #
-equals(T type : has_equality, a, b T) => T.equality a b
+equals(T type : equatable, a, b T) => T.equality a b
 
 
 # infix ≟ -- infix operation as short-hand for 'equals'
 #
-infix ≟(T type : has_equality, a, b T) => equals T a b
+infix ≟(T type : equatable, a, b T) => equals T a b
 
 
 # infix = -- infix operation as short-hand for 'equals'
 #
-infix =(T type : has_equality, a, b T) => equals T a b
+infix =(T type : equatable, a, b T) => equals T a b
 
 
 # infix = -- infix operation as short-hand for 'equals'
 #
-infix !=(T type : has_equality, a, b T) => !equals T a b
+infix !=(T type : equatable, a, b T) => !equals T a b
 
 
 # lteq -- feature that compares two values using the lteq relation

--- a/lib/equatable.fz
+++ b/lib/equatable.fz
@@ -17,15 +17,15 @@
 #
 #  Tokiwa Software GmbH, Germany
 #
-#  Source code of Fuzion standard library feature has_equality
+#  Source code of Fuzion standard library feature equatable
 #
 #  Author: Fridtjof Siebert (siebert@tokiwa.software)
 #
 # -----------------------------------------------------------------------
 
-# has_equality -- feature for immutable values that define an equality relation
+# equatable -- feature for immutable values that define an equality relation
 #
-has_equality is
+equatable is
 
 
   # equality implements the default equality relation for values of this type.
@@ -39,4 +39,4 @@ has_equality is
   # result is true iff 'a' is considered to represent the same abstract value
   # as 'b'.
   #
-  type.equality(a, b has_equality.this.type) bool is abstract
+  type.equality(a, b equatable.this.type) bool is abstract

--- a/lib/has_hash.fz
+++ b/lib/has_hash.fz
@@ -26,7 +26,7 @@
 # NYI: the compiler should check that features inheriting from this are
 # actually immutable.
 #
-has_hash : has_equality
+has_hash : equatable
 
 /* NYI: quantor intrinsics not supported yet:
 

--- a/lib/has_partial_order.fz
+++ b/lib/has_partial_order.fz
@@ -30,7 +30,7 @@
 # NYI: the compiler should check that features inheriting from this are
 # actually immutable.
 #
-has_partial_order : has_equality
+has_partial_order : equatable
 
 /* NYI: quantor intrinsics not supported yet:
 

--- a/lib/int.fz
+++ b/lib/int.fz
@@ -253,7 +253,7 @@ minus is
 #
 # this can be plus or minus
 #
-sign : choice plus minus, has_equality is
+sign : choice plus minus, equatable is
 
   is_plus =>
     match sign.this

--- a/lib/list.fz
+++ b/lib/list.fz
@@ -469,7 +469,7 @@ lists is
     # equality
     #
     redef infix == (a, b list A) =>
-      fuzion.std.panic "NYI: lists.concat_monoid.infix ==, requires A : has_equality"
+      fuzion.std.panic "NYI: lists.concat_monoid.infix ==, requires A : equatable"
 
     # identity element
     #

--- a/lib/numeric_sequence.fz
+++ b/lib/numeric_sequence.fz
@@ -25,7 +25,7 @@
 
 # numeric_sequence -- a Sequence whose elements inherit from numeric
 #
-numeric_sequence(N type : numeric N, redef from Sequence N) : searchable_sequence N from, has_equality is
+numeric_sequence(N type : numeric N, redef from Sequence N) : searchable_sequence N from, equatable is
 
 
   # the arithmetic mean of the sequence
@@ -79,7 +79,7 @@ numeric_sequence(N type : numeric N, redef from Sequence N) : searchable_sequenc
         (arr[(arr.length / 2) - 1] + arr[(arr.length / 2)]) / (first.two)
 
 
-  # equality check implementation for inherited has_equality
+  # equality check implementation for inherited equatable
   #
   fixed type.equality(a, b numeric_sequence N) bool is
     aa := a.as_array

--- a/lib/searchable_list.fz
+++ b/lib/searchable_list.fz
@@ -23,13 +23,13 @@
 #
 # -----------------------------------------------------------------------
 
-# searchable_list -- a list whose elements inherit from has_equality
+# searchable_list -- a list whose elements inherit from equatable
 #
 # In contrast to searchable_sequence, this uses choice type 'list' and not ref
 # type 'Sequence', so it is more efficient.
 #
 #
-searchable_list(A type : has_equality, from Sequence A) : Sequence A
+searchable_list(A type : equatable, from Sequence A) : Sequence A
 /* : list A -- NYI: we might allow inherting from a choice to get a choice
                     with more restrictions on the type arguments
 
@@ -37,7 +37,7 @@ searchable_list(A type : has_equality, from Sequence A) : Sequence A
   such as
 
     pre
-      A : has_equality
+      A : equatable
 
   Then, the inner features of searchableList could move to list.fz.
 

--- a/lib/searchable_sequence.fz
+++ b/lib/searchable_sequence.fz
@@ -23,13 +23,13 @@
 #
 # -----------------------------------------------------------------------
 
-# searchable_sequence -- a Sequence whose elements inherit from has_equality
+# searchable_sequence -- a Sequence whose elements inherit from equatable
 #
 # In contrast to searchable_list, this uses ref type 'Sequence' and not choice
 # type 'list', so it is more flexible.
 #
 #
-searchable_sequence(A type : has_equality, from Sequence A) : Sequence A, has_equality
+searchable_sequence(A type : equatable, from Sequence A) : Sequence A, equatable
 is
 
   # create a list from this Sequence.
@@ -85,7 +85,7 @@ is
     (searchable_list as_list).count_matches l.as_list
 
 
-  # equality check implementation for inherited has_equality
+  # equality check implementation for inherited equatable
   #
   fixed type.equality(a, b searchable_sequence A) bool is
     aa := a.as_array

--- a/src/dev/flang/ast/AbstractType.java
+++ b/src/dev/flang/ast/AbstractType.java
@@ -979,7 +979,7 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
    *   say (type_of a.l)    # should print `list a`
    *   say (type_of b.l)    # should print `list b`
    *
-   * @param tf the type feature we are calling (`has_equality.type` in the example
+   * @param tf the type feature we are calling (`equatable.type` in the example
    * above).
    *
    * @param tc the target call (`T` in the example above).
@@ -1076,22 +1076,22 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
    *
    * example:
    *
-   *   has_equality is
+   *   equatable is
    *
-   *     type.equality(a, b has_equality.this.type) bool is abstract
+   *     type.equality(a, b equatable.this.type) bool is abstract
    *
-   *   equals(T type : has_equality, x, y T) => T.equality x y
+   *   equals(T type : equatable, x, y T) => T.equality x y
    *
    * For the call `T.equality x y` this will be called on the formal argument
    * type for `a` (and `b`).
    *
-   * The type of the formal arguments `a` and `b` is `has_equality.this.type`,
+   * The type of the formal arguments `a` and `b` is `equatable.this.type`,
    * which was replaced by the implicit first generic argument of
-   * `has_equality.type`.  This method will replaced it by `T` in the call
+   * `equatable.type`.  This method will replaced it by `T` in the call
    * `T.equality x y`, such that actual arguments of the same type are
    * assignment compatible to it.
    *
-   * @param tf the type feature we are calling (`has_equality.type` in the example
+   * @param tf the type feature we are calling (`equatable.type` in the example
    * above).
    *
    * @param tc the target call (`T` in the example above).

--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -1206,11 +1206,11 @@ public class Call extends AbstractCall
                  *
                  * example:
                  *
-                 *   has_equality is
+                 *   equatable is
                  *
-                 *     type.equality(a, b has_equality.this.type) bool is abstract
+                 *     type.equality(a, b equatable.this.type) bool is abstract
                  *
-                 *   equals(T type : has_equality, x, y T) => T.equality x y
+                 *   equals(T type : equatable, x, y T) => T.equality x y
                  *
                  * For the call `T.equality x y`, we must replace the the formal argument type
                  * for `a` (and `b`) by `T`.
@@ -1442,11 +1442,11 @@ public class Call extends AbstractCall
    *
    * example:
    *
-   *   has_equality is
+   *   equatable is
    *
-   *     type.equality(a, b has_equality.this.type) bool is abstract
+   *     type.equality(a, b equatable.this.type) bool is abstract
    *
-   *   equals(T type : has_equality, x, y T) => T.equality x y
+   *   equals(T type : equatable, x, y T) => T.equality x y
    *
    * For the call `T.equality x y`, we must replace the the formal argument type
    * for `a` (and `b`) by `T`.

--- a/tests/equals/test_equals.fz
+++ b/tests/equals/test_equals.fz
@@ -109,7 +109,7 @@ test_equals_types is
   # Has_color provides an equality relation for instances that provide
   # a 'col' feature
   #
-  Has_color ref : has_equality is
+  Has_color ref : equatable is
 
     # the color of this instance
     #
@@ -144,7 +144,7 @@ test_equals_types is
     # the string
     utf8 Sequence u8)
 
-   : Has_color, String, has_equality is
+   : Has_color, String, equatable is
 
     # equality relation comparing color and strings
     #

--- a/tests/equals_negative/equals_test_negative.fz
+++ b/tests/equals_negative/equals_test_negative.fz
@@ -50,7 +50,7 @@ equals_test_negative is
   say "c1 ≟ c2 is {c1 ≟ c2}"                # 3. should flag an error: equals_test_c does not implement equality
 
 # control test that should pass
-equals_test_ok(x i32) : has_equality is
+equals_test_ok(x i32) : equatable is
   equals_test_ok.type.equality(a, b equals_test_ok) => a.x = b.x
 
 # negative tests should fail

--- a/tests/reg_issue309_check_constraints_of_types/issue309.fz
+++ b/tests/reg_issue309_check_constraints_of_types/issue309.fz
@@ -30,5 +30,5 @@ issue309 is
 
   b(T type) Set T is abstract  // 2. should flag an error: Incompatible type parameter
 
-  c(T type : has_equality) is
+  c(T type : equatable) is
   d c a is abstract            // 3. should flag an error: Incompatible type parameter

--- a/tests/type_feature/test_type_feature.fz
+++ b/tests/type_feature/test_type_feature.fz
@@ -26,11 +26,11 @@
 hasTypeArg is
   type.showTypeArgs String is abstract
 
-ex(T, U type) : hasTypeArg, has_equality is
+ex(T, U type) : hasTypeArg, equatable is
   type.showTypeArgs => "T:$T U:$U"
   fixed type.equality(a, b ex T U) bool is false
 
-ex2(T, U type: has_equality, a, b T, c U) : hasTypeArg, has_equality is
+ex2(T, U type: equatable, a, b T, c U) : hasTypeArg, equatable is
   type.showTypeArgs => "T:$T U:$U"
   fixed type.equality(a, b ex2 T U) bool is
     (a.a ≟ b.a &&


### PR DESCRIPTION
Swift uses the name `Equatable` as well for its analogon of this feature. Likewise, there is a Dart library called `equatable`.