### PR TITLE
dfa: Fixed code to replace default effect

### DIFF
--- a/src/dev/flang/fuir/analysis/dfa/DFA.java
+++ b/src/dev/flang/fuir/analysis/dfa/DFA.java
@@ -1586,24 +1586,11 @@ public class DFA extends ANY
    */
   void replaceDefaultEffect(int ecl, Value e)
   {
-    var oe = _defaultEffects.get(ecl);
-    Value ne;
-    if (oe == null)
+    var old_e = _defaultEffects.get(ecl);
+    var new_e = old_e == null ? e : old_e.join(e);
+    if (old_e == null || Value.compare(old_e, new_e) != 0)
       {
-        if (false)
-          {
-            // NYI: Check why this can happen.
-            throw new Error("replaceDefaultEffect called when there is no default effect!");
-          }
-        ne = oe;
-      }
-    else
-      {
-        ne = e.join(oe);
-      }
-    if (Value.compare(oe, ne) != 0)
-      {
-        _defaultEffects.put(ecl, ne);
+        _defaultEffects.put(ecl, new_e);
         if (!_changed)
           {
             _changedSetBy = "effect.replace called: " + _fuir.clazzAsString(ecl);
@@ -1611,7 +1598,6 @@ public class DFA extends ANY
         _changed = true;
       }
   }
-
 
 
   /**


### PR DESCRIPTION
This code was quite broken, setting the effect to null instead of the new value if it was not set.

This fixes failing flang.dev examples when run with C backend:

  content.design.examples.monadiclifting_hello3.fz
  content.design.examples.monadiclifting_helloabort.fz
  content.design.examples.monadiclifting_hello4.fz
  content.design.examples.monadiclifting_hello5.fz