### PR TITLE
lib/option: remove lazyGet, make get lazy

### DIFF
--- a/lib/option.fz
+++ b/lib/option.fz
@@ -115,18 +115,10 @@ is
 
   # unwraps an option if it exists, returns default value otherwise.
   #
-  get(default T)
+  get(default Lazy T)
     =>
       option.this ? v T => v
                   | nil => default
-
-  # unwraps an option if it exists, returns default value otherwise. default
-  # is evaluated lazily.
-  #
-  lazyGet(default ()->T)
-    =>
-      option.this ? v T => v
-                  | nil => default()
 
 
   # return function


### PR DESCRIPTION
This is now possible due to the new syntax sugar for lazy features.