### PR TITLE
fe: Add support for nested lazy values, fix #1665

### DIFF
--- a/src/dev/flang/ast/AbstractAssign.java
+++ b/src/dev/flang/ast/AbstractAssign.java
@@ -196,6 +196,27 @@ public abstract class AbstractAssign extends ANY implements Stmnt
 
 
   /**
+   * During type inference: Wrap value that is assigned to lazy type variable
+   * into Functions.
+   *
+   * @param res this is called during type inference, res gives the resolution
+   * instance.
+   *
+   * @param outer the feature that contains this expression
+   */
+  public void wrapValueInLazy(Resolution res, AbstractFeature outer)
+  {
+    if (CHECKS) check
+      (_assignedField != Types.f_ERROR || Errors.count() > 0);
+
+    if (resultTypeKnown())
+      {
+        _value = _value.wrapInLazy(res, outer, _assignedField.resultType());
+      }
+  }
+
+
+  /**
    * @return Is the result type of this field already known?
    */
   private boolean resultTypeKnown()

--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -685,11 +685,12 @@ public class Call extends AbstractCall
        ? thiz.outer().state().atLeast(Feature.State.RESOLVED_DECLARATIONS)
        : thiz        .state().atLeast(Feature.State.RESOLVED_DECLARATIONS));
 
-    var actualsResolved = false;
     if (_calledFeature == null)
       {
         if (CHECKS) check
           (Errors.count() > 0 || _name != Errors.ERROR_STRING);
+
+        var actualsResolved = false;
         if (_name != Errors.ERROR_STRING)    // If call parsing failed, don't even try
           {
             var targetFeature = targetFeature(res, thiz);
@@ -744,22 +745,22 @@ public class Call extends AbstractCall
                   }
               }
           }
-      }
-    if (_calledFeature == null)
-      {
-        _calledFeature = Types.f_ERROR;
-        if (_target == null)
+        if (_calledFeature == null)
           {
-            _target = Expr.ERROR_VALUE;
+            _calledFeature = Types.f_ERROR;
+            if (_target == null)
+              {
+                _target = Expr.ERROR_VALUE;
+              }
           }
-      }
-    if (_calledFeature == Types.f_ERROR)
-      {
-        _actuals = new List<>();
-      }
-    if (!actualsResolved)
-      {
-        resolveTypesOfActuals(res,thiz);
+        if (_calledFeature == Types.f_ERROR)
+          {
+            _actuals = new List<>();
+          }
+        if (!actualsResolved)
+          {
+            resolveTypesOfActuals(res,thiz);
+          }
       }
 
     if (POSTCONDITIONS) ensure
@@ -1087,22 +1088,41 @@ public class Call extends AbstractCall
     _generics = _generics.map(g -> g.visit(v, outer));
     if (v.doVisitActuals())
       {
-        ListIterator<Expr> i = _actuals.listIterator(); // _actuals can change during resolveTypes, so create iterator early
-        while (i.hasNext())
-          {
-            var a = i.next();
-            if (a != null)
-              {
-                i.set(a.visit(v, outer));
-              }
-          }
+        visitActuals(v, outer);
       }
     if (_target != null)
       {
         _target = _target.visit(v, outer);
       }
     v.action((AbstractCall) this);
-    return v.action(this, outer);
+    var result = v.action(this, outer);
+    if (v.visitActualsLate())
+      {
+        visitActuals(v, outer);
+      }
+    return result;
+  }
+
+
+  /**
+   * Helper for visit to visit all the actual value arguments of this call.
+   *
+   * @param v the visitor instance that defines an action to be performed on
+   * visited objects.
+   *
+   * @param outer the feature surrounding this expression.
+   */
+  private void visitActuals(FeatureVisitor v, AbstractFeature outer)
+  {
+    ListIterator<Expr> i = _actuals.listIterator();
+    while (i.hasNext())
+      {
+        var a = i.next();
+        if (a != null)
+          {
+            i.set(a.visit(v, outer));
+          }
+      }
   }
 
 
@@ -1555,7 +1575,7 @@ public class Call extends AbstractCall
                 var t = _generics.get(g.index());
                 if (t != Types.t_UNDEFINED)
                   {
-                    actual = actual.wrapInLazyAndThenPropagateExpectedType(res, outer, t);
+                    actual = actual.propagateExpectedType(res, outer, t);
                   }
               }
           }
@@ -2131,6 +2151,41 @@ public class Call extends AbstractCall
    */
   public void propagateExpectedType(Resolution res, AbstractFeature outer)
   {
+    applyToActualsAndFormalTypes((actual, formalType) -> actual.propagateExpectedType(res, outer, formalType));
+
+    if (_target != null)
+      {
+        // NYI: Need to check why this is needed, it does not make sense to
+        // propagate the target's type to target. But if removed,
+        // tests/reg_issue16_chainedBool/ fails with C backend:
+        _target = _target.propagateExpectedType(res, outer, _target.typeIfKnown());
+      }
+  }
+
+
+  /**
+   * During type inference: Wrap expressions that are assigned to lazy actuals
+   * in functions.
+   *
+   * @param res this is called during type inference, res gives the resolution
+   * instance.
+   *
+   * @param outer the feature that contains this expression
+   */
+  public void wrapActualsInLazy(Resolution res, AbstractFeature outer)
+  {
+    applyToActualsAndFormalTypes((actual, formalType) -> actual.wrapInLazy(res, outer, formalType));
+  }
+
+
+  /**
+   * Helper for propagateExpectedType and wrapActualsInLazy to apply `f` to all
+   * actual value arguments and their formal types.
+   *
+   * @param f function to apply to all actuals
+   */
+  void applyToActualsAndFormalTypes(java.util.function.BiFunction<Expr, AbstractType, Expr> f)
+  {
     if (_type != Types.t_ERROR &&
         _resolvedFormalArgumentTypes != null &&
         _actuals.size() == _resolvedFormalArgumentTypes.length /* this will cause an error in checkTypes() */ )
@@ -2146,20 +2201,12 @@ public class Call extends AbstractCall
                frmlT != Types.t_ERROR || Errors.count() > 0);
             if (actl != null)
               {
-                var a = actl.wrapInLazyAndThenPropagateExpectedType(res, outer, frmlT);
+                var a = f.apply(actl, frmlT);
                 if (CHECKS) check
                   (a != null);
                 i.set(a);
               }
             count++;
-          }
-
-        if (_target != null)
-          {
-            // NYI: Need to check why this is needed, it does not make sense to
-            // propagate the target's type to target. But if removed,
-            // tests/reg_issue16_chainedBool/ fails with C backend:
-            _target = _target.wrapInLazyAndThenPropagateExpectedType(res, outer, _target.typeIfKnown());
           }
       }
   }

--- a/src/dev/flang/ast/Expr.java
+++ b/src/dev/flang/ast/Expr.java
@@ -263,15 +263,21 @@ public abstract class Expr extends ANY implements Stmnt
 
 
   /**
-   * Before propagateExpectedType: if type inference up until now has figured
+   * After propagateExpectedType: if type inference up until now has figured
    * out that a Lazy feature is expected, but the current expression is not
    * a Lazy feature, then wrap this expression in a Lazy feature.
+   *
+   * @param res this is called during type inference, res gives the resolution
+   * instance.
+   *
+   * @param  outer the feature that contains this expression
+   *
+   * @param t the type this expression is assigned to.
    */
-  public Expr wrapInLazyAndThenPropagateExpectedType(Resolution res, AbstractFeature outer, AbstractType t)
+  public Expr wrapInLazy(Resolution res, AbstractFeature outer, AbstractType t)
   {
     var result = this;
 
-    result = result.propagateExpectedType(res, outer, t);
     result = t.isLazyType() ? result.originalLazyValue() : result;
 
     if (t.isLazyType() && !result.type().isLazyType())

--- a/src/dev/flang/ast/Feature.java
+++ b/src/dev/flang/ast/Feature.java
@@ -1655,10 +1655,20 @@ public class Feature extends AbstractFeature implements Stmnt
          */
         visit(new FeatureVisitor() {
             public void  action(AbstractAssign a, AbstractFeature outer) { a.propagateExpectedType(res, outer); }
-            public Call  action(Call     c, AbstractFeature outer) { c.propagateExpectedType(res, outer); return c; }
-            public void  action(Cond     c, AbstractFeature outer) { c.propagateExpectedType(res, outer); }
-            public void  action(Impl     i, AbstractFeature outer) { i.propagateExpectedType(res, outer); }
-            public void  action(If       i, AbstractFeature outer) { i.propagateExpectedType(res, outer); }
+            public Call  action(Call           c, AbstractFeature outer) { c.propagateExpectedType(res, outer); return c; }
+            public void  action(Cond           c, AbstractFeature outer) { c.propagateExpectedType(res, outer); }
+            public void  action(Impl           i, AbstractFeature outer) { i.propagateExpectedType(res, outer); }
+            public void  action(If             i, AbstractFeature outer) { i.propagateExpectedType(res, outer); }
+          });
+
+        /* extra pass to automatically wrap values into 'Lazy' */
+        visit(new FeatureVisitor() {
+            // we must do this from the outside of calls towards the inside to
+            // get the corrected nesting of Lazy features created during this
+            // phase
+            public boolean visitActualsLate() { return true; }
+            public void  action(AbstractAssign a, AbstractFeature outer) { a.wrapValueInLazy  (res, outer); }
+            public Call  action(Call           c, AbstractFeature outer) { c.wrapActualsInLazy(res, outer); return c; }
           });
 
         if (isConstructor())

--- a/src/dev/flang/ast/FeatureVisitor.java
+++ b/src/dev/flang/ast/FeatureVisitor.java
@@ -82,7 +82,19 @@ public abstract class FeatureVisitor extends ANY
    * call can redefine this method to return false when visiting actuals is not
    * desired, but, e.g., done later manually.
    */
-  public boolean doVisitActuals() { return true; }
+  public boolean doVisitActuals() { return !visitActualsLate(); }
+
+  /**
+   * When visiting a Call, the actuals value arguments are visited before the
+   * target and before the call itself.
+   *
+   * If this is redefined to return true, the order will be changed to taget,
+   * call itself and actuals.  The reason is that nested lazy values must be
+   * processed from outside to the inside to ensure that the outer feature of
+   * the inner actual is set correctly (i.e., set to the Lazy instance created
+   * for the outer lazy value).
+   */
+  public boolean visitActualsLate() { return false; }
 
   /**
    * This can be redefined to suppress visiting Assigns that were created for

--- a/tests/nested_lazy/ex_nested_lazy.fz.expected_err
+++ b/tests/nested_lazy/ex_nested_lazy.fz.expected_err
@@ -23,7 +23,7 @@ To solve this, you could change the type of the target '[36mf[39m' to '[33mre
 [32m--CURDIR--/ex_nested_lazy.fz:39:18:[39m [1;31merror 2[0m[1m: Incompatible types in assignment[0m
 [34m  say (lazy0 ()->42)
 [33m-----------------^[0m
-assignment to field : '[35mex_nested_lazy.#fun5.call.result[39m'
+assignment to field : '[35mex_nested_lazy.#fun1.call.result[39m'
 expected formal type: '[33mFunction i32[39m'
 actual type found   : '[33mref i32[39m'
 assignable to       : '[33mAny[39m',
@@ -41,13 +41,13 @@ for value assigned  :
   box(42)
 }[39m
 
-To solve this, you could change the type of the target '[36mex_nested_lazy.#fun5.call.result[39m' to '[33mref i32[39m' or convert the type of the assigned value to '[33mFunction i32[39m'.
+To solve this, you could change the type of the target '[36mex_nested_lazy.#fun1.call.result[39m' to '[33mref i32[39m' or convert the type of the assigned value to '[33mFunction i32[39m'.
 
 
 [32m--CURDIR--/ex_nested_lazy.fz:47:18:[39m [1;31merror 3[0m[1m: Incompatible types in assignment[0m
 [34m  say (lazy1 ()->42)
 [33m-----------------^[0m
-assignment to field : '[35mex_nested_lazy.#fun8.call.result[39m'
+assignment to field : '[35mex_nested_lazy.#fun3.call.result[39m'
 expected formal type: '[33mLazy i32[39m'
 actual type found   : '[33mref i32[39m'
 assignable to       : '[33mAny[39m',
@@ -65,6 +65,6 @@ for value assigned  :
   box(42)
 }[39m
 
-To solve this, you could change the type of the target '[36mex_nested_lazy.#fun8.call.result[39m' to '[33mref i32[39m' or convert the type of the assigned value to '[33mLazy i32[39m'.
+To solve this, you could change the type of the target '[36mex_nested_lazy.#fun3.call.result[39m' to '[33mref i32[39m' or convert the type of the assigned value to '[33mLazy i32[39m'.
 
 3 errors.

--- a/tests/reg_issue1665_nested_lazy/Makefile
+++ b/tests/reg_issue1665_nested_lazy/Makefile
@@ -1,0 +1,27 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test Makefile
+#
+#  Author: Fridtjof Siebert (siebert@tokiwa.software)
+#
+# -----------------------------------------------------------------------
+
+override NAME = test_issue1665
+include ../simple.mk

--- a/tests/reg_issue1665_nested_lazy/test_issue1665.fz
+++ b/tests/reg_issue1665_nested_lazy/test_issue1665.fz
@@ -1,0 +1,78 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion example test_issue1665.fz
+#
+#  Author: Fridtjof Siebert (siebert@tokiwa.software)
+#
+# -----------------------------------------------------------------------
+
+# test_issue1665 creates three layers of nested lazy expressions and conditionally
+# executes them up to levels 0, 1, 2, and 3
+#
+test_issue1665 is
+
+  h(z Lazy String) is
+    show(n i32) =>
+      if n > 2
+        say "h received '$z'"
+      else
+        say "h called, but not using z"
+
+  g(y Lazy h) is
+    show(n i32) =>
+      if n > 1
+        y.show n
+      else
+        say "g called, but not using y"
+
+  f(n i32, x Lazy g) is
+    if n > 0
+      x.show n
+    else
+      say "f called, but not using x"
+
+  create_z =>
+    say "creating z"
+    "zzz"
+
+  say "------ testing calls: ------"
+
+  for i in 0..3 do
+    say "case $i:"
+    _ := f i ({say "using x"; g ({say "using y"; h ({say "using z"; create_z})})})
+
+
+  say "------ testing assignments: ------"
+
+  l1 Lazy i32 := ({say "*** using lazy l1 ***"; 4711})
+  say "created l1"
+  say "used l1: $l1"
+
+  l2 Lazy String := ({say "*** using lazy l2 ***"; create_z})
+  say "created l2"
+  say "used l2: $l2"
+
+  l3 Lazy i32 := ({say "*** using lazy l3 ***"; 32168})
+  say "created l3"
+  l3a Lazy i32 := l3
+  say "assigned to l3a"
+  l3b := l3
+  say "used l3 and assigned result to l3b"
+  say "using l3b: $l3b {type_of l3b}"

--- a/tests/reg_issue1665_nested_lazy/test_issue1665.fz.expected_out
+++ b/tests/reg_issue1665_nested_lazy/test_issue1665.fz.expected_out
@@ -1,0 +1,29 @@
+------ testing calls: ------
+case 0:
+f called, but not using x
+case 1:
+using x
+g called, but not using y
+case 2:
+using x
+using y
+h called, but not using z
+case 3:
+using x
+using y
+using z
+creating z
+h received 'zzz'
+------ testing assignments: ------
+created l1
+*** using lazy l1 ***
+used l1: 4711
+created l2
+*** using lazy l2 ***
+creating z
+used l2: zzz
+created l3
+assigned to l3a
+*** using lazy l3 ***
+used l3 and assigned result to l3b
+using l3b: 32168 Type of 'i32'


### PR DESCRIPTION
The problem essentially was that in nested calls, actual arguments of inner calls were mapped before outer calls, which results in wrong outer features for the instances of `Lazy` created.

This patch solves this by

- splitting up `wrapInLazyAndThenPropagateExpectedType` (what was named the wrong way around) into two phases: `propagateExpectedType` and `wrapInLazy`

- changing the order for `wrapInLazy` to process outer calls before actuals in inner calls.

As a bonus, this patch adds support for automatic `wrapInLazy` for assignments to fields such as
```
  i Lazy i32 := f x
```
A regression test testing three levels of nested lazy arguments and lazy assignments to fields is also added.