### PR TITLE
air: fix `require-condition3 failed: dev.flang.air.Clazz:<init>:325`

### DIFF
--- a/src/dev/flang/air/Clazz.java
+++ b/src/dev/flang/air/Clazz.java
@@ -2113,11 +2113,16 @@ public class Clazz extends ANY implements Comparable<Clazz>
      */
     var res = this;
     var i = feature();
-    while (i != o && i.outerRef() != null)
+    while (i != o)
       {
-        res = res.lookup(i.outerRef(), pos).resultClazz();
+        res =  i.hasOuterRef() ? res.lookup(i.outerRef(), pos).resultClazz()
+                               : res._outer;
         i = i.outer();
       }
+
+    if (CHECKS) check
+      (i == o);
+
     return res;
   }
 


### PR DESCRIPTION
Clazz.findOuter() did not cover the case where clazz is choice. In this case outer ref is null and thus can not be used for following to find the the clazz we are looking for.