### PR TITLE
LibrayOut: rename write as writeByte

### DIFF
--- a/src/dev/flang/fe/LibraryOut.java
+++ b/src/dev/flang/fe/LibraryOut.java
@@ -574,7 +574,7 @@ class LibraryOut extends ANY
           {
             _data.writeInt(t.generics().size());
             _data.writeOffset(t.featureOfType());
-            _data.write(t.isThisType() ? FuzionConstants.MIR_FILE_TYPE_IS_THIS :
+            _data.writeByte(t.isThisType() ? FuzionConstants.MIR_FILE_TYPE_IS_THIS :
                         t.isRef()      ? FuzionConstants.MIR_FILE_TYPE_IS_REF
                                        : FuzionConstants.MIR_FILE_TYPE_IS_VALUE);
             for (var gt : t.generics())
@@ -705,7 +705,7 @@ class LibraryOut extends ANY
    *   +--------+--------+---------------+-----------------------------------------------+
    */
         type(u.type());
-        _data.write(u._needed ? 1 : 0);
+        _data.writeByte(u._needed ? 1 : 0);
       }
     else if (s instanceof Box b)
       {
@@ -730,7 +730,7 @@ class LibraryOut extends ANY
           }
         if (!dumpResult)
           {
-            _data.write(IR.ExprKind.Unit.ordinal());
+            _data.writeByte(IR.ExprKind.Unit.ordinal());
           }
       }
     else if (s instanceof Constant c)
@@ -847,7 +847,7 @@ class LibraryOut extends ANY
           }
         if (dumpResult)
           {
-            _data.write(IR.ExprKind.Pop.ordinal());
+            _data.writeByte(IR.ExprKind.Pop.ordinal());
           }
       }
     else if (s instanceof AbstractMatch m)
@@ -995,12 +995,12 @@ class LibraryOut extends ANY
   {
     if (lastPos == null || lastPos.compareTo(newPos) != 0)
       {
-        _data.write(k.ordinal() | 0x80);
+        _data.writeByte(k.ordinal() | 0x80);
         pos(newPos);
       }
     else
       {
-        _data.write(k.ordinal());
+        _data.writeByte(k.ordinal());
       }
     return newPos;
   }

--- a/src/dev/flang/util/DataOut.java
+++ b/src/dev/flang/util/DataOut.java
@@ -84,7 +84,7 @@ public class DataOut extends ANY
   /**
    * Write given byte to this buffer and increase offset by 1.
    */
-  public void write(int b)
+  public void writeByte(int b)
   {
     if (PRECONDITIONS) require
       (0 <= b, b <= 0xFF);
@@ -104,7 +104,7 @@ public class DataOut extends ANY
    */
   public void writeBool(boolean b)
   {
-    write(b ? 1 : 0);
+    writeByte(b ? 1 : 0);
   }
 
 
@@ -113,8 +113,8 @@ public class DataOut extends ANY
    */
   public void writeShort(int i)
   {
-    write((i >>  8) & 0xFF);
-    write((i      ) & 0xFF);
+    writeByte((i >>  8) & 0xFF);
+    writeByte((i      ) & 0xFF);
   }
 
 
@@ -123,10 +123,10 @@ public class DataOut extends ANY
    */
   public void writeInt(int i)
   {
-    write((i >> 24) & 0xFF);
-    write((i >> 16) & 0xFF);
-    write((i >>  8) & 0xFF);
-    write((i      ) & 0xFF);
+    writeByte((i >> 24) & 0xFF);
+    writeByte((i >> 16) & 0xFF);
+    writeByte((i >>  8) & 0xFF);
+    writeByte((i      ) & 0xFF);
   }
 
 


### PR DESCRIPTION
I was using `write` looking only at the signature and not the comment. This led me to expecting it would write an `int`.
A precondition would catch if we passed something larger than `int` but in my case I did not do that and that therefore was confused for a little while.