### PR TITLE
call: propagateExpectedType, remove wrapInLazy workaround

### DIFF
--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -2151,14 +2151,6 @@ public class Call extends AbstractCall
               }
             count++;
           }
-
-        if (_target != null)
-          {
-            // NYI: Need to check why this is needed, it does not make sense to
-            // propagate the target's type to target. But if removed,
-            // tests/reg_issue16_chainedBool/ fails with C backend:
-            _target = _target.wrapInLazyAndThenPropagateExpectedType(res, outer, _target.typeIfKnown());
-          }
       }
   }
 


### PR DESCRIPTION
might be not needed anymore