### PR TITLE
fe: Make incompatible module version a fatal error, fix #1205

### DIFF
--- a/src/dev/flang/fe/FeErrors.java
+++ b/src/dev/flang/fe/FeErrors.java
@@ -124,7 +124,7 @@ public class FeErrors extends AstErrors
                                         byte[] expected_version,
                                         byte[] found_version)
   {
-    error("Incompatible module version encountered",
+    fatal("Incompatible module version encountered",
           "Module " + user + " references module " + m + "\n" +
           "Expected version: " + versionString(expected_version) + "\n" +
           "Actual version  : " + versionString(found_version));


### PR DESCRIPTION
Prevent any attempt to mix references to an incompatible .fum file.

`tests/javaBase` no longer crashes with a Java exception, but stops after the module version issue was detected:

```
 > make
../check_simple_example.sh "../../bin/fz -unsafeIntrinsics=on -modules=java.base" javaHello.fz || exit 1
RUN javaHello.fz 1,7d0
< Hello Java 🌍!
< Hello Java 🌍!
< Hello Java 🌍!
< Hello Java 🌍!
< Hello Java 🌍!
< string has 16 bytes: [72,101,108,108,111,32,74,97,118,97,32,-16,-97,-116,-115,33]
< Hello Java 🌍!
*** FAILED out on javaHello.fz
0a1,7
> 
> error 1: Incompatible module version encountered
> Module LibraryModule for 'java.base' references module LibraryModule for 'base'
> Expected version: e12a41ca8fe8e13cf9d8152901b2326d
> Actual version  : aa11f2b3054e7dbf1eb469ba7c4f2c7e
> 
> *** fatal errors encountered, stopping.
*** FAILED err on javaHello.fz
make: *** [../simple.mk:45: int] Fehler 1

```