### PR TITLE
lexer: use `codePointAt` in `raw` method

### DIFF
--- a/src/dev/flang/parser/Lexer.java
+++ b/src/dev/flang/parser/Lexer.java
@@ -2461,7 +2461,7 @@ PIPE        : "|"
     private int raw(Optional<Integer> pos)
     {
       return pos
-        .map(p -> codePoint(p))
+        .map(p -> codePointAt(p))
         .orElse(curCodePoint());
     }
 

--- a/src/dev/flang/util/SourceFile.java
+++ b/src/dev/flang/util/SourceFile.java
@@ -442,7 +442,7 @@ public class SourceFile extends ANY
   {
     if (PRECONDITIONS) require
       (cp >= 0,
-       cp <= 0x10FFFF || cp == BAD_CODEPOINT,
+       cp <= 0x10FFFF || cp == BAD_CODEPOINT || cp == END_OF_FILE,
        sz > 0,
        sz <= 4);
 
@@ -640,10 +640,19 @@ public class SourceFile extends ANY
   public int codePoint(int pos)
   {
     if (PRECONDITIONS) require
-      (pos >= 0,
-       pos < _bytes.length);
+      (pos >= 0);
 
-    int cpAndSz = decodeCodePointAndSize(pos);
+    int cpAndSz;
+
+    if (pos < _bytes.length)
+      {
+        cpAndSz = decodeCodePointAndSize(pos);
+      }
+    else
+      {
+        cpAndSz = makeCodePointWithSize(END_OF_FILE, 1);
+      }
+
     return codePointFromCpAndSize(cpAndSz);
   }
 

--- a/src/dev/flang/util/SourceFile.java
+++ b/src/dev/flang/util/SourceFile.java
@@ -442,7 +442,7 @@ public class SourceFile extends ANY
   {
     if (PRECONDITIONS) require
       (cp >= 0,
-       cp <= 0x10FFFF || cp == BAD_CODEPOINT || cp == END_OF_FILE,
+       cp <= 0x10FFFF || cp == BAD_CODEPOINT,
        sz > 0,
        sz <= 4);
 
@@ -640,19 +640,10 @@ public class SourceFile extends ANY
   public int codePoint(int pos)
   {
     if (PRECONDITIONS) require
-      (pos >= 0);
+      (pos >= 0,
+       pos < _bytes.length);
 
-    int cpAndSz;
-
-    if (pos < _bytes.length)
-      {
-        cpAndSz = decodeCodePointAndSize(pos);
-      }
-    else
-      {
-        cpAndSz = makeCodePointWithSize(END_OF_FILE, 1);
-      }
-
+    int cpAndSz = decodeCodePointAndSize(pos);
     return codePointFromCpAndSize(cpAndSz);
   }
 


### PR DESCRIPTION
This fixes an issue where a string literal at the end of file caused an error. The problem is that the string literal is read twice, the second time it accesses the codepoints explicitly, including the character after the closing quote. This did not return an END_OF_FILE codepoint until now, instead causing a precondition failure.

Fixes #1379.