### PR TITLE
lib/marray: add a type feature `new` to create a `marray` without elements

### DIFF
--- a/lib/marray.fz
+++ b/lib/marray.fz
@@ -165,6 +165,12 @@ is
     marray T length data unit
 
 
+  # initialize an empty mutable array of type T
+  #
+  type.new marray T is
+    marray T 0 (fuzion.sys.internal_array_init T 0) unit
+
+
 
 # marray -- initialize one-dimensional mutable array
 #

--- a/lib/stream.fz
+++ b/lib/stream.fz
@@ -72,7 +72,7 @@ stream(redef T type) ref : Sequence T is
   #
   redef take (n i32) =>
     for
-      a := marray T 0 (fuzion.sys.internal_array_init T 0) unit, a.add x
+      a := (marray T).type.new, a.add x
       i in (1..n)
     while has_next
       x := next
@@ -161,7 +161,7 @@ stream(redef T type) ref : Sequence T is
   #
   redef as_array array T is
     for
-      a := marray T 0 (fuzion.sys.internal_array_init T 0) unit, a.add x
+      a := (marray T).type.new, a.add x
     while has_next
       x := next
     else


### PR DESCRIPTION
This avoids other library code having to call Fuzion internals, which we want to avoid.