### PR TITLE
fe: Fix check failure in case `x` is not found in `x.this.type`, fix #1711

### DIFF
--- a/src/dev/flang/ast/QualThisType.java
+++ b/src/dev/flang/ast/QualThisType.java
@@ -1,0 +1,71 @@
+/*
+
+This file is part of the Fuzion language implementation.
+
+The Fuzion language implementation is free software: you can redistribute it
+and/or modify it under the terms of the GNU General Public License as published
+by the Free Software Foundation, version 3 of the License.
+
+The Fuzion language implementation is distributed in the hope that it will be
+useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+License for more details.
+
+You should have received a copy of the GNU General Public License along with The
+Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+*/
+
+/*-----------------------------------------------------------------------
+ *
+ * Tokiwa Software GmbH, Germany
+ *
+ * Source of class QualThisType
+ *
+ *---------------------------------------------------------------------*/
+
+package dev.flang.ast;
+
+import dev.flang.util.Errors;
+import dev.flang.util.FuzionConstants;
+import dev.flang.util.HasSourcePosition;
+import dev.flang.util.List;
+import dev.flang.util.SourcePosition;
+
+
+/**
+ * Type created by parser for types like `a.b.this`.
+ *
+ * @author Fridtjof Siebert (siebert@tokiwa.software)
+ */
+public class QualThisType extends Type
+{
+
+
+  /*----------------------------  variables  ----------------------------*/
+
+
+  final List<String> _qual;
+
+
+  /*--------------------------  constructors  ---------------------------*/
+
+
+  /**
+   * Create the type corresponding to "<qual>.this".
+   *
+   * @param pos the source position
+   *
+   * @param qual the qualifier
+   */
+  public QualThisType(HasSourcePosition pos, List<String> qual)
+  {
+    super(pos, qual.getLast(), Call.NO_GENERICS, null, null, Type.RefOrVal.ThisType);
+
+    this._qual = qual;
+  }
+
+
+}
+
+/* end of file */

--- a/src/dev/flang/ast/This.java
+++ b/src/dev/flang/ast/This.java
@@ -27,7 +27,10 @@ Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
 package dev.flang.ast;
 
 import java.util.Iterator;
+import java.util.TreeMap;
+import java.util.TreeSet;
 
+import dev.flang.util.ANY;
 import dev.flang.util.Errors;
 import dev.flang.util.List;
 import dev.flang.util.SourcePosition;
@@ -48,7 +51,7 @@ public class This extends ExprWithPos
   /**
    * the qualified name of the this that is to be accessed.
    */
-  final List<String> _qual;
+  public final List<String> _qual;
 
 
   /**
@@ -210,22 +213,7 @@ public class This extends ExprWithPos
   {
     if (_qual != null)
       {
-        int d = getThisDepth(outer);
-        if (d < 0)
-          {
-            if (CHECKS) check
-              (Errors.count() > 0);
-            this._feature = Types.f_ERROR;
-          }
-        else
-          {
-            var f = outer;
-            for (int i=0; i<d; i++)
-              {
-                f = f.outer();
-              }
-            this._feature = f;
-          }
+        this._feature = getThisFeature(this, _qual, outer);
       }
     else
       {
@@ -235,9 +223,13 @@ public class This extends ExprWithPos
           }
       }
 
-    Expr getOuter = null;
+    Expr getOuter;
     var f = this._feature;
-    if (f.isUniverse())
+    if (f == Types.f_ERROR)
+      {
+        getOuter = Expr.ERROR_VALUE;
+      }
+    else if (f.isUniverse())
       {
         getOuter = new Universe();
       }
@@ -303,65 +295,94 @@ public class This extends ExprWithPos
 
 
   /**
-   * getThisDepth
+   * getThisFeature find the outer feature `x.y.z.a.b.c` for a given qualified name 'a.b.c' as
+   * seen for a feature within outer `x.y.z.a.b.c.d.e.f.`.
    *
-   * @param feat
+   * @param thisOrType instance of `This` or `Type` depending on whether this is a lookup for `this` as a value or as a type.
    *
-   * @return
+   * @param qual the qualified name
+   *
+   * @param outer the outer feature that contains the 'this' expression.
+   *
+   * @return the feature that was found or Types.f_ERROR in case of an error.
    */
-  private int getThisDepth(AbstractFeature feat)
+  static AbstractFeature getThisFeature(ANY thisOrType, List<String> qual, AbstractFeature outer)
   {
-    Iterator<String> it = _qual.iterator();
-    int d = getDepth(0, feat, it.next(), it);
-    if (d < 0)
+    // The comments on the right hand side will give an example to illustrate how this works: Note
+    // that indices in outer start from the right, innermost name:
+    //
+    //                                               outer       is w.x.y.z.a.b.c.d.e
+    //                                               qual        is a.b.c
+    //                                               qual.size() is 3
+    var all = new TreeMap<String, Integer>();     // all.get(b)  is 8,7,6,5,4,3,2,1,0 == positions in outer
+    var ambig = new TreeSet<String>();
+    var o = outer;
+    var d = 0;                                    // d           is 9
+    while (o.outer() != null)
       {
-        var qname = new StringBuilder();
-        for (var name : _qual)
+        var b = o.featureName().baseName();
+        if (all.containsKey(b))
           {
-            qname.append(qname.length() > 0 ? "." : "")
-              .append(name);
+            ambig.add(b);
           }
-        var list = new List<String>();
-        var o = feat;
-        while (o.outer() != null) // exclude universe
-          {
-            list.add(o.qualifiedName());
-            o = o.outer();
-          }
-        AstErrors.outerFeatureNotFoundInThis(this, feat, qname.toString(), list);
+        all.put(b, d);
+        d++;
+        o = o.outer();
       }
-
-    return d;
-  }
-
-
-  /**
-   * recursive helper function for getThisDepth()
-   */
-  private int getDepth(int d, AbstractFeature feat, String name, Iterator<String> it)
-  {
-    if (feat.featureName().baseName().equals(name))
+    var s = qual.getFirst();                      // s           is 'a'
+    AbstractFeature result = Types.f_ERROR;
+    var isAmbiguous = ambig.contains(s);
+    var p = isAmbiguous ? -1 : all.getOrDefault(s, -1);
+    if (p >= 0)                                   // p           is 4
       {
-        return d;
-      }
-    else
-      {
-        var outer = feat.outer();
-        if (outer == null)
+        var q = p - qual.size() + 1;              // q           is 2, the index of 'c' in outer
+        if (q >= 0)
           {
-            d = -1;
-          }
-        else
-          {
-            d = getDepth(d + 1, outer, name, it);
-            if ((d >= 0) && it.hasNext())
+            // we found qual at positions p..q in outer, no check that all these
+            // positions contain the correct name:
+            var o2 = outer;
+            var d2 = 0;
+            while (p >= 0 && o2.outer() != null)
               {
-                d = it.next().equals(feat.featureName().baseName()) ? d - 1
-                                                                    : -1;
+                var b = o2.featureName().baseName();
+                if (d2 == q)
+                  {
+                    result = o2;
+                  }
+                if (p >= d2 && d2 >= q && !b.equals(qual.get(qual.size()-(d2-q)-1)))
+                  {
+                    p = -1;
+                    result =  Types.f_ERROR;
+                  }
+                o2 = o2.outer();
+                d2++;
               }
           }
       }
-    return d;
+    if (result == Types.f_ERROR)
+      { // find all available names to create error:
+        var ol   = new List<String>();  // all qualified names starting with o2 found so far
+        var list = new List<String>();  // all unambiguous names starting with o2 or later found so far
+        var o2 = outer;                  // go backwards from outer to fill ol and list.
+        while (o2.outer() != null)
+          {
+            var b = o2.featureName().baseName();
+            ol.add("this");
+            ol = ol.map(n -> b + "." + n);   // prefix all entries with o2's base name
+            if (!ambig.contains(b))
+              {
+                list.addAll(ol);             // unless ambiguous, add to list
+              }
+            o2 = o2.outer();
+          }
+        AstErrors.outerFeatureNotFoundInThis(thisOrType,
+                                             outer,
+                                             qual.toString("", ".", ""),
+                                             list,
+                                             isAmbiguous);
+      }
+
+    return result;
   }
 
 

--- a/src/dev/flang/ast/Type.java
+++ b/src/dev/flang/ast/Type.java
@@ -1064,7 +1064,7 @@ public class Type extends AbstractType
     if (!isGenericArgument())
       {
         var of = originalOuterFeature(outerfeat);
-        if (_outer != null)
+        if (_outer != null && !isThisType())
           {
             _outer = _outer.resolve(res, of);
             var ot = _outer.isGenericArgument() ?_outer.genericArgument().constraint() : _outer;
@@ -1072,11 +1072,23 @@ public class Type extends AbstractType
           }
         if (feature == null)
           {
-            var fo = res._module.lookupType(pos2BeRemoved(), of, name, _outer == null);
-            feature = fo._feature;
-            if (_outer == null && !fo._outer.isUniverse())
+            if (this instanceof QualThisType q)
               {
-                _outer = fo._outer.thisType(fo.isNextInnerFixed());
+                // resolve the feature for a type `a.this.type`, so `a` has to be one of the outer features.
+                feature = This.getThisFeature(this, q._qual, of.isTypeFeature() ? of.typeFeatureOrigin() : of);
+                var f0o = feature.outer();
+                _outer = f0o == null || f0o.isUniverse() ? null : f0o.thisType(false);
+              }
+            else
+              {
+                if (CHECKS) check
+                  (!isThisType());
+                var fo = res._module.lookupType(pos2BeRemoved(), of, name, _outer == null);
+                feature = fo._feature;
+                if (_outer == null && !fo._outer.isUniverse())
+                  {
+                    _outer = fo._outer.thisType(fo.isNextInnerFixed());
+                  }
               }
           }
       }

--- a/src/dev/flang/parser/Parser.java
+++ b/src/dev/flang/parser/Parser.java
@@ -3150,13 +3150,19 @@ qualThisType: qualThis
    */
   Expr qualThisType()
   {
+    Expr result;
+    var p = tokenSourcePos();
+    var q = qualThis();
     var f = fork();
-    Expr result = qualThisAsThis();
-    var f2 = fork();
-    if (f2.skipDot() && f2.skip(Token.t_type))
+    if (f.skipDot() && f.skip(Token.t_type))
       {
-        var ignore = skipDot();
-        result = dotTypeSuffx(f.qualThisAsType());
+        skipDot();
+        skip(Token.t_type);
+        result = new DotType(p, new QualThisType(p, q));
+      }
+    else
+      {
+        result = new This(p, q);
       }
     return result;
   }
@@ -3231,20 +3237,17 @@ anonymous   : "ref"
    *
    * @param asType select to parse this as a list of names or as a Type.
    *
-   * @return List<String> or Type depending on asType being false or true
+   * @return non-empty list of names in the qualifier, excluding "this".
    *
 qualThis    : name ( dot name )* dot "this"
             ;
    */
-  Object qualThis(boolean asType /* should result be Type or This? */)
+  List<String> qualThis()
   {
-    SourcePosition pos;
-    List<String> q = asType ? null : new List<>();
-    Type result = null;
-    var done = false;
+    var q = new List<String>();
     do
       {
-        var n = name();
+        q.add(name());
         if (!skipDot())
           {
             if (isFullStop())
@@ -3256,45 +3259,9 @@ qualThis    : name ( dot name )* dot "this"
                 syntaxError("'.'", "qualThis");
               }
           }
-        pos = tokenSourcePos();
-        done = skip(Token.t_this);
-        if (asType)
-          {
-            result = new Type(pos,
-                              n,
-                              Call.NO_GENERICS,
-                              result,
-                              null,
-                              done ? Type.RefOrVal.ThisType
-                                   : Type.RefOrVal.LikeUnderlyingFeature);
-          }
-        else
-          {
-            q.add(n);
-          }
       }
-    while (!done);
-    return asType ? result : new This(pos, q);
-  }
-
-
-  /**
-   * Parse qualThis producing an instance of 'This'.  This is used withing the
-   * rule callOrFeatOrThis.
-   */
-  This qualThisAsThis()
-  {
-    return (This) qualThis(false);
-  }
-
-
-  /**
-   * Parse qualThis producing an instance of Type.  This is used within the
-   * rule thistype.
-   */
-  Type qualThisAsType()
-  {
-    return (Type) qualThis(true);
+    while (!skip(Token.t_this));
+    return q;
   }
 
 
@@ -3337,7 +3304,7 @@ qualThis    : name ( dot name )* dot "this"
     var result = isQualThisPrefix();
     if (result)
       {
-        var ignore = qualThisAsThis();
+        var ignore = qualThis();
       }
     return result;
   }
@@ -3668,7 +3635,7 @@ type        : qualThis
     AbstractType result;
     if (isQualThisPrefix())
       {
-        result = qualThisAsType();
+        result = new QualThisType(tokenSourcePos(), qualThis());
       }
     else
       {


### PR DESCRIPTION
The special handling for `qualThis` to create either an Expression or a Type has been removed. `qualThis` now produces a list of strings that is then wrapped into an intance of `This` or `QualThisType`.

`QualThisType.java` is a new class for parsed types of the form `x.y.this.type`. They no longer have any outer types set, but contain the qualified name only that will be used to resolve the feature.

The code in `This.java` to look find `x.y` in an expression `x.y.this` was enhanced to complain about ambiguity and to become usable for `x.y.this.type` as well.

Failure of feature lookup in a `x.y.this` expression now results in `Expr.ERROR_VALUE` such that follow-on errors should be suppressed.

Feature lookup in `Type.resolveFeature` now performs special handling for `x.y.this.type`, where the lookup has to be done using `This.getThisFeature`.

Now, in case of `x.y.this` or `x.y.this.type` expression errors, a correct list of available qualified names is shown together with the information if the problem was an ambiguity or a not-found feature.