### PR TITLE
ast: Make Function.propagateExpectedType2 work with generic type, fix #1229

### DIFF
--- a/src/dev/flang/ast/Function.java
+++ b/src/dev/flang/ast/Function.java
@@ -266,11 +266,13 @@ public class Function extends ExprWithPos
     if (_call == null)
       {
         if (t != Types.t_ERROR &&
-            t.featureOfType() != Types.resolved.f_function &&
-            t.featureOfType() != Types.resolved.f_Lazy &&
-            t.featureOfType() != Types.resolved.f_Unary)
+            (t.isGenericArgument() ||
+             t.featureOfType() != Types.resolved.f_function &&
+             t.featureOfType() != Types.resolved.f_Lazy     &&
+             t.featureOfType() != Types.resolved.f_Unary       ))
           {
             AstErrors.expectedFunctionTypeForLambda(pos(), t);
+            t = Types.t_ERROR;
             result = Types.t_ERROR;
           }
 


### PR DESCRIPTION
Assigning a lambda to a generic type caused a require condition to faile (or worse if preconditions are switched off).  This patch fixes this and also avoids subsequent errors by setting `t` to `Types.t_ERROR` in `Function.propagateexpectedtype2`-

This also fixes #1230.