### PR TITLE
fe: fix outer of Lazy being set to Lazy.call instead of surrounding f…

### DIFF
--- a/src/dev/flang/fe/SourceModule.java
+++ b/src/dev/flang/fe/SourceModule.java
@@ -36,21 +36,16 @@ import java.nio.file.Path;
 
 import java.util.Collection;
 import java.util.Comparator;
-import java.util.Map;
-import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.TreeSet;
 
-import dev.flang.ast.AbstractAssign;
 import dev.flang.ast.AbstractBlock;
 import dev.flang.ast.AbstractFeature;
 import dev.flang.ast.AbstractType;
 import dev.flang.ast.AstErrors;
-import dev.flang.ast.Block;
 import dev.flang.ast.Call;
 import dev.flang.ast.Consts;
-import dev.flang.ast.Destructure;
 import dev.flang.ast.Feature;
 import dev.flang.ast.FeatureName;
 import dev.flang.ast.FeatureAndOuter;
@@ -62,7 +57,7 @@ import dev.flang.ast.SrcModule;
 import dev.flang.ast.Stmnt;
 import dev.flang.ast.Type;
 import dev.flang.ast.Types;
-
+import dev.flang.ast.AbstractFeature.State;
 import dev.flang.mir.MIR;
 import dev.flang.mir.MirModule;
 
@@ -574,7 +569,9 @@ public class SourceModule extends Module implements SrcModule, MirModule
               if (CHECKS) check
                 (Errors.count() > 0  || c.calledFeature() != null);
 
-              if (c.calledFeature() instanceof Feature cf)
+              if (c.calledFeature() instanceof Feature cf
+                  // fixes issue #1358
+                  && cf.state() == State.LOADING)
                 {
                   findDeclarations(cf, outer);
                 }

--- a/tests/reg_issue1358/Makefile
+++ b/tests/reg_issue1358/Makefile
@@ -1,0 +1,27 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test Makefile
+#
+#  Author: Fridtjof Siebert (siebert@tokiwa.software)
+#
+# -----------------------------------------------------------------------
+
+override NAME = issue1358
+include ../positive.mk

--- a/tests/reg_issue1358/issue1358.fz
+++ b/tests/reg_issue1358/issue1358.fz
@@ -1,0 +1,3 @@
+issue1358 is
+  a list i32 := 1:(2:nil)
+


### PR DESCRIPTION
…eature.

fixes #1358

example where this happened:
```
ex is
    a list i32 := 1:(2:nil)
```
First `nil` is wrapped in Lazy, the outer is set to ex. Second (2:nil) is wrapped in Lazy and in the process set the outer of the first lazy even though this anonymous function was already resolved. This time to the `call` feature of the second Lazy.