### PR TITLE
fe: cleanup: In AbstractType.actualTypeType swap `this` and the argument

### DIFF
--- a/src/dev/flang/ast/AbstractType.java
+++ b/src/dev/flang/ast/AbstractType.java
@@ -717,7 +717,7 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
           {
             var this_type = g2.get(0);
             g2 = g2.map(x -> x == this_type ? x   // leave first type parameter unchanged
-                                            : x.actualTypeType(this_type));
+                                            : this_type.actualTypeType(x));
           }
 
         if (g2 != result.generics() ||
@@ -738,18 +738,18 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
   /**
    * Helper for applyTypePars_ to determine the actual type of a type feature's
    * type. This needs special handling since the type feature has one additional
-   * first type parameter --the underlying type: this_type--, and all other type
-   * parameters need converted to the actual type relative to that.
+   * first type parameter --the underlying type: this--, and all other type
+   * parameters need to be converted to the actual type relative to that.
    *
-   * @param this_type the first type parameter that contains the actual type.
+   * @param t type parameter of a type feature (but not the first, this_type).
    */
-  private AbstractType actualTypeType(AbstractType this_type)
+  private AbstractType actualTypeType(AbstractType t)
   {
-    var t = replace_this_type_by_actual_outer(this_type);
-    if (!this_type.isGenericArgument() && !this_type.featureOfType().isUniverse())
+    t = t.replace_this_type_by_actual_outer(this);
+    if (!isGenericArgument() && !featureOfType().isUniverse())
       {
-        t = t.actualTypeType(this_type.outer());
-        t = this_type.actualType(t);
+        t = outer().actualTypeType(t);
+        t = actualType(t);
       }
     return t;
   }


### PR DESCRIPTION
This change make this method consistent with `AbstractType.actualType`.