### PR TITLE
remove outdated comment

### DIFF
--- a/lib/u128.fz
+++ b/lib/u128.fz
@@ -27,7 +27,6 @@
 #
 u128(hi, lo u64) : num.wrap_around, has_interval is
 
-  #  redef thiz => u128.this  -- NYI: This causes a type error when using C backend
   thiz => u128 hi lo
 
   # overflow checking


### PR DESCRIPTION
thiz should return type u128 but u128.this is an incompatible type. using `128.this` result in errors in frontend now.