### PR TITLE
lib/Monoid: remove `Monoid.infix ==` equality operation

### DIFF
--- a/lib/Monoid.fz
+++ b/lib/Monoid.fz
@@ -30,7 +30,7 @@
 # (string/concat/""), etc.
 #
 #
-Monoid(T type) ref
+Monoid(T type /* : equatable */) ref
 
 /* NYI: quantor intrinsics not supported yet:
 
@@ -56,10 +56,5 @@ is
   #
   e T is abstract
 
-  # equality operation
-  #
-  infix == (a, b T) bool is abstract
-
   # alternative names for infix operators
   op(a, b T) => infix ∙  a b
-  eq(a, b T) => infix == a b

--- a/lib/Sequence.fz
+++ b/lib/Sequence.fz
@@ -439,11 +439,6 @@ Sequence(T type) ref is
     #
     infix ∙ (a, b Sequence T) Sequence T is a.concat_sequences b
 
-    # equality
-    #
-    redef infix == (a, b Sequence T) =>
-      fuzion.std.panic "NYI: Sequences.concatMonoid.infix ==, requires T : equatable"
-
     # identity element
     #
     e => (Sequence T).type.empty

--- a/lib/String.fz
+++ b/lib/String.fz
@@ -689,7 +689,6 @@ String ref : equatable, has_hash, has_total_order is
   #
   type.concat : Monoid String is
     redef infix ∙ (a, b String) => a + b
-    redef infix == (a, b String) => a == b
     redef e => ""
 
 
@@ -698,7 +697,6 @@ String ref : equatable, has_hash, has_total_order is
   #
   type.concat(sep String) : Monoid String is
     redef infix ∙ (a, b String) String is if (a.is_empty || b.is_empty) a + b else a + sep + b
-    redef infix == (a, b String) => a == b
     redef e => ""
 
 

--- a/lib/bitset.fz
+++ b/lib/bitset.fz
@@ -113,5 +113,4 @@ has     -- NYI: 'has' keyword not supported yet, so the following require an ins
   #
   type.union : Monoid bitset is
     redef infix ∙ (a, b bitset) => a ∪ b
-    redef infix == (a, b bitset) => a == b
     redef e bitset is bitset.type.empty

--- a/lib/list.fz
+++ b/lib/list.fz
@@ -466,11 +466,6 @@ lists is
     #
     infix ∙ (a, b list A) list A is a.concat b
 
-    # equality
-    #
-    redef infix == (a, b list A) =>
-      fuzion.std.panic "NYI: lists.concat_monoid.infix ==, requires A : equatable"
-
     # identity element
     #
     e list A is

--- a/lib/numeric.fz
+++ b/lib/numeric.fz
@@ -225,7 +225,6 @@ numeric(redef T type : numeric T) : has_hash, has_total_order, numerics T is
   #
   type.sum : Monoid T is
     redef infix ∙ (a, b T) => a + b
-    redef infix == (a, b T) => a = b
     redef e => zero.thiz
 
 
@@ -234,7 +233,6 @@ numeric(redef T type : numeric T) : has_hash, has_total_order, numerics T is
   #
   type.product : Monoid T is
     redef infix ∙ (a, b T) => a * b
-    redef infix == (a, b T) => a = b
     redef e => one.thiz
 
 
@@ -243,7 +241,6 @@ numeric(redef T type : numeric T) : has_hash, has_total_order, numerics T is
   #
   type.sumSaturating : Monoid T is
     redef infix ∙ (a, b T) => a +^ b
-    redef infix == (a, b T) => a = b
     redef e => zero.thiz
 
 
@@ -252,7 +249,6 @@ numeric(redef T type : numeric T) : has_hash, has_total_order, numerics T is
   #
   type.productSaturating : Monoid T is
     redef infix ∙ (a, b T) => a *^ b
-    redef infix == (a, b T) => a = b
     redef e => one.thiz
 
 

--- a/lib/ps_set.fz
+++ b/lib/ps_set.fz
@@ -128,8 +128,14 @@ has     -- NYI: 'has' keyword not supported yet, so the following require an ins
   #
   union : Monoid (ps_set K) is
     redef infix ∙ (a, b ps_set K) => a ∪ b
-    redef infix == (a, b ps_set K) => (a ∪ b).size ≟ a.size  # NYI: a bit expensive
     redef e => empty
+
+
+  # equality
+  #
+  fixed type.equality(a, b ps_set K) bool is
+    # NYI: a bit expensive
+    (a ∪ b).size = a.size
 
 
 # ps_sets -- unit type feature declaring features related to ps_set

--- a/lib/unit.fz
+++ b/lib/unit.fz
@@ -100,5 +100,4 @@ unit is
   # and the identity element of this monoid are canonically defined.
   type.monoid : Monoid unit is
     redef infix ∙ (a, b unit) unit is unit
-    redef infix == (a, b unit) bool is true
     redef e unit is unit


### PR DESCRIPTION
Ideally, the type parameter of `Monoid` should be restricted to `equatable` types, and the monoid property could in the future be checked using that operation. There are few cases where using a different equality operation would be a good idea, and in this case, implementing your own monoid isn't that hard either.

However, we do not yet introduce a type contraint to `equatable`. This is because in some places (`list` and `Sequence`, in particular, which do not have an equality operation), the `Monoid` is (ab)used to implement a nice variant of `fold` whose starting element is the neutral element of the monoid.