### PR TITLE
parser: allow dismissing newlines in multiline strings

### DIFF
--- a/src/dev/flang/parser/Lexer.java
+++ b/src/dev/flang/parser/Lexer.java
@@ -2518,7 +2518,14 @@ PIPE        : "|"
                     }
                   if (c < 0)
                     {
-                      Errors.unknownEscapedChar(sourcePos(), p, escapeChars);
+                      if (p == (int) '\n')
+                        {
+                          // codepoint is skipped
+                        }
+                      else
+                        {
+                          Errors.unknownEscapedChar(sourcePos(), p, escapeChars);
+                        }
                     }
                   escaped = false;
                 }

--- a/src/dev/flang/parser/Lexer.java
+++ b/src/dev/flang/parser/Lexer.java
@@ -2389,7 +2389,7 @@ PIPE        : "|"
      * If this is changed, https://flang.dev/tutorial/string_constants
      * must be changed as well.
      */
-    char[][] escapeChars = new char[][] {
+    int[][] escapeChars = new int[][] {
         { 'b', '\b'  },  // BS 0x08
         { 't', '\t'  },  // HT 0x09
         { 'n', '\n'  },  // LF 0x0a
@@ -2402,6 +2402,8 @@ PIPE        : "|"
         { '\\', '\\' },  // \  0x5c
         { '{',  '{'  },  // {  0x7b
         { '}',  '}'  },  // }  0x7d
+        { '\n', -1   },
+        { '\r', -1   },
       };
 
 
@@ -2509,25 +2511,24 @@ PIPE        : "|"
               checkIndentation(pos);
               if (escaped)
                 {
-                  for (var i = 0; i < escapeChars.length && c < 0; i++)
+                  var i = 0;
+                  while (i < escapeChars.length && p != (int) escapeChars[i][0])
                     {
-                      if (p == (int) escapeChars[i][0])
-                        {
-                          c = (int) escapeChars[i][1];
-                        }
+                      i++;
                     }
-                  if (c < 0)
+                  if (i < escapeChars.length)
                     {
-                      if (p == (int) '\n')
-                        {
-                          // codepoint is skipped
-                        }
-                      else
-                        {
-                          Errors.unknownEscapedChar(sourcePos(), p, escapeChars);
-                        }
+                      c = (int) escapeChars[i][1];
                     }
-                  escaped = false;
+                  else
+                    {
+                      Errors.unknownEscapedChar(sourcePos(), p, escapeChars);
+                    }
+                  if (p != (int) '\r')
+                    {
+                      // if carriage return is encountered, wait for line feed
+                      escaped = false;
+                    }
                 }
               else if (p == '\\')
                 {

--- a/src/dev/flang/util/Errors.java
+++ b/src/dev/flang/util/Errors.java
@@ -575,19 +575,26 @@ public class Errors extends ANY
                 detail);
   }
 
-  private static String legalEscapes(char[][] escapes)
+  private static String legalEscapes(int[][] escapes)
   {
     var legal = new StringBuilder();
     var comma = "";
     for (var c : escapes)
       {
-        legal.append(comma).append("'\\" + c[0] + "'");
+        if (c[1] < 0)
+          {
+            legal.append(comma).append("'\\<ASCII " + c[0] + ">'");
+          }
+        else
+          {
+            legal.append(comma).append("'\\" + (char) c[0] + "'");
+          }
         comma = ", ";
       }
     return legal.toString();
   }
 
-  public static void unknownEscapedChar(SourcePosition pos, int found, char[][] escapes)
+  public static void unknownEscapedChar(SourcePosition pos, int found, int[][] escapes)
   {
     syntaxError(pos,
                 "Unknown escaped character found in constant string.",

--- a/tests/strings_multiline/multiline_strings_test.fz
+++ b/tests/strings_multiline/multiline_strings_test.fz
@@ -77,3 +77,9 @@ else
     "hell😀 world"!
     ""hell😀 world""!
   """
+
+
+  # multiline string where a newline is dismissed
+  say """
+    hello \
+    world"""

--- a/tests/strings_multiline/multiline_strings_test.fz.expected_out
+++ b/tests/strings_multiline/multiline_strings_test.fz.expected_out
@@ -12,3 +12,4 @@ hell😀 w😀rld
 "hell😀 world"!
 ""hell😀 world""!
 
+hello world


### PR DESCRIPTION
The escape character followed by a line feed now causes the newline to be dismissed. This makes it possible to write
```
say """
   hello \
   world"""
```
to print
```
hello world
```

Closes #1277.