### PR TITLE
fz: allow specifying -1 as maximum warning/error count for no limit

### DIFF
--- a/src/dev/flang/util/Errors.java
+++ b/src/dev/flang/util/Errors.java
@@ -257,7 +257,7 @@ public class Errors extends ANY
       {
         _errors_.add(e);
         print(pos, errorMessage(msg), detail);
-        if (count() >= MAX_ERROR_MESSAGES)
+        if (count() >= MAX_ERROR_MESSAGES && MAX_ERROR_MESSAGES != -1)
           {
             showAndExit();
           }
@@ -454,7 +454,7 @@ public class Errors extends ANY
   {
     if (count() > 0)
       {
-        if (count() >= MAX_ERROR_MESSAGES)
+        if (count() >= MAX_ERROR_MESSAGES && MAX_ERROR_MESSAGES != -1)
           {
             warning(SourcePosition.builtIn,
                     "Maximum error count reached, terminating.",
@@ -519,9 +519,9 @@ public class Errors extends ANY
     if (PRECONDITIONS) require
       (msg != null);
 
-    if (warningCount() < MAX_WARNING_MESSAGES)
+    if (warningCount() < MAX_WARNING_MESSAGES || MAX_WARNING_MESSAGES == -1)
       {
-        if (warningCount()+1 == MAX_WARNING_MESSAGES)
+        if (warningCount()+1 == MAX_WARNING_MESSAGES && MAX_WARNING_MESSAGES != -1)
           {
             pos = SourcePosition.builtIn;
             msg = "Maximum warning count reached, suppressing further warnings";

--- a/src/dev/flang/util/Errors.java
+++ b/src/dev/flang/util/Errors.java
@@ -89,6 +89,16 @@ public class Errors extends ANY
    */
   public static String MAX_ERROR_MESSAGES_PROPERTY = "fuzion.maxErrorCount";
   public static String MAX_ERROR_MESSAGES_OPTION = "-XmaxErrors";
+
+
+  /**
+   * The case that this option is set to 0 is equivalent to setting it to 1.
+   * This is because if there are error messages, there is no point in really
+   * suppressing all of them, there needs to be some indication that an error
+   * happened.
+   *
+   * If this is set to -1, all errors will be displayed.
+   */
   public static int MAX_ERROR_MESSAGES = Integer.getInteger(MAX_ERROR_MESSAGES_PROPERTY, 10);
 
 
@@ -98,6 +108,13 @@ public class Errors extends ANY
    */
   public static String MAX_WARNING_MESSAGES_PROPERTY = "fuzion.maxWarningCount";
   public static String MAX_WARNING_MESSAGES_OPTION = "-XmaxWarnings";
+
+
+  /**
+   * If this option is set to 0, all warning messages will be suppressed.
+   *
+   * If it is set to -1, all warnings will be displayed.
+   */
   public static int MAX_WARNING_MESSAGES = Integer.getInteger(MAX_WARNING_MESSAGES_PROPERTY, Integer.MAX_VALUE);
 
 

--- a/src/dev/flang/util/Errors.java
+++ b/src/dev/flang/util/Errors.java
@@ -276,6 +276,10 @@ public class Errors extends ANY
         print(pos, errorMessage(msg), detail);
         if (count() >= MAX_ERROR_MESSAGES && MAX_ERROR_MESSAGES != -1)
           {
+            warning(SourcePosition.builtIn,
+                    "Maximum error count reached, terminating.",
+                    "Maximum error count is " + MAX_ERROR_MESSAGES + ".\n" +
+                    "Change this via property '" + MAX_ERROR_MESSAGES_PROPERTY + "' or command line option '" + MAX_ERROR_MESSAGES_OPTION + "'.");
             showAndExit();
           }
         //Thread.dumpStack();
@@ -471,13 +475,6 @@ public class Errors extends ANY
   {
     if (count() > 0)
       {
-        if (count() >= MAX_ERROR_MESSAGES && MAX_ERROR_MESSAGES != -1)
-          {
-            warning(SourcePosition.builtIn,
-                    "Maximum error count reached, terminating.",
-                    "Maximum error count is " + MAX_ERROR_MESSAGES + ".\n" +
-                    "Change this via property '" + MAX_ERROR_MESSAGES_PROPERTY + "' or command line option '" + MAX_ERROR_MESSAGES_OPTION + "'.");
-          }
         println(singularOrPlural(count(), "error") +
                 (warningCount() > 0 ? " and " + singularOrPlural(warningCount(), "warning")
                                     : "") +
@@ -538,7 +535,7 @@ public class Errors extends ANY
 
     if (warningCount() < MAX_WARNING_MESSAGES || MAX_WARNING_MESSAGES == -1)
       {
-        if (warningCount()+1 == MAX_WARNING_MESSAGES && MAX_WARNING_MESSAGES != -1)
+        if (warningCount()+1 == MAX_WARNING_MESSAGES)
           {
             pos = SourcePosition.builtIn;
             msg = "Maximum warning count reached, suppressing further warnings";


### PR DESCRIPTION
If given a maximum error or warning count of -1, fz will display all the errors or warnings. The value -1 was chosen because while 0 would work for errors, 0 can be used to disable all warnings.

Closes #1329.