### PR TITLE
parser, fe: Add source position information for names, fix #1723

### DIFF
--- a/src/dev/flang/ast/Assign.java
+++ b/src/dev/flang/ast/Assign.java
@@ -68,7 +68,22 @@ public class Assign extends AbstractAssign
    *
    * @param v the value assigned to field with name n
    */
-  public Assign(SourcePosition pos, String n, Expr v)
+  public Assign(SourcePosition pos, ParsedName n, Expr v)
+  {
+    this(pos, n._name, v);
+  }
+
+
+  /**
+   * Constructor used be the parser
+   *
+   * @param pos the sourcecode position, used for error messages.
+   *
+   * @param n the name of the assigned field
+   *
+   * @param v the value assigned to field with name n
+   */
+  Assign(SourcePosition pos, String n, Expr v)
   {
     super(v);
 

--- a/src/dev/flang/ast/AstErrors.java
+++ b/src/dev/flang/ast/AstErrors.java
@@ -166,6 +166,10 @@ public class AstErrors extends ANY
   {
     return names.map(s -> ss(s)).toString();
   }
+  static String spn(List<ParsedName> names) // names as list "`a`, `b`, `c`"
+  {
+    return sn2((names.map2(n->n._name)));
+  }
   static String sqn(List<String> names) // names as qualified name "a.b.c"
   {
     return ss(names.toString("", ".", ""));
@@ -1338,11 +1342,11 @@ public class AstErrors extends ANY
           "Min representable value > 0: " + ss(min) + " or " + ss(minH));
   }
 
-  static void wrongNumberOfArgumentsInLambda(SourcePosition pos, List<String> names, AbstractType funType)
+  static void wrongNumberOfArgumentsInLambda(SourcePosition pos, List<ParsedName> names, AbstractType funType)
   {
     int req = funType.generics().size() - 1;
     int delta = names.size() - req;
-    var ns = sn(names);
+    var ns = spn(names);
     error(pos,
           "Wrong number of arguments in lambda expression",
           "Lambda expression has " + singularOrPlural(names.size(), "argument") + " while the target type expects " +
@@ -1583,12 +1587,12 @@ public class AstErrors extends ANY
       }
   }
 
-  static void destructuringForGeneric(SourcePosition pos, AbstractType t, List<String> names)
+  static void destructuringForGeneric(SourcePosition pos, AbstractType t, List<ParsedName> names)
   {
     error(pos,
           "Destructuring not possible for value whose type is a type parameter.",
           "Type of expression is " + s(t) + "\n" +
-          "Cannot destructure value of type parameter type into (" + sn(names) + ")");
+          "Cannot destructure value of type parameter type into (" + spn(names) + ")");
   }
 
   static void destructuringRepeatedEntry(SourcePosition pos, String n, int count)
@@ -1599,7 +1603,7 @@ public class AstErrors extends ANY
   }
 
 
-  static void destructuringMisMatch(SourcePosition pos, List<String> fieldNames, List<String> names)
+  static void destructuringMisMatch(SourcePosition pos, List<String> fieldNames, List<ParsedName> names)
   {
     int fn = fieldNames.size();
     int nn = names.size();
@@ -1609,8 +1613,8 @@ public class AstErrors extends ANY
                       (fn == 1) ? "one visible argument field" :
                       "" + fn + " visible argument fields"     ) + " " + sn(fieldNames) + "\n" +
           (nn == 0 ? "while there are no destructuring variables" :
-           nn == 1 ? "while there is one destructuring variable: " + sn(names)
-           : "while there are " + nn + " destructuring variables: " + sn(names)) + ".\n"
+           nn == 1 ? "while there is one destructuring variable: " + spn(names)
+                   : "while there are " + nn + " destructuring variables: " + spn(names)) + ".\n"
           );
   }
 

--- a/src/dev/flang/ast/Expr.java
+++ b/src/dev/flang/ast/Expr.java
@@ -325,7 +325,7 @@ public abstract class Expr extends ANY implements Stmnt
         else
           {
             var fn = new Function(pos(),
-                                  new List<String>(),
+                                  new List<>(),
                                   new List<>(),
                                   Contract.EMPTY_CONTRACT,
                                   result);

--- a/src/dev/flang/ast/Feature.java
+++ b/src/dev/flang/ast/Feature.java
@@ -559,6 +559,42 @@ public class Feature extends AbstractFeature implements Stmnt
 
 
   /**
+   * Constructor used by parser
+   *
+   * @param v the visibility
+   *
+   * @param m the modifiers
+   *
+   * @param r the result type
+   *
+   * @param qname the name of this feature
+   *
+   * @param a the arguments
+   *
+   * @param i the inherits calls
+   *
+   * @param c the contract
+   *
+   * @param p the implementation (feature body etc).
+   */
+  public Feature(Visi v,
+                 int m,
+                 ReturnType r,
+                 List<ParsedName> qpname,
+                 List<Feature> a,
+                 List<AbstractCall> i,
+                 Contract c,
+                 Impl p)
+  {
+    this(qpname.getLast()._pos, v, m, r, qpname.map2(x -> x._name), a, i, c, p);
+
+    if (PRECONDITIONS) require
+      (qpname.size() >= 1,
+       p != null);
+  }
+
+
+  /**
    * Constructor
    *
    * @param pos the sourcecode position, used for error messages.

--- a/src/dev/flang/ast/Function.java
+++ b/src/dev/flang/ast/Function.java
@@ -108,7 +108,7 @@ public class Function extends ExprWithPos
    *
    * In this case, _wrapper and _call will be created during propagateExpectedType().
    */
-  List<String> _names;  // names of the arguments: "x", "y"
+  List<ParsedName> _names;  // names of the arguments: "x", "y"
   List<AbstractCall> _inherits; // inherits calls, currently always empty
   Contract _contract;   // contract of the lambda
   Expr _expr;           // the right hand side of the '->'
@@ -133,7 +133,7 @@ public class Function extends ExprWithPos
    * @param e the code on the right hand side of '->'.
    */
   public Function(SourcePosition pos,
-                  List<String> names,
+                  List<ParsedName> names,
                   List<AbstractCall> i,
                   Contract c,
                   Expr e)
@@ -260,11 +260,11 @@ public class Function extends ExprWithPos
         int i = 1;
         for (var n : _names)
           {
-            var arg = new Feature(pos() /* better n.pos() */,
+            var arg = new Feature(n._pos,
                                   Visi.PRIV,
                                   0,
                                   i < gs.size() ? gs.get(i) : Types.t_ERROR,
-                                  n,
+                                  n._name,
                                   Contract.EMPTY_CONTRACT);
             a.add(arg);
             i++;

--- a/src/dev/flang/ast/ParsedCall.java
+++ b/src/dev/flang/ast/ParsedCall.java
@@ -39,15 +39,13 @@ public class ParsedCall extends Call
   /**
    * Constructor to read a field in target t
    *
-   * @param pos the sourcecode position, used for error messages.
-   *
    * @param target the target of the call, null if none.
    *
    * @param name the name of the called feature
    */
-  public ParsedCall(SourcePosition pos, Expr target, String name)
+  public ParsedCall(Expr target, ParsedName name)
   {
-    super(pos, target, name);
+    super(name._pos, target, name._name);
   }
 
 
@@ -55,25 +53,21 @@ public class ParsedCall extends Call
    * Constructor to call feature with name 'n' on target 't' with actual
    * arguments 'la'.
    *
-   * @param pos the sourcecode position, used for error messages.
-   *
    * @param target the target of the call, null if none.
    *
    * @param name the name of the called feature
    *
    * @param arguments list of actual arguments
    */
-  public ParsedCall(SourcePosition pos, Expr target, String name, List<Actual> arguments)
+  public ParsedCall(Expr target, ParsedName name, List<Actual> arguments)
   {
-    super(pos, target, name, arguments);
+    super(name._pos, target, name._name, arguments);
   }
 
 
   /**
    * Constructor to call field 'n' on target 't' and select an open generic
    * variant.
-   *
-   * @param pos the sourcecode position, used for error messages.
    *
    * @param target the target of the call, null if none.
    *
@@ -82,9 +76,9 @@ public class ParsedCall extends Call
    * @param select for selecting a open type parameter field, this gives the
    * index '.0', '.1', etc. -1 for none.
    */
-  public ParsedCall(SourcePosition pos, Expr target, String name, int select)
+  public ParsedCall(Expr target, ParsedName name, int select)
   {
-    super(pos, target, name, select, NO_PARENTHESES);
+    super(name._pos, target, name._name, select, NO_PARENTHESES);
   }
 
 

--- a/src/dev/flang/ast/ParsedName.java
+++ b/src/dev/flang/ast/ParsedName.java
@@ -20,64 +20,70 @@ Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
  *
  * Tokiwa Software GmbH, Germany
  *
- * Source of class Operator
+ * Source of class ParsedName
  *
  *---------------------------------------------------------------------*/
 
-package dev.flang.parser;
+package dev.flang.ast;
 
 import dev.flang.util.ANY;
-import dev.flang.util.SourceRange;
+import dev.flang.util.Errors;
+import dev.flang.util.HasSourcePosition;
+import dev.flang.util.SourcePosition;
 
 
 /**
- * Operator represents an infix, prefix or postfix operator encountered while
- * parsing.
+ * ParsedName represents a name created by the parser for the rule for `name`.
  *
  * @author Fridtjof Siebert (siebert@tokiwa.software)
  */
-public class Operator extends ANY
+public class ParsedName extends ANY implements HasSourcePosition
 {
+
+  /*----------------------------  constants  ----------------------------*/
+
+
+  /**
+   * Name to be used in case we need a name, but there was an error parsing the
+   * name.
+   */
+  public final static ParsedName ERROR_NAME = new ParsedName(SourcePosition.builtIn,
+                                                             Errors.ERROR_STRING);
+
 
   /*----------------------------  variables  ----------------------------*/
 
 
-  public final SourceRange pos;
+  /**
+   * The actual name.
+   */
+  public final String _name;
 
-  public final String text;
 
-  public final boolean _whiteSpaceBefore, _whiteSpaceAfter;
+  /**
+   * The sourcecode position of this name.
+   */
+  public final SourcePosition _pos;
 
 
   /*--------------------------  constructors  ---------------------------*/
 
 
   /**
-   * Constructor for operator
+   * Constructor for name at given pos.
    *
-   * @param pos where was this operator found
+   * @param pos the position where name was found
    *
-   * @param text the operator itself, e.g., ">>="
-   *
-   * @param whiteSpaceBefore is there any white space, comments, etc. between
-   * this operator and the previous symbol?
-   *
-   * @param whiteSpaceAfter is there any white space, comments, etc. between
-   * this operator and the next symbol?
+   * @param name the name.
    */
-  public Operator(SourceRange pos,
-                  String text,
-                  boolean whiteSpaceBefore,
-                  boolean whiteSpaceAfter)
+  public ParsedName(SourcePosition pos, String name)
   {
     if (PRECONDITIONS) require
       (pos != null,
-       text != null);
+       name != null);
 
-    this.pos = pos;
-    this.text = text;
-    this._whiteSpaceBefore = whiteSpaceBefore;
-    this._whiteSpaceAfter = whiteSpaceAfter;
+    this._pos = pos;
+    this._name = name;
   }
 
 
@@ -85,11 +91,22 @@ public class Operator extends ANY
 
 
   /**
-   * Convert this to String for debugging.
+   * The sourcecode position of this name.
+   */
+  public SourcePosition pos()
+  {
+    return _pos;
+  }
+
+
+  /**
+   * toString creates a string representation for debug output.
+   *
+   * @retur just the name.
    */
   public String toString()
   {
-    return "OP:"+text;
+    return _name;
   }
 
 }

--- a/src/dev/flang/ast/QualThisType.java
+++ b/src/dev/flang/ast/QualThisType.java
@@ -45,7 +45,7 @@ public class QualThisType extends Type
   /*----------------------------  variables  ----------------------------*/
 
 
-  final List<String> _qual;
+  final List<ParsedName> _qual;
 
 
   /*--------------------------  constructors  ---------------------------*/
@@ -58,9 +58,11 @@ public class QualThisType extends Type
    *
    * @param qual the qualifier
    */
-  public QualThisType(HasSourcePosition pos, List<String> qual)
+  public QualThisType(List<ParsedName> qual)
   {
-    super(pos, qual.getLast(), Call.NO_GENERICS, null, null, Type.RefOrVal.ThisType);
+    super(SourcePosition.range(qual),
+          qual.getLast()._name,
+          Call.NO_GENERICS, null, null, Type.RefOrVal.ThisType);
 
     this._qual = qual;
   }

--- a/src/dev/flang/ast/This.java
+++ b/src/dev/flang/ast/This.java
@@ -51,7 +51,7 @@ public class This extends ExprWithPos
   /**
    * the qualified name of the this that is to be accessed.
    */
-  public final List<String> _qual;
+  public final List<ParsedName> _qual;
 
 
   /**
@@ -79,9 +79,9 @@ public class This extends ExprWithPos
    *
    * @param a
    */
-  public This(SourcePosition pos, List<String> qual)
+  public This(List<ParsedName> qual)
   {
-    super(pos);
+    super(SourcePosition.range(qual));
 
     if (PRECONDITIONS) require
       (!qual.isEmpty());
@@ -306,7 +306,7 @@ public class This extends ExprWithPos
    *
    * @return the feature that was found or Types.f_ERROR in case of an error.
    */
-  static AbstractFeature getThisFeature(ANY thisOrType, List<String> qual, AbstractFeature outer)
+  static AbstractFeature getThisFeature(ANY thisOrType, List<ParsedName> qual, AbstractFeature outer)
   {
     // The comments on the right hand side will give an example to illustrate how this works: Note
     // that indices in outer start from the right, innermost name:
@@ -329,7 +329,7 @@ public class This extends ExprWithPos
         d++;
         o = o.outer();
       }
-    var s = qual.getFirst();                      // s           is 'a'
+    var s = qual.getFirst()._name;                // s           is 'a'
     AbstractFeature result = Types.f_ERROR;
     var isAmbiguous = ambig.contains(s);
     var p = isAmbiguous ? -1 : all.getOrDefault(s, -1);
@@ -349,7 +349,7 @@ public class This extends ExprWithPos
                   {
                     result = o2;
                   }
-                if (p >= d2 && d2 >= q && !b.equals(qual.get(qual.size()-(d2-q)-1)))
+                if (p >= d2 && d2 >= q && !b.equals(qual.get(qual.size()-(d2-q)-1)._name))
                   {
                     p = -1;
                     result =  Types.f_ERROR;
@@ -377,7 +377,7 @@ public class This extends ExprWithPos
           }
         AstErrors.outerFeatureNotFoundInThis(thisOrType,
                                              outer,
-                                             qual.toString("", ".", ""),
+                                             qual.map2(x -> x._name).toString("", ".", ""),
                                              list,
                                              isAmbiguous);
       }
@@ -395,7 +395,7 @@ public class This extends ExprWithPos
   {
     if (_qual != null)
       {
-        return _qual+".this";
+        return _qual.map2(n -> n._name)+".this";
       }
     else if (_feature != null)
       {

--- a/src/dev/flang/parser/Lexer.java
+++ b/src/dev/flang/parser/Lexer.java
@@ -36,6 +36,7 @@ import dev.flang.util.Errors;
 import dev.flang.util.Pair;
 import dev.flang.util.SourceFile;
 import dev.flang.util.SourcePosition;
+import dev.flang.util.SourceRange;
 import dev.flang.util.UnicodeData;
 
 
@@ -944,9 +945,18 @@ public class Lexer extends SourceFile
 
 
   /**
+   * The start and end position of the current token as a SourceRange instance
+   */
+  SourceRange tokenSourceRange()
+  {
+    return sourceRange(tokenPos(), tokenEndPos());
+  }
+
+
+  /**
    * Position of the first byte in source file after the current token.
    */
-  private int tokenEndPos()
+  int tokenEndPos()
   {
     return bytePos();
   }

--- a/src/dev/flang/parser/OpExpr.java
+++ b/src/dev/flang/parser/OpExpr.java
@@ -33,6 +33,7 @@ import dev.flang.ast.Call;
 import dev.flang.ast.Expr;
 import dev.flang.ast.NumLiteral;
 import dev.flang.ast.ParsedCall;
+import dev.flang.ast.ParsedName;
 
 import dev.flang.util.ANY;
 import dev.flang.util.List;
@@ -196,7 +197,7 @@ public class OpExpr extends ANY
           {             // infix op:
             Expr e1 = expr(max-1);
             Expr e2 = expr(max+1);
-            Expr e = new ParsedCall(op.pos, e1, "infix "+op.text, new List<>(new Actual(e2)));
+            Expr e = new ParsedCall(e1, new ParsedName(op.pos, "infix "+op.text), new List<>(new Actual(e2)));
             els.remove(max+1);
             els.remove(max);
             els.set(max-1, e);
@@ -206,14 +207,14 @@ public class OpExpr extends ANY
             Expr e2 = expr(max+1);
             Expr e =
               (op.text.equals("+") && (e2 instanceof NumLiteral i2)) ? i2             :
-              (op.text.equals("-") && (e2 instanceof NumLiteral i2)) ? i2.neg(op.pos) : new ParsedCall(op.pos, e2, "prefix "+op.text);
+              (op.text.equals("-") && (e2 instanceof NumLiteral i2)) ? i2.neg(op.pos) : new ParsedCall(e2, new ParsedName(op.pos, "prefix "+op.text));
             els.remove(max+1);
             els.set(max, e);
           }
         else
           {                                          // postfix op:
             Expr e1 = expr(max-1);
-            Expr e = new ParsedCall(op.pos, e1, "postfix "+op.text);
+            Expr e = new ParsedCall( e1, new ParsedName(op.pos, "postfix "+op.text));
             els.remove(max);
             els.set(max-1, e);
           }

--- a/src/dev/flang/util/List.java
+++ b/src/dev/flang/util/List.java
@@ -455,6 +455,22 @@ public class List<T>
 
 
   /**
+   * Create a mapping of this list by applying f to all elements
+   *
+   * @return A new list of the same length, containing the result of f applied to each element.
+   */
+  public <V> List<V> map2(Function<T,V> f)
+  {
+    var result = new List<V>();
+    for (var i = 0; i < size(); i++)
+      {
+        result.add(f.apply(get(i)));
+      }
+    return result;
+  }
+
+
+  /**
    * Create a String by applying f to all elements and concatenating the result
    * in order.
    *

--- a/src/dev/flang/util/SourceFile.java
+++ b/src/dev/flang/util/SourceFile.java
@@ -845,6 +845,24 @@ public class SourceFile extends ANY
 
 
   /**
+   * Obtain the given range pos..endPos as a SourceRange object.
+   *
+   * @param pos a byte position within this file.
+   *
+   * @param endPos a byte position after pos within this file.
+   */
+  public SourceRange sourceRange(int pos, int endPos)
+  {
+    if (PRECONDITIONS) require
+      (0 <= pos,
+       pos < endPos,
+       endPos <= byteLength());
+
+    return new SourceRange(this, pos, endPos);
+  }
+
+
+  /**
    * Get the contents of the line with the given number.
    *
    * @param l a line number

--- a/src/dev/flang/util/SourceFile.java
+++ b/src/dev/flang/util/SourceFile.java
@@ -774,11 +774,28 @@ public class SourceFile extends ANY
 
 
   /**
-   * Determine the start byte position of the given line
+   * Determine the start byte position of the given line.
+   *
+   * @param line the line number starting at 1 for the first line. May be 0
+   *
+   + @return byte position of the beginning of the line, -1 for line==0.
    */
   public int lineStartPos(int line)
   {
+    if (PRECONDITIONS) require
+      (line >= 0,
+       line <= numLines());
+
     return lines()[line];
+  }
+
+
+  /**
+   * Number of lines in the file.
+   */
+  public int numLines()
+  {
+    return lines().length-1;
   }
 
 

--- a/src/dev/flang/util/SourceRange.java
+++ b/src/dev/flang/util/SourceRange.java
@@ -1,0 +1,133 @@
+/*
+
+This file is part of the Fuzion language implementation.
+
+The Fuzion language implementation is free software: you can redistribute it
+and/or modify it under the terms of the GNU General Public License as published
+by the Free Software Foundation, version 3 of the License.
+
+The Fuzion language implementation is distributed in the hope that it will be
+useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+License for more details.
+
+You should have received a copy of the GNU General Public License along with The
+Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+*/
+
+/*-----------------------------------------------------------------------
+ *
+ * Tokiwa Software GmbH, Germany
+ *
+ * Source of class SourceRange
+ *
+ *---------------------------------------------------------------------*/
+
+package dev.flang.util;
+
+
+/**
+ * SourceRange represents a position in a source code file with a given, non-empty length.
+ *
+ * @author Fridtjof Siebert (siebert@tokiwa.software)
+ */
+public class SourceRange extends SourcePosition
+{
+
+
+  /*----------------------------  variables  ----------------------------*/
+
+
+  /**
+   * The byte position in the source file of the first byte after _bytePos that
+   * is not part of this range.
+   */
+  private final int _byteEndPos;
+
+
+  /*--------------------------  constructors  ---------------------------*/
+
+
+  /**
+   * Create source range for given source file and byte start and end position.
+   *
+   * @param sourceFile the source file
+   *
+   * @param bytePos the byte position within sourceFile
+   *
+   * @param byteEndPos the byte position just after this range.
+   */
+  public SourceRange(SourceFile sourceFile, int bytePos, int byteEndPos)
+  {
+    super(sourceFile, bytePos);
+
+    if (PRECONDITIONS) require
+      (sourceFile != null,
+       0 <= bytePos,
+       bytePos <= byteEndPos,
+       byteEndPos <= sourceFile._bytes.length);
+
+    this._byteEndPos = byteEndPos;
+  }
+
+
+  /*-----------------------------  methods  -----------------------------*/
+
+
+  /**
+   * End position within _sourceFile.  This is equal to bytePos() for a plain
+   * SourcePosition and may be larger than bytePos for a SourceRange.
+   */
+  public int byteEndPos()
+  {
+    return _byteEndPos;
+  }
+
+
+  /**
+   * Convert this into a two or more line string that shows the referenced source code
+   * line followed by a line with caret (^) at the relevant position.  The
+   * last line is not terminated by LF.
+   */
+  public String showInSource()
+  {
+    StringBuilder sb = new StringBuilder();
+    sb.append(Terminal.BLUE);
+    var l = line();
+    sb.append(_sourceFile.line(l));
+
+    // add LF in case this is the last line of a file that does not end in a line break
+    if (sb.length() > 0 && sb.charAt(sb.length()-1) != '\n')
+      {
+        sb.append("\n");
+      }
+    sb.append(Terminal.YELLOW);
+    for (int j=0; j < column()-1; j++)
+      {
+        sb.append('-');
+      }
+    for(var p = _bytePos; p < _byteEndPos; p++)
+      {
+        sb.append('^');
+        while (_sourceFile.lineStartPos(l+1) < p)
+          {
+            l = l + 1;
+            sb.append(Terminal.RESET);
+            sb.append("\n");
+            sb.append(_sourceFile.line(l));
+            // add LF in case this is the last line of a file that does not end in a line break
+            if (sb.charAt(sb.length()-1) != '\n')
+              {
+                sb.append("\n");
+              }
+            sb.append(Terminal.YELLOW);
+          }
+      }
+    sb.append(Terminal.RESET);
+    return sb.toString();
+  }
+
+}
+
+/* end of file */

--- a/src/dev/flang/util/SourceRange.java
+++ b/src/dev/flang/util/SourceRange.java
@@ -84,50 +84,6 @@ public class SourceRange extends SourcePosition
     return _byteEndPos;
   }
 
-
-  /**
-   * Convert this into a two or more line string that shows the referenced source code
-   * line followed by a line with caret (^) at the relevant position.  The
-   * last line is not terminated by LF.
-   */
-  public String showInSource()
-  {
-    StringBuilder sb = new StringBuilder();
-    sb.append(Terminal.BLUE);
-    var l = line();
-    sb.append(_sourceFile.line(l));
-
-    // add LF in case this is the last line of a file that does not end in a line break
-    if (sb.length() > 0 && sb.charAt(sb.length()-1) != '\n')
-      {
-        sb.append("\n");
-      }
-    sb.append(Terminal.YELLOW);
-    for (int j=0; j < column()-1; j++)
-      {
-        sb.append('-');
-      }
-    for(var p = _bytePos; p < _byteEndPos; p++)
-      {
-        sb.append('^');
-        while (_sourceFile.lineStartPos(l+1) < p)
-          {
-            l = l + 1;
-            sb.append(Terminal.RESET);
-            sb.append("\n");
-            sb.append(_sourceFile.line(l));
-            // add LF in case this is the last line of a file that does not end in a line break
-            if (sb.charAt(sb.length()-1) != '\n')
-              {
-                sb.append("\n");
-              }
-            sb.append(Terminal.YELLOW);
-          }
-      }
-    sb.append(Terminal.RESET);
-    return sb.toString();
-  }
-
 }
 
 /* end of file */

--- a/tests/contracts_negative/SquareRoot.fz.expected_err
+++ b/tests/contracts_negative/SquareRoot.fz.expected_err
@@ -1,11 +1,11 @@
 
 --CURDIR--/SquareRoot.fz:30:9: error 1: Precondition does not hold
       a ≥ 0
---------^
+--------^^^
 For call to SquareRoot.sqrt
 Call stack:
 SquareRoot: --CURDIR--/SquareRoot.fz:45:21:
   say "sqrt(-16) = {sqrt(-16)}" // 1. should flag an error, precondition failed
---------------------^
+--------------------^^^^
 
 *** fatal errors encountered, stopping.

--- a/tests/nested_lazy/ex_nested_lazy.fz.expected_err
+++ b/tests/nested_lazy/ex_nested_lazy.fz.expected_err
@@ -1,7 +1,7 @@
 
 --CURDIR--/ex_nested_lazy.fz:49:14: error 1: Incompatible types when passing argument in a call
   say (lazy1 x1)
--------------^
+-------------^^
 Actual type for argument #1 'f' does not match expected type.
 In call to          : 'ex_nested_lazy.lazy1'
 expected formal type: 'Function (Lazy i32)'

--- a/tests/reg_issue19_redef_choice_result/testRedefine.fz.expected_err
+++ b/tests/reg_issue19_redef_choice_result/testRedefine.fz.expected_err
@@ -1,27 +1,27 @@
 
 --CURDIR--/testRedefine.fz:43:5: error 1: Wrong result type in redefined feature
     get i32 is 42
-----^
+----^^^
 In 'testRedefine.bad1.get' that redefines 'testRedefine.getter.get'
 result type is       : 'i32'
 result type should be: 'choice String i32 nil' (from 'testRedefine.getter.A')
 
 Original feature declared at --CURDIR--/testRedefine.fz:37:5:
     get A is abstract
-----^
+----^^^
 To solve this, change type of result to 'choice String i32 nil'
 
 
 --CURDIR--/testRedefine.fz:46:5: error 2: Wrong result type in redefined feature
     get => 42
-----^
+----^^^
 In 'testRedefine.bad2.get' that redefines 'testRedefine.getter.get'
 result type is       : 'i32'
 result type should be: 'choice String i32 nil' (from 'testRedefine.getter.A')
 
 Original feature declared at --CURDIR--/testRedefine.fz:37:5:
     get A is abstract
-----^
+----^^^
 To solve this, change type of result to 'choice String i32 nil'
 
 2 errors.

--- a/tests/reg_issue270/issue270.fz.expected_err
+++ b/tests/reg_issue270/issue270.fz.expected_err
@@ -1,7 +1,7 @@
 
 --CURDIR--/issue270.fz:2:7: error 1: Precondition does not hold
   pre false # 1. should flag an error: Precondition does not hold
-------^
+------^^^^^
 For call to issue270
 Call stack:
 

--- a/tests/reg_issue356_check_condition_failure_in_call_inferGenericsFromArgs/issue356.fz.expected_err
+++ b/tests/reg_issue356_check_condition_failure_in_call_inferGenericsFromArgs/issue356.fz.expected_err
@@ -1,7 +1,7 @@
 
 --CURDIR--/issue356.fz:27:7: error 1: Failed to infer actual type parameters
   a : choice is
-------^
+------^^^^^^
 In call to 'choice', no actual type parameters are given and inference of the type parameters failed.
 Expected type parameters: 'CHOICE_ELEMENT_TYPE...'
 Type inference failed for one type parameter 'CHOICE_ELEMENT_TYPE'

--- a/tests/reg_issue698_np_excep_in_choice_with_call_to_outer_ref/issue698.fz.expected_err
+++ b/tests/reg_issue698_np_excep_in_choice_with_call_to_outer_ref/issue698.fz.expected_err
@@ -1,7 +1,7 @@
 
 --CURDIR--/issue698.fz:8:3: error 1: Choice type must not access fields of surrounding scope.
   tree(A type : property.orderable) : choice nil (Node A (tree A) (tree A)) is
---^
+--^^^^
 A closure cannot be built for a choice type. Forbidden accesses occur at 
 --CURDIR--/issue698.fz:15:7:
       ref : Node A (tree A) (tree A)

--- a/tests/reg_issue7_genericConstraint/checkGenericConstraint.fz.expected_err
+++ b/tests/reg_issue7_genericConstraint/checkGenericConstraint.fz.expected_err
@@ -1,7 +1,7 @@
 
 --CURDIR--/checkGenericConstraint.fz:41:8: error 1: Incompatible type parameter
   m := hm m32 m32     # should produce error, m32 is not compatible to H
--------^
+-------^^
 formal type parameter 'T' with constraint 'checkGenericConstraint.this.type.H'
 actual type parameter 'checkGenericConstraint.this.type.m32'
 

--- a/tests/reg_issue8_optionFalse/bugOptionFalse.fz.expected_err
+++ b/tests/reg_issue8_optionFalse/bugOptionFalse.fz.expected_err
@@ -1,7 +1,7 @@
 
 --CURDIR--/bugOptionFalse.fz:36:9: error 1: Incompatible types in assignment
         false  # SHOULD FLAG AN ERROR!
---------^
+--------^^^^^
 assignment to field : 'bugOptionFalse.x.b.#stmtResult0'
 expected formal type: 'option bugOptionFalse.x.V'
 actual type found   : 'bool'

--- a/tests/typeinference_for_formal_args_negative/typeinference_for_args_negative.fz.expected_err
+++ b/tests/typeinference_for_formal_args_negative/typeinference_for_args_negative.fz.expected_err
@@ -11,22 +11,22 @@ actuals are values of type of type 'f64' at --CURDIR--/typeinference_for_args_ne
 ----------^
 and at --CURDIR--/typeinference_for_args_negative.fz:43:14:
   say (a3 10.as_f64   " world!")
--------------^
+-------------^^^^^^
 and at --CURDIR--/typeinference_for_args_negative.fz:44:11:
   say (a3 1.1         " world!")
 ----------^
 
 
---CURDIR--/typeinference_for_args_negative.fz:31:6: error 2: Type inference from actual arguments failed due to incompatible types of actual arguments
+--CURDIR--/typeinference_for_args_negative.fz:31:9: error 2: Type inference from actual arguments failed due to incompatible types of actual arguments
   a4(a, b) => a+b    # *** error ***, mixes String, i32, f64 and bool in arg `b`
------^
+--------^
 For the formal argument 'typeinference_for_args_negative.a4.b' the following incompatible actual arguments where found for type inference:
 actual is value of type of type 'String' at --CURDIR--/typeinference_for_args_negative.fz:46:23:
   say (a4 "hello"     " world!")
 ----------------------^
 actual is value of type of type 'i32' at --CURDIR--/typeinference_for_args_negative.fz:47:33:
   say (a4 "1.0"       " world!".byte_length)
---------------------------------^
+--------------------------------^^^^^^^^^^^
 actual is value of type of type 'f64' at --CURDIR--/typeinference_for_args_negative.fz:48:23:
   say (a4 "10.as_f64" 3.14)
 ----------------------^
@@ -40,4 +40,10 @@ actual is value of type of type 'bool' at --CURDIR--/typeinference_for_args_nega
 -----^
 For the formal argument 'typeinference_for_args_negative.a5.a' the type can only be derifed if there is a call to 'typeinference_for_args_negative.a5'.
 
-3 errors.
+
+--CURDIR--/typeinference_for_args_negative.fz:32:9: error 4: Type inference from actual arguments failed since no actual call was found
+  a5(a, b) => a+b    # *** error ***, never called
+--------^
+For the formal argument 'typeinference_for_args_negative.a5.b' the type can only be derifed if there is a call to 'typeinference_for_args_negative.a5'.
+
+4 errors.


### PR DESCRIPTION
Add new class `SourceRange` that extends `SourcePosition` but covers a range of source code.

Added class `ParsedName` that combines a String parsed for the rule for `name` with a `SourceRange`.  Used this to enhance error messages by marking the exact name in the source code.