### PR TITLE
fe: replace `this` and `t` in `this.applyTypePars(t)`, fix #1527

### DIFF
--- a/src/dev/flang/ast/AbstractType.java
+++ b/src/dev/flang/ast/AbstractType.java
@@ -542,7 +542,7 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
 
 
   /**
-   * Replace generic types used in by this type by the actual types given in
+   * Replace generic types used by this type by the actual types given in
    * target.
    *
    * @param target a target type this is used in
@@ -578,7 +578,7 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
 
 
   /**
-   * Replace generic types used in by this type by the actual types given in
+   * Replace generic types used by this type by the actual types given in
    * target.
    *
    * Internal version of applyTypePars(target) that does not perform caching.

--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -1337,9 +1337,9 @@ public class Call extends AbstractCall
         tc._calledFeature.resultType().featureOfType().typeFeature(res).selfType()
       : targetTypeOrConstraint(res);
 
-    t = resolveSelect(t, tt);
-    t = tt.applyTypePars(t);
-    t = t.resolve(res, tt.featureOfType());
+    t = resolveSelect(t, tt)
+      .applyTypePars(tt)
+      .resolve(res, tt.featureOfType());
     t = adjustThisTypeForTarget(t);
     t = resolveForCalledFeature(res, t, tt);
     _type = Types.intern(t);
@@ -1842,7 +1842,7 @@ public class Call extends AbstractCall
                 var pt = p.typeIfKnown();
                 if (pt != null)
                   {
-                    var apt = actualType.applyTypePars(pt);
+                    var apt = pt.applyTypePars(actualType);
                     inferGeneric(res, outer, formalType, apt, pos, conflict, foundAt);
                   }
               }


### PR DESCRIPTION
With this change, `AbstractTypes.applyPars(AbstractType)` and `AbstractTypes.applyPars(AbstractFeature, List<AbstractType>)` both modify the type given as `this`.