### PR TITLE
fe: Fix for flang.dev/design/example/brd_choic.fz, redefine of choice

### DIFF
--- a/src/dev/flang/ast/AstErrors.java
+++ b/src/dev/flang/ast/AstErrors.java
@@ -984,6 +984,14 @@ public class AstErrors extends ANY
                    "To solve this, ask the Fuzion team to remove this restriction :-)."); // NYI: inheritance and generics
   }
 
+  public static void cannotRedefineChoice(AbstractFeature f, AbstractFeature existing)
+  {
+    cannotRedefine(f.pos(), f, existing, "Cannot redefine choice feature",
+                   "To solve this, re-think what you want to do.  Choice types are fairly static and not extensible. " +
+                   "If you need an extensible type, an abstract "+code("ref")+" feature with children for each case " +
+                   "might fit better. ");
+  }
+
   public static void redefineModifierMissing(SourcePosition pos, AbstractFeature f, AbstractFeature existing)
   {
     cannotRedefine(pos, f, existing, "Redefinition must be declared using modifier " + skw("redef") + "",

--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -688,7 +688,11 @@ public class Call extends AbstractCall
                   { // nothing found, try if we can built operator call: `a + b` => `x.y.z.this.infix + a b`
                     findOperatorOnOuter(res, thiz);
                   }
-                if (_calledFeature == null) // nothing found, so flag error
+                if (_calledFeature == null && !fos.isEmpty() && _actuals.size() == 0 && fos.get(0)._feature.isChoice())
+                  { // give a more specific error when trying to call a choice feature
+                    AstErrors.cannotCallChoice(pos(), fos.get(0)._feature);
+                  }
+                else if (_calledFeature == null) // nothing found, so flag error
                   {
                     AstErrors.calledFeatureNotFound(this, calledName, targetFeature,
                                                     FeatureAndOuter.findExactOrCandidate(fos,

--- a/src/dev/flang/fe/SourceModule.java
+++ b/src/dev/flang/fe/SourceModule.java
@@ -1233,6 +1233,10 @@ public class SourceModule extends Module implements SrcModule, MirModule
         if (o.isTypeFeaturesThisType() && f.isTypeFeaturesThisType())
           { // NYI: CLEANUP: #706: allow redefinition of THIS_TYPE in type features for now, these are created internally.
           }
+        else if (o.isChoice())
+          {
+            AstErrors.cannotRedefineChoice(f, o);
+          }
         else if ((t1.isChoice()
                   ? t1.compareTo(t2) != 0  // we (currently) do not tag the result in a redefined feature, see testRedefine
                   : !t1.isAssignableFrom(t2)) &&


### PR DESCRIPTION
This fixes two things: First, it re-establishes the specifiic error produced when an attempt is made to call a choice feature. This specific error got lost during the recent work on call feature resolution.

Second, it adds a check that forbids the redefinition of choice features and creates a new error if an attempt to do so is made.