### PR TITLE
lib: separate IEEE-like and mathematical floating point comparision

### DIFF
--- a/lib/f32.fz
+++ b/lib/f32.fz
@@ -44,22 +44,8 @@ f32(val f32) : float is
 
   # comparision
   #
-  # These infixes compare floating point numbers according to the IEEE
-  # standards. They shadow the infixes provided globally by type.equality
-  # so that someone who expects floating point comparision operators to
-  # behave according to IEEE standards will not be surprised.
-  #
-  # If comparision based on a proper equivalence relation or partial order
-  # is desired, this can still be achieved by using the implementations of
-  # type.equality and type.lteq. These additionally define NaN = NaN and
-  # NaN <= x for all x in f32, respectively.
-  #
-  infix = (other f32) bool is intrinsic
-  infix != (other f32) bool is !(infix = other)
-  infix <= (other f32) bool is intrinsic
-  infix >= (other f32) bool is other <= val
-  infix > (other f32) bool is !(infix <= other)
-  infix < (other f32) bool is !(other <= val)
+  fixed infix = (other f32) bool is intrinsic
+  fixed infix <= (other f32) bool is intrinsic
 
 
   # conversion
@@ -165,18 +151,6 @@ f32(val f32) : float is
   # identity element for 'infix *'
   #
   fixed type.one  f32 is 1
-
-
-  # equality
-  #
-  fixed type.equality(a, b f32) bool is
-    a.infix = b || (is_NaN a && is_NaN b)
-
-
-  # total order
-  #
-  fixed type.lteq(a, b f32) bool is
-    a.infix <= b || is_NaN a
 
 
   fixed type.bytes => 4

--- a/lib/f32.fz
+++ b/lib/f32.fz
@@ -42,6 +42,26 @@ f32(val f32) : float is
   fixed infix ** (other f32) f32 is intrinsic
 
 
+  # comparision
+  #
+  # These infixes compare floating point numbers according to the IEEE
+  # standards. They shadow the infixes provided globally by type.equality
+  # so that someone who expects floating point comparision operators to
+  # behave according to IEEE standards will not be surprised.
+  #
+  # If comparision based on a proper equivalence relation or partial order
+  # is desired, this can still be achieved by using the implementations of
+  # type.equality and type.lteq. These additionally define NaN = NaN and
+  # NaN <= x for all x in f32, respectively.
+  #
+  infix = (other f32) bool is intrinsic
+  infix != (other f32) bool is !(infix = other)
+  infix <= (other f32) bool is intrinsic
+  infix >= (other f32) bool is other <= val
+  infix > (other f32) bool is !(infix <= other)
+  infix < (other f32) bool is !(other <= val)
+
+
   # conversion
   redef as_i64 => as_f64.as_i64
 
@@ -149,12 +169,14 @@ f32(val f32) : float is
 
   # equality
   #
-  fixed type.equality(a, b f32) bool is intrinsic
+  fixed type.equality(a, b f32) bool is
+    a.infix = b || (is_NaN a && is_NaN b)
 
 
   # total order
   #
-  fixed type.lteq(a, b f32) bool is intrinsic
+  fixed type.lteq(a, b f32) bool is
+    a.infix <= b || is_NaN a
 
 
   fixed type.bytes => 4

--- a/lib/f32.fz
+++ b/lib/f32.fz
@@ -46,6 +46,9 @@ f32(val f32) : float is
   #
   fixed infix = (other f32) bool is intrinsic
   fixed infix <= (other f32) bool is intrinsic
+  fixed infix >= (other f32) bool is intrinsic
+  fixed infix < (other f32) bool is intrinsic
+  fixed infix > (other f32) bool is intrinsic
 
 
   # conversion

--- a/lib/f64.fz
+++ b/lib/f64.fz
@@ -44,6 +44,26 @@ f64(val f64) : float is
   fixed infix ** (other f64) f64 is intrinsic
 
 
+  # comparision
+  #
+  # These infixes compare floating point numbers according to the IEEE
+  # standards. They shadow the infixes provided globally by type.equality
+  # so that someone who expects floating point comparision operators to
+  # behave according to IEEE standards will not be surprised.
+  #
+  # If comparision based on a proper equivalence relation or partial order
+  # is desired, this can still be achieved by using the implementations of
+  # type.equality and type.lteq. These additionally define NaN = NaN and
+  # NaN <= x for all x in f64, respectively.
+  #
+  infix = (other f64) bool is intrinsic
+  infix != (other f64) bool is !(infix = other)
+  infix <= (other f64) bool is intrinsic
+  infix >= (other f64) bool is other <= thiz
+  infix > (other f64) bool is !(infix <= other)
+  infix < (other f64) bool is !(other <= thiz)
+
+
   # conversion
 
   # NaN is converted to 0
@@ -162,12 +182,14 @@ f64(val f64) : float is
 
   # equality
   #
-  fixed type.equality(a, b f64) bool is intrinsic
+  fixed type.equality(a, b f64) bool is
+    a.infix = b || (is_NaN a && is_NaN b)
 
 
   # total order
   #
-  fixed type.lteq(a, b f64) bool is intrinsic
+  fixed type.lteq(a, b f64) bool is
+    a.infix <= b || is_NaN a
 
 
   fixed type.bytes => 8

--- a/lib/f64.fz
+++ b/lib/f64.fz
@@ -48,6 +48,9 @@ f64(val f64) : float is
   #
   fixed infix = (other f64) bool is intrinsic
   fixed infix <= (other f64) bool is intrinsic
+  fixed infix >= (other f64) bool is intrinsic
+  fixed infix < (other f64) bool is intrinsic
+  fixed infix > (other f64) bool is intrinsic
 
 
   # conversion

--- a/lib/f64.fz
+++ b/lib/f64.fz
@@ -46,22 +46,8 @@ f64(val f64) : float is
 
   # comparision
   #
-  # These infixes compare floating point numbers according to the IEEE
-  # standards. They shadow the infixes provided globally by type.equality
-  # so that someone who expects floating point comparision operators to
-  # behave according to IEEE standards will not be surprised.
-  #
-  # If comparision based on a proper equivalence relation or partial order
-  # is desired, this can still be achieved by using the implementations of
-  # type.equality and type.lteq. These additionally define NaN = NaN and
-  # NaN <= x for all x in f64, respectively.
-  #
-  infix = (other f64) bool is intrinsic
-  infix != (other f64) bool is !(infix = other)
-  infix <= (other f64) bool is intrinsic
-  infix >= (other f64) bool is other <= thiz
-  infix > (other f64) bool is !(infix <= other)
-  infix < (other f64) bool is !(other <= thiz)
+  fixed infix = (other f64) bool is intrinsic
+  fixed infix <= (other f64) bool is intrinsic
 
 
   # conversion
@@ -178,18 +164,6 @@ f64(val f64) : float is
   # identity element for 'infix *'
   #
   fixed type.one  f64 is 1
-
-
-  # equality
-  #
-  fixed type.equality(a, b f64) bool is
-    a.infix = b || (is_NaN a && is_NaN b)
-
-
-  # total order
-  #
-  fixed type.lteq(a, b f64) bool is
-    a.infix <= b || is_NaN a
 
 
   fixed type.bytes => 8

--- a/lib/float.fz
+++ b/lib/float.fz
@@ -55,6 +55,21 @@ float : numeric is
   redef infix ** (other float.this.type) float.this.type is abstract
 
 
+  # comparision
+  #
+  # This provides comparision operators using IEEE semantics.
+  #
+  # type.equality and type.lteq should be used for equivalence relations
+  # and total ordering in the mathematical sense.
+  #
+  infix = (other float.this.type) bool is abstract
+  infix != (other float.this.type) bool is !(infix = other)
+  infix <= (other float.this.type) bool is abstract
+  infix >= (other float.this.type) bool is other <= float.this
+  infix > (other float.this.type) bool is !(infix <= other)
+  infix < (other float.this.type) bool is !(other <= float.this)
+
+
   # convert a float value to i64 dropping any fraction.
   # the value must be in the range of i64
   #
@@ -239,3 +254,23 @@ float : numeric is
   type.atanh(val float.this.type) float.this.type is
     # 1/2*ln((1+x)/(1-x))
     log ((one + val)/(one - val)) / two
+
+
+  # equality
+  #
+  # This provides an equivalence relation in the mathematical
+  # sense and therefore breaks the IEEE semantics. infix = should
+  # be used for IEEE semantics.
+  #
+  type.equality(a, b float.this.type) bool is
+    a.infix = b || (is_NaN a && is_NaN b)
+
+
+  # total order
+  #
+  # This provides a total order in the mathematical sense and
+  # therefore breaks the IEEE semantics. infix <= should be
+  # used for IEEE semantics.
+  #
+  type.lteq(a, b float.this.type) bool is
+    a.infix <= b || is_NaN a

--- a/lib/float.fz
+++ b/lib/float.fz
@@ -65,9 +65,9 @@ float : numeric is
   infix = (other float.this.type) bool is abstract
   infix != (other float.this.type) bool is !(infix = other)
   infix <= (other float.this.type) bool is abstract
-  infix >= (other float.this.type) bool is other <= float.this
-  infix > (other float.this.type) bool is !(infix <= other)
-  infix < (other float.this.type) bool is !(other <= float.this)
+  infix >= (other float.this.type) bool is abstract
+  infix > (other float.this.type) bool is abstract
+  infix < (other float.this.type) bool is abstract
 
 
   # convert a float value to i64 dropping any fraction.

--- a/lib/float.fz
+++ b/lib/float.fz
@@ -262,6 +262,9 @@ float : numeric is
   # sense and therefore breaks the IEEE semantics. infix = should
   # be used for IEEE semantics.
   #
+  # The equivalence relation is provided by the usual comparision
+  # of floating-point numbers, with the definition of NaN = NaN.
+  #
   type.equality(a, b float.this.type) bool is
     a.infix = b || (is_NaN a && is_NaN b)
 
@@ -271,6 +274,10 @@ float : numeric is
   # This provides a total order in the mathematical sense and
   # therefore breaks the IEEE semantics. infix <= should be
   # used for IEEE semantics.
+  #
+  # The total order is provided by the usual comparision of
+  # floating-point numbers, with the definition that NaN <= x,
+  # for any x (including x = NaN).
   #
   type.lteq(a, b float.this.type) bool is
     a.infix <= b || is_NaN a

--- a/src/dev/flang/be/c/Intrinsics.java
+++ b/src/dev/flang/be/c/Intrinsics.java
@@ -670,10 +670,10 @@ public class Intrinsics extends ANY
         "f64.infix %"          , (c,cl,outer,in) -> CExpr.call("fmod", new List<>(outer, A0)).ret());
     put("f32.infix **"         ,
         "f64.infix **"         , (c,cl,outer,in) -> CExpr.call("pow", new List<>(outer, A0)).ret());
-    put("f32.type.equality"    ,
-        "f64.type.equality"    , (c,cl,outer,in) -> A0.eq(A1).cond(c._names.FZ_TRUE, c._names.FZ_FALSE).ret());
-    put("f32.type.lteq"        ,
-        "f64.type.lteq"        , (c,cl,outer,in) -> A0.le(A1).cond(c._names.FZ_TRUE, c._names.FZ_FALSE).ret());
+    put("f32.infix ="          ,
+        "f64.infix ="          , (c,cl,outer,in) -> outer.eq(A0).cond(c._names.FZ_TRUE, c._names.FZ_FALSE).ret());
+    put("f32.infix <="         ,
+        "f64.infix <="         , (c,cl,outer,in) -> outer.le(A0).cond(c._names.FZ_TRUE, c._names.FZ_FALSE).ret());
     put("f32.as_f64"           , (c,cl,outer,in) -> outer.castTo("fzT_1f64").ret());
     put("f64.as_f32"           , (c,cl,outer,in) -> outer.castTo("fzT_1f32").ret());
     put("f64.as_i64_lax"       , (c,cl,outer,in) ->

--- a/src/dev/flang/be/c/Intrinsics.java
+++ b/src/dev/flang/be/c/Intrinsics.java
@@ -674,6 +674,12 @@ public class Intrinsics extends ANY
         "f64.infix ="          , (c,cl,outer,in) -> outer.eq(A0).cond(c._names.FZ_TRUE, c._names.FZ_FALSE).ret());
     put("f32.infix <="         ,
         "f64.infix <="         , (c,cl,outer,in) -> outer.le(A0).cond(c._names.FZ_TRUE, c._names.FZ_FALSE).ret());
+    put("f32.infix >="         ,
+        "f64.infix >="         , (c,cl,outer,in) -> outer.ge(A0).cond(c._names.FZ_TRUE, c._names.FZ_FALSE).ret());
+    put("f32.infix <"          ,
+        "f64.infix <"          , (c,cl,outer,in) -> outer.lt(A0).cond(c._names.FZ_TRUE, c._names.FZ_FALSE).ret());
+    put("f32.infix >"          ,
+        "f64.infix >"          , (c,cl,outer,in) -> outer.gt(A0).cond(c._names.FZ_TRUE, c._names.FZ_FALSE).ret());
     put("f32.as_f64"           , (c,cl,outer,in) -> outer.castTo("fzT_1f64").ret());
     put("f64.as_f32"           , (c,cl,outer,in) -> outer.castTo("fzT_1f32").ret());
     put("f64.as_i64_lax"       , (c,cl,outer,in) ->

--- a/src/dev/flang/be/interpreter/Intrinsics.java
+++ b/src/dev/flang/be/interpreter/Intrinsics.java
@@ -1066,8 +1066,8 @@ public class Intrinsics extends ANY
     put("f32.infix /"           , (interpreter, innerClazz) -> args -> new f32Value (                (args.get(0).f32Value() /  args.get(1).f32Value())));
     put("f32.infix %"           , (interpreter, innerClazz) -> args -> new f32Value (                (args.get(0).f32Value() %  args.get(1).f32Value())));
     put("f32.infix **"          , (interpreter, innerClazz) -> args -> new f32Value ((float) Math.pow(args.get(0).f32Value(),   args.get(1).f32Value())));
-    put("f32.type.equality"     , (interpreter, innerClazz) -> args -> new boolValue(                (args.get(1).f32Value() == args.get(2).f32Value())));
-    put("f32.type.lteq"         , (interpreter, innerClazz) -> args -> new boolValue(                (args.get(1).f32Value() <= args.get(2).f32Value())));
+    put("f32.infix ="           , (interpreter, innerClazz) -> args -> new boolValue(                (args.get(0).f32Value() == args.get(1).f32Value())));
+    put("f32.infix <="          , (interpreter, innerClazz) -> args -> new boolValue(                (args.get(0).f32Value() <= args.get(1).f32Value())));
     put("f32.as_f64"            , (interpreter, innerClazz) -> args -> new f64Value((double)                                    args.get(0).f32Value() ));
     put("f32.cast_to_u32"       , (interpreter, innerClazz) -> args -> new u32Value (    Float.floatToIntBits(                  args.get(0).f32Value())));
     put("f32.as_string"         , (interpreter, innerClazz) -> args -> Interpreter.value(Float.toString      (                  args.get(0).f32Value())));
@@ -1078,8 +1078,8 @@ public class Intrinsics extends ANY
     put("f64.infix /"           , (interpreter, innerClazz) -> args -> new f64Value (                (args.get(0).f64Value() /  args.get(1).f64Value())));
     put("f64.infix %"           , (interpreter, innerClazz) -> args -> new f64Value (                (args.get(0).f64Value() %  args.get(1).f64Value())));
     put("f64.infix **"          , (interpreter, innerClazz) -> args -> new f64Value (        Math.pow(args.get(0).f64Value(),   args.get(1).f64Value())));
-    put("f64.type.equality"     , (interpreter, innerClazz) -> args -> new boolValue(                (args.get(1).f64Value() == args.get(2).f64Value())));
-    put("f64.type.lteq"         , (interpreter, innerClazz) -> args -> new boolValue(                (args.get(1).f64Value() <= args.get(2).f64Value())));
+    put("f64.infix ="           , (interpreter, innerClazz) -> args -> new boolValue(                (args.get(0).f64Value() == args.get(1).f64Value())));
+    put("f64.infix <="          , (interpreter, innerClazz) -> args -> new boolValue(                (args.get(0).f64Value() <= args.get(1).f64Value())));
     put("f64.as_i64_lax"        , (interpreter, innerClazz) -> args -> new i64Value((long)                                      args.get(0).f64Value() ));
     put("f64.as_f32"            , (interpreter, innerClazz) -> args -> new f32Value((float)                                     args.get(0).f64Value() ));
     put("f64.cast_to_u64"       , (interpreter, innerClazz) -> args -> new u64Value (    Double.doubleToLongBits(               args.get(0).f64Value())));

--- a/src/dev/flang/be/interpreter/Intrinsics.java
+++ b/src/dev/flang/be/interpreter/Intrinsics.java
@@ -1068,6 +1068,9 @@ public class Intrinsics extends ANY
     put("f32.infix **"          , (interpreter, innerClazz) -> args -> new f32Value ((float) Math.pow(args.get(0).f32Value(),   args.get(1).f32Value())));
     put("f32.infix ="           , (interpreter, innerClazz) -> args -> new boolValue(                (args.get(0).f32Value() == args.get(1).f32Value())));
     put("f32.infix <="          , (interpreter, innerClazz) -> args -> new boolValue(                (args.get(0).f32Value() <= args.get(1).f32Value())));
+    put("f32.infix >="          , (interpreter, innerClazz) -> args -> new boolValue(                (args.get(0).f32Value() >= args.get(1).f32Value())));
+    put("f32.infix <"           , (interpreter, innerClazz) -> args -> new boolValue(                (args.get(0).f32Value() <  args.get(1).f32Value())));
+    put("f32.infix >"           , (interpreter, innerClazz) -> args -> new boolValue(                (args.get(0).f32Value() >  args.get(1).f32Value())));
     put("f32.as_f64"            , (interpreter, innerClazz) -> args -> new f64Value((double)                                    args.get(0).f32Value() ));
     put("f32.cast_to_u32"       , (interpreter, innerClazz) -> args -> new u32Value (    Float.floatToIntBits(                  args.get(0).f32Value())));
     put("f32.as_string"         , (interpreter, innerClazz) -> args -> Interpreter.value(Float.toString      (                  args.get(0).f32Value())));
@@ -1080,6 +1083,9 @@ public class Intrinsics extends ANY
     put("f64.infix **"          , (interpreter, innerClazz) -> args -> new f64Value (        Math.pow(args.get(0).f64Value(),   args.get(1).f64Value())));
     put("f64.infix ="           , (interpreter, innerClazz) -> args -> new boolValue(                (args.get(0).f64Value() == args.get(1).f64Value())));
     put("f64.infix <="          , (interpreter, innerClazz) -> args -> new boolValue(                (args.get(0).f64Value() <= args.get(1).f64Value())));
+    put("f64.infix >="          , (interpreter, innerClazz) -> args -> new boolValue(                (args.get(0).f64Value() >= args.get(1).f64Value())));
+    put("f64.infix <"           , (interpreter, innerClazz) -> args -> new boolValue(                (args.get(0).f64Value() <  args.get(1).f64Value())));
+    put("f64.infix >"           , (interpreter, innerClazz) -> args -> new boolValue(                (args.get(0).f64Value() >  args.get(1).f64Value())));
     put("f64.as_i64_lax"        , (interpreter, innerClazz) -> args -> new i64Value((long)                                      args.get(0).f64Value() ));
     put("f64.as_f32"            , (interpreter, innerClazz) -> args -> new f32Value((float)                                     args.get(0).f64Value() ));
     put("f64.cast_to_u64"       , (interpreter, innerClazz) -> args -> new u64Value (    Double.doubleToLongBits(               args.get(0).f64Value())));

--- a/src/dev/flang/fuir/analysis/dfa/DFA.java
+++ b/src/dev/flang/fuir/analysis/dfa/DFA.java
@@ -1197,6 +1197,12 @@ public class DFA extends ANY
     put("f64.infix ="                    , cl -> cl._dfa._bool );
     put("f32.infix <="                   , cl -> cl._dfa._bool );
     put("f64.infix <="                   , cl -> cl._dfa._bool );
+    put("f32.infix >="                   , cl -> cl._dfa._bool );
+    put("f64.infix >="                   , cl -> cl._dfa._bool );
+    put("f32.infix <"                    , cl -> cl._dfa._bool );
+    put("f64.infix <"                    , cl -> cl._dfa._bool );
+    put("f32.infix >"                    , cl -> cl._dfa._bool );
+    put("f64.infix >"                    , cl -> cl._dfa._bool );
     put("f32.as_f64"                     , cl -> new NumericValue(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc)) );
     put("f64.as_f32"                     , cl -> new NumericValue(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc)) );
     put("f64.as_i64_lax"                 , cl -> new NumericValue(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc)) );

--- a/src/dev/flang/fuir/analysis/dfa/DFA.java
+++ b/src/dev/flang/fuir/analysis/dfa/DFA.java
@@ -1193,10 +1193,10 @@ public class DFA extends ANY
     put("f64.infix %"                    , cl -> new NumericValue(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc)) );
     put("f32.infix **"                   , cl -> new NumericValue(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc)) );
     put("f64.infix **"                   , cl -> new NumericValue(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc)) );
-    put("f32.type.equality"              , cl -> cl._dfa._bool );
-    put("f64.type.equality"              , cl -> cl._dfa._bool );
-    put("f32.type.lteq"                  , cl -> cl._dfa._bool );
-    put("f64.type.lteq"                  , cl -> cl._dfa._bool );
+    put("f32.infix ="                    , cl -> cl._dfa._bool );
+    put("f64.infix ="                    , cl -> cl._dfa._bool );
+    put("f32.infix <="                   , cl -> cl._dfa._bool );
+    put("f64.infix <="                   , cl -> cl._dfa._bool );
     put("f32.as_f64"                     , cl -> new NumericValue(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc)) );
     put("f64.as_f32"                     , cl -> new NumericValue(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc)) );
     put("f64.as_i64_lax"                 , cl -> new NumericValue(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc)) );

--- a/src/dev/flang/fuir/cfg/CFG.java
+++ b/src/dev/flang/fuir/cfg/CFG.java
@@ -396,10 +396,10 @@ public class CFG extends ANY
     put("f64.infix %"                    , (cfg, cl) -> { } );
     put("f32.infix **"                   , (cfg, cl) -> { } );
     put("f64.infix **"                   , (cfg, cl) -> { } );
-    put("f32.type.equality"              , (cfg, cl) -> { } );
-    put("f64.type.equality"              , (cfg, cl) -> { } );
-    put("f32.type.lteq"                  , (cfg, cl) -> { } );
-    put("f64.type.lteq"                  , (cfg, cl) -> { } );
+    put("f32.infix ="                    , (cfg, cl) -> { } );
+    put("f64.infix ="                    , (cfg, cl) -> { } );
+    put("f32.infix <="                   , (cfg, cl) -> { } );
+    put("f64.infix <="                   , (cfg, cl) -> { } );
     put("f32.as_f64"                     , (cfg, cl) -> { } );
     put("f64.as_f32"                     , (cfg, cl) -> { } );
     put("f64.as_i64_lax"                 , (cfg, cl) -> { } );

--- a/src/dev/flang/fuir/cfg/CFG.java
+++ b/src/dev/flang/fuir/cfg/CFG.java
@@ -400,6 +400,12 @@ public class CFG extends ANY
     put("f64.infix ="                    , (cfg, cl) -> { } );
     put("f32.infix <="                   , (cfg, cl) -> { } );
     put("f64.infix <="                   , (cfg, cl) -> { } );
+    put("f32.infix >="                   , (cfg, cl) -> { } );
+    put("f64.infix >="                   , (cfg, cl) -> { } );
+    put("f32.infix <"                    , (cfg, cl) -> { } );
+    put("f64.infix <"                    , (cfg, cl) -> { } );
+    put("f32.infix >"                    , (cfg, cl) -> { } );
+    put("f64.infix >"                    , (cfg, cl) -> { } );
     put("f32.as_f64"                     , (cfg, cl) -> { } );
     put("f64.as_f32"                     , (cfg, cl) -> { } );
     put("f64.as_i64_lax"                 , (cfg, cl) -> { } );


### PR DESCRIPTION
Previously, f32 and f64 implemented type.equality and type.lteq by using the = and <= intrinsics. This is actually wrong because the = and <= intrinsics compare floating point numbers using IEEE rules, where NaN != NaN, and thus type.equality did not implement a proper equivalence relation.

This reintroduces the comparision infixes local to f32 and f64 that by default shadow the infixes provided by `lib/equals.fz`. If a proper equivalence relation or partial order is still desired, comparisions can still be done using `equals f32 f32.type.NaN f32.type.NaN` or `lteq f64 0.57721 f64.type.NaN`, for example.

The idea for this behavior is from [1].

[1]: https://forums.swift.org/t/comparable-and-floatingpoint-types/16886