### PR TITLE
lib, substring: implement substring via `type.from_bytes`

### DIFF
--- a/lib/String.fz
+++ b/lib/String.fz
@@ -366,22 +366,9 @@ String ref : equatable, has_hash, has_total_order is
   substring(from, to i32) String
     pre
       debug: 0 ≤ from ≤ to ≤ String.this.byte_length
+    # NYI check if from/to are valid start/end bytes?
   is
-    # NYI: #776: put this code from substring0 here, to avoid an unnecessary feature
-    # ref : string
-    #   redef utf8 Sequence u8 is
-    #     string.this.utf8.slice from to
-    Substring0 from to
-
-
-  # create substring of the string consisting of bytes from (inclusive) .. to (exclusive).
-  #
-  private Substring0(from, to i32) ref : String
-    pre
-      debug: 0 ≤ from ≤ to ≤ String.this.byte_length
-  is
-    redef utf8 Sequence u8 is
-      String.this.utf8.slice from to
+    String.type.from_bytes (String.this.utf8.slice from to)
 
 
   # create substring of this string consisting of bytes from (inclusive) .. byte_length (exclusive).


### PR DESCRIPTION
issue 776 is still valid though...