### PR TITLE
fe: in `redefineModifierMissing` use redefining feature instead of outer

### DIFF
--- a/src/dev/flang/fe/SourceModule.java
+++ b/src/dev/flang/fe/SourceModule.java
@@ -780,7 +780,7 @@ public class SourceModule extends Module implements SrcModule, MirModule
          */
         if (Errors.count() == 0 || !f.isTypeFeature())
           {
-            AstErrors.redefineModifierMissing(f.pos(), outer, existing);
+            AstErrors.redefineModifierMissing(f.pos(), f, existing);
           }
       }
     else


### PR DESCRIPTION
`f` is the feature redefining `existing` so this should be used in error message not `outer`.