### PR TITLE
parser: remove the `lazy` keyword

### DIFF
--- a/lib/bool.fz
+++ b/lib/bool.fz
@@ -91,7 +91,7 @@ bool : choice FALSE TRUE, equatable is
       true
 
   # ternary ? : -- NYI: This will be replaced by a more powerful match syntax
-  ternary ? : (T type, lazy a, b T) => if bool.this a else b
+  ternary ? : (T type, a, b T) => if bool.this a else b
 
   # human readable string
   redef as_string => if bool.this "true" else "false"

--- a/src/dev/flang/ast/Consts.java
+++ b/src/dev/flang/ast/Consts.java
@@ -46,26 +46,20 @@ public class Consts extends ANY
   /**
    *
    */
-  public static final String[] MODIFIER_STRINGS = {"lazy", "redef", "fixed"};
+  public static final String[] MODIFIER_STRINGS = {"redef", "fixed"};
 
 
   /**
    *
    */
-  public static final int MODIFIER_LAZY         = 0x01;
-  static { if (CHECKS) check(modifierToString(MODIFIER_LAZY).trim().equals("lazy")); }
-
-  /**
-   *
-   */
-  public static final int MODIFIER_REDEFINE     = 0x02;
+  public static final int MODIFIER_REDEFINE     = 0x01;
   static { if (CHECKS) check(modifierToString(MODIFIER_REDEFINE).trim().equals("redef")); }
 
   /**
    * 'fixed' modifier to force feature to be fixed, i.e., not inherited by
    * heirs.
    */
-  public static final int MODIFIER_FIXED        = 0x04;
+  public static final int MODIFIER_FIXED        = 0x02;
   static { if (CHECKS) check(modifierToString(MODIFIER_FIXED).trim().equals("fixed")); }
 
 

--- a/src/dev/flang/parser/Lexer.java
+++ b/src/dev/flang/parser/Lexer.java
@@ -191,7 +191,6 @@ public class Lexer extends SourceFile
     t_match("match"),
     t_value("value"),
     t_ref("ref"),
-    t_lazy("lazy"),
     t_synchronized("synchronized"),   // unused
     t_redef("redef"),
     t_redefine("redefine"),

--- a/src/dev/flang/parser/Parser.java
+++ b/src/dev/flang/parser/Parser.java
@@ -778,10 +778,9 @@ opName      : "infix"   op
 modifiers   : modifier modifiers
             |
             ;
-modifier    : "lazy"
-            | "redef"
+modifier    : "redef"
             | "redefine"
-            | "dyn"
+            | "fixed"
             ;
    *
    * @return logically or'ed set of Consts.MODIFIER_* constants found.
@@ -796,7 +795,6 @@ modifier    : "lazy"
         int p2 = tokenPos();
         switch (current())
           {
-          case t_lazy        : m = Consts.MODIFIER_LAZY        ; break;
           case t_redef       : m = Consts.MODIFIER_REDEFINE    ; break;
           case t_redefine    : m = Consts.MODIFIER_REDEFINE    ; break;
           case t_fixed       : m = Consts.MODIFIER_FIXED       ; break;
@@ -827,7 +825,6 @@ modifier    : "lazy"
   {
     switch (current())
       {
-      case t_lazy        :
       case t_redef       :
       case t_redefine    :
       case t_fixed       : return true;


### PR DESCRIPTION
The `lazy` keyword did not do anything, therefore it can be removed. An issue that remains is that the boolean ternary operator can't be changed to accept `Lazy` values due to a type inference issue. However, it seems there is no special handling to make the ternary operator lazy, so this should not behave differently.