### PR TITLE
add visibilty unspecified

### DIFF
--- a/src/dev/flang/ast/Visi.java
+++ b/src/dev/flang/ast/Visi.java
@@ -37,6 +37,12 @@ public enum Visi
 {
 
   /*
+   * visibility not explicitly stated
+   */
+  UNSPECIFIED("unspecified"),
+
+
+  /*
    * visible only in the current file
    */
   PRIV("private"),

--- a/src/dev/flang/parser/Parser.java
+++ b/src/dev/flang/parser/Parser.java
@@ -487,7 +487,7 @@ visiFlag    : "private" colon "module"
   */
   Visi visibility()
   {
-    Visi v = Visi.PRIV;
+    Visi v = Visi.UNSPECIFIED;
     if (isNonEmptyVisibilityPrefix())
       {
         if (skip(Token.t_private)) {


### PR DESCRIPTION
This makes it possible to later distinguish if a visibility was explicitly provided or not.