### PR TITLE
tests/check_simple_example_c: fail when stderr differs

### DIFF
--- a/tests/check_simple_example_c.sh
+++ b/tests/check_simple_example_c.sh
@@ -80,13 +80,9 @@ else
         if diff "$experr" tmp_err.txt >/dev/null; then
             echo -ne "\033[32;1mPASSED\033[0m."
         else
-            if [ -s "$experr" ] && [ -s tmp_err.txt ]; then
-                echo -ne "\033[33;1mDIFF IN STDERR\033[0m."
-            else
-                diff "$experr" tmp_err.txt
-                echo -e "\033[31;1m*** FAILED\033[0m err on $2"
-                RC=1
-            fi
+            diff "$experr" tmp_err.txt
+            echo -e "\033[31;1m*** FAILED\033[0m err on $2"
+            RC=1
         fi
     else
         diff "$experr" tmp_err.txt


### PR DESCRIPTION
Previously, this would only print a warning/information that stderr differed which was not even shown when all other tests passed.