### PR TITLE
fe: to get actual type pars of type type, use this_type.actualType fix #1624

### DIFF
--- a/src/dev/flang/ast/AbstractType.java
+++ b/src/dev/flang/ast/AbstractType.java
@@ -749,7 +749,7 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
     if (!this_type.isGenericArgument() && !this_type.featureOfType().isUniverse())
       {
         t = t.actualTypeType(this_type.outer());
-        t = t.applyTypePars(this_type.featureOfType(), this_type.generics());
+        t = this_type.actualType(t);
       }
     return t;
   }


### PR DESCRIPTION
The original code used `applyTypePars`, which only replaces type parameters declared for one given feature, the new code uses `actualType`, which handles al type parameters, including those declared in outer classes, and also replces `this.type` by the actual type.