### PR TITLE
lib: remove comments NYI: #167: 'ref' due to lack of 'like this'

### DIFF
--- a/examples/javaGraphics/gfx.fz
+++ b/examples/javaGraphics/gfx.fz
@@ -100,12 +100,12 @@ is
   sin240 := -866
 
 
-  G2D (g Java.java.awt.Graphics, tx, ty, rot0 i32) ref is  # NYI: #167: 'ref' due to lack of 'like this'
+  G2D (g Java.java.awt.Graphics, tx, ty, rot0 i32) is
     rot := if rot0 >= 0 rot0 % 360 else rot0 % 360 + 360
 
     rotate (d i32) => G2D g tx ty rot+d
 
-    threeTimes(d (G2D, Java.java.awt.Color) -> unit) unit is
+    threeTimes(d (ref G2D, Java.java.awt.Color) -> unit) unit is
       d  G2D.this              C1
       d (G2D.this.rotate -120) C2
       d (G2D.this.rotate -240) C3

--- a/lib/ps_map.fz
+++ b/lib/ps_map.fz
@@ -316,14 +316,14 @@ O(n log n).
   # both ps_map.this and other, it will be mapped to ps_map.this[k] or to other[k],
   # but it is undefined to which of these two.
   #
-  union (other ref ps_map PK V) ref ps_map PK V is  # NYI: #167: 'ref' due to lack of 'like this'
+  union (other ps_map PK V) ps_map PK V is
     if other.size < size
-      other ∪ ps_map.this
+      other ∪ (ps_map PK V data size fill)
     else
 
       # helper to add 'ps_map.this.data[l..r]' to 'a' and return the resulting map.
       #
-      add_all (a ref ps_map PK V, l i32, r i32) ref ps_map PK V is  # NYI: #167: 'ref' due to lack of 'like this'
+      add_all (a ps_map PK V, l i32, r i32) ps_map PK V is
         if l > r
           a
         else
@@ -335,7 +335,7 @@ O(n log n).
       # 'tail' elements at indices larger or equal to 'at+sz' added recursively as
       # well.
       #
-      add_all (a ref ps_map PK V, at i32, sz i32, tail i32) ref ps_map PK V is  # NYI: #167: 'ref' due to lack of 'like this'
+      add_all (a ps_map PK V, at i32, sz i32, tail i32) ps_map PK V is
         if sz = 0
           a
         else
@@ -355,7 +355,7 @@ O(n log n).
 
   # infix operator synonym for union of two ps_maps
   #
-  infix ∪ (other ref ps_map PK V) => union other  # NYI: #167: 'ref' due to lack of 'like this'
+  infix ∪ (other ps_map PK V) => union other
 
 
 # ps_maps -- unit type feature declaring features related to ps_map

--- a/lib/ps_set.fz
+++ b/lib/ps_set.fz
@@ -36,7 +36,7 @@
 #
 ps_set
   (K type : has_total_order,
-   psm ref ps_map K unit,  # NYI: #167: 'ref' due to lack of 'like this'
+   psm ps_map K unit,
    dummy unit    # just to distinguish this from routine ps_set(vs Sequence K)
   )
   : Set K
@@ -60,7 +60,7 @@ is
 
   # add new element k to this set.
   #
-  add (k K) ref ps_set K is  # NYI: #167: 'ref' due to lack of 'like this'
+  add (k K) ref ps_set K is
     if has k
       ps_set.this
     else
@@ -89,20 +89,20 @@ is
 
   # union of two ps_sets
   #
-  infix ∪ (other ref ps_set K) => ps_set K (psm ∪ other.psm) unit  # NYI: #167: 'ref' due to lack of 'like this'
+  infix ∪ (other ps_set K) ref ps_set K is
+    ps_set K (psm ∪ other.psm) unit
 
 
   # intersection of two ps_sets
-  infix ∩ (other ref ps_set K) =>
+  infix ∩ (other ps_set K) ref ps_set K is
     s := (ps_set.this ∪ other).filter (x -> ps_set.this.has x && other.has x)
     (ps_sets K).empty.add_all s
 
 
   # add all elements of the given Sequence to this set
   #
-  add_all (s Sequence K) ref ps_set K is  # NYI: #167: 'ref' due to lack of 'like this'
-    this_ref ref ps_set K := ps_set.this
-    s.reduce this_ref ((r,k) -> r.add k)
+  add_all (s Sequence K) ref ps_set K is
+    s.reduce (ref ps_set K) ps_set.this ((r,k) -> r.add k)
 
 
   # number of entries in this set.  May be undefined, i.e., a range of
@@ -127,7 +127,7 @@ has     -- NYI: 'has' keyword not supported yet, so the following require an ins
   # monoid of ps_set with infix ∪ operation.
   #
   union : Monoid (ps_set K) is
-    redef infix ∙ (a, b ps_set K) => a ∪ b
+    redef infix ∙ (a, b ps_set K) => ps_set K (a ∪ b).psm unit
     redef e => empty
 
 
@@ -155,4 +155,6 @@ ps_sets(K type : has_total_order) is
 #
 # This feature creates a pre-initialized instance of ps_set.
 #
-ps_set(K type : has_total_order, vs Sequence K) => (ps_sets K).empty.add_all vs
+ps_set(K type : has_total_order, vs Sequence K) ps_set K is
+  ps_set K ((ps_sets K).empty.add_all vs).psm unit
+

--- a/lib/sorted_array.fz
+++ b/lib/sorted_array.fz
@@ -80,7 +80,7 @@ is
   is
     # check if the array is fully sorted
     if heap_size ≥ a.length
-      a.as_array  # NYI: #167: convert 'ref'-array due to lack of 'like this' back to non-'ref' array
+      a
     else
       # h1 is the mutable index within the current first heap, this is updated
       # by the function passed to the array constructor.

--- a/tests/reg_issue25_unbox_outerref/unboxOuterRef.fz
+++ b/tests/reg_issue25_unbox_outerref/unboxOuterRef.fz
@@ -34,11 +34,11 @@ unboxOuterRef is
 
   y (i i32) is
     redef as_string => "y $i"
-    g (v y) is
+    g (v ref y) is
       vs := v.as_string
       say "in g: $vs $i"
     f unit is
-#     g y.this   # y.this is not assignable to y, should be type 'like y.this', see #167
+      g y.this
       g (y i)
       unit
 

--- a/tests/reg_issue25_unbox_outerref/unboxOuterRef.fz.expected_out
+++ b/tests/reg_issue25_unbox_outerref/unboxOuterRef.fz.expected_out
@@ -1,2 +1,4 @@
 in g: y 42 42
 in g: y 42 42
+in g: y 42 42
+in g: y 42 42


### PR DESCRIPTION
I am not sure what is desirable here? The way I have done it in this PR:
ps_set.add returns a `ref ps_set` because it implements abstract method add from `Set`
ps_map.add returns a value and can do that because `Map` does not have `add`.

