### PR TITLE
tests: Add dependency from base.fum in modules test

### DIFF
--- a/tests/modules/Makefile
+++ b/tests/modules/Makefile
@@ -17,7 +17,7 @@ sources_only:
 	$(FZ) -sourceDirs=./src_a,./src_b,./src                          test_modules $(CHECK)
 
 # compile src_a into a.fum
-modules/a.fum:
+modules/a.fum: ../../modules/base.fum
 	mkdir -p $(@D)
 	$(FZ) -sourceDirs=./src_a                                        -saveLib=$@  $(CHECK)
 


### PR DESCRIPTION
This helps in some cases where this test currently fails because an earlier test run did not delete the generated .fum files properly.