### PR TITLE
fix: calledFeature must not be called if call not resolved yet.

### DIFF
--- a/src/dev/flang/ast/Feature.java
+++ b/src/dev/flang/ast/Feature.java
@@ -2164,10 +2164,10 @@ public class Feature extends AbstractFeature implements Stmnt
         var from = _impl._kind == Impl.Kind.RoutineDef ? _impl._code
                                                        : _impl._initialValue;
         result = from.typeIfKnown();
-        if (!(from instanceof Call c && c.calledFeature() == Types.resolved.f_Types_get) &&
-            result != null &&
+        if (result != null &&
             !result.isGenericArgument() &&
-            result.featureOfType().isTypeFeature())
+            result.featureOfType().isTypeFeature() &&
+            !(from instanceof Call c && c.calledFeature() == Types.resolved.f_Types_get))
           {
             result = Types.resolved.f_Type.selfType();
           }


### PR DESCRIPTION
example triggering the problem:
```
# ported from https://github.com/smarr/are-we-fast-yet/blob/master/benchmarks/Java/src/Bounce.java
bounce =>

  rand is
    seed := mut 74755
    next =>
      seed <- (((seed.get * 1309) + 13849) & 65535)
      seed.get

  r := rand

  ball is
    x    := mut ( r.next % 500)
    y    := mut ( r.next % 500)
    x_vel := mut ((r.next % 300) - 150)
    y_vel := mut ((r.next % 300) - 150)

    bounce =>
      x_limit := mut 500
      y_limit := mut 500
      bounced := mut false

      x <- x.get + x_vel.get
      y <- y.get + y_vel.get

      if x.get > x_limit.get
        x <- x_limit.get; x_vel <- 0 - x_vel.get.abs; bounced <- true
      if x.get < 0
        x <- 0; x_vel <- x_vel.get.abs; bounced <- true
      if y.get > y_limit.get
        y <- y_limit.get; y_vel <- 0 - y_vel.get.abs; bounced <- true
      if y.get < 0
        y <- 0; y_vel <- y_vel.get.abs; bounced <- true

      bounced.get

  ball_count := 100
  bounces:= mut 0
  balls := marray ball ball_count ball

  for i in 0..49 do
    for b in 0..99 do
      # NYI
      cur_ball := balls[b]
      if cur_ball.bounce
        bounces <- bounces.get + 1
      balls[b] := cur_ball

  say bounces.get # expect 1331
```