### PR TITLE
ast: Make AbstractFeature.typeFeature robust against previous errors, fix #1237

### DIFF
--- a/src/dev/flang/ast/AbstractFeature.java
+++ b/src/dev/flang/ast/AbstractFeature.java
@@ -704,7 +704,7 @@ public abstract class AbstractFeature extends ANY implements Comparable<Abstract
     if (PRECONDITIONS) require
       (state().atLeast(Feature.State.FINDING_DECLARATIONS),
        res != null,
-       !isUniverse(),
+       Errors.count() > 0 || !isUniverse(),
        !isTypeFeature());
 
     if (_typeFeature == null)
@@ -712,6 +712,12 @@ public abstract class AbstractFeature extends ANY implements Comparable<Abstract
         if (hasTypeFeature())
           {
             _typeFeature = typeFeature();
+          }
+        else if (isUniverse())
+          {
+            if (CHECKS) check
+              (Errors.count() > 0);
+            _typeFeature = Types.f_ERROR;
           }
         else
           {


### PR DESCRIPTION
typeFeature() can actually be called on universe in case of a previous error, so permit this.

The example from #1237 now produces errors, but no crashes:

```
 > PRECONDITIONS=true POSTCONDITIONS=true ./build/bin/fz ex_1237.fz 

/home/fridi/fuzion/work/ex_1237.fz:1:22: error 1: Syntax error: expected term (lbrace, lparen, lcrochet, fun, string, integer, old, match, or name), found keyword 'type'
socket_type : choice type.stream datagram raw is
---------------------^
While parsing: term, parse stack: term, opTail, opExpr, expr, actual, actualSpace, actualsList, actualArgs, call, callList, skipCallList, skipInherits, skipFeaturePrefix, isFeaturePrefix, stmnt, stmnts, unit


/home/fridi/fuzion/work/ex_1237.fz:1:1: error 2: Could not find called feature
socket_type : choice type.stream datagram raw is
^
Feature not found: 'socket_type' (no arguments)
Target feature: '#universe'
In call: 'socket_type'


/home/fridi/fuzion/work/ex_1237.fz:1:43: error 3: Type not found
socket_type : choice type.stream datagram raw is
------------------------------------------^
Type 'raw' was not found, no corresponding feature nor formal type parameter exists
Type that was not found: 'raw'
in feature: '#universe.stream'
To solve this, check the spelling of the type you have used.


/home/fridi/fuzion/work/ex_1237.fz:1:34: error 4: Type not found
socket_type : choice type.stream datagram raw is
---------------------------------^
Type 'datagram' was not found, no corresponding feature nor formal type parameter exists
Type that was not found: 'datagram'
in feature: '#universe.stream'
To solve this, check the spelling of the type you have used.

4 errors.

```