### PR TITLE
lib/outcome: change `val`, `err` to use try-effect instead of panic

### DIFF
--- a/lib/outcome.fz
+++ b/lib/outcome.fz
@@ -77,15 +77,13 @@ is
 
   # value of an outcome that is known to contain a value
   #
-  # This can only be called in cases where it is known for sure that this
-  # outcomee is not an error.  A runtime error will be created otherwise.
+  # In case outcome is an error `try.env.raise` is called
+  # which aborts the current execution.
   #
-  val T
-    pre
-      safety: outcome.this??
+  val T ! try.this.type
   is
     outcome.this ? v T   => v
-                 | error => panic "outcome.val called on error"
+                 | error => try.env.raise (error "outcome.val called on error")
 
 
   # value of an outcome or default if outcome contains err
@@ -98,14 +96,12 @@ is
 
   # error of an outcome that is known to contain an error
   #
-  # This can only be called in cases where it is known for sure that this
-  # outcomee is an error.  A runtime error will be created otherwise.
+  # In case outcome is not an error `try.env.raise` is called
+  # which aborts the current execution.
   #
-  err error
-    pre
-      safety: outcome.this!!
+  err error ! try.this.type
   is
-    outcome.this ? T       => panic "outcome.err called on successful outcome"
+    outcome.this ? T       => try.env.raise (error "outcome.err called on successful outcome")
                  | e error => e
 
 

--- a/lib/try.fz
+++ b/lib/try.fz
@@ -28,7 +28,7 @@
 # try provides an operation 'raise' that immediately stops execution and
 # returns an 'error' wrapped in an 'oucome'.
 #
-try : effect effect_mode.plain
+private try : effect effect_mode.plain
 is
 
   # mutuable field to receive the error in case raise is called

--- a/tests/fileio/fileiotests.fz
+++ b/tests/fileio/fileiotests.fz
@@ -56,7 +56,8 @@ fileiotests =>
     error =>
   say "$file exists: {exists file}"
 
-  say "$file size is {(f.stat file true).val.size}"
+  try ()->
+    say "$file size is {(f.stat file true).val.size}"
 
   # NYI: we need to use fuzion.sys.fileio directly until we have a
   # closeable effect.


### PR DESCRIPTION
This PR is a suggestion.
Similar changes could be done for `Sequence.first`, `Sequence.last` or even `array. index[]`.