### PR TITLE
fix GC crash when using threads, add '#define GC_THREADS'

### DIFF
--- a/src/dev/flang/be/c/C.java
+++ b/src/dev/flang/be/c/C.java
@@ -634,7 +634,7 @@ public class C extends ANY
   private void createCode(CFile cf, COptions _options) throws IOException
   {
     cf.print
-      ((_options._useBoehmGC ? "#include <gc.h>\n" : "")+
+      ((_options._useBoehmGC ? "#define GC_THREADS\n#include <gc.h>\n" : "")+
        "#include <stdlib.h>\n"+
        "#include <stdio.h>\n"+
        "#include <unistd.h>\n"+


### PR DESCRIPTION
> In the case of multithreaded code, gc.h should be included after the threads header file, and after defining the appropriate GC_XXXX_THREADS macro. (For 6.2alpha4 and later, simply defining GC_THREADS should suffice.) The header file gc.h must be included in files that use either GC or threads primitives, since threads primitives will be redefined to cooperate with the GC on many platforms. 