### PR TITLE
parser: be lazier when creating type parameters for `choice of`, fix #1289

### DIFF
--- a/src/dev/flang/ast/OuterType.java
+++ b/src/dev/flang/ast/OuterType.java
@@ -1,0 +1,79 @@
+/*
+
+This file is part of the Fuzion language implementation.
+
+The Fuzion language implementation is free software: you can redistribute it
+and/or modify it under the terms of the GNU General Public License as published
+by the Free Software Foundation, version 3 of the License.
+
+The Fuzion language implementation is distributed in the hope that it will be
+useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+License for more details.
+
+You should have received a copy of the GNU General Public License along with The
+Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+*/
+
+/*-----------------------------------------------------------------------
+ *
+ * Tokiwa Software GmbH, Germany
+ *
+ * Source of class OuterType
+ *
+ *---------------------------------------------------------------------*/
+
+package dev.flang.ast;
+
+import dev.flang.util.SourcePosition;
+
+
+/**
+ * OuterType is a type created by the parser to represent the type of the
+ * enclosing feature's outer feature.
+ *
+ * This will be replaced by that outer feature's thisType during resolve().
+ *
+ * @author Fridtjof Siebert (siebert@tokiwa.software)
+ */
+public class OuterType extends Type
+{
+
+  /*--------------------------  constructors  ---------------------------*/
+
+
+  /**
+   * Constructor
+   */
+  public OuterType(SourcePosition pos)
+  {
+    super(pos, "#outer", AbstractCall.NO_GENERICS, null);
+  }
+
+
+  /*-----------------------------  methods  -----------------------------*/
+
+
+  /**
+   * resolve this type
+   *
+   * @param res this is called during type resolution, res gives the resolution
+   * instance.
+   *
+   * @param feat the outer feature that this type is declared in, used
+   * for resolution of generic parameters etc.
+   */
+  AbstractType resolve(Resolution res, AbstractFeature outerfeat)
+  {
+    if (PRECONDITIONS) require
+      (outerfeat != null,
+       outerfeat.state().atLeast(Feature.State.RESOLVED_DECLARATIONS),
+       checkedForGeneric);
+
+    return outerfeat.outer().thisType(false);
+  }
+
+}
+
+/* end of file */

--- a/src/dev/flang/ast/Type.java
+++ b/src/dev/flang/ast/Type.java
@@ -397,7 +397,7 @@ public class Type extends AbstractType
    *
    * @param n the name, such as "int", "bool".
    */
-  public static Type type(Resolution res, String n, AbstractFeature universe)
+  public static AbstractType type(Resolution res, String n, AbstractFeature universe)
   {
     if (PRECONDITIONS) require
       (n.length() > 0);
@@ -412,7 +412,7 @@ public class Type extends AbstractType
    *
    * @param n the name, such as "int", "bool".
    */
-  public static Type type(Resolution res, boolean ref, String n, AbstractFeature universe)
+  public static AbstractType type(Resolution res, boolean ref, String n, AbstractFeature universe)
   {
     if (PRECONDITIONS) require
       (n.length() > 0);
@@ -952,7 +952,7 @@ public class Type extends AbstractType
    * @param feat the outer feature that this type is declared in, used
    * for resolution of generic parameters etc.
    */
-  Type resolve(Resolution res, AbstractFeature outerfeat)
+  AbstractType resolve(Resolution res, AbstractFeature outerfeat)
   {
     if (PRECONDITIONS) require
       (outerfeat != null,
@@ -963,7 +963,7 @@ public class Type extends AbstractType
       {
         ensureNotOpen();
       }
-    var result = this;
+    AbstractType result = this;
     if (!checkedForGeneric)
       {
         findGenerics(outerfeat);
@@ -991,7 +991,7 @@ public class Type extends AbstractType
               }
           }
       }
-    return (Type) Types.intern(result);
+    return Types.intern(result);
   }
 
 

--- a/src/dev/flang/parser/Parser.java
+++ b/src/dev/flang/parser/Parser.java
@@ -367,7 +367,7 @@ field       : returnType
    * @param s the statements containing the feature declarations to be added, in
    * this case "x, y, z."
    *
-   * @param g the list of type to be collected, will be added as generic
+   * @param g the list of types to be collected, will be added as generic
    * arguments to 'choice' in this example
    *
    * @param p Impl that contains the position of 'of' for error messages.
@@ -402,7 +402,7 @@ field       : returnType
               {
                 list.add(f);
               }
-            g.add(new Type(f.pos(), f.featureName().baseName(), new List<>(), null, f, Type.RefOrVal.LikeUnderlyingFeature));
+            g.add(new Type(f.pos(), f.featureName().baseName(), new List<>(), null));
           }
       }
     else

--- a/src/dev/flang/parser/Parser.java
+++ b/src/dev/flang/parser/Parser.java
@@ -402,7 +402,7 @@ field       : returnType
               {
                 list.add(f);
               }
-            g.add(new Type(f.pos(), f.featureName().baseName(), new List<>(), null));
+            g.add(new Type(f.pos(), f.featureName().baseName(), new List<>(), new OuterType(f.pos())));
           }
       }
     else


### PR DESCRIPTION
When creating type parameters for choice in `a : choice of x, y`, do not set the feature references directly even though they are known, but leave the type resolution for later. This has the effect that the outer type will be set correctly to `outer.this.type`.

This might result in additional errors in case the feature names are ambiguous. But if this is the case, I guess it is better to flag an error anyway.