### PR TITLE
lib: reintroduce usage of `!=` infix

### DIFF
--- a/lib/String.fz
+++ b/lib/String.fz
@@ -80,7 +80,7 @@ String ref : equatable, has_hash, has_total_order is
       .zip b.utf8 (c,d)->(c,d)
       .filter (x ->
         (c, d) := x
-        !(c = d))
+        c != d)
       .map_sequence (x ->
         (c, d) := x
         c ≤ d)
@@ -306,7 +306,7 @@ String ref : equatable, has_hash, has_total_order is
             c2 Cons =>
               b2 := c2.head
               e2(msg String) => ret (e "$b1, $b2: $msg") c2.tail
-              if !((b2 & 0xc0) = (u8 0x80))
+              if (b2 & 0xc0) != (u8 0x80)
                 e2 "expected continuation byte in the range 0x80..0xbf."
               else if u8 0xc0 ≤ b1 ≤ (u8 0xdf)   # 0x0080..0x7ff encoded in 2 bytes
                 res := (b1.as_u32 & 0x1f) << 6 | (b2.as_u32 & 0x3f)
@@ -320,7 +320,7 @@ String ref : equatable, has_hash, has_total_order is
                   c3 Cons =>
                     b3 := c3.head
                     e3(msg String) => ret (e "$b1, $b2, $b3: $msg") c3.tail
-                    if !((b3 & 0xc0) = (u8 0x80))
+                    if (b3 & 0xc0) != (u8 0x80)
                       e3 "expected two continuation bytes in the range 0x80..0xbf."
                     else if b1 ≤ (u8 0xef)       # 0x0800..0xffff encoded in 3 bytes
                       res := (((b1.as_u32 & 0x0f) << 12) |
@@ -340,7 +340,7 @@ String ref : equatable, has_hash, has_total_order is
                         c4 Cons =>
                           b4 := c4.head
                           e4(msg String) => ret (e "$b1, $b2, $b3, $b4: $msg") c4.tail
-                          if !((b4 & 0xc0) = (u8 0x80))
+                          if (b4 & 0xc0) != (u8 0x80)
                             e4 "expected three continuation bytes in the range 0x80..0xbf."
                           else
                             res := (((b1.as_u32 & 0x07) << 18) |

--- a/lib/ctrie.fz
+++ b/lib/ctrie.fz
@@ -385,7 +385,7 @@ is
       match m.data
         cn container_node CTK CTV =>
           (flag, pos) := flagpos hash lev cn.bmp
-          if !((cn.bmp & flag) = u32 0)
+          if (cn.bmp & flag) != u32 0
             sub := cn.array[pos.as_i32]
             match sub
               Indirection_Node Indirection_Node CTK CTV =>
@@ -471,7 +471,7 @@ is
 
   # find k in linked nodes
   private find(ln list_node CTK CTV, k CTK) choice restart not_found CTV is
-    match ln.drop_while(sn -> !(sn.k = k)).head
+    match ln.drop_while(sn -> sn.k != k).head
           nil => not_found
           sn singleton_node => sn.v
 
@@ -507,7 +507,7 @@ is
                   ctrie_ok => add i k v lev parent gen
                   restart => restart
             sn singleton_node =>
-              if !(sn.k = k)
+              if sn.k != k
                 nin := Indirection_Node (mut (dual sn (singleton_node k v) (lev + width) i.data.get.gen))
                 ncn := (if m.gen = gen then cn else cn.renewed gen CTrie.this).updated pos nin
                 i.gcas m (Main_Node ncn gen) CTrie.this
@@ -518,7 +518,7 @@ is
         clean parent (lev - width) gen
         restart
       ln list_node =>
-        i.gcas m (Main_Node (list_node ([singleton_node k v] ++ (ln.filter (sn -> !(sn.k = k))))) i.data.get.gen) CTrie.this
+        i.gcas m (Main_Node (list_node ([singleton_node k v] ++ (ln.filter (sn -> sn.k != k)))) i.data.get.gen) CTrie.this
 
 
   # remove key from ctrie
@@ -549,7 +549,7 @@ is
                   ctrie_ok => remove i k lev parent gen
                   restart => restart
             sn singleton_node =>
-              if !(sn.k = k)
+              if sn.k != k
                 not_found
               else
                 ncn  := cn.removed pos flag
@@ -568,7 +568,7 @@ is
         clean parent (lev - width) gen
         restart
       ln list_node =>
-        fln := list_node ln.filter(sn -> !(sn.k = k))
+        fln := list_node ln.filter(sn -> sn.k != k)
         nln Main_Node CTK CTV := if fln.count = 1 then Main_Node (tomb_node fln.first) i.data.get.gen else Main_Node fln i.data.get.gen
         match (i.gcas m nln CTrie.this)
           ctrie_ok => find ln k

--- a/lib/i64.fz
+++ b/lib/i64.fz
@@ -43,8 +43,8 @@ i64(val i64) : wrapping_integer i64, has_interval i64, i64s is
   redef underflow_on_sub(other i64) => thiz < i64 0 && thiz -° i64.type.min < other
 
   # would multiplication thiz * other cause an overflow or underflow?
-  redef overflow_on_mul (other i64) => if sign *° other.sign ≤ 0 false else !((thiz *° other / other) = thiz)
-  redef underflow_on_mul(other i64) => if sign *° other.sign ≥ 0 false else !((thiz *° other / other) = thiz)
+  redef overflow_on_mul (other i64) => if sign *° other.sign ≤ 0 false else (thiz *° other / other) != thiz
+  redef underflow_on_mul(other i64) => if sign *° other.sign ≥ 0 false else (thiz *° other / other) != thiz
 
   # neg, add, sub, mul with wrap-around semantics
   redef prefix -° i64 is intrinsic

--- a/lib/matrix.fz
+++ b/lib/matrix.fz
@@ -66,7 +66,7 @@ is
     for
       x in a.e
       y in a.e
-    until !(x = y)
+    until x != y
       false
     else
       true

--- a/lib/time/date_time.fz
+++ b/lib/time/date_time.fz
@@ -115,5 +115,5 @@ private days_in_year(year i32) =>
 
 # is the given year a leap year?
 private is_leap_year(year i32) =>
-  (year % 4 = 0 & !(year % 100 = 0)) |
+  (year % 4 = 0 & year % 100 != 0) |
     ((year % 100 = 0) & (year % 400 = 0))

--- a/lib/u128.fz
+++ b/lib/u128.fz
@@ -44,7 +44,7 @@ u128(hi, lo u64) : wrapping_integer u128, has_interval u128, u128s is
   redef underflow_on_sub(other u128) => thiz < other
 
   # would multiplication thiz * other cause an overflow or underflow?
-  redef overflow_on_mul (other u128) => if (other = zero) false else !((thiz *° other / other) = thiz)
+  redef overflow_on_mul (other u128) => if (other = zero) false else (thiz *° other / other) != thiz
   redef underflow_on_mul(other u128) => false
 
   # neg, add, sub, mul with wrap-around semantics

--- a/lib/u64.fz
+++ b/lib/u64.fz
@@ -43,7 +43,7 @@ u64(val u64) : wrapping_integer u64, has_interval u64, u64s is
   redef underflow_on_sub(other u64) => thiz < other
 
   # would multiplication thiz * other cause an overflow or underflow?
-  redef overflow_on_mul (other u64) => if other = (u64 0) false else !((thiz *° other / other) = thiz)
+  redef overflow_on_mul (other u64) => if other = (u64 0) false else (thiz *° other / other) != thiz
   redef underflow_on_mul(other u64) => false
 
   # neg, add, sub, mul with wrap-around semantics


### PR DESCRIPTION
When the `!=` infix was (temporarily) removed, calls to it had been replaced with calls to infix `=` and prefix `!`. We can undo this change now.