### PR TITLE
lib/bool: implement lazy boolean operations

### DIFF
--- a/lib/bool.fz
+++ b/lib/bool.fz
@@ -43,12 +43,20 @@ bool : choice FALSE TRUE, equatable is
     if bool.this then FALSE else TRUE
 
   # or with lazy evaluation
-  infix ||  (lazy other bool) bool is
-    fuzion.std.panic "bool.infix || is handled by front end"
+  #
+  infix || (other Lazy bool) bool is
+    if bool.this
+      true
+    else
+      other
 
   # and with lazy evaluation
-  infix &&  (lazy other bool) bool is
-    fuzion.std.panic "bool.infix && is handled by front end"
+  #
+  infix && (other Lazy bool) bool is
+    if bool.this
+      other
+    else
+      false
 
   # or
   infix |   (other bool) => bool.this || other
@@ -75,8 +83,12 @@ bool : choice FALSE TRUE, equatable is
   infix ^   (other bool) => if bool.this (!other) else  other
 
   # implies
-  infix :   (lazy other bool) bool is
-    fuzion.std.panic "bool.infix : is handled by front end"
+  #
+  infix : (other Lazy bool) bool is
+    if bool.this
+      other
+    else
+      true
 
   # ternary ? : -- NYI: This will be replaced by a more powerful match syntax
   ternary ? : (T type, lazy a, b T) => if bool.this a else b


### PR DESCRIPTION
This implements the lazy boolean operations currently handled by the front end in the standard library. This does not remove the special handling in the front end for now, so it is not a solution to #1348.