### PR TITLE
fe: Do not resolve call if called feature not found, this avoids a NullPointerException to fix #1505

### DIFF
--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -2017,31 +2017,32 @@ public class Call extends AbstractCall
       }
     _resolvedFor = outer;
     loadCalledFeature(res, outer);
-    _generics = FormalGenerics.resolve(res, _generics, outer);
-    _generics = _generics.map(g -> g.resolve(res, _calledFeature.outer()));
 
     if (CHECKS) check
-      (Errors.count() > 0 || _calledFeature != null);
+      (_calledFeature != null);
 
-    ListIterator<Expr> i = _actuals.listIterator();
-    while (i.hasNext())
-      {
-        Expr actl = i.next();
-        if (actl instanceof Actual aa)
-          {
-            actl = aa.expr(this);
-          }
-        if (CHECKS) check
-          (actl != null);
-        i.set(actl);
-      }
-
-    if (_calledFeature == null)
+    if (_calledFeature == Types.f_ERROR)
       {
         _type = Types.t_ERROR;
       }
     else
       {
+        _generics = FormalGenerics.resolve(res, _generics, outer);
+        _generics = _generics.map(g -> g.resolve(res, _calledFeature.outer()));
+
+        ListIterator<Expr> i = _actuals.listIterator();
+        while (i.hasNext())
+          {
+            Expr actl = i.next();
+            if (actl instanceof Actual aa)
+              {
+                actl = aa.expr(this);
+              }
+            if (CHECKS) check
+                          (actl != null);
+            i.set(actl);
+          }
+
         if (needsToInferTypeParametersFromArgs())
           {
             inferGenericsFromArgs(res, outer);

--- a/src/dev/flang/ast/Type.java
+++ b/src/dev/flang/ast/Type.java
@@ -926,7 +926,7 @@ public class Type extends AbstractType
   {
     if (PRECONDITIONS) require
       (outerfeat != null,
-       outerfeat.state().atLeast(Feature.State.RESOLVED_DECLARATIONS),
+       outerfeat != null && outerfeat.state().atLeast(Feature.State.RESOLVED_DECLARATIONS),
        checkedForGeneric);
 
     Type result = this;
@@ -977,7 +977,7 @@ public class Type extends AbstractType
   {
     if (PRECONDITIONS) require
       (outerfeat != null,
-       outerfeat.state().atLeast(Feature.State.RESOLVED_DECLARATIONS),
+       outerfeat != null && outerfeat.state().atLeast(Feature.State.RESOLVED_DECLARATIONS),
        checkedForGeneric);
 
     if (!(outerfeat instanceof Feature of && of.isLastArgType(this)))
@@ -1029,7 +1029,7 @@ public class Type extends AbstractType
   {
     if (PRECONDITIONS) require
       (outerfeat != null,
-       outerfeat.state().atLeast(Feature.State.RESOLVED_DECLARATIONS));
+       outerfeat != null && outerfeat.state().atLeast(Feature.State.RESOLVED_DECLARATIONS));
 
     if (!checkedForGeneric)
       {


### PR DESCRIPTION
Also fix two subsequent errors in the example from #1505
    
First, when inherited features cannot be found, not attempt should be made to call these as parents of the corresponding type features (otherwise we try to create and call call Types.f_ERROR's type feature resulting in all sorts of issues).
    
Second, the type feature should not redefine the 'THIS_TYPE' type parameter if the inherits list is empty due to previous errors, so there is nothing to redefine.

To cleanup the code, extracted code from `AbstractFeature.typeFeature` into new method `typeFeatureInherits`.
