### PR TITLE
ast: Add possibility for FormalGenerics.resolve to return new array

### DIFF
--- a/src/dev/flang/ast/AbstractFeature.java
+++ b/src/dev/flang/ast/AbstractFeature.java
@@ -1265,11 +1265,12 @@ public abstract class AbstractFeature extends ANY implements Comparable<Abstract
                       }
                     else
                       {
+                        var actualTypes = c.actualTypeParameters();
                         if (res != null)
                           {
-                            FormalGenerics.resolve(res, c.actualTypeParameters(), heir);
+                            actualTypes = FormalGenerics.resolve(res, actualTypes, heir);
                           }
-                        ti = ti.actualType(c.calledFeature(), c.actualTypeParameters());
+                        ti = ti.actualType(c.calledFeature(), actualTypes);
                         a[i] = Types.intern(ti);
                       }
                   }

--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -2038,7 +2038,7 @@ public class Call extends AbstractCall
       }
     _resolvedFor = outer;
     loadCalledFeature(res, outer);
-    FormalGenerics.resolve(res, _generics, outer);
+    _generics = FormalGenerics.resolve(res, _generics, outer);
 
     if (CHECKS) check
       (Errors.count() > 0 || _calledFeature != null);

--- a/src/dev/flang/ast/FormalGenerics.java
+++ b/src/dev/flang/ast/FormalGenerics.java
@@ -190,13 +190,16 @@ public class FormalGenerics extends ANY
    * arguments of a call or a type.
    *
    * @param generics the actual generic arguments that should be resolved
+   *
+   * @return a new array of the resolved generics
    */
-  public static void resolve(Resolution res, List<AbstractType> generics, AbstractFeature outer)
+  public static List<AbstractType> resolve(Resolution res, List<AbstractType> generics, AbstractFeature outer)
   {
     if (!(generics instanceof FormalGenerics.AsActuals))
       {
         generics = generics.map(t -> t.resolve(res, outer));
       }
+    return generics;
   }
 
 

--- a/src/dev/flang/ast/Function.java
+++ b/src/dev/flang/ast/Function.java
@@ -481,8 +481,7 @@ public class Function extends ExprWithPos
     else if (this._feature == null)
       {
         var fr = functionOrRoutine();
-        var generics = generics(res);
-        FormalGenerics.resolve(res, generics, outer);
+        var generics = FormalGenerics.resolve(res, generics(res), outer);
         _type = fr != null ? new Type(pos(), fr.featureName().baseName(), generics, null, fr, Type.RefOrVal.LikeUnderlyingFeature).resolve(res, outer)
                            : Types.t_ERROR;
       }

--- a/src/dev/flang/ast/Type.java
+++ b/src/dev/flang/ast/Type.java
@@ -981,7 +981,7 @@ public class Type extends AbstractType
               {
                 this._generics = feature.generics().asActuals();
               }
-            FormalGenerics.resolve(res, _generics, outerfeat);
+            _generics = FormalGenerics.resolve(res, _generics, outerfeat);
             if (!feature.generics().errorIfSizeOrTypeDoesNotMatch(_generics,
                                                                   this.pos2BeRemoved(),
                                                                   "type",


### PR DESCRIPTION
Since generics.map perfomed by FormelGenerics.resolve could create a new array, this new array has to be used by the caller.

This caused additional type errors being reported and endless recursion during Clazzes.create in some design/examples/typ_*.fz since broken types in generic args where not properly replaced by Types.t_ERROR.