### PR TITLE
dependabot: check for updates monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,4 +3,4 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: weekly
+      interval: monthly


### PR DESCRIPTION
This will reduce some of the noise caused by dependabot. However, this will apparently not affect security updates which according to the dependabot documentation, work independently of the interval configured in this file.