### PR TITLE
fe: suppress subsequent `cannot redefine` errors,

### DIFF
--- a/src/dev/flang/fe/SourceModule.java
+++ b/src/dev/flang/fe/SourceModule.java
@@ -775,7 +775,11 @@ public class SourceModule extends Module implements SrcModule, MirModule
       }
     else if (existing.generics() != FormalGenerics.NONE)
       {
-        AstErrors.cannotRedefineGeneric(f.pos(), outer, existing);
+        if (!existing.isTypeFeature() && Errors.count() == 0)
+          { // if this occurs for a type feature, this is likely a subsequent
+            // error for a duplicate feature declaration, so we suppress it:
+            AstErrors.cannotRedefineGeneric(f.pos(), outer, existing);
+          }
       }
     else if (f instanceof Feature ff && (ff._modifiers & Consts.MODIFIER_REDEFINE) == 0 && !existing.isAbstract())
       {


### PR DESCRIPTION
This occurs in flang.dev's content/design/examples/typ_const2.fz example recently, so we suppress it.

This is related to #1474, but does not fix it.