### PR TITLE
C backend: Unit type fields do not need to be included into structs.

### DIFF
--- a/src/dev/flang/be/c/CTypes.java
+++ b/src/dev/flang/be/c/CTypes.java
@@ -91,10 +91,7 @@ public class CTypes extends ANY
    */
   String clazzField(int cf)
   {
-    var rc = _fuir.clazzResultClazz(cf);
-    return (_fuir.clazzIsVoidType(rc)
-            ? "struct { }"
-            : clazz(rc)) + (_fuir.clazzFieldIsAdrOfValue(cf) ? "*" : "");
+    return clazz(_fuir.clazzResultClazz(cf)) + (_fuir.clazzFieldIsAdrOfValue(cf) ? "*" : "");
   }
 
 
@@ -308,7 +305,12 @@ public class CTypes extends ANY
             for (int i = 0; i < _fuir.clazzNumFields(cl); i++)
               {
                 var f = _fuir.clazzField(cl, i);
-                els.add(CStmnt.decl(clazzField(f), _names.fieldName(f)));
+                var t = _fuir.clazzResultClazz(f);
+                if (!_fuir.clazzIsUnitType(t) &&
+                    !_fuir.clazzIsVoidType(t))
+                  {
+                    els.add(CStmnt.decl(clazzField(f), _names.fieldName(f)));
+                  }
               }
           }
         l.add(CStmnt.struct(_names.struct(cl), els));


### PR DESCRIPTION
This avoids unused entries in declared structs, e.g., for `panic`, we used to define
```
  // for fuzion.std.panic#1
  struct fzT_fuzion__std__1panic
  {
    fzT__RString* fzF_0_msg;
    struct { } fzF_1_result;
    fzT_fuzion__std* fzF_2__U40__1074231254;
  };
```
which is now
```
  // for fuzion.std.panic#1
  struct fzT_fuzion__std__1panic
  {
    fzT__RString* fzF_0_msg;
  };
```