### PR TITLE
ast: handle `Intrinsic`, `Abstract` in `Feature.containsOnlyDeclarations`

### DIFF
--- a/src/dev/flang/ast/Feature.java
+++ b/src/dev/flang/ast/Feature.java
@@ -1464,7 +1464,9 @@ public class Feature extends AbstractFeature implements Stmnt
       case Field,        // a field
            FieldActual,  // a field with implicit type taken from actual argument to call
            RoutineDef,   // normal feature with code and implicit result type
-           Routine       // normal feature with code
+           Routine,      // normal feature with code
+           Intrinsic,    // intrinsic feature
+           Abstract      // abstract feature
         -> true;
       default -> throw new Error("missing case "+_impl._kind);
       };


### PR DESCRIPTION
This unhandled case was exposed by `content/design/examples/dec_choic.fz` in `flang_dev`.