### PR TITLE
fix #1290 "Bad UTF8 encoding found"

### DIFF
--- a/src/dev/flang/parser/Lexer.java
+++ b/src/dev/flang/parser/Lexer.java
@@ -2718,7 +2718,7 @@ PIPE        : "|"
     {
       return (pos < 0 || pos+2 >= byteLength())
         ? false
-        : codePoint(pos) == '"' && codePoint(pos+1) == '"' && codePoint(pos+2) == '"';
+        : byteAt(pos) == '"' && byteAt(pos+1) == '"' && byteAt(pos+2) == '"';
     }
 
 


### PR DESCRIPTION
fix #1290 
- replaced codePoint(pos) by byteAt(pos) because codePoint raises an error if there it finds invalid byte at some position.