### PR TITLE
util/air: Improve FeatureAndActuals.toString

### DIFF
--- a/src/dev/flang/air/FeatureAndActuals.java
+++ b/src/dev/flang/air/FeatureAndActuals.java
@@ -198,7 +198,7 @@ public class FeatureAndActuals extends ANY implements Comparable<FeatureAndActua
     return
       (_preconditionClazz ? "pre " : "") +
       _f.qualifiedName() +
-      (_tp != null ? (_tp.size() == 0 ? "" : " " + _tp)
+      (_tp != null ? _tp.toString(t -> " " + t.asStringWrapped())
                    : (_max ? " MAX" : " MIN"));
   }
 

--- a/src/dev/flang/util/List.java
+++ b/src/dev/flang/util/List.java
@@ -453,6 +453,25 @@ public class List<T>
     return g;
   }
 
+
+  /**
+   * Create a String by applying f to all elements and concatenating the result
+   * in order.
+   *
+   * @param f function that maps an element to a string
+   *
+   * @return "" + f.apply(get(0)) +  f.apply(get(1)) + ... + f.apply(get(size()-1))
+   */
+  public String toString(Function<T,String> f)
+  {
+    var result = new StringBuilder();
+    for (var e : this)
+      {
+        result.append(f.apply(e));
+      }
+    return result.toString();
+  }
+
 }
 
 /* end of file */


### PR DESCRIPTION
The output looked a bit confusing during debugging, now uses space separated parameters that are wrapped in parentheses if needed (used to be comma separation and not wrapped).