### PR TITLE
be/c: include just `fcntl.h`

### DIFF
--- a/src/dev/flang/be/c/C.java
+++ b/src/dev/flang/be/c/C.java
@@ -655,7 +655,7 @@ public class C extends ANY
        "#include <errno.h>\n"+
        "#include <sys/stat.h>\n"+
        // defines _O_BINARY
-       "#include <sys/fcntl.h>\n");
+       "#include <fcntl.h>\n");
 
     var fzH = _options.fuzionHome().resolve("include/fz.h").normalize().toAbsolutePath();
     cf.println("#include \"" + fzH.toString() + "\"\n");


### PR DESCRIPTION
`sys/fcntl.h` does not exist in all libc, such as musl. This will cause a compiler warning/error when attempting to compile Fuzion code using the C backend.