### PR TITLE
air: Remove Clazz.isDynamicOuterRef

### DIFF
--- a/src/dev/flang/air/Clazz.java
+++ b/src/dev/flang/air/Clazz.java
@@ -944,33 +944,8 @@ public class Clazz extends ANY implements Comparable<Clazz>
 
 
   /**
-   * Check if this clazz is a value type that is used as an outer instance that
-   * requires dynamic binding when called.
-   */
-  public boolean isDynamicOuterRef()
-  {
-    if (!isRef())
-      {
-        if (isUsedAsDynamicOuterRef())
-          {
-            return true;
-          }
-        for (var p : parents())
-          {
-            if (p != this && p.isUsedAsDynamicOuterRef())
-              {
-                return true;
-              }
-          }
-      }
-    return false;
-  }
-
-
-  /**
    * Is this clazz the static clazz of a target of a call to a dynamic outer
-   * ref.  This is slightly different to isDynamicOuterRef() which is also true
-   * for all heirs.
+   * ref.
    */
   public boolean isUsedAsDynamicOuterRef()
   {
@@ -1005,7 +980,7 @@ public class Clazz extends ANY implements Comparable<Clazz>
       (this._type != Types.t_ADDRESS);
 
     if (Clazzes.isCalledDynamically(f) &&
-        (isRef() || isDynamicOuterRef()) &&
+        isRef() &&
         isInstantiated())
       {
         for (var ft : Clazzes.calledDynamicallyWithTypePars(f))

--- a/src/dev/flang/be/interpreter/ValueWithClazz.java
+++ b/src/dev/flang/be/interpreter/ValueWithClazz.java
@@ -87,7 +87,7 @@ public abstract class ValueWithClazz extends Value
   {
     Clazz result = _clazz;
     if (CHECKS) check
-      ((result == null) || result.isRef() || result.isDynamicOuterRef());
+      (result == null || result.isRef() || result.isUsedAsDynamicOuterRef());
     return result;
   }
 


### PR DESCRIPTION
This method is not needed, was used only in the interpreter backend.