### PR TITLE
tools: allow builds including reduced build information

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -378,9 +378,12 @@ $(JAVA_FILE_TOOLS_VERSION): $(FZ_SRC)/version.txt $(JAVA_FILE_TOOLS_VERSION_IN)
 	mkdir -p $(@D)
 	cat $(JAVA_FILE_TOOLS_VERSION_IN) \
           | sed "s^@@VERSION@@^$(VERSION)^g" \
-          | sed "s^@@GIT_HASH@@^`cd $(FZ_SRC); echo -n \`git rev-parse HEAD\` \`git diff-index --quiet HEAD -- || echo with local changes\``^g" \
-          | sed "s^@@DATE@@^`date +%Y-%m-%d\ %H:%M:%S`^g"  \
-          | sed "s^@@BUILTBY@@^`echo -n $(USER)@; hostname`^g" >$@
+          | sed "s^@@GIT_HASH@@^`cd $(FZ_SRC); echo -n \`git rev-parse HEAD\` \`git diff-index --quiet HEAD -- || echo with local changes\``^g" >$@
+ifeq ($(FUZION_REPRODUCIBLE_BUILD),true)
+	sed -i "s^@@DATE@@^^g;s^@@BUILTBY@@^^g" $@
+else
+	sed -i "s^@@DATE@@^`date +%Y-%m-%d\ %H:%M:%S`^g;s^@@BUILTBY@@^`echo -n $(USER)@; hostname`^g" $@
+endif
 
 $(CLASS_FILES_UTIL): $(JAVA_FILES_UTIL)
 	mkdir -p $(CLASSES_DIR)

--- a/src/dev/flang/tools/Tool.java
+++ b/src/dev/flang/tools/Tool.java
@@ -189,7 +189,23 @@ public abstract class Tool extends ANY
    */
   public String fullVersion()
   {
-    return Version.VERSION + " (" + Version.DATE + " GIT hash " + Version.GIT_HASH + " built by " + Version.BUILTBY + ")";
+    var result = Version.VERSION + " (";
+
+    if (!Version.DATE.isEmpty())
+      {
+        result = result + Version.DATE + " ";
+      }
+
+    result = result + "GIT hash " + Version.GIT_HASH;
+
+    if (!Version.BUILTBY.isEmpty())
+      {
+        result = result + " built by " + Version.BUILTBY;
+      }
+
+    result = result + ")";
+
+    return result;
   }
 
 


### PR DESCRIPTION
By setting `FUZION_REPRODUCIBLE_BUILD=true` when running `make`, a build of Fuzion can be produced which does not include the following information: the date and time that the build was produced, the username of the user building Fuzion as well as the hostname of the machine building Fuzion. This is intended for perhaps reproducible builds, or some CI environments.

Closes #1222.