### PR TITLE
lib: remove redundent `list.this.` in call to `as_string`

### DIFF
--- a/lib/list.fz
+++ b/lib/list.fz
@@ -245,7 +245,7 @@ list(A type) : choice nil (Cons A (list A)), Sequence A is
   # and ']'.
   #
   redef as_string =>
-    "[{list.this.as_string ","}]"
+    "[{as_string ","}]"
 
 
   # create a string representation of this list including all the string


### PR DESCRIPTION
A previous PR (#1170) fixes #775, so we can change the base lib code accordingly: `as_string ","` now expands to `list.this.as_string ","`.