### PR TITLE
parser: multiline strings, refinements

### DIFF
--- a/src/dev/flang/parser/Lexer.java
+++ b/src/dev/flang/parser/Lexer.java
@@ -2385,6 +2385,10 @@ PIPE        : "|"
     private StringState _state;
 
 
+    /**
+     * If this is changed, https://flang.dev/tutorial/string_constants
+     * must be changed as well.
+     */
     char[][] escapeChars = new char[][] {
         { 'b', '\b'  },  // BS 0x08
         { 't', '\t'  },  // HT 0x09

--- a/src/dev/flang/util/Errors.java
+++ b/src/dev/flang/util/Errors.java
@@ -678,7 +678,8 @@ public class Errors extends ANY
   {
     syntaxError(sourcePos,
                 "Found codepoint at less indentation than expected in multiline string.",
-                "To solve this, indent offending line by at least " + indentation + " spaces.");
+                "To solve this, indent offending line by at least " + indentation + " spaces." + "\n" +
+                "Alternatively decrease indentation of first line. One way to do this is by using the \\s escape code which equals a space.");
   }
 
   public static void trailingWhiteSpaceInMultiLineString(SourcePosition sourcePos)

--- a/tests/strings_multiline/multiline_strings_test.fz
+++ b/tests/strings_multiline/multiline_strings_test.fz
@@ -70,3 +70,10 @@ if true
 else
   "?"
     }"""
+
+
+  # multiline string containing " and ""
+  say """
+    "hell😀 world"!
+    ""hell😀 world""!
+  """

--- a/tests/strings_multiline/multiline_strings_test.fz.expected_out
+++ b/tests/strings_multiline/multiline_strings_test.fz.expected_out
@@ -9,3 +9,6 @@ hell😀 w😀rld !
 
 hell😀 w😀rld
 hell😀 w😀rld
+"hell😀 world"!
+""hell😀 world""!
+

--- a/tests/strings_multiline_negative/strings_multiline_negative.fz
+++ b/tests/strings_multiline_negative/strings_multiline_negative.fz
@@ -43,3 +43,9 @@ strings_multiline_negative is
   hello
   """
   //   ^  5. should NYI flag NYI an NYI error: (error in line 43) Illegal trailing whitespace in multiline string.
+
+
+  f := """
+  A string 'ending' in four quotes, essentially ending the multiline
+  string and immediately starting a new string.
+  """"  // 6. should flag an error: Found unexpected control sequence 'LF '


### PR DESCRIPTION
- refinded error 'not enough indent' to include hint to \s escape char
- add test case for multiline string including single and double quotes
- add test case for multiline string 'ending' in four quotes.
- added comment on Lexer.StringLexer.escapeChars