### PR TITLE
dfa: Remove workaround for #990

### DIFF
--- a/lib/fuzion/sys/internal_array.fz
+++ b/lib/fuzion/sys/internal_array.fz
@@ -56,9 +56,3 @@ internal_array(T type, data Any, private length i32) is
     #array.this[i] == o
   is
     setel T data i o
-
-
-  # NYI workaround for performance issue in DFA #990
-  private set_no_pre_condition (i i32, o T) unit
-  is
-    setel T data i o

--- a/src/dev/flang/ast/InlineArray.java
+++ b/src/dev/flang/ast/InlineArray.java
@@ -323,8 +323,7 @@ public class InlineArray extends ExprWithPos
                                                    new Actual(e));
             var readSysArrayVar = new Call(e.pos(), null           , sysArrayName     ).resolveTypes(res, outer);
             var setElement      = new Call(e.pos(), readSysArrayVar,
-                                           // NYI workaround for performance issue in DFA #990
-                                           "set_no_pre_condition",
+                                           FuzionConstants.FEATURE_NAME_INDEX_ASSIGN,
                                            setArgs                                    ).resolveTypes(res, outer);
             stmnts.add(setElement);
           }


### PR DESCRIPTION
Re-introduce index checks for inline arrays. This decreases the DFA performance by a factor of approx. two, but at least this is linear so not such a big issue.