### PR TITLE
add intrinsic to print a stack trace

### DIFF
--- a/include/fz.h
+++ b/include/fz.h
@@ -56,8 +56,9 @@ Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
 #include <poll.h>       // poll
 #include <sys/mman.h>   // mmap
 #include <fcntl.h>      // fcntl
-#include <unistd.h>     // close
+#include <unistd.h>     // close, STDERR_FILENO
 #include <netdb.h>      // getaddrinfo
+#include <execinfo.h>   // backtrace, backtrace_symbols_fd
 
 #endif
 
@@ -412,5 +413,18 @@ int fzE_munmap(void * mapped_address, const int file_size){
 }
 
 
+// uses GNU extension backtrace/backtrace_symbols
+// to print a backtrace to stderr
+void fzE_stacktrace() {
+#if _WIN32
+  printf("Stacktrace, not supported on this plattform.\n");
+#else
+  size_t size;
+  enum Constexpr { MAX_SIZE = 1024 };
+  void *array[MAX_SIZE];
+  size = backtrace(array, MAX_SIZE);
+  backtrace_symbols_fd(array, size, STDERR_FILENO);
+#endif
+}
 
 #endif /* fz.h  */

--- a/lib/fuzion/sys.fz
+++ b/lib/fuzion/sys.fz
@@ -35,3 +35,10 @@ sys is
   #
   private c_string (s String) =>
     (s + codepoint 0).utf8.as_array.internal_array.data
+
+
+  # for debugging only
+  # this is plattform and backend dependent
+  # for the c backend use      : -enableStacktraces
+  # for the interpreter backend: -unsafeIntrinsics=on
+  private print_stacktrace is intrinsic

--- a/src/dev/flang/be/c/C.java
+++ b/src/dev/flang/be/c/C.java
@@ -563,7 +563,14 @@ public class C extends ANY
             command.addAll("-Wno-unused-but-set-variable");
           }
 
-        command.addAll("-O3");
+        if (_options._enableStacktraces)
+          {
+            command.addAll("-rdynamic");
+          }
+        else
+          {
+            command.addAll("-O3");
+          }
       }
     if(_options._useBoehmGC)
       {

--- a/src/dev/flang/be/c/COptions.java
+++ b/src/dev/flang/be/c/COptions.java
@@ -74,13 +74,22 @@ public class COptions extends FuzionOptions
   final String _cFlags;
 
 
+  /**
+   * enable printing of stacktraces via fuzion.sys.print_stacktrace.
+   * This needs disabling of -O3 and enabling -rdynamic.
+   *
+   * NYI can we detect the usage of the intrinsic automatically?
+   */
+  final boolean _enableStacktraces;
+
+
   /*--------------------------  constructors  ---------------------------*/
 
 
   /**
    * Constructor initializing fields as given.
    */
-  public COptions(FuzionOptions fo, String binaryName, boolean useBoehmGC, boolean Xdfa, String cCompiler, String cFlags)
+  public COptions(FuzionOptions fo, String binaryName, boolean useBoehmGC, boolean Xdfa, String cCompiler, String cFlags, boolean enableStacktraces)
   {
     super(fo);
 
@@ -89,6 +98,7 @@ public class COptions extends FuzionOptions
     _Xdfa = Xdfa;
     _cCompiler = cCompiler;
     _cFlags = cFlags;
+    this._enableStacktraces = enableStacktraces;
   }
 
 

--- a/src/dev/flang/be/c/Intrinsics.java
+++ b/src/dev/flang/be/c/Intrinsics.java
@@ -995,6 +995,8 @@ public class Intrinsics extends ANY
       A1.castTo("int")  // blocking
     )).ret());
 
+    put("fuzion.sys.print_stacktrace", (c,cl,outer,in) -> CExpr.call("fzE_stacktrace", new List<>()));
+
 
     put("effect.replace"       ,
         "effect.default"       ,

--- a/src/dev/flang/be/interpreter/Intrinsics.java
+++ b/src/dev/flang/be/interpreter/Intrinsics.java
@@ -1005,6 +1005,11 @@ public class Intrinsics extends ANY
         }
     });
 
+    putUnsafe("fuzion.sys.print_stacktrace" , (interpreter, innerClazz) -> args -> {
+      System.err.println(interpreter.callStack());
+      return Value.EMPTY_VALUE;
+    });
+
     put("safety"                , (interpreter, innerClazz) -> args -> new boolValue(Interpreter._options_.fuzionSafety()));
     put("debug"                 , (interpreter, innerClazz) -> args -> new boolValue(Interpreter._options_.fuzionDebug()));
     put("debug_level"           , (interpreter, innerClazz) -> args -> new i32Value(Interpreter._options_.fuzionDebugLevel()));

--- a/src/dev/flang/fuir/analysis/dfa/DFA.java
+++ b/src/dev/flang/fuir/analysis/dfa/DFA.java
@@ -1514,6 +1514,7 @@ public class DFA extends ANY
     put("fuzion.sys.net.write"           , cl -> new NumericValue(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc)) );
     put("fuzion.sys.net.close0"          , cl -> new NumericValue(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc)) );
     put("fuzion.sys.net.set_blocking0"   , cl -> new NumericValue(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc)) );
+    put("fuzion.sys.print_stacktrace"    , cl -> Value.UNIT );
 
     put("fuzion.std.nano_sleep"          , cl -> Value.UNIT );
     put("fuzion.std.nano_time"           , cl -> new NumericValue(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc)) );

--- a/src/dev/flang/fuir/cfg/CFG.java
+++ b/src/dev/flang/fuir/cfg/CFG.java
@@ -476,6 +476,7 @@ public class CFG extends ANY
     put("fuzion.sys.net.write"           , (cfg, cl) -> { } );
     put("fuzion.sys.net.close0"          , (cfg, cl) -> { } );
     put("fuzion.sys.net.set_blocking0"   , (cfg, cl) -> { } );
+    put("fuzion.sys.print_stacktrace"    , (cfg, cl) -> { } );
 
     put("fuzion.std.nano_sleep"          , (cfg, cl) -> { } );
     put("fuzion.std.nano_time"           , (cfg, cl) -> { } );

--- a/src/dev/flang/tools/Fuzion.java
+++ b/src/dev/flang/tools/Fuzion.java
@@ -88,6 +88,7 @@ class Fuzion extends Tool
   static boolean _xdfa_ = true;
   static String _cCompiler_ = null;
   static String _cFlags_ = null;
+  static boolean _enableStacktraces = false;
 
 
   /**
@@ -111,7 +112,7 @@ class Fuzion extends Tool
     {
       String usage()
       {
-        return "[-o=<file>] [-useGC] [-Xdfa=(on|off)] [-CC=<c compiler>] [-CFlags=\"list of c compiler flags\"] ";
+        return "[-o=<file>] [-useGC] [-Xdfa=(on|off)] [-CC=<c compiler>] [-CFlags=\"list of c compiler flags\"] [-enableStacktraces] ";
       }
       boolean handleOption(Fuzion f, String o)
       {
@@ -141,11 +142,16 @@ class Fuzion extends Tool
             _cFlags_ = o.substring(8);
             result = true;
           }
+        else if (o.startsWith("-enableStacktraces"))
+          {
+            _enableStacktraces = true;
+            result = true;
+          }
         return result;
       }
       void process(FuzionOptions options, FUIR fuir)
       {
-        new C(new COptions(options, _binaryName_, _useBoehmGC_, _xdfa_, _cCompiler_, _cFlags_), fuir).compile();
+        new C(new COptions(options, _binaryName_, _useBoehmGC_, _xdfa_, _cCompiler_, _cFlags_, _enableStacktraces), fuir).compile();
       }
     },
 


### PR DESCRIPTION
this is how it looks currently. could be improved by unmangling the names in the c backend.
example:
```
ex =>
  feature_a is
    feature_b is
      fuzion.sys.print_stacktrace

  feature_a.feature_b

```
c:
```
~/n/fuzion (main)$ fz -c -enableStacktraces ~/playground/test.fz 
~/n/fuzion (main)$ ./ex
./ex(fzE_stacktrace+0x1c)[0x402b2c]
./ex(fzC__L40fuzion__sy___stacktrace+0x9)[0x402be9]
./ex(fzC__L75ex__featur__feature_u_b+0x24)[0x402c14]
./ex(fzC_ex+0x12)[0x402c52]
./ex(main+0xe6)[0x402d46]
/lib/x86_64-linux-gnu/libc.so.6(+0x2718a)[0x7f222961b18a]
/lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0x85)[0x7f222961b245]
./ex(_start+0x21)[0x402221]
```
interpreter:
```
~/n/fuzion (main)130$ fz -unsafeIntrinsics=on ~/playground/test.fz 
Call stack:
ex.feature_a.feature_b: /home/sam/playground/test.fz:4:18:
      fuzion.sys.print_stacktrace
-----------------^
ex: /home/sam/playground/test.fz:6:13:
  feature_a.feature_b
------------^

~/n/fuzion (main)$ 
```