### PR TITLE
parser: make `infix :` right-associative

### DIFF
--- a/src/dev/flang/parser/OpExpr.java
+++ b/src/dev/flang/parser/OpExpr.java
@@ -458,7 +458,7 @@ public class OpExpr extends ANY
   /**
    * Initial characters of operators that bind to the right.
    */
-  public final String RIGHT_TO_LEFT_CHARS = "^";
+  public final String RIGHT_TO_LEFT_CHARS = "^:";
 
 }
 


### PR DESCRIPTION
This makes it easier to create lists using `list.infix :` because it is now possible to declare `a list i32 := 1:2:3:nil` instead of `a list i32 := 1:(2:(3:nil))`.

The big problem with this change is that `infix :` is also used for boolean implication. In this case right-associativity is unwanted.