### PR TITLE
be/c: create binary named `universe` if main feature omitted.

### DIFF
--- a/src/dev/flang/fe/SourceModule.java
+++ b/src/dev/flang/fe/SourceModule.java
@@ -817,7 +817,7 @@ public class SourceModule extends Module implements SrcModule, MirModule
    * Add inner to the set of declared inner features of outer.
    *
    * Note that inner must be declared in this module, but outer may be defined
-   * in a different module.  E.g. #universe is declared in stdlib, while an
+   * in a different module.  E.g. universe is declared in stdlib, while an
    * inner feature 'main' may be declared in the application's module.
    *
    * @param outer the declaring feature

--- a/src/dev/flang/util/FuzionConstants.java
+++ b/src/dev/flang/util/FuzionConstants.java
@@ -53,7 +53,7 @@ public class FuzionConstants extends ANY
   /**
    * Artificial name of universe feature.
    */
-  public static final String UNIVERSE_NAME    = INTERNAL_NAME_PREFIX + "universe";
+  public static final String UNIVERSE_NAME    = "universe";
 
   /**
    * Prefix of artificially generated name of outer refs.

--- a/tests/this_type/skip_int
+++ b/tests/this_type/skip_int
@@ -22,7 +22,7 @@ RUN test_this_type.fz 18,26c18
 > simple_test_for_this_type_value: --CURDIR--/test_this_type.fz:91:47:
 >   say; yak "r.x.b3.print: (expecting rr) "; r.x.b3.print
 > ----------------------------------------------^
-> #universe: --CURDIR--/test_this_type.fz:96:1:
+> universe: --CURDIR--/test_this_type.fz:96:1:
 > simple_test_for_this_type_value
 > ^
 >


### PR DESCRIPTION
fixes #1399