### PR TITLE
fe: in fixed features, allow covariant redefinition in type pars, fix #1556

### DIFF
--- a/src/dev/flang/air/Clazz.java
+++ b/src/dev/flang/air/Clazz.java
@@ -730,7 +730,7 @@ public class Clazz extends ANY implements Comparable<Clazz>
           {
             o = replaceThisTypeForTypeFeature(o);
           }
-        t = Types.intern(new Type(t, g, o));
+        t = Types.intern(new Type(t, g, o, true));
       }
     return t;
   }

--- a/src/dev/flang/ast/AbstractFeature.java
+++ b/src/dev/flang/ast/AbstractFeature.java
@@ -550,7 +550,7 @@ public abstract class AbstractFeature extends ANY implements Comparable<Abstract
    * is created is fixed.  In this case. the type is exactly selfType(), and not
    * a placeholder for any possible child's type.
    */
-  AbstractType thisType(boolean innerFixed)
+  public AbstractType thisType(boolean innerFixed)
   {
     AbstractType result = innerFixed ? _thisTypeFixed : _thisType;
 

--- a/src/dev/flang/ast/Type.java
+++ b/src/dev/flang/ast/Type.java
@@ -230,15 +230,43 @@ public class Type extends AbstractType
    */
   public Type(AbstractType t, List<AbstractType> g, AbstractType o)
   {
+    this(t, g, o, false);
+
+    if (PRECONDITIONS) require
+      ( (t.generics() instanceof FormalGenerics.AsActuals   ) || t.generics().size() == g.size(),
+       !(t.generics() instanceof FormalGenerics.AsActuals aa) || aa.sizeMatches(g),
+        t == Types.t_ERROR || (t.outer() == null) == (o == null));
+
+    checkedForGeneric = t.checkedForGeneric();
+  }
+
+
+  /**
+   * Constructor to create a type from an existing type after formal generics
+   * have been replaced in the generics arguments and in the outer type.
+   *
+   * @param t the original type
+   *
+   * @param g the actual generic arguments that replace t.generics
+   *
+   * @param o the actual outer type, or null, that replaces t.outer
+   *
+   * @param fixOuterThisType NYI: CLEANUP: #737, see below, unclear why this is needed.
+   */
+  public Type(AbstractType t, List<AbstractType> g, AbstractType o, boolean fixOuterThisType)
+  {
     this(t.pos2BeRemoved(),
          t.name(),
          g,
          o,
          t instanceof Type tt ? tt.feature   : t.featureOfType(),
+
+         // NYI: CLEANUP: This seems unnecessarily complex:
          t instanceof Type tt ? tt._refOrVal : (t.isRef() == t.featureOfType().isThisRef() ? RefOrVal.LikeUnderlyingFeature :
                                                 t.isRef() ? RefOrVal.Boxed
                                                 : RefOrVal.Value),
-         true);
+
+         fixOuterThisType);
 
     if (PRECONDITIONS) require
       ( (t.generics() instanceof FormalGenerics.AsActuals   ) || t.generics().size() == g.size(),

--- a/src/dev/flang/fe/SourceModule.java
+++ b/src/dev/flang/fe/SourceModule.java
@@ -1146,13 +1146,31 @@ public class SourceModule extends Module implements SrcModule, MirModule
        (to.featureOfType() == original    .outer()             ) &&
        (tr.featureOfType() == redefinition.outer()             )   ) ||
 
-      /* to is original.this.type  and
-       * redefinition is fixed and tr is redefinition.selfType.
+      /* to depends on original.this.type, redefinition is fixed and tr is
+       * equals the actual type of to as seen by redefinition.outer.
+       *
+       * Ex.
+       *
+       *   p is
+       *     maybe option p.this.type
+       *     is abstract
+       *
+       *   h : p is
+       *     fixed redef maybe option h
+       *     is
+       *       if random.next_bool then
+       *         nil
+       *       else
+       *         h
+       *
+       * here, the result type of inherited `p.maybe` is `option p.this.type`,
+       * which gets turned into `option h.this.type` when inherited. However,
+       * since `h.maybe` is fixed, we can use the actual type in the outer
+       * feature `h`, i.e., `option h`, which is equal to the result type of the
+       * redefinition `h.maybe`.
        */
-      ((to.isThisType()                                        ) &&
-       ((redefinition.modifiers() & Consts.MODIFIER_FIXED) != 0) &&
-       (to.featureOfType() == original    .outer()             ) &&
-       (tr.featureOfType() == redefinition.outer()             )   ) ||
+      (((redefinition.modifiers() & Consts.MODIFIER_FIXED) != 0         ) &&
+       redefinition.outer().thisType(true).actualType(to).compareTo(tr) == 0    ) ||
 
       /* original and redefinition are inner features of type features, to is
        * THIS_TYPE and tr is the underlying non-type features selfType.


### PR DESCRIPTION
A fixed feature `h.f` that redefines `p.f` that uses type`p.this.type` in its signature already was allowed to use `h` instead.  This patch relaxes this condition and permits types depending on `p.this.type` in their type parameters to use `h` instead.

This patch removes the special handling from issue #737 in the case of `new Type(t, g, o)` being called from `AbstractType.applyToGenericsAndOuter()`, but I could not fully remove this in all cases, there remain constructors in `Type` with a boolean `fixOuterThisType` that should be checked and removed later.