### PR TITLE
util/fe/tests: Fix check if two positions refer to same source file fix #1550

### DIFF
--- a/src/dev/flang/fe/SourceModule.java
+++ b/src/dev/flang/fe/SourceModule.java
@@ -582,7 +582,7 @@ public class SourceModule extends Module implements SrcModule, MirModule
       });
 
     if (inner.impl().initialValue() != null &&
-        outer.pos()._sourceFile != inner.pos()._sourceFile &&
+        !outer.pos()._sourceFile.sameAs(inner.pos()._sourceFile) &&
         (!outer.isUniverse() || !inner.isLegalPartOfUniverse()) &&
         !inner.isIndexVarUpdatedByLoop() /* required for loop in universe, e.g.
                                           *

--- a/src/dev/flang/util/SourceFile.java
+++ b/src/dev/flang/util/SourceFile.java
@@ -938,6 +938,18 @@ public class SourceFile extends ANY
     return result;
   }
 
+
+  /**
+   * Check if this SourceFile operates on the same byte array as other.
+   *
+   * This ensures that any clones created via `new SourceFile(origin)` will be
+   * considered to be the same.
+   */
+  public boolean sameAs(SourceFile other)
+  {
+    return _bytes == other._bytes;
+  }
+
 }
 
 /* end of file */

--- a/tests/visibility/visibility.fz
+++ b/tests/visibility/visibility.fz
@@ -313,7 +313,7 @@ visibility is
     until a * (ix1 + ix2 + it1 + it2 + ix3 + b) > 1000000
       r := a + ix1 + ix2 + it1 + it2 + ix3 + b
     else
-      // s := a + ix1 + ix2   // NYI: field declaration in else clause does not work yet
+      s := a + ix1 + ix2
     t := a
   visi9
 


### PR DESCRIPTION
Since the lexer and parser inherit from SourceFile we end up with many instances refering to the same file.  This breaks the equality test using `==` and `!=`. This patch introduces a new feature `SourceFile.sameAs` that handles clones as equal.

The enable uncommenting a line of code in tests/visibility that did not compile before.