### PR TITLE
tests/reg_issue293: Remove no longer needed declaration of abstract feature

### DIFF
--- a/tests/reg_issue293_confusion_of_type_and_value_params/issue293.fz
+++ b/tests/reg_issue293_confusion_of_type_and_value_params/issue293.fz
@@ -53,9 +53,6 @@ issue293 is
   # a reducing function takes a previous result and a value and returns a new result
   reducing_fn(TACC, T type) ref : Function TACC TACC T is
 
-    # NYI redef call abstract is currently necessary because of bug in c backend
-    call(res TACC, val T) TACC is abstract
-
   # TACC result     type
   # B    input      type
   # C    transduced type


### PR DESCRIPTION
A NYI states this was a bug in the C backend. This bug is apparently gone.