### PR TITLE
dfa: refine escape analysis for direct tail calls

### DIFF
--- a/src/dev/flang/fuir/analysis/dfa/DFA.java
+++ b/src/dev/flang/fuir/analysis/dfa/DFA.java
@@ -367,7 +367,10 @@ public class DFA extends ANY
                   {
                     res = new EmbeddedValue(cl, c, i, res);
                   }
-                if (tvalue == _call._instance || original_tvalue instanceof EmbeddedValue ev && ev._instance == _call._instance)
+                if (tvalue == _call._instance
+                     || original_tvalue instanceof EmbeddedValue ev
+                     && ev._instance == _call._instance
+                     && /* but not calling itself */ _call._cc != cl)
                   {
                     _call.escapes();
                   }

--- a/src/dev/flang/fuir/analysis/dfa/EmbeddedValue.java
+++ b/src/dev/flang/fuir/analysis/dfa/EmbeddedValue.java
@@ -26,11 +26,7 @@ Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
 
 package dev.flang.fuir.analysis.dfa;
 
-import java.util.TreeMap;
 import java.util.function.Function;
-import java.util.stream.Collectors;
-
-import dev.flang.util.Errors;
 
 
 /**


### PR DESCRIPTION
- if the instances of original value and call match, call escapes only if it is not calling itself

This fixes issue #1680 but there is probably a better way to this? Also I'm not at all sure if this is correct in all cases...