### PR TITLE
fe, tests: Type inference for formal arguments

### DIFF
--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -766,7 +766,7 @@ public class Call extends AbstractCall
       }
 
     if (POSTCONDITIONS) ensure
-                          (Errors.count() > 0 || calledFeature() != Types.f_ERROR || targetFeature == Types.resolved.f_void,
+      (Errors.count() > 0 || calledFeature() != Types.f_ERROR || targetFeature == Types.resolved.f_void,
        Errors.count() > 0 || _target         != Expr.ERROR_VALUE,
        calledFeature() != null,
        _target         != null);

--- a/src/dev/flang/ast/Feature.java
+++ b/src/dev/flang/ast/Feature.java
@@ -598,7 +598,7 @@ public class Feature extends AbstractFeature implements Stmnt
     this._visibility = v;
     this._modifiers  = m;
     this._returnType = r;
-    this._posOfReturnType =  r == NoType.INSTANCE || r.isConstructorType() ? pos : r.functionReturnType().pos2BeRemoved();
+    this._posOfReturnType = r == NoType.INSTANCE || r.isConstructorType() ? pos : r.functionReturnType().pos2BeRemoved();
     String n = qname.getLast();
     if (n.equals("_"))
       {

--- a/src/dev/flang/ast/Impl.java
+++ b/src/dev/flang/ast/Impl.java
@@ -105,7 +105,7 @@ public class Impl extends ANY
   {
     FieldInit,    // a field with initialization syntactic sugar
     FieldDef,     // a field with implicit type
-    FieldActual, // an argument field with type defined by actual argument
+    FieldActual,  // an argument field with type defined by actual argument
     FieldIter,    // a field f declared as an iterator index in a loop (eg., for f in myset { print(f); } )
     Field,        // a field
     TypeParameter,// a type parameter Field
@@ -121,7 +121,7 @@ public class Impl extends ANY
         {
           case FieldInit         : yield "field initialization";
           case FieldDef          : yield "field definition";
-          case FieldActual      : yield "actual argument";
+          case FieldActual       : yield "actual argument";
           case FieldIter         : yield "iterator";
           case Field             : yield "field";
           case TypeParameter     : yield "type parameter";

--- a/src/dev/flang/ast/InlineArray.java
+++ b/src/dev/flang/ast/InlineArray.java
@@ -310,7 +310,7 @@ public class InlineArray extends ExprWithPos
         var sysT         = new Type(pos(), "sys"   , Type.NONE, fuzionT);
         var sysArrayT    = new Type(pos(), "internal_array", eT, sysT);
         var sysArrayName = FuzionConstants.INLINE_SYS_ARRAY_PREFIX + (_id_++);
-        var sysArrayVar  = new Feature(pos(), Visi.PRIV, sysArrayT, sysArrayName, null, outer);
+        var sysArrayVar  = new Feature(pos(), Visi.PRIV, sysArrayT, sysArrayName, Impl.FIELD);
         res._module.findDeclarations(sysArrayVar, outer);
         res.resolveDeclarations(sysArrayVar);
         res.resolveTypes();

--- a/src/dev/flang/ast/Loop.java
+++ b/src/dev/flang/ast/Loop.java
@@ -541,8 +541,8 @@ public class Loop extends ANY
                               Visi.PRIV,
                               type,
                               f.featureName().baseName(),
-                              type == null ? ia : null,
-                              null /* NYI outer */);
+                              type != null ? Impl.FIELD
+                                           : new Impl(Impl.Kind.FieldActual));
         arg._isIndexVarUpdatedByLoop = true;
         formalArguments.add(arg);
         initialActuals .add(new Actual(ia));

--- a/src/dev/flang/fe/SourceModule.java
+++ b/src/dev/flang/fe/SourceModule.java
@@ -1211,6 +1211,7 @@ public class SourceModule extends Module implements SrcModule, MirModule
    */
   public void checkTypes(Feature f)
   {
+    f.impl().checkTypes(f);
     var args = f.arguments();
     int ean = args.size();
     var fixed = (f.modifiers() & Consts.MODIFIER_FIXED) != 0;

--- a/src/dev/flang/parser/Parser.java
+++ b/src/dev/flang/parser/Parser.java
@@ -951,25 +951,15 @@ argType     : type
                                       }
                                     else
                                       {
-                                        i = new Impl(Impl.Kind.FieldActual);
+                                        i = null; // alloc one instance of Impl for each arg since they contain state
                                         t = null;
                                       }
                                     Contract c = contract();
                                     for (String s : n)
                                       {
-                                        if (i._kind == Impl.Kind.FieldActual)
-                                          {
-                                            var arg = new Feature(pos,
-                                                                  Visi.PRIV,
-                                                                  m,
-                                                                  null,
-                                                                  s,
-                                                                  c,
-                                                                  new Impl(Impl.Kind.FieldActual));
-                                            result.add(arg);
-                                          }
-                                        else
-                                          result.add(new Feature(pos, v, m, t, s, c, i));
+                                        result.add(new Feature(pos, v, m, t, s, c,
+                                                               i == null ? new Impl(Impl.Kind.FieldActual)
+                                                                         : i));
                                       }
                                   }
                                 while (skipComma());

--- a/src/dev/flang/parser/Parser.java
+++ b/src/dev/flang/parser/Parser.java
@@ -922,6 +922,7 @@ argument    : visibility
 argType     : type
             | typeType
             | typeType COLON type
+            |
             ;
    */
   List<Feature> formArgs()
@@ -943,15 +944,32 @@ argType     : type
                                         t = skipColon() ? type()
                                                         : new Type(FuzionConstants.ANY_NAME);
                                       }
-                                    else
+                                    else if (isTypePrefix())
                                       {
                                         i = Impl.FIELD;
                                         t = type();
                                       }
+                                    else
+                                      {
+                                        i = new Impl(Impl.Kind.FieldActual);
+                                        t = null;
+                                      }
                                     Contract c = contract();
                                     for (String s : n)
                                       {
-                                        result.add(new Feature(pos, v, m, t, s, c, i));
+                                        if (i._kind == Impl.Kind.FieldActual)
+                                          {
+                                            var arg = new Feature(pos,
+                                                                  Visi.PRIV,
+                                                                  m,
+                                                                  null,
+                                                                  s,
+                                                                  c,
+                                                                  new Impl(Impl.Kind.FieldActual));
+                                            result.add(arg);
+                                          }
+                                        else
+                                          result.add(new Feature(pos, v, m, t, s, c, i));
                                       }
                                   }
                                 while (skipComma());

--- a/tests/reg_issue952/issue952.fz.expected_err
+++ b/tests/reg_issue952/issue952.fz.expected_err
@@ -1,7 +1,7 @@
 
---CURDIR--/issue952.fz:27:13: error 1: Syntax error: expected identifier name, infix/prefix/postfix operator, 'ternary ? :', 'index' or 'set' name, found right parenthesis ')'
+--CURDIR--/issue952.fz:27:12: error 1: Type inference from actual arguments failed since no actual call was found
   a(b u64, f) is
-------------^
-While parsing: name, parse stack: name (2 times), simpletype, onetype, type, formArgs, formArgsOpt, routOrField, feature, stmnt, stmnts, block, implRout, implFldOrRout, routOrField, feature, stmnt, stmnts, unit
+-----------^
+For the formal argument 'issue952.a.f' the type can only be derifed if there is a call to 'issue952.a'.
 
 one error.

--- a/tests/typeinference_for_formal_args_negative/Makefile
+++ b/tests/typeinference_for_formal_args_negative/Makefile
@@ -1,0 +1,27 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test Makefile
+#
+#  Author: Fridtjof Siebert (siebert@tokiwa.software)
+#
+# -----------------------------------------------------------------------
+
+override NAME = typeinference_for_args_negative
+include ../simple.mk

--- a/tests/typeinference_for_formal_args_negative/typeinference_for_args_negative.fz
+++ b/tests/typeinference_for_formal_args_negative/typeinference_for_args_negative.fz
@@ -1,0 +1,49 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test typeinference_for_args_negative
+#
+#  Author: Fridtjof Siebert (siebert@tokiwa.software)
+#
+# -----------------------------------------------------------------------
+
+typeinference_for_args_negative is
+
+  a1(a, b) => a+b    # ok, only i32
+  a2(a, b) => a+b    # ok, only String
+  a3(a, b) => a+b    # *** error ***, mixes String and f64 in arg `a`
+  a4(a, b) => a+b    # *** error ***, mixes String, i32, f64 and bool in arg `b`
+  a5(a, b) => a+b    # *** error ***, never called
+
+  say (a1 32 64)
+
+  say (a2 "hello"     " world!")
+  say (a2 "1.0"       " world!")
+  say (a2 "10.as_f64" " world!")
+  say (a2 "1.1"       " world!")
+
+  say (a3 "hello"     " world!")
+  say (a3 1.0         " world!")
+  say (a3 10.as_f64   " world!")
+  say (a3 1.1         " world!")
+
+  say (a4 "hello"     " world!")
+  say (a4 "1.0"       " world!".byte_length)
+  say (a4 "10.as_f64" 3.14)
+  say (a4 "1.1"       " world!"=" monde!")

--- a/tests/typeinference_for_formal_args_negative/typeinference_for_args_negative.fz.expected_err
+++ b/tests/typeinference_for_formal_args_negative/typeinference_for_args_negative.fz.expected_err
@@ -1,0 +1,43 @@
+
+--CURDIR--/typeinference_for_args_negative.fz:30:6: error 1: Type inference from actual arguments failed due to incompatible types of actual arguments
+  a3(a, b) => a+b    # *** error ***, mixes String and f64 in arg `a`
+-----^
+For the formal argument 'typeinference_for_args_negative.a3.a' the following incompatible actual arguments where found for type inference:
+actual is value of type of type 'String' at --CURDIR--/typeinference_for_args_negative.fz:41:11:
+  say (a3 "hello"     " world!")
+----------^
+actuals are values of type of type 'f64' at --CURDIR--/typeinference_for_args_negative.fz:42:11:
+  say (a3 1.0         " world!")
+----------^
+and at --CURDIR--/typeinference_for_args_negative.fz:43:14:
+  say (a3 10.as_f64   " world!")
+-------------^
+and at --CURDIR--/typeinference_for_args_negative.fz:44:11:
+  say (a3 1.1         " world!")
+----------^
+
+
+--CURDIR--/typeinference_for_args_negative.fz:31:6: error 2: Type inference from actual arguments failed due to incompatible types of actual arguments
+  a4(a, b) => a+b    # *** error ***, mixes String, i32, f64 and bool in arg `b`
+-----^
+For the formal argument 'typeinference_for_args_negative.a4.b' the following incompatible actual arguments where found for type inference:
+actual is value of type of type 'String' at --CURDIR--/typeinference_for_args_negative.fz:46:23:
+  say (a4 "hello"     " world!")
+----------------------^
+actual is value of type of type 'i32' at --CURDIR--/typeinference_for_args_negative.fz:47:33:
+  say (a4 "1.0"       " world!".byte_length)
+--------------------------------^
+actual is value of type of type 'f64' at --CURDIR--/typeinference_for_args_negative.fz:48:23:
+  say (a4 "10.as_f64" 3.14)
+----------------------^
+actual is value of type of type 'bool' at --CURDIR--/typeinference_for_args_negative.fz:49:32:
+  say (a4 "1.1"       " world!"=" monde!")
+-------------------------------^
+
+
+--CURDIR--/typeinference_for_args_negative.fz:32:6: error 3: Type inference from actual arguments failed since no actual call was found
+  a5(a, b) => a+b    # *** error ***, never called
+-----^
+For the formal argument 'typeinference_for_args_negative.a5.a' the type can only be derifed if there is a call to 'typeinference_for_args_negative.a5'.
+
+3 errors.


### PR DESCRIPTION
NOTE: This is experimental, would like to gain experience and know if this is useful or does harm.

With this patch, formal arguments types in a feature declaration can be omitted provided that the currently compiled module has a call to the formal argument's outer feature that provides an actual argument that permits type inference.

As an example, here is the first example from https://flang.dev/tutorial/feature_decl_fields
```
    Point(x, y i32) is

    show (Point 3 4 )
    show (Point 5 12)

    show(p Point) => say "{p.x}, {p.y}"
```
Type inference permits omitting all formal argument types in this example, so we can omit `i32` and `Point` types for `x`, `y` and `p` and write
```
    Point(x, y) is

    show (Point 3 4 )
    show (Point 5 12)

    show(p) => say "{p.x}, {p.y}"
```
This looks like magic, but it is in fact just a removal of redundant information, the language is still fully statically typed.  One caveat is that the documentation function of types in the source code gets lost, in particular since the call to a feature may be far away from its declaration, even in a separate file, but always in the same module. Documentation tools like `fz -docs` operate after the front end is done, so they should have full type information.

This, however, also creates new possibilities for errors: First, there might be several calls to the same feature with incompatible actual argument types. Second, there might be no call at all so the argument type is unknown. Both cases result in new errors.

A new negative test `typeinference_for_formal_args_negative` checks these error cases.