### PR TITLE
fe: Explicitly show Types.f_ERROR and Types.t_ERROR in error messages

### DIFF
--- a/src/dev/flang/ast/AstErrors.java
+++ b/src/dev/flang/ast/AstErrors.java
@@ -58,7 +58,8 @@ public class AstErrors extends ANY
    */
   public static String s(AbstractFeature f)
   {
-    return sqn(f.qualifiedName());
+    return f == Types.f_ERROR ? err()
+                              : sqn(f.qualifiedName());
   }
   public static String s(Feature f)
   {
@@ -70,7 +71,8 @@ public class AstErrors extends ANY
   }
   static String sbn(AbstractFeature f) // feature base name
   {
-    return sbn(f.featureName().baseName());
+    return f == Types.f_ERROR ? err()
+                              : sbn(f.featureName().baseName());
   }
   static String sbn(FeatureName fn) // feature base name plus arg count and id string
   {
@@ -167,6 +169,7 @@ public class AstErrors extends ANY
   static String code(String s) { return ticksOrNewLine(Terminal.PURPLE + s + Terminal.REGULAR_COLOR); }
   static String type(String s) { return ticksOrNewLine(Terminal.YELLOW + s + Terminal.REGULAR_COLOR); }
   static String expr(String s) { return ticksOrNewLine(Terminal.CYAN   + s + Terminal.REGULAR_COLOR); }
+  static String err()          { return Terminal.RED + ERROR_STRING + Terminal.REGULAR_COLOR; }
 
   /**
    * Enclose s in "'" unless s contains a new line. If s contains a new line,

--- a/src/dev/flang/ast/Type.java
+++ b/src/dev/flang/ast/Type.java
@@ -713,7 +713,11 @@ public class Type extends AbstractType
   {
     String result;
 
-    if (Types.INTERNAL_NAMES.contains(name))
+    if (this == Types.t_ERROR)
+      {
+        result = Errors.ERROR_STRING;
+      }
+    else if (Types.INTERNAL_NAMES.contains(name))
       {
         result = name;
       }


### PR DESCRIPTION
In principle, Types.f_ERROR and Types.t_ERROR can occur only as a consequence of previous errors.  So any errors reported that contain these should be ignored since they are only subsequent errors caused by a previously detected problem.

Nevertheless, sometimes these are shown anyways, so this patch marks them in red color when f_ERROR is shown and prints `**error**` instead of the very confusing `universe` in case of t_ERROR.

In a later phase, we could lat `fz` crash with a failed `check` if these are part of errors printed.