### PR TITLE
fe: propagate `unit` expected type for code in constructors, fix #1066

### DIFF
--- a/src/dev/flang/ast/Feature.java
+++ b/src/dev/flang/ast/Feature.java
@@ -1661,6 +1661,11 @@ public class Feature extends AbstractFeature implements Stmnt
             public void  action(If       i, AbstractFeature outer) { i.propagateExpectedType(res, outer); }
           });
 
+        if (isConstructor())
+          {
+            _impl._code = _impl._code.propagateExpectedType(res, this, Types.resolved.t_unit);
+          }
+
         _state = State.TYPES_INFERENCED;
         res.scheduleForBoxing(this);
       }

--- a/src/dev/flang/ast/Loop.java
+++ b/src/dev/flang/ast/Loop.java
@@ -398,7 +398,7 @@ public class Loop extends ANY
    * (until condition holds) or failed (while condition is false or iteration
    * ended) execution.
    *
-   * This is the case loops that have an until condition and that are iterating
+   * This is the case for loops that have an until condition and that are iterating
    * or have a while condition and that have neither a else nor a success block.
    */
   private boolean booleanAsImplicitResult(Expr whileCond, Expr untilCond)

--- a/tests/outerNormalization/outerNormalization.fz
+++ b/tests/outerNormalization/outerNormalization.fz
@@ -148,7 +148,6 @@ outerNormalization is
     for i in 0.. do
       say $i
     until i > 3
-    unit # NYI #1066: This has to be added since the loop result is bool. A loop should not force the bool result upon us if we do not need it.
 
   testInterval
 


### PR DESCRIPTION
This avoids errors for loops that may produce a boolean result if these loops are used as the last statement in a constructor.  The infrastructure to suppress the result in case `unit` is expeced was already in place, what was missing was providing this information during type inference on the expected result type of the code of a constructor.