### PR TITLE
ast: Remove redundant checks and throws, fix #283

### DIFF
--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -1468,10 +1468,6 @@ public class Call extends AbstractCall
   {
     if (_calledFeature.isTypeParameter())
       {
-        if (_select >= 0 || _calledFeature.isOpenTypeParameter())
-          {
-            throw new Error("NYI (see #283): Calling open type parameter");
-          }
         if (!t.isGenericArgument())
           {
             t = t.featureOfType().typeFeature(res).selfType();
@@ -1488,10 +1484,6 @@ public class Call extends AbstractCall
             gt = gt.typeType(res);
           }
         t = gt.resolve(res, tt.featureOfType());
-        if (t == null)
-          {
-            throw new Error("NYI (see #283): resolveTypes for .type: resultType not present at "+pos().show());
-          }
       }
     else if (_calledFeature.isOuterRef())
       {


### PR DESCRIPTION
The first check (select >= 0 in a call to a type parameter) is handled in resolveSelect.

The second check for that the result of gt.resolve() is not null is also redundant since null is no longer used to indicate an error, but Types.t_ERROR is returned in this case.