### PR TITLE
fe: Ignore type constraint in Call.handDownFormalArg, fix #1634

### DIFF
--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -1158,10 +1158,10 @@ public class Call extends AbstractCall
       (frmlT == Types.intern(frmlT));
 
     var declF = _calledFeature.outer();
-    var heirF = targetTypeOrConstraint(res).featureOfType();
-    if (declF != heirF)
+    var heir = _target.typeForCallTarget();
+    if (!heir.isGenericArgument() && declF != heir.featureOfType())
       {
-        var a = _calledFeature.handDown(res, new AbstractType[] { frmlT }, heirF);
+        var a = _calledFeature.handDown(res, new AbstractType[] { frmlT }, heir.featureOfType());
         if (a.length != 1)
           {
             // Check that the number or args can only change for the


### PR DESCRIPTION
handDownFormalArg changes a formal type used in a declared feature into the actual type of the call target.  This performs replacing formal generics along he inheritance chain by the actual generics provided in the inheritance calls.

The Problem was that for a target of generic type, the type constraint was used, which is wron ghere.