### PR TITLE
lib: introduce global min and max features

### DIFF
--- a/lib/array.fz
+++ b/lib/array.fz
@@ -79,7 +79,7 @@ array(redef T type,
     # NYI: This is very inefficent since it copies the whole array.  Should
     # better use a persistent array implementation such as persistent hash array
     # mapped trie.
-    array T length.max(i+1) (ix -> if (ix ≟ i) v else array.this[ix])
+    array T (max length i+1) (ix -> if (ix ≟ i) v else array.this[ix])
 
   # create a new array with element i set to v. Grow the array in case i >= length.
   # New array elements at indices array.this.length..i-1 will be set to z.
@@ -93,7 +93,7 @@ array(redef T type,
     # NYI: This is very inefficent since it copies the whole array.  Should
     # better use a persistent array implementation such as persistent hash array
     # mapped trie.
-    array T length.max(i+1) (ix -> if (ix ≟ i) v else if (ix ≥ length) z else array.this[ix])
+    array T (max length i+1) (ix -> if (ix ≟ i) v else if (ix ≥ length) z else array.this[ix])
 
 
   # apply f to all elements in this array

--- a/lib/bitset.fz
+++ b/lib/bitset.fz
@@ -50,7 +50,7 @@ is
     else
       match bitset.this
         _ nil   => bit
-        x u64   => array bool bit.max(x).as_i32+1 (i -> i.as_u64 ≟ bit || i.as_u64 ≟ x)
+        x u64   => array bool (max bit x).as_i32+1 (i -> i.as_u64 ≟ bit || i.as_u64 ≟ x)
         a array => a.put bit.as_i32 true false
 
   # union of two bitsets
@@ -64,7 +64,7 @@ is
           _ nil   => bitset.this
           x u64   => bitset.this.put x
           b array =>
-            array bool a.length.max(b.length) (i -> (has i.as_u64) || (other.has i.as_u64))
+            array bool (max a.length b.length) (i -> (has i.as_u64) || (other.has i.as_u64))
 
   # get the highest bit in this bitset
   #
@@ -77,7 +77,7 @@ is
   # equality
   #
   fixed type.equality(a, b bitset) bool is
-     h := a.highest >>= i -> b.highest >>= j -> i.max j
+     h := a.highest >>= i -> b.highest >>= j -> max i j
      match h
        _ nil => a.highest!! && b.highest!!
        m u64 =>

--- a/lib/equals.fz
+++ b/lib/equals.fz
@@ -118,3 +118,15 @@ infix <>(T type : has_total_order, a, b T) i32 is
   if      a ⩻ b then -1
   else if a ⩼ b then +1
   else                0
+
+
+# maximum of two values
+#
+max(T type : has_total_order, a, b T) =>
+  if a > b then a else b
+
+
+# minimum of two values
+#
+min(T type : has_total_order, a, b T) =>
+  if a < b then a else b

--- a/lib/integer.fz
+++ b/lib/integer.fz
@@ -149,7 +149,7 @@ integer(I type : integer I) : numeric I is
     (sgn, digits) := if (integer.this.sign ⩻ 0) ("-", String.type.from_bytes (n.utf8.drop 1)) else ("", n)
 
     # create required additional zeros
-    zeros := "0" * 0.max (len - n.byte_length)
+    zeros := "0" * (max 0 (len - n.byte_length))
 
     # put it all together
     sgn + zeros + digits

--- a/lib/marray.fz
+++ b/lib/marray.fz
@@ -88,7 +88,7 @@ is
   is
     d := if (data.length ⩼ length) data
       else
-        newData := fuzion.sys.internal_array_init T (8.max data.length*2)
+        newData := fuzion.sys.internal_array_init T (max 8 data.length*2)
         for i in indices do
           newData[i] := data[i]
         newData

--- a/lib/numeric.fz
+++ b/lib/numeric.fz
@@ -121,14 +121,6 @@ numeric(redef T type : numeric T) : has_hash, has_total_order, numerics T is
 
   abs => if sign ≥ 0 then thiz else -thiz
 
-  # minimum of numeric.this and other
-  #
-  min(other T) T is if (thiz ≤ other) thiz else other
-
-  # maximum of numeric.this and other
-  #
-  max(other T) T is if (thiz ≥ other) thiz else other
-
 
   # the u32 value corresponding to this
   # note: potential fraction will be discarded

--- a/lib/ps_map.fz
+++ b/lib/ps_map.fz
@@ -257,7 +257,7 @@ O(n log n).
     if size ≟ 0
       nil
     else
-      min (m PK, l i32, r i32) PK is
+      min0 (m PK, l i32, r i32) PK is
         (lk, _) := data[l]
         if (m ≤ lk) m else lk
 
@@ -271,7 +271,7 @@ O(n log n).
                   + (if (size & sz0) != 0 nt else 0)
                   + (if (size & sz ) != 0 sz else 0))
           m0 := if (size & sz) != 0
-              min m at at+sz-1
+              min0 m at at+sz-1
             else
               m
           min m0 at0 sz0 nt
@@ -286,7 +286,7 @@ O(n log n).
     if size ≟ 0
       nil
     else
-      max (m PK, l i32, r i32) PK is
+      max0 (m PK, l i32, r i32) PK is
         (rk, _) := data[r]
         if (m ≥ rk) m else rk
 
@@ -300,7 +300,7 @@ O(n log n).
                   + (if (size & sz0) != 0 nt else 0)
                   + (if (size & sz ) != 0 sz else 0))
           m0 := if (size & sz) != 0
-              max m at at+sz-1
+              max0 m at at+sz-1
             else
               m
           max m0 at0 sz0 nt


### PR DESCRIPTION
These allow conviently writing `min a b` or `max a b` and use the total order defined on the given type.

Remove the `numeric.min` and `numeric.max` features, and replace their usage with use of the new global features.

Rename (local) features in `ps_map` named `min` and `max` as `min0` and `max0`. This is to avoid a conflict with the new `min` and `max` features.