### PR TITLE
dfa: record life time of outer ref created in inheritance call, fix #1659

### DIFF
--- a/src/dev/flang/fuir/FUIR.java
+++ b/src/dev/flang/fuir/FUIR.java
@@ -462,6 +462,7 @@ public class FUIR extends IR
     var f = fc.feature();
     return f.isOuterRef() &&
       !fc.resultClazz().isRef() &&
+      !fc.resultClazz().isUnitType() &&
       !fc.resultClazz().feature().isBuiltInPrimitive();
   }
 

--- a/tests/reg_issue1610_outer_escapes/test_issue1610.fz
+++ b/tests/reg_issue1610_outer_escapes/test_issue1610.fz
@@ -402,3 +402,44 @@ test_issue1610 =>
     say "case 4mut_ref: {if $m.get.get.v = "1234567890" "PASS" else "FAIL"}"
 
   case4mut_ref_field_field
+
+
+  case_inh1 =>
+
+    # f defines a heir `h` of `a.g` such that the outer ref refers to `a`, and instance
+    # o f `h` is returned
+
+    f =>
+      h : a.g is
+      h
+
+    a is
+      e := 1234567890
+      g is
+        v => e
+
+    say "case inh1: {if $f.v = "1234567890" "PASS" else "FAIL"}"
+
+  case_inh1
+
+/* NYI: #1642 this case commented out since target in inheritance call currently cannot be a field:
+
+  case_inh2_field =>
+
+    # f defines a heir `h` of `a.g` such that the outer ref refers to `a`, and instance
+    # o f `h` is returned.  The value of `a` is passed via a field.
+
+    f =>
+      x := a 1234567890
+      h : x.g is
+      h
+
+    a(e i32) is
+      g is
+        v => e
+
+    say "case inh2_field: {if $f.v = "1234567890" "PASS" else "FAIL"}"
+
+  case_inh2_field
+
+*/

--- a/tests/reg_issue1610_outer_escapes/test_issue1610.fz.expected_out
+++ b/tests/reg_issue1610_outer_escapes/test_issue1610.fz.expected_out
@@ -14,3 +14,4 @@ case 1mut_ref: PASS
 case 2mut_ref: PASS
 case 3mut_ref: PASS
 case 4mut_ref: PASS
+case inh1: PASS


### PR DESCRIPTION
A call in the inherits clause will store a ref to the target of that call in the heir instance, so we might extend the life time of that target.  This `patch` records this lifetime changes to enforce heap allocation of the target.

Also add a commented out test-case that requires #1642 to be fixed first.

