### PR TITLE
fe: Suppress `redefine` missing error for type features

### DIFF
--- a/src/dev/flang/fe/SourceModule.java
+++ b/src/dev/flang/fe/SourceModule.java
@@ -774,8 +774,14 @@ public class SourceModule extends Module implements SrcModule, MirModule
       {
       }
     else if (f instanceof Feature ff && (ff._modifiers & Consts.MODIFIER_REDEFINE) == 0 && !existing.isAbstract())
-      {
-        AstErrors.redefineModifierMissing(f.pos(), outer, existing);
+      { /* previous duplicate feature declaration could result in this error for
+         * type features, so suppress them in this case. See flang.dev's
+         * design/examples/typ_const2.fz as an example.
+         */
+        if (Errors.count() == 0 || !f.isTypeFeature())
+          {
+            AstErrors.redefineModifierMissing(f.pos(), outer, existing);
+          }
       }
     else
       {


### PR DESCRIPTION
A previous duplicate feature declaration could result in this error for type features, so suppress them in this case.  See flang.dev's design/examples/typ_const2.fz as an example.