### PR TITLE
parser: Fix parsing of `if` following `else`, fix #327

### DIFF
--- a/src/dev/flang/ast/If.java
+++ b/src/dev/flang/ast/If.java
@@ -137,6 +137,7 @@ public class If extends ExprWithPos
       }
     else
       {
+        b._newScope = true;
         elseBlock = b;
       }
   }

--- a/src/dev/flang/ast/If.java
+++ b/src/dev/flang/ast/If.java
@@ -131,26 +131,14 @@ public class If extends ExprWithPos
       (elseBlock == null,
        elseIf == null);
 
-    elseBlock = b;
-    if (this.elseBlock != null)
+    if (b._statements.size() == 1 && b._statements.get(0) instanceof If i)
       {
-        this.elseBlock._newScope = true;
+        elseIf = i;
       }
-  }
-
-
-  /**
-   * setElse
-   *
-   * @param f
-   */
-  public void setElse(If f)
-  {
-    if (PRECONDITIONS) require
-      (elseBlock == null,
-       elseIf == null);
-
-    elseIf = f;
+    else
+      {
+        elseBlock = b;
+      }
   }
 
 

--- a/src/dev/flang/parser/Parser.java
+++ b/src/dev/flang/parser/Parser.java
@@ -2780,8 +2780,8 @@ loopBody    : "while" exprInLine      block
             | "while" exprInLine "do" block
             |                    "do" block
             ;
-loopEpilog  : "until" exprInLine thenPart elseBlockOpt
-            |                             elseBlock
+loopEpilog  : "until" exprInLine thenPart elseBlock
+            |                             "else" Block
             ;
    */
   Expr loop()
@@ -2797,8 +2797,8 @@ loopEpilog  : "until" exprInLine thenPart elseBlockOpt
         var hasDo    = skip(true, Token.t_do     ); var b   = hasWhile || hasDo   ? block()         : null;
         var hasUntil = skip(true, Token.t_until  ); var u   = hasUntil            ? exprInLine()    : null;
                                                     var ub  = hasUntil            ? thenPart(true)  : null;
-                                                    var els1 =               fork().elseBlockOpt();
-                                                    var els =                       elseBlockOpt();
+                                                    var els1= fork().elseBlock();
+                                                    var els =        elseBlock();
 
         if (!hasWhile && !hasDo && !hasUntil && els == null)
           {
@@ -2932,7 +2932,7 @@ cond        : exprInLine
   /**
    * Parse ifstmnt
    *
-ifstmnt      : "if" exprInLine thenPart elseBlockOpt
+ifstmnt      : "if" exprInLine thenPart elseBlock
             ;
    */
   If ifstmnt()
@@ -2943,22 +2943,11 @@ ifstmnt      : "if" exprInLine thenPart elseBlockOpt
         Expr e = exprInLine();
         Block b = thenPart(false);
         If result = new If(pos, e, b);
-        Expr els = elseBlockOpt();
-        if (els instanceof If i)
-          {
-            result.setElse(i);
-          }
-        else if (els instanceof Block blk
-                // do no set empty blocks as else blocks since the source position
-                // of those block might be somewhere unexpected.
-                 && !blk._statements.isEmpty())
-          {
-            result.setElse(blk);
-          }
-        else
-          {
-            if (CHECKS) check
-              (els == null || (els instanceof Block blk && blk._statements.isEmpty()));
+        var els = elseBlock();
+        if (els._statements.size() > 0)
+          { // do no set empty blocks as else blocks since the source position
+            // of those block might be somewhere unexpected.
+            result.setElse(els);
           }
         return result;
       });
@@ -2982,34 +2971,19 @@ thenPart    : "then" block
 
 
   /**
-   * Parse elseBlockOpt
+   * Parse elseBlock
    *
-elseBlockOpt: elseBlock
+elseBlock   : "else" block
             |
             ;
-elseBlock   : "else" ( ifstmnt
-                     | block
-                     )
-            ;
    */
-  Expr elseBlockOpt()
+  Block elseBlock()
   {
-    Expr result = null;
-    if (skip(true, Token.t_else))
-      {
-        if (isIfPrefix())
-          {
-            result = ifstmnt();
-          }
-        else
-          {
-            result = block();
-          }
-      }
+    var result = skip(true, Token.t_else) ? block()
+                                          : null;
 
     if (POSTCONDITIONS) ensure
       (result == null          ||
-       result instanceof If    ||
        result instanceof Block    );
 
     return result;

--- a/src/dev/flang/parser/Parser.java
+++ b/src/dev/flang/parser/Parser.java
@@ -2944,7 +2944,7 @@ ifstmnt      : "if" exprInLine thenPart elseBlock
         Block b = thenPart(false);
         If result = new If(pos, e, b);
         var els = elseBlock();
-        if (els._statements.size() > 0)
+        if (els != null && els._statements.size() > 0)
           { // do no set empty blocks as else blocks since the source position
             // of those block might be somewhere unexpected.
             result.setElse(els);


### PR DESCRIPTION
The problem was that an `if` statement was parsed as a single statement, not as a block. So if an `else` was followed by a block that happened to start with an `if`, only the `if`-statement was parsed and the remaining statements of that block caused an error due to wrong indentation.

Now, the `else`-part is always parsed as a block.

The following code (from #327 with variations added) is legal now:
```
  some_fun bool is
    if true
      true
    else
      if true
        say "hello"
      else
        say "hello"
      true

  some_fun2 bool is
    if true
      true
    else if true
           say "hello"
         else
            say "hello"
         say "ok..."
         true

  some_fun3 bool is
    if true
      true
    else if true
      say "hello"
    else
      say "hello"
    say "ok..."
    true
```