### PR TITLE
fe: Remove `AbstractFeature.initialValue` and `implKind`

### DIFF
--- a/src/dev/flang/air/Clazz.java
+++ b/src/dev/flang/air/Clazz.java
@@ -2249,41 +2249,10 @@ public class Clazz extends ANY implements Comparable<Clazz>
       {
         var ft = f.resultType();
         var t = _outer.actualType(ft, _select);
-
-        if (ft.isThisType())
+        result = actualClazz(t);
+        if (result.feature().isTypeFeature())
           {
-            // find outer clazz corresponding to ft:
-            var res = (f.isField() ? _outer : this).findOuter(ft.featureOfType(), feature());
-            // even if outer changed from ref to value or vice versa, keep it as it was:
-            result = ft.featureOfType().selfType().isRef() ? res.asRef()
-                                                           : res.asValue();
-          }
-        else if (!t.dependsOnGenerics())
-          {
-            result = actualClazz(t);
-            if (t.featureOfType().isTypeFeature() && f.implKind() == Impl.Kind.FieldDef)
-              { /* NYI: actualClazz fails for the result type of i.u.y in this example:
-
-n is
-
-  type.z n.this.type is abstract
-
-  u unit is
-    y := n.this.type
-    q := y.z
-
-i : n is
-  fixed type.z => i
-
-i.u
-
-                 */
-                result = Clazzes.clazz(f.initialValue(), _outer);
-              }
-          }
-        else
-          {
-            result = actualClazz(t);
+            result = actualClazz(result._type.generics().get(0)).typeClazz();
           }
       }
     return result;

--- a/src/dev/flang/ast/AbstractFeature.java
+++ b/src/dev/flang/ast/AbstractFeature.java
@@ -1568,15 +1568,6 @@ public abstract class AbstractFeature extends ANY implements Comparable<Abstract
   // following are used in IR/Clazzes middle end or later only:
   public abstract AbstractFeature choiceTag();
 
-  // following are used in IR/Clazzes middle end or later only:
-  public Impl.Kind implKind() { return Impl.Kind.Routine; /* NYI! */ }      // NYI: remove, used only in Clazz.java for some obscure case
-
-  public Expr initialValue()   // NYI: remove, used only in Clazz.java for some obscure case
-  {
-    throw new Error("AbstractFeature.initialValue");
-  }
-
-
   // following used in MIR or later
   public abstract Expr code();
 
@@ -1699,7 +1690,7 @@ public abstract class AbstractFeature extends ANY implements Comparable<Abstract
       (state().atLeast(State.RESOLVED_TYPES) ? resultType() : "***not yet known***") + " " +
       (inherits().isEmpty() ? "" : ": " + inherits() + " ") +
       ((contract() == Contract.EMPTY_CONTRACT) ? "" : "🤝 ")
-       +  "is " + implKind().toString();
+       +  "is " + kind();
 
   }
 

--- a/src/dev/flang/ast/Feature.java
+++ b/src/dev/flang/ast/Feature.java
@@ -797,22 +797,6 @@ public class Feature extends AbstractFeature implements Stmnt
 
 
   /**
-   * get the initial value of this feature.
-   */
-  public Expr initialValue()
-  {
-    // if (PRECONDITIONS) require
-    //  (switch (implKind()) { case FieldInit, FieldDef, FieldActual, FieldIter -> true; default -> false; });
-
-    return
-      switch (implKind())
-        {
-        case FieldInit, FieldDef, FieldActual, FieldIter -> _impl._initialValue;
-        default -> null;
-        };
-  }
-
-  /**
    * get the code of this feature.
    */
   public Expr code()

--- a/src/dev/flang/ast/Impl.java
+++ b/src/dev/flang/ast/Impl.java
@@ -76,9 +76,14 @@ public class Impl extends ANY
 
 
   /**
-   *
+   * For a field declared using `:=` or a function declared using `=>`, this
+   * gives the value of that field or function.
    */
   Expr _initialValue;
+  public Expr initialValue()
+  {
+    return _initialValue;
+  }
 
 
   AbstractFeature _outerOfInitialValue = null;

--- a/src/dev/flang/fe/SourceModule.java
+++ b/src/dev/flang/fe/SourceModule.java
@@ -581,7 +581,7 @@ public class SourceModule extends Module implements SrcModule, MirModule
         public Feature   action(Feature   f, AbstractFeature outer) { findDeclarations(f, outer); return f; }
       });
 
-    if (inner.initialValue() != null &&
+    if (inner.impl().initialValue() != null &&
         outer.pos()._sourceFile != inner.pos()._sourceFile &&
         (!outer.isUniverse() || !inner.isLegalPartOfUniverse()) &&
         !inner.isIndexVarUpdatedByLoop() /* required for loop in universe, e.g.
@@ -823,8 +823,9 @@ public class SourceModule extends Module implements SrcModule, MirModule
     var existing = df.get(fn);
     if (existing != null)
       {
-        if (f       .implKind() == Impl.Kind.FieldDef &&
-            existing.implKind() == Impl.Kind.FieldDef    )
+        if (existing instanceof Feature ef &&
+            f .implKind() == Impl.Kind.FieldDef &&
+            ef.implKind() == Impl.Kind.FieldDef    )
           {
             var existingFields = FeatureName.getAll(df, fn.baseName(), 0);
             fn = FeatureName.get(fn.baseName(), 0, existingFields.size());


### PR DESCRIPTION
The are no longer needed after the front end, so it is sufficient to have them in `Feature`.

This PR is based on PR#1495 which should be merged first.