### PR TITLE
dfa: Fix quadratic performance of DFA for sequence of calls, fix #990

### DIFF
--- a/src/dev/flang/fuir/analysis/dfa/DFA.java
+++ b/src/dev/flang/fuir/analysis/dfa/DFA.java
@@ -1486,7 +1486,7 @@ public class DFA extends ANY
 
 
   /**
-   * Helper for newCall to analyse a newly created call immediately. This helps
+   * Helper for newCall to analyze a newly created call immediately. This helps
    * to avoid quadratic performance when analysing a sequence of calls as in
    *
    *  a 1; a 2; a 3; a 4; a 5; ...
@@ -1494,8 +1494,8 @@ public class DFA extends ANY
    * Since a new call das not return, the analysis would stop for each iteration
    * after the fist new call.
    *
-   * However, we cannot analyse all calls immediately since a recursive call
-   * would result in an unbounded recursion during DFA.  So this analyses the
+   * However, we cannot analyze all calls immediately since a recursive call
+   * would result in an unbounded recursion during DFA.  So this analyzes the
    * call immediately unless it is part of a recursion or there are already
    * MAX_NEW_CALL_RECURSION new calls being analyzed right now.
    *


### PR DESCRIPTION
The problem was that a sequence of calls of the form

  a 1; a 2; a 3; a 4; a 5; ...

results in the DFA to create one new Call per iteration since the newly created
call in the current iteration was not analysed yet and hence is assumed not to
return.

This patch performs the analysis of new calls immediately unless they are
recursive or the depth of recurisve analysis of new calls exceeds 20.

The performance of the example from https://github.com/tokiwa-software/fuzion/issues/990 using 128 lines of array code went down
from 22s to 2s:

before:

  > time ./build/bin/fz -c ex_990.fz -CC=echo
  ...
  real	0m22,604s
  user	0m38,519s
  sys	0m0,725s

after:

  > time ./build/bin/fz -c ex_990.fz -CC=echo
  ...
  real	0m2,241s
  user	0m8,768s
  sys	0m0,404s