### PR TITLE
tests/iftest_negative: Fixed to work with unit type propagation for constructor

### DIFF
--- a/tests/if_negative/iftest_negative.fz
+++ b/tests/if_negative/iftest_negative.fz
@@ -62,8 +62,16 @@ iftest_negative is
       "Hello"
 
   # NYI improve error message
-  constructor (b bool) is
+  function1 (b bool) String is
     if b // 6. should flag an error: Incompatible types in branches of if statement
+      "Hello"
+
+  function2 (b bool) unit is
+    if b // ok, we ignore a result in an `if` if assigned to `unit`
+      "Hello"
+
+  constructor (b bool) is
+    if b // ok, we ignore a result in an `if` if assigned to `unit`
       "Hello"
 
   exit exit_code.get


### PR DESCRIPTION
This fixes a test that brakes after the fix for #1066 and addes two new sub-tests.