### PR TITLE
lib/map_of_total_order: add effect map_of_total_order

### DIFF
--- a/lib/map_of_total_order.fz
+++ b/lib/map_of_total_order.fz
@@ -1,0 +1,53 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion standard library feature map_of_total_order
+#
+# -----------------------------------------------------------------------
+
+
+# defines effect map_of_total_order
+# this allows creating a map from a keys and values array
+map_of_total_order (
+  K type : has_total_order, V type,
+  # the provider this effect uses to create a Map
+  public new (array K, array V) -> Map K V,
+  private em effectMode.val
+  ) : effect em
+is
+  type.install_default =>
+    if !effects.exists (map_of_total_order K V)
+      _ := map_of_total_order K V (ks,vs -> ordered_map ks vs) effectMode.default
+
+
+
+# shorthand to install a new provider for effect map_of_total_order.
+map_of_total_order(K type : has_total_order, V type, p (array K, array V) -> Map K V) =>
+  (map_of_total_order K V).type.install_default
+  _ := map_of_total_order K V p effectMode.repl
+
+
+
+
+# get currently installed effect map_of_total_order
+# which allows creating a map from a keys array and a values array
+map_of_total_order(K type : has_total_order, V type) =>
+  (map_of_total_order K V).type.install_default
+  (map_of_total_order K V)
+    .env

--- a/lib/map_of_total_order.fz
+++ b/lib/map_of_total_order.fz
@@ -24,24 +24,23 @@
 
 # defines effect map_of_total_order
 # this allows creating a map from a keys and values array
-map_of_total_order (
+private map_of_total_order (
   K type : has_total_order, V type,
   # the provider this effect uses to create a Map
   public new (array K, array V) -> Map K V,
-  private em effectMode.val
+  private em effectMode.val,
+  _ unit
   ) : effect em
 is
   type.install_default =>
     if !effects.exists (map_of_total_order K V)
-      _ := map_of_total_order K V (ks,vs -> ordered_map ks vs) effectMode.default
+      _ := map_of_total_order K V (ks,vs -> ordered_map ks vs) effectMode.default unit
 
 
 
-# shorthand to install a new provider for effect map_of_total_order.
-map_of_total_order(K type : has_total_order, V type, p (array K, array V) -> Map K V) =>
-  (map_of_total_order K V).type.install_default
-  _ := map_of_total_order K V p effectMode.repl
-
+# shorthand to run code with custom map initializer.
+map_of_total_order(K type : has_total_order, V type, map_init (array K, array V) -> Map K V, code () -> unit) =>
+  _ := map_of_total_order K V map_init (effectMode.inst code) unit
 
 
 


### PR DESCRIPTION
Abstracts implementation of Map with totally ordered keys. This could be done for other data structures as well.

example:

```
ex =>
  a := (map_of_total_order i32 String)
    .new [1,2,3] ["a", "b", "c"]

  say a

  # install CTrie as default map implementation
  map_of_total_order i32 String (ks,vs->
    ct := CTrie i32 String
    for idx in ks.indices do
      ct.add ks[idx] vs[idx]
    ct
  )

  b := (map_of_total_order i32 String)
    .new [1,2,3] ["a", "b", "c"]

  say b

```
```
(1 => a), (2 => b), (3 => c)
(1 => a), (2 => b), (3 => c)
```