### PR TITLE
lib: remove workaround for issue #1634

### DIFF
--- a/lib/float.fz
+++ b/lib/float.fz
@@ -45,15 +45,6 @@ float : numeric is
   redef infix %! (other float.this.type) bool is true
   redef infix **!(other float.this.type) bool is true
 
-  # NYI: These redefinitions are required to avoid errors when removing the
-  # type parameter from numeric. Why?
-  redef infix + (other float.this.type) float.this.type is abstract
-  redef infix - (other float.this.type) float.this.type is abstract
-  redef infix * (other float.this.type) float.this.type is abstract
-  redef infix / (other float.this.type) float.this.type is abstract
-  redef infix % (other float.this.type) float.this.type is abstract
-  redef infix ** (other float.this.type) float.this.type is abstract
-
 
   # convert a float value to i64 dropping any fraction.
   # the value must be in the range of i64

--- a/lib/integer.fz
+++ b/lib/integer.fz
@@ -37,13 +37,6 @@ integer : numeric is
       safety: other != integer.this.type.zero
   is abstract
 
-  # NYI: These redefinitions are required to avoid errors in some tests when
-  # removing the type parameter from numeric. Why?
-  redef infix + (other integer.this.type) integer.this.type is abstract
-  redef infix - (other integer.this.type) integer.this.type is abstract
-  redef infix * (other integer.this.type) integer.this.type is abstract
-  redef infix / (other integer.this.type) integer.this.type is abstract
-
   # test divisibility by other
   infix %% (other integer.this.type) bool
     pre

--- a/lib/wrapping_integer.fz
+++ b/lib/wrapping_integer.fz
@@ -110,10 +110,6 @@ wrapping_integer : integer is
   redef infix -? (other wrapping_integer.this.type) num_option wrapping_integer.this.type is if wrapped_on_sub(other) then nil else wrapping_integer.this - other
   redef infix *? (other wrapping_integer.this.type) num_option wrapping_integer.this.type is if wrapped_on_mul(other) then nil else wrapping_integer.this * other
 
-  # NYI: These redefinitions are required to avoid errors in some tests when
-  # removing the type parameter from numeric. Why?
-  redef infix / (other wrapping_integer.this.type) wrapping_integer.this.type is abstract
-  redef infix % (other wrapping_integer.this.type) wrapping_integer.this.type is abstract
 
   # saturating  operations
   redef prefix -^          => if wrapped_on_neg if wrapping_integer.this > wrapping_integer.this.type.zero then wrapping_integer.this.type.min else wrapping_integer.this.type.max else - wrapping_integer.this


### PR DESCRIPTION
These redefinitions were added to work around the problem described in issue #1634. Since issue #1634 is now fixed, we can remove them.