### PR TITLE
fe: Fix IndexOutOfBoundsException in chained boolean, fix #1473

### DIFF
--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -496,7 +496,7 @@ public class Call extends AbstractCall
   private void findChainedBooleans(Resolution res, AbstractFeature thiz)
   {
     var cb = chainedBoolTarget(res, thiz);
-    if (cb != null && _actuals.size() == 1 && cb._actuals.getLast().typeIfKnown() != Types.t_ERROR)
+    if (cb != null && _actuals.size() == 1)
       {
         var b = cb._actuals.getLast();
         if (b.typeIfKnown() != Types.t_ERROR)

--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -496,33 +496,34 @@ public class Call extends AbstractCall
   private void findChainedBooleans(Resolution res, AbstractFeature thiz)
   {
     var cb = chainedBoolTarget(res, thiz);
-    if (cb != null && _actuals.size() == 1)
+    if (cb != null && _actuals.size() == 1 && cb._actuals.getLast().typeIfKnown() != Types.t_ERROR)
       {
-        var bix = cb._actuals.size() - 1; // index of 'b' in first call 'a < b'
-        var b = cb._actuals.get(bix);
-        b = res.resolveType(b, thiz);
-        String tmpName = FuzionConstants.CHAINED_BOOL_TMP_PREFIX + (_chainedBoolTempId_++);
-        var tmp = new Feature(res,
-                              pos(),
-                              Visi.INVISIBLE,
-                              b.type(),
-                              tmpName,
-                              thiz);
-        Expr t1 = new Call(pos(), new Current(pos(), thiz), tmp, -1);
-        Expr t2 = new Call(pos(), new Current(pos(), thiz), tmp, -1);
-        Expr result = new Call(pos(), t2, _name, _actualsNew)
+        var b = cb._actuals.getLast();
+        if (b.typeIfKnown() != Types.t_ERROR)
           {
-            boolean isChainedBoolRHS() { return true; }
-          };
-        Stmnt as = new Assign(res, pos(), tmp, b, thiz);
-        t1 = res.resolveType(t1    , thiz);
-        as = res.resolveType(as    , thiz);
-        result = res.resolveType(result, thiz);
-        cb._actuals.set(cb._actuals.size()-1,
-                        new Block(b.pos(),new List<Stmnt>(as, t1)));
-        _actuals = new List<Expr>(result);
-        _calledFeature = Types.resolved.f_bool_AND;
-        _name = _calledFeature.featureName().baseName();
+            String tmpName = FuzionConstants.CHAINED_BOOL_TMP_PREFIX + (_chainedBoolTempId_++);
+            var tmp = new Feature(res,
+                                  pos(),
+                                  Visi.INVISIBLE,
+                                  b.type(),
+                                  tmpName,
+                                  thiz);
+            Expr t1 = new Call(pos(), new Current(pos(), thiz), tmp, -1);
+            Expr t2 = new Call(pos(), new Current(pos(), thiz), tmp, -1);
+            Expr result = new Call(pos(), t2, _name, _actualsNew)
+              {
+                boolean isChainedBoolRHS() { return true; }
+              };
+            Stmnt as = new Assign(res, pos(), tmp, b, thiz);
+            t1 = res.resolveType(t1    , thiz);
+            as = res.resolveType(as    , thiz);
+            result = res.resolveType(result, thiz);
+            cb._actuals.set(cb._actuals.size()-1,
+                            new Block(b.pos(),new List<Stmnt>(as, t1)));
+            _actuals = new List<Expr>(result);
+            _calledFeature = Types.resolved.f_bool_AND;
+            _name = _calledFeature.featureName().baseName();
+          }
       }
   }
 

--- a/src/dev/flang/ast/Expr.java
+++ b/src/dev/flang/ast/Expr.java
@@ -76,6 +76,10 @@ public abstract class Expr extends ANY implements Stmnt
       {
         return Types.t_ERROR;
       }
+      public String toString()
+      {
+        return Errors.ERROR_STRING;
+      }
     };
 
 


### PR DESCRIPTION
To avoid complete chaos, this batch stops chained boolean conversion when any intermediate value is of error type.

For easier debugging, added `toString` to `Expr.ERROR_VALUE`.