### PR TITLE
`check_simple_example`: import missing features from flang.dev repo

### DIFF
--- a/tests/check_simple_example.sh
+++ b/tests/check_simple_example.sh
@@ -56,7 +56,7 @@ else
     head -n 1 "$2" | grep -q -E "# fuzion.debugLevel=2( .*|)$" && export OPT=-Dfuzion.debugLevel=2
     head -n 1 "$2" | grep -q -E "# fuzion.debugLevel=1( .*|)$" && export OPT=-Dfuzion.debugLevel=1
     head -n 1 "$2" | grep -q -E "# fuzion.debugLevel=0( .*|)$" && export OPT=-Dfuzion.debugLevel=0
-    ($1 "$2" >tmp_out.txt 2>tmp_err.txt) || true
+    (FUZION_JAVA_OPTIONS="${FUZION_JAVA_OPTIONS="-Xss${FUZION_JAVA_STACK_SIZE=5m}"} ${OPT:-}" $1 "$2" >tmp_out.txt 2>tmp_err.txt) || true
     sed -i "s|${CURDIR//\\//}/|--CURDIR--/|g" tmp_err.txt
     diff "$2".expected_out tmp_out.txt || (echo -e "\033[31;1m*** FAILED\033[0m out on $2")
     diff "$2".expected_err tmp_err.txt || (echo -e "\033[31;1m*** FAILED\033[0m err on $2")

--- a/tests/check_simple_example_c.sh
+++ b/tests/check_simple_example_c.sh
@@ -44,10 +44,22 @@ if [ -f "$2".skip ]; then
     echo "SKIP $2"
 else
     echo -n "RUN $2 "
+    unset OPT
+    head -n 1 "$2" | grep -q -E "# fuzion.debugLevel=.*$"      && export OPT=-Dfuzion.debugLevel=10
+    head -n 1 "$2" | grep -q -E "# fuzion.debugLevel=9( .*|)$" && export OPT=-Dfuzion.debugLevel=9
+    head -n 1 "$2" | grep -q -E "# fuzion.debugLevel=8( .*|)$" && export OPT=-Dfuzion.debugLevel=8
+    head -n 1 "$2" | grep -q -E "# fuzion.debugLevel=7( .*|)$" && export OPT=-Dfuzion.debugLevel=7
+    head -n 1 "$2" | grep -q -E "# fuzion.debugLevel=6( .*|)$" && export OPT=-Dfuzion.debugLevel=6
+    head -n 1 "$2" | grep -q -E "# fuzion.debugLevel=5( .*|)$" && export OPT=-Dfuzion.debugLevel=5
+    head -n 1 "$2" | grep -q -E "# fuzion.debugLevel=4( .*|)$" && export OPT=-Dfuzion.debugLevel=4
+    head -n 1 "$2" | grep -q -E "# fuzion.debugLevel=3( .*|)$" && export OPT=-Dfuzion.debugLevel=3
+    head -n 1 "$2" | grep -q -E "# fuzion.debugLevel=2( .*|)$" && export OPT=-Dfuzion.debugLevel=2
+    head -n 1 "$2" | grep -q -E "# fuzion.debugLevel=1( .*|)$" && export OPT=-Dfuzion.debugLevel=1
+    head -n 1 "$2" | grep -q -E "# fuzion.debugLevel=0( .*|)$" && export OPT=-Dfuzion.debugLevel=0
 
     rm -f testbin
 
-    ( ($1 -c "$2" -o=testbin                && ./testbin) 2>tmp_err.txt | head -n 100) >tmp_out.txt || true # tail my result in 141
+    ( (FUZION_JAVA_OPTIONS="${FUZION_JAVA_OPTIONS="-Xss${FUZION_JAVA_STACK_SIZE=5m}"} ${OPT:-}" $1 -c "$2" -o=testbin                && ./testbin) 2>tmp_err.txt | head -n 100) >tmp_out.txt || true # tail my result in 141
 
     # This version dumps stderr output if fz was successful, which essentially ignores C compiler warnings:
     # (($1 -c $2 -o=testbin 2>tmp_err0.txt && ./testbin  2>tmp_err0.txt | head -n 100) >tmp_out.txt || true # tail my result in 141


### PR DESCRIPTION
The variant of the `check_simple_example` scripts in the flang.dev repository included some features which were missing here, import them. This is in preparation of removing the now redundant scripts from the flang.dev repository.