### PR TITLE
lib: remove `Sequences`

### DIFF
--- a/lib/Sequence.fz
+++ b/lib/Sequence.fz
@@ -460,21 +460,3 @@ Sequence(T type) ref is
     #
     e Sequence T is
       (Sequence T).type.empty
-
-
-# Sequences -- unit type defining features related to Sequence but not requiring
-# an instance
-#
-Sequences is
-
-
-  # determine the index of element x within Sequence l.  0 if x is at the head
-  # of the list, 1 if it comes directly after head, etc. nil if x is not
-  # in the list.
-  #
-  index_in(A type : equatable, l Sequence A, x A) => (container.searchable_sequence A l).index_of x
-
-
-  # get the index of x within this Sequence or nil if it does not exist
-  #
-  find(A type : equatable, l Sequence A, x Sequence A) => (container.searchable_sequence A l).find x


### PR DESCRIPTION
The benefit of theses short hands is not great so my suggestion is to remove them for now.