### PR TITLE
ast/air: fix #282 by deciding not to remove the special handling

### DIFF
--- a/src/dev/flang/air/Clazz.java
+++ b/src/dev/flang/air/Clazz.java
@@ -2103,9 +2103,6 @@ public class Clazz extends ANY implements Comparable<Clazz>
       }
     else if (f  == Types.resolved.f_Types_get                          ||
              of == Types.resolved.f_Types_get && f == of.resultField()   )
-      // NYI (see #282): Would be nice if this would not need special handling but would
-      // work in general for any feature with type parameters that returns one
-      // of this type parameters as its result using '=>'.
       {
         var ag = (f == Types.resolved.f_Types_get ? this : _outer).actualGenerics();
         result = ag[0].typeClazz();

--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -1478,16 +1478,12 @@ public class Call extends AbstractCall
           }
       }
     else if (_calledFeature == Types.resolved.f_Types_get)
-      { // NYI (see #282): special handling could maybe be avoided? Maybe make
-        // this special handling the normal handling for all features whose
-        // result type depends on a generic that can be replaced by an actual
-        // generic given in the call?
-        var gt = _generics.get(0);
-        if (!gt.isGenericArgument())
+      { t = _generics.get(0);
+        if (!t.isGenericArgument())
           {
-            gt = gt.typeType(res);
+            t = t.typeType(res);
           }
-        t = gt.resolve(res, tt.featureOfType());
+        t = t.resolve(res, tt.featureOfType());
         if (t == null)
           {
             throw new Error("NYI (see #283): resolveTypes for .type: resultType not present at "+pos().show());

--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -1478,7 +1478,8 @@ public class Call extends AbstractCall
           }
       }
     else if (_calledFeature == Types.resolved.f_Types_get)
-      { t = _generics.get(0);
+      {
+        t = _generics.get(0);
         if (!t.isGenericArgument())
           {
             t = t.typeType(res);


### PR DESCRIPTION
Types.get is like a special intrinsic that converts a type into an instance of a type feature.  It is used internally whenever a type feature is used in an expression.