### PR TITLE
Remove explicit `ref` types

### DIFF
--- a/lib/container/ctrie.fz
+++ b/lib/container/ctrie.fz
@@ -104,7 +104,7 @@ private container_node(CTK type : property.hashable, CTV type, bmp u32, array ar
 
 
   # create copy of this container_node and children
-  renewed(new_gen i32, ct ref C_Trie CTK CTV) =>
+  renewed(new_gen i32, ct C_Trie CTK CTV) =>
     copy := array.map (branch CTK CTV) x->
                      match x
                        i Indirection_Node => i.copy_to_gen new_gen ct
@@ -174,7 +174,7 @@ private Indirection_Node(CTK type : property.hashable, CTV type, data mutate.new
     true
 
   # completes the generation sensitive compare and set
-  private gcas_commit(m Main_Node CTK CTV, ct ref C_Trie CTK CTV) Main_Node CTK CTV is
+  private gcas_commit(m Main_Node CTK CTV, ct C_Trie CTK CTV) Main_Node CTK CTV is
     # abortably read root and get the current gen
     gen := (ct.read_root true).data.get.gen
     match m.prev.get
@@ -195,14 +195,14 @@ private Indirection_Node(CTK type : property.hashable, CTV type, data mutate.new
           gcas_commit data.get ct
 
   # read `data`, if prev is set commit first
-  private gcas_read(ct ref C_Trie CTK CTV) Main_Node CTK CTV is
+  private gcas_read(ct C_Trie CTK CTV) Main_Node CTK CTV is
     m := data.get
     match m.prev.get
       nil => m
       * => (gcas_commit m ct)
 
   # generation aware compare and set
-  gcas(o Main_Node CTK CTV, n Main_Node CTK CTV, ct ref C_Trie CTK CTV) choice restart ctrie_ok is
+  gcas(o Main_Node CTK CTV, n Main_Node CTK CTV, ct C_Trie CTK CTV) choice restart ctrie_ok is
     n.cas_prev o nil
     if(cas o n)
       gcas_commit n ct
@@ -214,7 +214,7 @@ private Indirection_Node(CTK type : property.hashable, CTV type, data mutate.new
 
 
   # copy this node to a new generation
-  private copy_to_gen(new_gen i32, ct ref C_Trie CTK CTV) Indirection_Node CTK CTV is
+  private copy_to_gen(new_gen i32, ct C_Trie CTK CTV) Indirection_Node CTK CTV is
     m := gcas_read ct
     # increase the generation of node by one
     Indirection_Node (mut (Main_Node m.data new_gen))

--- a/lib/container/ps_map.fz
+++ b/lib/container/ps_map.fz
@@ -131,7 +131,7 @@ O(n log n).
 
   # add mapping from k to v
   #
-  add (k PK, v V) ps_map PK V is
+  fixed add (k PK, v V) ps_map PK V is
     if has k
       panic "NYI: ps_map currently does not handle updates for existing key"
     else
@@ -316,14 +316,14 @@ O(n log n).
   # both ps_map.this and other, it will be mapped to ps_map.this[k] or to other[k],
   # but it is undefined to which of these two.
   #
-  union (other ref ps_map PK V) ref ps_map PK V is  # NYI: #167: 'ref' due to lack of 'like this'
+  fixed union (other ps_map PK V) ps_map PK V is
     if other.size < size
       other ∪ ps_map.this
     else
 
       # helper to add 'ps_map.this.data[l..r]' to 'a' and return the resulting map.
       #
-      add_all (a ref ps_map PK V, l i32, r i32) ref ps_map PK V is  # NYI: #167: 'ref' due to lack of 'like this'
+      add_all (a ps_map PK V, l i32, r i32) ps_map PK V is
         if l > r
           a
         else
@@ -335,7 +335,7 @@ O(n log n).
       # 'tail' elements at indices larger or equal to 'at+sz' added recursively as
       # well.
       #
-      add_all (a ref ps_map PK V, at i32, sz i32, tail i32) ref ps_map PK V is  # NYI: #167: 'ref' due to lack of 'like this'
+      add_all (a ps_map PK V, at i32, sz i32, tail i32) ps_map PK V is
         if sz = 0
           a
         else
@@ -355,7 +355,7 @@ O(n log n).
 
   # infix operator synonym for union of two ps_maps
   #
-  infix ∪ (other ref ps_map PK V) => union other  # NYI: #167: 'ref' due to lack of 'like this'
+  infix ∪ (other ps_map PK V) => union other
 
 
 # ps_maps -- unit type feature declaring features related to ps_map

--- a/lib/container/ps_set.fz
+++ b/lib/container/ps_set.fz
@@ -36,7 +36,7 @@
 #
 ps_set
   (K type : property.orderable,
-   psm ref ps_map K unit,  # NYI: #167: 'ref' due to lack of 'like this'
+   psm ps_map K unit,
    dummy unit    # just to distinguish this from routine ps_set(vs Sequence K)
   )
   : Set K
@@ -60,11 +60,21 @@ is
 
   # add new element k to this set.
   #
-  add (k K) ref ps_set K is  # NYI: #167: 'ref' due to lack of 'like this'
+  # NYI: Resolve duality of `add0` (that results in `ps_set`) and `add` (that
+  #      results in `Set`). Maybe `Set.add` should result in `Set.this.type`,
+  #      so we do not need `add0`?
+  #
+  fixed add0 (k K) ps_set K is
     if has k
       ps_set.this
     else
       ps_set K (psm.add k unit) unit
+
+
+  # add new element k to this set.
+  #
+  add (k K) Set K is
+    add0 k
 
 
   # create a sorted array from the elements of this set
@@ -89,20 +99,19 @@ is
 
   # union of two ps_sets
   #
-  infix ∪ (other ref ps_set K) => ps_set K (psm ∪ other.psm) unit  # NYI: #167: 'ref' due to lack of 'like this'
+  infix ∪ (other ps_set.this.type) => ps_set K (psm ∪ other.psm) unit
 
 
   # intersection of two ps_sets
-  infix ∩ (other ref ps_set K) =>
+  infix ∩ (other ps_set.this.type) =>
     s := (ps_set.this ∪ other).filter (x -> ps_set.this.has x && other.has x)
     (ps_sets K).empty.add_all s
 
 
   # add all elements of the given Sequence to this set
   #
-  add_all (s Sequence K) ref ps_set K is  # NYI: #167: 'ref' due to lack of 'like this'
-    this_ref ref ps_set K := ps_set.this
-    s.reduce this_ref ((r,k) -> r.add k)
+  fixed add_all (s Sequence K) ps_set K is
+    s.reduce (ps_set K) ps_set.this ((r,k) -> r.add0 k)
 
 
   # number of entries in this set.  May be undefined, i.e., a range of

--- a/lib/fuzion/sys/err.fz
+++ b/lib/fuzion/sys/err.fz
@@ -27,10 +27,10 @@
 #
 public err: character_encodings is
 
-  public print(s ref Any) =>
+  public print(s Any) =>
     write s.as_string.utf8.as_array
 
-  public println(s ref Any) =>
+  public println(s Any) =>
     write (s.as_string.utf8 ++ [ascii.lf]).as_array
 
   public println =>

--- a/lib/fuzion/sys/out.fz
+++ b/lib/fuzion/sys/out.fz
@@ -27,10 +27,10 @@
 #
 public out : character_encodings is
 
-  public print(s ref Any) =>
+  public print(s Any) =>
     write s.as_string.utf8.as_array
 
-  public println(s ref Any) =>
+  public println(s Any) =>
     write (s.as_string.utf8 ++ [ascii.lf]).as_array
 
   public println =>

--- a/lib/say.fz
+++ b/lib/say.fz
@@ -28,7 +28,7 @@
 # A handy shortcut for io.out.println, output string representation of
 # an object followed by a line break.
 #
-say(s ref Any) => io.out.println s
+say(s Any) => io.out.println s
 
 
 # A handy shortcut for stdout.println, output a line break.

--- a/lib/stream.fz
+++ b/lib/stream.fz
@@ -178,7 +178,7 @@ stream(redef T type) ref : Sequence T is
 
   # create a string from the elements of this stream
   #
-  redef as_string ref String is
+  redef as_string String is
     map String (x -> x.as_string)
       .fold (String.type.concat ", ")
 

--- a/lib/yak.fz
+++ b/lib/yak.fz
@@ -31,4 +31,4 @@
 # The term 'yak' was taken from the expression 'Yakety Yak' as in the
 # song by The Coasters.
 #
-yak(s ref Any) => io.out.print s
+yak(s Any) => io.out.print s

--- a/src/dev/flang/ast/Type.java
+++ b/src/dev/flang/ast/Type.java
@@ -257,13 +257,8 @@ public class Type extends AbstractType
          t.name(),
          g,
          o,
-         t instanceof Type tt ? tt.feature   : t.featureOfType(),
-
-         // NYI: CLEANUP: This seems unnecessarily complex:
-         t instanceof Type tt ? tt._refOrVal : (t.isRef() == t.featureOfType().isThisRef() ? RefOrVal.LikeUnderlyingFeature :
-                                                t.isRef() ? RefOrVal.Boxed
-                                                : RefOrVal.Value),
-
+         t.featureOfType(),
+         refOrVal(t),
          fixOuterThisType);
 
     if (PRECONDITIONS) require
@@ -272,6 +267,24 @@ public class Type extends AbstractType
         t == Types.t_ERROR || (t.outer() == null) == (o == null));
 
     checkedForGeneric = t.checkedForGeneric();
+  }
+
+
+  /**
+   * Helper to extract `RefOrVal` from given type.
+   *
+   * @param t a type, must not be generic argument.
+   */
+  private static RefOrVal refOrVal(AbstractType t)
+  {
+    if (PRECONDITIONS) require
+      (!t.isGenericArgument());
+
+    return
+      t instanceof Type tt                       ? tt._refOrVal                   :
+      t.isRef() == t.featureOfType().isThisRef() ? RefOrVal.LikeUnderlyingFeature :
+      t.isRef()                                  ? RefOrVal.Boxed
+                                                 : RefOrVal.Value;
   }
 
 
@@ -297,9 +310,7 @@ public class Type extends AbstractType
     else
       {
         result = new Type(t.pos2BeRemoved(), t.featureOfType().featureName().baseName(), t.generics(), o, t.featureOfType(),
-                          t.isRef() == t.featureOfType().isThisRef() ? RefOrVal.LikeUnderlyingFeature :
-                          t.isRef()                                  ? RefOrVal.Boxed
-                                                                     : RefOrVal.Value,
+                          refOrVal(t),
                           false);
 
         if (t.checkedForGeneric())

--- a/src/dev/flang/ast/Type.java
+++ b/src/dev/flang/ast/Type.java
@@ -668,19 +668,6 @@ public class Type extends AbstractType
 
 
   /**
-   * setRef is called by the parser when parsing a type of the form "ref
-   * <simpletype>".
-   */
-  public void setRef()
-  {
-    if (PRECONDITIONS) require
-      (this._refOrVal == RefOrVal.LikeUnderlyingFeature);
-
-    this._refOrVal = RefOrVal.Boxed;
-  }
-
-
-  /**
    * isRef
    */
   public boolean isRef()

--- a/tests/calls_on_ref_and_val_target/calls.fz
+++ b/tests/calls_on_ref_and_val_target/calls.fz
@@ -207,19 +207,25 @@ calls is
     #        * called on boxed
     #          - unbox(oa).f   -- target is uncopied value type.
 
-    on is
+    ron ref is
+      f String is abstract
+      cnt mutate.new i32 is abstract
+
+    on : ron is
       cnt := mut 0
       f String is
         cnt <- cnt.get + 1
         "f#$cnt in $where type {on.this.type.name}"
       where => "on"
 
-    oa : on is
+    roa ref : on is
+
+    oa : roa is
       redef where => "oa"
 
-    oa1 ref on is on
-    oa2 ref on is oa
-    oa3 ref oa is oa
+    oa1 ron is on
+    oa2 ron is oa
+    oa3 roa is oa
 
     t := oa1
     yak "case3a: "; chck t.f "f#1 in on type calls.case3.on"
@@ -416,19 +422,23 @@ calls is
     #        * called on boxed
     #          - *** error ***
 
-    on is
+    ron ref is
+
+    on : ron is
       cnt := mut 0
       f is
         cnt <- cnt.get + 1
         s := "f#$cnt in $where type {on.this.type.name}"
       where => "on"
 
-    oa : on is
+    roa ref : on is
+
+    oa : roa is
       redef where => "oa"
 
-    oa1 ref on is on
-    oa2 ref on is oa
-    oa3 ref oa is oa
+    oa1 ron is on
+    oa2 ron is oa
+    oa3 roa is oa
 
     t := oa1
     # yak "caseC3a: "; chck t.f.s "f#1 in oa type calls.caseC2.oa"     # ******  MOVE TO NEGATIVE TEST, causes ERROR!  ******
@@ -528,8 +538,8 @@ calls is
     oあ : on is
       redef where => "oあ"
 
-    oa1 ref on is oa
-    oa2 ref on is oあ
+    oa1 on is oa
+    oa2 on is oあ
 
     t := oa1
     yak "caseC6a: "; chck t.f.s "f#0 in oa type calls.caseC6.on"    # NYI f#1..

--- a/tests/choice_negative2/choice_negative.fz
+++ b/tests/choice_negative2/choice_negative.fz
@@ -37,11 +37,12 @@ choice_negative is
   cyclic7.A.s // NYI: would be nice if this was detected w/o a call to x
 
   cyclic8 is
-    A is
-      x ref A | i32 | String := "Hello"
+    rA ref is
+    A : rA is
+      x rA | i32 | String := "Hello"
       s is
         match x
-          a ref A  => say "A.x is A"
+          a rA     => say "A.x is A"
           i i32    => say "A.x is i32"
           s String => say "A.x is String"
 
@@ -59,11 +60,12 @@ choice_negative is
   cyclic9.A.s // NYI: would be nice if this was detected w/o a call to x
 
   cyclic10 is
-    A is
-      x i32 | ref A | String := "Hello"
+    rA ref is
+    A : rA is
+      x i32 | rA | String := "Hello"
       s is
         match x
-          a ref A  => say "A.x is A"
+          a rA     => say "A.x is A"
           i i32    => say "A.x is i32"
           s String => say "A.x is String"
 
@@ -81,11 +83,12 @@ choice_negative is
   cyclic11.A.s // NYI: would be nice if this was detected w/o a call to x
 
   cyclic12 is
-    A is
-      x i32 | String | ref A := "Hello"
+    rA ref is
+    A : rA is
+      x i32 | String | rA := "Hello"
       s is
         match x
-          a ref A  => say "A.x is A"
+          a rA  => say "A.x is A"
           i i32    => say "A.x is i32"
           s String => say "A.x is String"
 

--- a/tests/inheritance_for_value_types/inheritance_for_value_types.fz
+++ b/tests/inheritance_for_value_types/inheritance_for_value_types.fz
@@ -43,7 +43,10 @@ inheritance_for_value_types is
       say "FAILED: $msg"
       exit_code <- 1
 
-  a is
+  ra ref is
+    x, y, z (msg String, expected i32) unit is abstract
+
+  a : ra is
     x (msg String, expected i32) unit is chck msg expected=1
     y (msg String, expected i32) unit is x msg expected
     z (msg String, expected i32) =>      x msg expected
@@ -60,13 +63,13 @@ inheritance_for_value_types is
     v.xx
     unit
 
-  rx (rv ref a, msg String, expected i32) unit is
+  rx (rv ra, msg String, expected i32) unit is
     rv.x msg expected
 
-  ry (rv ref a, msg String, expected i32) unit is
+  ry (rv ra, msg String, expected i32) unit is
     rv.y msg expected
 
-  rz (rv ref a, msg String, expected i32) unit is
+  rz (rv ra, msg String, expected i32) unit is
     rv.z msg expected
 
   a.y "a.y" 1

--- a/tests/outerNormalization/outerNormalization.fz
+++ b/tests/outerNormalization/outerNormalization.fz
@@ -32,17 +32,6 @@
 outerNormalization is
 
 
-  # call numeric.as_u8 via a ref.  This only works if the actual clazz is
-  # i32.as_u8, it would fail for (numeric i32).as_u8 or (integer i32).as_u8 since
-  # zero is abstract in those clazzes
-  #
-  test_as_u8 is
-    x ref i32 := 3
-    z := x.as_u8
-
-  say "test_as_u8.z is {test_as_u8.z}"
-
-
   # string.as_codepoints is a constructor that, if it was specialized for
   # actual strings, would result in different, incompatible types
   #
@@ -104,11 +93,12 @@ outerNormalization is
       a T is abstract
       b T is a
 
-    j : n j is
+    rj ref : n j is
+    j : rj is
       a => j
       redef as_string => "a 'j'"
 
-    t(r ref j) is
+    t(r rj) is
       say "testNormalize: {r.b}"
 
     t j
@@ -125,11 +115,12 @@ outerNormalization is
       a i32 is abstract
       b i32 is a
 
-    j : n is
+    rj ref : n is
+    j : rj is
       a => 3
       redef as_string => "a 'j'"
 
-    t(r ref j) is
+    t(r rj) is
       say "testNormalize2: {r.b}"
 
     t j

--- a/tests/outerNormalization/outerNormalization.fz.expected_out
+++ b/tests/outerNormalization/outerNormalization.fz.expected_out
@@ -1,4 +1,3 @@
-test_as_u8.z is 3
 testCodepointsStream of $1234 is [1,2,3,4]
 testCodepointsStream of $true is [t,r,u,e]
 testConstructor: 4

--- a/tests/redef_args/redef_args.fz
+++ b/tests/redef_args/redef_args.fz
@@ -35,11 +35,15 @@ redef_args is
       "FAILED: "
     say (s + msg)
 
-  Complex(T type, real, imag T) is
+  RComplex(RT type) ref is
+    real, imag RT is abstract
+
+  Complex(T type, real, imag T) : RComplex T is
   Complex1(real, imag i32) is
   Complex2(rr, ii i32) : Complex i32 rr ii is
   Complex3(redef real, imag i32) : Complex i32 real imag is
-  Complex4(redef real, imag i32) : Complex3(real, imag) is
+  RComplex4(redef real, imag i32) ref : Complex3(real, imag) is
+  Complex4(redef real, imag i32) : RComplex4(real, imag) is
 
   chck ((Complex i32 3 4).real  = 3) "generic field real set correctly"
   chck ((Complex i32 3 4).imag  = 4) "generic field imag set correctly"
@@ -51,15 +55,15 @@ redef_args is
   chck ((Complex2    3 4).ii = 4) "non-generic field ii set correctly"
   chck ((Complex3    3 4).real  = 3) "redefined generic field real set correctly"
   chck ((Complex3    3 4).imag  = 4) "redefined generic field imag set correctly"
-  c ref Complex i32 := Complex3 3 4
+  c RComplex i32 := Complex3 3 4
   chck (c                .real  = 3) "redefined generic field real accessed through super feature set correctly"
   chck (c                .imag  = 4) "redefined generic field imag accessed through super feature set correctly"
   chck ((Complex4    3 4).real  = 3) "double redefined generic field real set correctly"
   chck ((Complex4    3 4).imag  = 4) "double redefined generic field imag set correctly"
-  c2 ref Complex i32 := Complex4 3 4
+  c2 RComplex i32 := Complex4 3 4
   chck (c2               .real  = 3) "double redefined generic field real accessed through super-super feature set correctly"
   chck (c2               .imag  = 4) "double redefined generic field imag accessed through super-super feature set correctly"
-  c3 ref Complex3 := Complex4 3 4
+  c3 RComplex4 := Complex4 3 4
   chck (c3               .real  = 3) "double redefined generic field real accessed through super feature set correctly"
   chck (c3               .imag  = 4) "double redefined generic field imag accessed through super feature set correctly"
 

--- a/tests/reg_issue25_unbox_outerref/unboxOuterRef.fz
+++ b/tests/reg_issue25_unbox_outerref/unboxOuterRef.fz
@@ -32,18 +32,21 @@
 #
 unboxOuterRef is
 
-  y (i i32) is
+  ry ref is
+    f unit is abstract
+
+  y (i i32) : ry is
     redef as_string => "y $i"
     g (v y) is
       vs := v.as_string
       say "in g: $vs $i"
-    f unit is
-#     g y.this   # y.this is not assignable to y, should be type 'like y.this', see #167
+    fixed f unit is
+      g y.this
       g (y i)
       unit
 
   v := y 42
   v.f
-  r ref y := v
+  r ry := v
   r.f
   unit

--- a/tests/reg_issue25_unbox_outerref/unboxOuterRef.fz.expected_out
+++ b/tests/reg_issue25_unbox_outerref/unboxOuterRef.fz.expected_out
@@ -1,2 +1,4 @@
 in g: y 42 42
 in g: y 42 42
+in g: y 42 42
+in g: y 42 42

--- a/tests/reg_issue874ff/issue874.fz
+++ b/tests/reg_issue874ff/issue874.fz
@@ -151,7 +151,10 @@ say (test_cov.i false)
 #
 test_cov_DFA_pop is
 
-  n is
+  rn ref is
+    r String is abstract
+
+  n : rn is
     r =>
       x := n.this
       x.as_string
@@ -159,7 +162,7 @@ test_cov_DFA_pop is
   i : n is
 
   _ := i.r
-  o ref n := i
+  o rn := i
   _ := o.r
 
 test_cov_DFA_pop

--- a/tests/this_type/test_this_type.fz
+++ b/tests/this_type/test_this_type.fz
@@ -35,9 +35,9 @@ simple_test_for_this_type_ref =>
       print
       b1 := q.this
       b2 := b1
-      b3 ref q := q.this
-      b4 ref q := b1
-      b5 ref q := b2
+      b3 q := q.this
+      b4 q := b1
+      b5 q := b2
 
     print => yak "q"
 
@@ -66,14 +66,16 @@ simple_test_for_this_type_value =>
 
   # a simple test for 'this.type'
   #
-  q is
+  rq ref is
+    print unit is abstract
+  q : rq is
     x is
       print
       b1 := q.this
       b2 := b1
-      b3 ref q := q.this
-      b4 ref q := b1
-      b5 ref q := b2
+      b3 rq := q.this
+      b4 rq := b1
+      b5 rq := b2
 
     print => yak "q"
 


### PR DESCRIPTION
Explicit `ref ` types can be replaced by inheriting from a `ref`  features and using this instead. I do no see that creating a `ref` explicitly has many advantages. 

Not having  `ref` types brings us one step closer to avoiding the double parsing for `actual` that can be a type or an expression.