### PR TITLE
lib, tests: Removed and updated NYI-comments from tests/visibility

### DIFF
--- a/lib/float.fz
+++ b/lib/float.fz
@@ -48,7 +48,14 @@ float(F type : float F) : numeric F is
 
   # convert a float value to i64 dropping any fraction.
   # the value must be in the range of i64
+  #
   as_i64 i64 is abstract
+
+
+  # convert a float value to i32 dropping any fraction.
+  # the value must be in the range of i32
+  #
+  as_i32 => as_i64.as_i32
 
 
   fract F is abstract

--- a/tests/visibility/visibility.fz
+++ b/tests/visibility/visibility.fz
@@ -259,10 +259,10 @@ visibility is
 // NYI:   visi5
 
   visi6 is
-    x := 2;                             say "x is $x"
-    // NYI:    x := x as f64;           say "x is $x"
-    x := x * 3 / 100 /* NYI: 3.14   */; say "x is $x"
-    x := x.as_string  /* NYI: as i32 */; say "x is $x"
+    x := 2;        chck $x="2"                                    "x := 2"
+    x := x.as_f64; chck ($x="2.0" || $x="2")                      "x := x.as_f64"
+    x := x * 3.14; chck ($x="6.28"|| $x="6.28000000000000024869") "x := x * 3.14"
+    x := x.as_i32; chck $x="6"                                    "x := x.as_i32"
   visi6
 
   visi7 is
@@ -313,7 +313,7 @@ visibility is
     until a * (ix1 + ix2 + it1 + it2 + ix3 + b) > 1000000
       r := a + ix1 + ix2 + it1 + it2 + ix3 + b
     else
-      // s := a + ix1 + ix2   // NYI: field declaration in else clause does not work yet
+      // s := a + ix1 + ix2   // NYI: #1550: field declaration in else clause does not work yet
     t := a
   visi9
 


### PR DESCRIPTION
Added `float.as_i32` which was used in one commented-out line of the visibility test.

Uncommented and removed NYI-comment from visibility tests using floats.  Added cases to cover the different string conversion results in interpreter and C backends.

Added reference to #1550 to one NYI-comment.