### PR TITLE
switch from msys (cygwin) to clang64 (ucrt)

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -20,13 +20,12 @@ jobs:
         with:
           update: true
           path-type: minimal
-# NYI maybe use mingw64 here?
-          msystem: MSYS
+          msystem: CLANG64
 # git is used in Makefile: JAVA_FILE_TOOLS_VERSION
           install: >-
             make
             git
-            mingw-w64-x86_64-clang
+            mingw-w64-ucrt-x86_64-clang
             diffutils
 
       - name: install choco packages
@@ -35,12 +34,14 @@ jobs:
 
       - uses: actions/checkout@dc323e67f16fb5f7663d20ff7941f27f5809e9b6 # v2.6.0
 
-# NYI how can we set PATH???
+      - name: set PATH
+        run: echo "/ucrt64/bin/:/c/Program Files/OpenJDK/jdk-17/bin:$PATH" >> $GITHUB_PATH
+
       - name: echo PATH
-        run: export PATH="/mingw64/bin/:/c/Program Files/OpenJDK/jdk-17/bin:$PATH" && echo "$PATH"
+        run: echo "$PATH"
 
       - name: echo versions
-        run:  export PATH="/mingw64/bin/:/c/Program Files/OpenJDK/jdk-17/bin:$PATH" && clang --version && javac --version
+        run: clang --version && javac --version
 
       - name: run tests
-        run: export PATH="/mingw64/bin/:/c/Program Files/OpenJDK/jdk-17/bin:$PATH" && make run_tests
+        run: make run_tests

--- a/.github/workflows/windows_c.yml
+++ b/.github/workflows/windows_c.yml
@@ -18,13 +18,12 @@ jobs:
         with:
           update: true
           path-type: minimal
-# NYI maybe use mingw64 here?
-          msystem: MSYS
+          msystem: CLANG64
 # git is used in Makefile: JAVA_FILE_TOOLS_VERSION
           install: >-
             make
             git
-            mingw-w64-x86_64-clang
+            mingw-w64-ucrt-x86_64-clang
             diffutils
 
       - name: install choco packages
@@ -33,12 +32,14 @@ jobs:
 
       - uses: actions/checkout@dc323e67f16fb5f7663d20ff7941f27f5809e9b6 # v2.6.0
 
-# NYI how can we set PATH???
+      - name: set PATH
+        run: echo "/ucrt64/bin/:/c/Program Files/OpenJDK/jdk-17/bin:$PATH" >> $GITHUB_PATH
+
       - name: echo PATH
-        run: export PATH="/mingw64/bin/:/c/Program Files/OpenJDK/jdk-17/bin:$PATH" && echo "$PATH"
+        run: echo "$PATH"
 
       - name: echo versions
-        run:  export PATH="/mingw64/bin/:/c/Program Files/OpenJDK/jdk-17/bin:$PATH" && clang --version && javac --version
+        run: clang --version && javac --version
 
       - name: run tests
-        run: export PATH="/mingw64/bin/:/c/Program Files/OpenJDK/jdk-17/bin:$PATH" && make run_tests_c
+        run: make run_tests_c


### PR DESCRIPTION
On windows there are several options of a C standard library. ucrt (Universal C Runtime) seems to be the better choice than cygwin.
For more information see also:
https://www.msys2.org/docs/environments/
![image](https://user-images.githubusercontent.com/88769212/224948514-bdb52d71-2f91-49b9-ae5f-71b11482dd80.png)
