### PR TITLE
fe: Allow redefinition of feature with type parameters, fix #1387

### DIFF
--- a/src/dev/flang/ast/AstErrors.java
+++ b/src/dev/flang/ast/AstErrors.java
@@ -983,12 +983,6 @@ public class AstErrors extends ANY
           solution);
   }
 
-  public static void cannotRedefineGeneric(SourcePosition pos, AbstractFeature f, AbstractFeature existing)
-  {
-    cannotRedefine(pos, f, existing, "Cannot redefine feature with type parameters",
-                   "To solve this, ask the Fuzion team to remove this restriction :-)."); // NYI: inheritance and generics
-  }
-
   public static void cannotRedefineChoice(AbstractFeature f, AbstractFeature existing)
   {
     cannotRedefine(f.pos(), f, existing, "Cannot redefine choice feature",

--- a/src/dev/flang/fe/SourceModule.java
+++ b/src/dev/flang/fe/SourceModule.java
@@ -773,14 +773,6 @@ public class SourceModule extends Module implements SrcModule, MirModule
     else if (existing == f)
       {
       }
-    else if (existing.generics() != FormalGenerics.NONE)
-      {
-        if (!existing.isTypeFeature() && Errors.count() == 0)
-          { // if this occurs for a type feature, this is likely a subsequent
-            // error for a duplicate feature declaration, so we suppress it:
-            AstErrors.cannotRedefineGeneric(f.pos(), outer, existing);
-          }
-      }
     else if (f instanceof Feature ff && (ff._modifiers & Consts.MODIFIER_REDEFINE) == 0 && !existing.isAbstract())
       {
         AstErrors.redefineModifierMissing(f.pos(), outer, existing);

--- a/tests/redef_with_type_parameters/Makefile
+++ b/tests/redef_with_type_parameters/Makefile
@@ -1,0 +1,27 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test Makefile
+#
+#  Author: Fridtjof Siebert (siebert@tokiwa.software)
+#
+# -----------------------------------------------------------------------
+
+override NAME = redef_test
+include ../simple.mk

--- a/tests/redef_with_type_parameters/redef_test.fz
+++ b/tests/redef_with_type_parameters/redef_test.fz
@@ -75,8 +75,8 @@ one error.
 
   /* NYI: redefinition using types that use other type parameters does not work yet:
 
-  # thrid case, redefining feature x.q whose type parameter has a
-  # constraint depending same feature's type parameter.
+  # third case, redefining feature x.q whose type parameter has a
+  # constraint depending on the same feature's type parameter.
   #
   case3 =>
     x is

--- a/tests/redef_with_type_parameters/redef_test.fz
+++ b/tests/redef_with_type_parameters/redef_test.fz
@@ -1,0 +1,113 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test redef_test
+#
+#  Author: Fridtjof Siebert (siebert@tokiwa.software)
+#
+# -----------------------------------------------------------------------
+
+redef_test unit is
+
+  # first case, plainly redefining feature x.q
+  #
+  case1 =>
+    # example from #1387
+    x is
+      q(T type) => say "x: $T"
+
+    y : x is
+      redef q(T type) => say "y: $T"
+
+    x.q i32
+    x.q String
+    y.q f64
+    y.q (option bool)
+
+  case1
+
+  /* NYI: This does not work yet, causes error for type feature of `y`:
+
+/home/fridi/fuzion/fuzion/tests/redef_with_type_parameters/redef_test.fz:47:5: error 1: Wrong number of type parameters
+    y : x is
+----^
+Wrong number of actual type parameters in call:
+Called feature: redef_test.case2.type
+expected 2 generic arguments for 'THIS#TYPE, C'
+found 1: 'redef_test.case2 redef_test.case2.C'.
+
+one error.
+
+  # second case, redefining feature x.q whose type parameter has a
+  # constraint depending on outer feature's type parameter.
+  #
+  case2(C type, v C) =>
+    x is
+      q(U type: Sequence C) => say "x: $U $C"
+
+    y : x is
+      redef q(U type: Sequence C) => say "y: $U $C"
+
+    x.q (array C)
+    x.q (list C)
+    y.q (list C)
+
+  case2 String "str"
+  case2 f32 3.14
+
+  */
+
+  /* NYI: redefinition using types that use other type parameters does not work yet:
+
+  # thrid case, redefining feature x.q whose type parameter has a
+  # constraint depending same feature's type parameter.
+  #
+  case3 =>
+    x is
+      q(T type, U type: option T) => say "x: $T $U"
+
+    y : x is
+      redef q(T type, U type: option T) => say "y: $T $U"
+
+    x.q i32 (option i32)
+    y.q f64 (option f64)
+
+  case3
+
+  */
+
+
+  /* NYI: redefinition using types that use type parameters does not work yet:
+
+  # fourth case, redefining feature x.q whose type parameter is
+  # used in the formal type of a value parameter
+  #
+  case4 =>
+    x is
+      q(T type, v option T) => say "x: $T $v"
+
+    y : x is
+      redef q(T type, v option T) => say "y: $T $v"
+
+    x.q i32 (option 43)
+    y.q f64 (option 3.14)
+
+  case4
+
+  */

--- a/tests/redef_with_type_parameters/redef_test.fz.expected_out
+++ b/tests/redef_with_type_parameters/redef_test.fz.expected_out
@@ -1,0 +1,4 @@
+x: Type of 'i32'
+x: Type of 'String'
+y: Type of 'f64'
+y: Type of 'option bool'


### PR DESCRIPTION
This does allow the execution of the example given in #1387.  The example is added to a new test case.

However, the new test case also add three variants that currently do not work yet.  I will add separate issues for those to get fixed.  The main problem is types used in the signature that depend on type parameters of the redefined feature.