### PR TITLE
parser: return effects list instead of always `Type.NONE`

### DIFF
--- a/src/dev/flang/parser/Parser.java
+++ b/src/dev/flang/parser/Parser.java
@@ -1225,7 +1225,7 @@ EXCLAMATION : "!"
     var result = Type.NONE;
     if (skip('!'))
       {
-        var effects = typeList();
+        result = typeList();
       }
     return result;
   }


### PR DESCRIPTION
Even though this effects-list is not really evaluated yet I think it doesn't hurt that it is returned already.