### PR TITLE
remove duplicate `ref` in error message:

### DIFF
--- a/src/dev/flang/ast/AstErrors.java
+++ b/src/dev/flang/ast/AstErrors.java
@@ -364,7 +364,7 @@ public class AstErrors extends ANY
         if (actlT.isThisType())
           {
             assignableToSB
-              .append("assignable to       : ref ")
+              .append("assignable to       : ")
               .append(st(actlT.asRef().toString()));
             if (frmlT.isAssignableFromOrContainsError(actlT))
               {


### PR DESCRIPTION
was `assignable to       : ref 'ref u128'`