### PR TITLE
issue 1055: fix ensure-condition failures in `findInheritanceChain`

### DIFF
--- a/src/dev/flang/ast/AbstractType.java
+++ b/src/dev/flang/ast/AbstractType.java
@@ -1442,6 +1442,16 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
   }
 
 
+  /**
+   * @return Is this the self type belonging to a type features this type?
+   */
+  public boolean isTypeFeatureThisType()
+  {
+    // NYI: CLEANUP: #706: Replace string operation by a flag marking this features as a 'THIS_TYPE' type parameter
+    return name().equals(FuzionConstants.TYPE_FEATURE_THIS_TYPE);
+  }
+
+
 }
 
 /* end of file */

--- a/src/dev/flang/ast/AstErrors.java
+++ b/src/dev/flang/ast/AstErrors.java
@@ -1764,6 +1764,20 @@ public class AstErrors extends ANY
           code(new_code_ref) + "to return a reference.");
   }
 
+  public static void illegalUseOfThisTypeInTypeFeature(DotType d, AbstractFeature outer)
+  {
+    error(d.pos(),
+          "Illegal use of " + code(".this.type") + " inside of type feature " + s(outer) + ".",
+          "To solve this, remove the offending code.");
+  }
+
+  public static void featureRequiringInstanceCalledOnDotType(Call c, AbstractFeature cf)
+  {
+    error(c.pos(),
+          "Called feature " + s(cf) + " needs an instance, but was called like a type feature.",
+          "To solve this, remove the offending code.");
+  }
+
 
 }
 

--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -663,7 +663,15 @@ public class Call extends AbstractCall
                   }
                 if (fo != null)
                   {
-                    _calledFeature = fo._feature;
+                    if (_target != null && _target.isDotTypeCall() && needsInstance(fo))
+                      {
+                        AstErrors.featureRequiringInstanceCalledOnDotType(this, fo._feature);
+                        _calledFeature = Types.f_ERROR;
+                      }
+                    else
+                      {
+                        _calledFeature = fo._feature;
+                      }
                     if (_target == null)
                       {
                         _target = fo.target(pos(), res, thiz);
@@ -714,6 +722,17 @@ public class Call extends AbstractCall
     if (POSTCONDITIONS) ensure
       (Errors.count() > 0 || calledFeature() != null,
        Errors.count() > 0 || _target         != null);
+  }
+
+
+  /**
+   * Does fo require an instance to be called?
+   * @param fo
+   * @return
+   */
+  private boolean needsInstance(FeatureAndOuter fo)
+  {
+    return !(fo._feature.isTypeFeature() || fo._outer.isTypeFeature());
   }
 
 

--- a/src/dev/flang/ast/DotType.java
+++ b/src/dev/flang/ast/DotType.java
@@ -108,14 +108,37 @@ public class DotType extends Expr
    *
    * @param outer the root feature that contains this statement.
    */
-  public Call resolveTypes(Resolution res, AbstractFeature outer)
+  public Expr resolveTypes(Resolution res, AbstractFeature outer)
   {
-    var tc = new Call(_pos, new Universe(), "Types");
-    tc.resolveTypes(res, outer);
+    if (withinTypeFeature(outer) && _lhs.isTypeFeatureThisType())
+      {
+        AstErrors.illegalUseOfThisTypeInTypeFeature(this, outer);
+        return Expr.ERROR_VALUE;
+      }
+    var tc = new Call(_pos, new Universe(), "Types").resolveTypes(res, outer);
     return new Call(_pos,
                     tc,
                     "get",
-                    new List<>(new Actual(_lhs))).resolveTypes(res, outer);
+                    new List<>(new Actual(_lhs))){
+                     @Override
+                     public boolean isDotTypeCall()
+                     {
+                       return true;
+                     }
+                    }.resolveTypes(res, outer);
+
+  }
+
+  /**
+   * @return Are we within a type feature?
+   */
+  private boolean withinTypeFeature(AbstractFeature f)
+  {
+    return f == null
+      ? false
+      : f.isTypeFeature()
+      ? true
+      : withinTypeFeature(f.outer());
   }
 
 

--- a/src/dev/flang/ast/Expr.java
+++ b/src/dev/flang/ast/Expr.java
@@ -562,6 +562,14 @@ public abstract class Expr extends ANY implements Stmnt, HasSourcePosition
            : toString();
   }
 
+  /**
+   * @return Is this expr a .type call?
+   */
+  public boolean isDotTypeCall()
+  {
+    return false;
+  }
+
 
 }
 

--- a/tests/reg_issue1055_call_feature_requiring_instance_via_dot_type/Makefile
+++ b/tests/reg_issue1055_call_feature_requiring_instance_via_dot_type/Makefile
@@ -1,0 +1,27 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test Makefile
+#
+#  Author: Fridtjof Siebert (siebert@tokiwa.software)
+#
+# -----------------------------------------------------------------------
+
+override NAME = issue1055
+include ../simple.mk

--- a/tests/reg_issue1055_call_feature_requiring_instance_via_dot_type/issue1055.fz
+++ b/tests/reg_issue1055_call_feature_requiring_instance_via_dot_type/issue1055.fz
@@ -1,0 +1,44 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test issue1055
+#
+# -----------------------------------------------------------------------
+
+
+issue1055 =>
+
+  self_referential_feature(T type:self_referential_feature T) is
+    some_feat_requiring_instance self_referential_feature.this.type is
+      self_referential_feature.this
+    type.a_type_feature =>
+      self_referential_feature.this.type.some_feat_requiring_instance
+      unit
+
+  a : self_referential_feature a is
+
+  say a.type.a_type_feature
+
+
+
+
+  b(T type : float T) is
+    say T.type.fract
+
+  b f32

--- a/tests/reg_issue1055_call_feature_requiring_instance_via_dot_type/issue1055.fz.expected_err
+++ b/tests/reg_issue1055_call_feature_requiring_instance_via_dot_type/issue1055.fz.expected_err
@@ -1,0 +1,13 @@
+
+[32m--CURDIR--/issue1055.fz:42:16:[39m [1;31merror 1[0m[1m: Called feature '[35mfloat.fract[39m' needs an instance, but was called like a type feature.[0m
+[34m    say T.type.fract
+[33m---------------^[0m
+To solve this, remove the offending code.
+
+
+[32m--CURDIR--/issue1055.fz:31:32:[39m [1;31merror 2[0m[1m: Illegal use of '[35m.this.type[39m' inside of type feature '[35missue1055.self_referential_feature.type.a_type_feature[39m'.[0m
+[34m      self_referential_feature.this.type.some_feat_requiring_instance
+[33m-------------------------------^[0m
+To solve this, remove the offending code.
+
+2 errors.


### PR DESCRIPTION
- must not refer to - `.this.type` - none existant instance in type feautre
- must not call feature needing instance via `.type.<feat>`