### PR TITLE
lib: redefine `dynamic_type` in Type to fix #1276

### DIFF
--- a/lib/Any.fz
+++ b/lib/Any.fz
@@ -49,4 +49,8 @@ Any ref is
   # the actual runtime type, while `type_of x` results in the static
   # compile-time type.
   #
+  # There is no dynamic type of a type instance since this would result in an
+  # endless hierachy of types.  So for Type values, dynamic_type is redefined
+  # to just return Type.type.
+  #
   dynamic_type => Any.this.type

--- a/lib/Type.fz
+++ b/lib/Type.fz
@@ -46,6 +46,13 @@ Type ref is
   redef as_string => "Type of '$name'"
 
 
+  # There is no dynamic type of a type instance since this would result in an
+  # endless hierachy of types, so dynamic_type is redefined to just return
+  # Type.type here.
+  #
+  redef dynamic_type => Type.type
+
+
 # Types -- features related to Type but not requiring an instance of Type
 #
 Types is


### PR DESCRIPTION
`XYZ.type.dynamic_type` is `Type.type` now for all types `XYZ`.  This avoids an otherwise endless hierachy of type instances.