### PR TITLE
lib/list: remove `list_of_none_lazy`

### DIFF
--- a/lib/list.fz
+++ b/lib/list.fz
@@ -486,25 +486,16 @@ list(T type, h T, t Lazy (list T)) list T is
     tail => t
 
 
-# convenience routine to create a list from head h and tail t.
-# NYI: #1166, syntax sugar for lazy evaluation
-#
-list_of_none_lazy(T type, h T, t list T) list T is
-  ref : Cons T (list T)
-    head => h
-    tail => t
-
-
 # infix operator to create a list from head h and lazy tail t.
 #
 # This is convenient to append an element before a list as in
 #
-#   0 : ()->[1,2,3,4].as_list
+#   0 : [1,2,3,4].as_list
 #
 # or to create lists by recursion, e.g., a an endless list containing
 # integer 1 repeatedly is
 #
-#   ones => 1 : ()->ones
+#   ones => 1 : ones
 #
 infix : (A type, h A, t Lazy (list A)) =>
   list h t

--- a/lib/mutable_tree_map.fz
+++ b/lib/mutable_tree_map.fz
@@ -46,7 +46,7 @@ mutable_tree_map(LM type : mutate, K type : has_total_order, V type) is
   # returns a string representation of the map
   #
   redef as_string String is
-    "\{" + (String.type.join (fold (lists.empty String) ((i, x) -> list_of_none_lazy "{x.key}={x.val}" i)) ", ") + "\}"
+    "\{" + (String.type.join (fold (lists.empty String) ((i, x) -> list "{x.key}={x.val}" i)) ", ") + "\}"
 
 
   # freeze the map, such that it is no longer mutable afterwards


### PR DESCRIPTION
This is no longer necessary now that `list` and `infix :` take values directly.