### PR TITLE
air: remove duplicate method `Clazzes.isUsedAtAll`

### DIFF
--- a/src/dev/flang/air/Clazz.java
+++ b/src/dev/flang/air/Clazz.java
@@ -2383,7 +2383,7 @@ public class Clazz extends ANY implements Comparable<Clazz>
       case Routine    :
         {
           var or = f.outerRef();
-          if (or != null && Clazzes.isUsedAtAll(or))
+          if (or != null && Clazzes.isUsed(or))
             {
               result = lookup(or);
             }
@@ -2504,7 +2504,7 @@ public class Clazz extends ANY implements Comparable<Clazz>
         if (!this.isVoidType() &&
             field.isField() &&
             field == findRedefinition(field) && // NYI: proper field redefinition handling missing, see tests/redef_args/*
-            Clazzes.isUsed(field, this))
+            Clazzes.isUsed(field))
           {
             if (field.isOpenGenericField())
               {

--- a/src/dev/flang/air/Clazzes.java
+++ b/src/dev/flang/air/Clazzes.java
@@ -542,10 +542,10 @@ public class Clazzes extends ANY
   static void calledDynamically(AbstractFeature f)
   {
     if (PRECONDITIONS) require
-      (Errors.count() > 0 || isUsedAtAll(f) || true /* NYI: clazzes are created for type features's type parameters without being called,
-                                                     * see tests/reg_issue1236 for an example. We might treat clazzes that are only used
-                                                     * in types differently.
-                                                     */,
+      (Errors.count() > 0 || isUsed(f) || true /* NYI: clazzes are created for type features's type parameters without being called,
+                                                * see tests/reg_issue1236 for an example. We might treat clazzes that are only used
+                                                * in types differently.
+                                                */,
        f.generics().list.isEmpty());
 
     if (!_calledDynamically_.contains(f))
@@ -750,7 +750,7 @@ public class Clazzes extends ANY
         var vc = sClazz.asValue();
         var fc = vc.lookup(a._assignedField, a);
         propagateExpectedClazz(a._value, fc.resultClazz(), outerClazz);
-        if (isUsed(a._assignedField, sClazz))
+        if (isUsed(a._assignedField))
           {
             outerClazz.setRuntimeClazz(a._tid + 1, fc);
           }
@@ -967,7 +967,7 @@ public class Clazzes extends ANY
     int i = c._runtimeClazzId;
     if (f != null)
       {
-        var fOrFc = isUsed(f, outerClazz)
+        var fOrFc = isUsed(f)
           ? outerClazz.lookup(f)
           : outerClazz.actualClazz(f.resultType());
         outerClazz.setRuntimeClazz(i, fOrFc);
@@ -1309,18 +1309,9 @@ public class Clazzes extends ANY
 
 
   /**
-   * Has this feature been found to be used within the given static clazz?
-   */
-  public static boolean isUsed(AbstractFeature thiz, Clazz staticClazz)
-  {
-    return isUsedAtAll(thiz);
-  }
-
-
-  /**
    * Has this feature been found to be used?
    */
-  public static boolean isUsedAtAll(AbstractFeature thiz)
+  public static boolean isUsed(AbstractFeature thiz)
   {
     return thiz._usedAt != null;
   }

--- a/src/dev/flang/be/interpreter/Interpreter.java
+++ b/src/dev/flang/be/interpreter/Interpreter.java
@@ -426,7 +426,7 @@ public class Interpreter extends ANY
           {
             var c = it.next();
 
-            if (c.field() != null && Clazzes.isUsed(c.field(), staticClazz))
+            if (c.field() != null && Clazzes.isUsed(c.field()))
               {
                 Clazz fieldClazz = staticClazz.getRuntimeClazz(c._runtimeClazzId).resultClazz();
                 if (fieldClazz.isDirectlyAssignableFrom(subjectClazz))
@@ -521,7 +521,7 @@ public class Interpreter extends ANY
                   {
                     // see tests/redef_args and issue #86 for a case where this lookup is needed:
                     f = vc.lookup(f, b).feature();
-                    if (Clazzes.isUsed(f, vc))
+                    if (Clazzes.isUsed(f))
                       {
                         Value v = getField(f, vc, val, true /* allow for uninitialized ref field */);
                         // NYI: Check that this works well for internal fields such as choice tags.
@@ -809,7 +809,7 @@ public class Interpreter extends ANY
                 var rc = innerClazz.resultClazz();
                 if (CHECKS) check  // check that outer ref, if exists, is unused:
                   (true || // NYI: This check is currently disabled, outer ref of types are not properly removed yet and not properly initialized here
-                   rc.feature().outerRef() == null || !Clazzes.isUsedAtAll(rc.feature().outerRef()));
+                   rc.feature().outerRef() == null || !Clazzes.isUsed(rc.feature().outerRef()));
                 return new Instance(rc);
               };
               break;
@@ -843,7 +843,7 @@ public class Interpreter extends ANY
     FuzionThread.current()._callStackFrames.push(staticClazz);
 
     if (CHECKS) check
-      (Clazzes.isUsedAtAll(thiz));
+      (Clazzes.isUsed(thiz));
 
     setOuter(thiz, staticClazz, cur, args.get(0));
     int aix = 1;
@@ -1382,7 +1382,7 @@ public class Interpreter extends ANY
        (curValue instanceof Instance) || (curValue instanceof LValue),
        staticClazz != null);
 
-    if (Clazzes.isUsed(thiz, staticClazz))
+    if (Clazzes.isUsed(thiz))
       {
         Clazz  fclazz = staticClazz.clazzForFieldX(thiz, select);
         LValue slot   = fieldSlot(thiz, select, staticClazz, fclazz, curValue);
@@ -1402,7 +1402,7 @@ public class Interpreter extends ANY
   public static void setOuter(AbstractFeature thiz, Clazz staticClazz, Instance cur, Value outer)
   {
     var or = thiz.outerRef();
-    if (or != null && Clazzes.isUsedAtAll(or))
+    if (or != null && Clazzes.isUsed(or))
       {
         setField(or, -1, staticClazz, cur, outer);
       }

--- a/src/dev/flang/fuir/FUIR.java
+++ b/src/dev/flang/fuir/FUIR.java
@@ -1659,7 +1659,7 @@ hw25 is
       {
         var mc = m.cases().get(cix);
         var f = mc.field();
-        var fc = f != null && Clazzes.isUsed(f, cc) ? cc.getRuntimeClazz(mc._runtimeClazzId) : null;
+        var fc = f != null && Clazzes.isUsed(f) ? cc.getRuntimeClazz(mc._runtimeClazzId) : null;
         result = fc != null ? id(fc) : -1;
       }
     return result;

--- a/src/dev/flang/me/MiddleEnd.java
+++ b/src/dev/flang/me/MiddleEnd.java
@@ -208,7 +208,7 @@ public class MiddleEnd extends ANY
    */
   void markUsed(AbstractFeature f, boolean dynamically, HasSourcePosition usedAt)
   {
-    if (!Clazzes.isUsedAtAll(f))
+    if (!Clazzes.isUsed(f))
       {
         Clazzes.addUsedFeature(f, usedAt);
         if (!(f instanceof Feature ff) || ff.state() == Feature.State.RESOLVED)
@@ -241,7 +241,7 @@ public class MiddleEnd extends ANY
           {
             for (AbstractFeature of : df.redefines())
               {
-                if (Clazzes.isUsedAtAll(of))
+                if (Clazzes.isUsed(of))
                   {
                     markUsed(df, usedAt);
                   }


### PR DESCRIPTION
The methods `Clazzes.isUsed` and `Clazzes.isUsedAtAll` did the same thing, even though according to the comments they should be doing different things. Unify them into the `isUsed` method, and remove the unused argument.