### PR TITLE
ast: reset statically held FeatureAndOuter.ERROR

### DIFF
--- a/src/dev/flang/ast/FeatureAndOuter.java
+++ b/src/dev/flang/ast/FeatureAndOuter.java
@@ -50,9 +50,7 @@ public class FeatureAndOuter extends ANY
   /**
    * FeatureAndOuter instance returned in case of an error.
    */
-  public static final FeatureAndOuter ERROR = new FeatureAndOuter(Types.f_ERROR,
-                                                                  Types.f_ERROR,
-                                                                  null);
+  public static FeatureAndOuter ERROR;
 
 
   /*----------------------------  variables  ----------------------------*/
@@ -296,6 +294,16 @@ public class FeatureAndOuter extends ANY
       (isNextInnerFixed() ? " fixed" : " not fixed") + "]";
   }
 
+
+  /**
+   * Reset static fields such as the intern()ed types.
+   */
+  public static void reset()
+  {
+    ERROR = new FeatureAndOuter(Types.f_ERROR,
+                                Types.f_ERROR,
+                                null);
+  }
 
 }
 

--- a/src/dev/flang/fe/FrontEnd.java
+++ b/src/dev/flang/fe/FrontEnd.java
@@ -43,6 +43,7 @@ import dev.flang.mir.MIR;
 import dev.flang.ast.AbstractFeature;
 import dev.flang.ast.AstErrors;
 import dev.flang.ast.Feature;
+import dev.flang.ast.FeatureAndOuter;
 import dev.flang.ast.FeatureName;
 import dev.flang.ast.Types;
 
@@ -144,6 +145,7 @@ public class FrontEnd extends ANY
   {
     _options = options;
     Types.reset();
+    FeatureAndOuter.reset();
     Errors.reset();
     FeatureName.reset();
     var universe = new Universe();


### PR DESCRIPTION
Led to problems in language server. Because `Types.f_ERROR` is reset but `FeatureAndOuter.ERROR` holds first instance of `Types.f_ERROR` forever.