### PR TITLE
tools: Add -XjavaProf=file.txt and -XjavaProf=file.svg to create flame graph

### DIFF
--- a/src/dev/flang/tools/Tool.java
+++ b/src/dev/flang/tools/Tool.java
@@ -64,7 +64,7 @@ public abstract class Tool extends ANY
   /*----------------------------  constants  ----------------------------*/
 
 
-  private static final String XTRA_OPTIONS = "[-X|--Xhelp] [-XjavaProf] " +
+  private static final String XTRA_OPTIONS = "[-X|--Xhelp] [-XjavaProf] [-XjavaProf=<graph.svg>] " +
     "[" + Errors.MAX_ERROR_MESSAGES_OPTION   + "=<n>] " +
     "[" + Errors.MAX_WARNING_MESSAGES_OPTION + "=<n>] ";
 
@@ -258,6 +258,10 @@ public abstract class Tool extends ANY
     else if (a.equals("-XjavaProf"))
       {
         Profiler.start();
+      }
+    else if (a.startsWith("-XjavaProf="))
+      {
+        Profiler.start(a.substring(a.indexOf("=")+1));
       }
     else if (a.startsWith(Errors.MAX_ERROR_MESSAGES_OPTION) && a.startsWith(Errors.MAX_ERROR_MESSAGES_OPTION + "="))
       {


### PR DESCRIPTION
A text file uses the flame graph input format. To create an .svg file, the `flamegraph.pl` script must be in the current $PATH, it is used to create a flame graph from the profileing data.