### PR TITLE
parser: Set pos of empty block followed by LF to end of previous line, fix #1215

### DIFF
--- a/src/dev/flang/parser/Parser.java
+++ b/src/dev/flang/parser/Parser.java
@@ -2527,7 +2527,7 @@ block       : stmnts
         var l = stmnts();
         var pos2 = l.size() > 0 ? l.getLast().pos() : pos1;
         if (pos1 == pos2 && current() == Token.t_indentationLimit)
-          { /* we have a non-indented new line, e.g., the empty block after `x i32 is` n
+          { /* we have a non-indented new line, e.g., the empty block after `x i32 is` in
              *
              *   x i32 is
              *   y u8 is

--- a/src/dev/flang/parser/Parser.java
+++ b/src/dev/flang/parser/Parser.java
@@ -2506,7 +2506,8 @@ block       : stmnts
    */
   Block block()
   {
-    SourcePosition pos1 = posObject();
+    var p1 = pos();
+    var pos1 = posObject();
     if (current() == Token.t_semicolon)
       { // we have code like
         //
@@ -2525,6 +2526,17 @@ block       : stmnts
       {
         var l = stmnts();
         var pos2 = l.size() > 0 ? l.getLast().pos() : pos1;
+        if (pos1 == pos2 && current() == Token.t_indentationLimit)
+          { /* we have a non-indented new line, e.g., the empty block after `x i32 is` n
+             *
+             *   x i32 is
+             *   y u8 is
+             *
+             * so we set start and end pos to the position after `x i32 is`.
+             */
+            pos1 = posObject(lineEndPos(lineNum(p1)-1));
+            pos2 = pos1;
+          }
         return new Block(pos1, pos2, l);
       }
     else


### PR DESCRIPTION
The example from #1215
```
  unit_result is

    a i32 is
    b i32 is 42
```
used to produce the error

```
  ex_1215.fz:4:3: error 1: Incompatible types in assignment
    b i32 is 42
  --^
  assignment to field : 'unit_result.a.result'
  expected formal type: 'i32'
  actual type found   : 'unit'
  assignable to       : 'unit'
  for value assigned  :
  {
  }
```
now it produces
```
  ex_1215.fz:3:11: error 1: Incompatible types in assignment
    a i32 is
  ----------^
  assignment to field : 'unit_result.a.result'
  expected formal type: 'i32'
  actual type found   : 'unit'
  assignable to       : 'unit'
  for value assigned  :
  {
  }
```
Using a single line as in
```
  unit_result is

    a i32 is; b i32 is 42
```
works as expected:
```
  ex_1215a.fz:3:11: error 1: Incompatible types in assignment
    a i32 is; b i32 is 42
  ----------^
  assignment to field : 'unit_result.a.result'
  expected formal type: 'i32'
  actual type found   : 'unit'
  assignable to       : 'unit'
  for value assigned  :
  {
  }
```
