### PR TITLE
tests: Fix ambiguous type error in tests/mix_inheritance_and_outer, #88

### DIFF
--- a/tests/mix_inheritance_and_outer/mix_inheritance_and_outer.fz
+++ b/tests/mix_inheritance_and_outer/mix_inheritance_and_outer.fz
@@ -48,7 +48,7 @@ mix_inheritance_and_outer is
       getXThisV => x.this.v
 
       # this should access the inherited x.v field of type i32
-      getInheritedV => v
+      getInheritedV => y.this.v
 
       # NYI: if renaming is supported, we could change the inherited v's name and access
       # the outer v without qualification.


### PR DESCRIPTION
Issue #88 remains open, but it makes the test compilable again.