### PR TITLE
air: Fix NullPointer in Clazz.typeClazz in case of previous errors, fix #1626

### DIFF
--- a/src/dev/flang/air/Clazz.java
+++ b/src/dev/flang/air/Clazz.java
@@ -2179,7 +2179,8 @@ public class Clazz extends ANY implements Comparable<Clazz>
   {
     if (_typeClazz == null)
       {
-        _typeClazz = feature().isUniverse() ? this
+        _typeClazz = _type.containsError()  ? Clazzes.error.get() :
+                     feature().isUniverse() ? this
                                             : Clazzes.create(_type.typeType(),
                                                              _outer.typeClazz());
       }


### PR DESCRIPTION
Do not try to create a type clazz from an error clazz, just return Clazzes.error.get() instead.