### PR TITLE
fe: Produce an error in case of a declaration in a lazy expression, #1666

### DIFF
--- a/src/dev/flang/ast/AstErrors.java
+++ b/src/dev/flang/ast/AstErrors.java
@@ -1838,6 +1838,28 @@ public class AstErrors extends ANY
           "or change the result type of " + s(c.calledFeature()) + " to no longer depend on " + s(from) + ".");
   }
 
+
+  public static void declarationsInLazy(Expr lazy, List<Feature> declarations)
+  {
+    StringBuilder declarationsMsg = new StringBuilder();
+    for (var f : declarations)
+      {
+        declarationsMsg.append("declared " + s(f) + " at " + f.pos().show() + "\n");
+      }
+
+    error(lazy.pos(),
+          "IMPLEMENTATION RESTRICTION: An expression used as a lazy value cannot contain feature declarations",
+          "Declared features:\n" +
+          declarationsMsg +
+          "This is an implementation restriction that should be removed in a future version of Fuzion.\n" +
+          "\n"+
+          "To solve this, you may create a helper feature that calculates the value as follows:\n" +
+          "\n" +
+          "  lazy_value => " + lazy + "\n" +
+          "\n" +
+          "and then use " + expr("lazy_value") + " as an actual argument instead\n");
+  }
+
 }
 
 /* end of file */


### PR DESCRIPTION
Currently, features declared in an expression used as a lazy value will cause errors since the declaraions are resolved twice, once before and once after they were wrapped in the Lazy instance.

This patch is only a workaround that produces an error message, explains what to do alternatively and what needs to be improved in the Fuzion code to properly fix this.