### PR TITLE
air: Remove redundant `_heirs.add(this)`

### DIFF
--- a/src/dev/flang/air/Clazz.java
+++ b/src/dev/flang/air/Clazz.java
@@ -551,7 +551,6 @@ public class Clazz extends ANY implements Comparable<Clazz>
     if (_heirs == null)
       {
         _heirs = new TreeSet<>();
-        _heirs.add(this);
       }
     return _heirs;
   }

--- a/src/dev/flang/air/Clazz.java
+++ b/src/dev/flang/air/Clazz.java
@@ -544,6 +544,9 @@ public class Clazz extends ANY implements Comparable<Clazz>
    * Set of heirs of this clazz, including this itself.  This is defined for
    * clazzes with isRef() only.
    *
+   * This set is initialially empty, it will be filled by `registerAsHeir()`
+   * which is called for every new Clazz created via Clazzes.create().
+   *
    * @return the heirs including this.
    */
   public Set<Clazz> heirs()


### PR DESCRIPTION
The same is done in `registerAsHeir()` which is called for every clazz anyway.