### PR TITLE
fuir: do not assign outer and arg fields twice

### DIFF
--- a/src/dev/flang/fuir/analysis/AbstractInterpreter.java
+++ b/src/dev/flang/fuir/analysis/AbstractInterpreter.java
@@ -463,10 +463,6 @@ public class AbstractInterpreter<VALUE, RESULT> extends ANY
   Pair<VALUE,RESULT> processContract(int cl, FUIR.ContractKind ck)
   {
     var l = new List<RESULT>();
-    if (ck == FUIR.ContractKind.Pre)
-      {
-        assignOuterAndArgFields(l, cl);
-      }
     for (var ci = 0;
          _fuir.clazzContract(cl, ck, ci) != -1;
          ci++)


### PR DESCRIPTION
this was the case for precondition where `assignOuterAndArgFields` is called in `process` and `processContract`