### PR TITLE
lib/num/ryu: cache large arrays in step 3

### DIFF
--- a/lib/num/ryu.fz
+++ b/lib/num/ryu.fz
@@ -138,7 +138,8 @@ public ryū is
 
     ***************/
 
-    pow5_split array (array i64) := [
+    private pow5_split_cache_key(val array (array i64)) is
+    pow5_split array (array i64) := (cache pow5_split_cache_key (()->pow5_split_cache_key [
         [134217728,0,0,0],
         [167772160,0,0,0],
         [209715200,0,0,0],
@@ -465,9 +466,10 @@ public ryū is
         [265249473,1869726050,152685176,129711535],
         [165780921,363272413,632299147,81069709],
         [207226151,990961428,1327244845,1711949873]
-      ]
+      ])).val
 
-    pow5_inv_split array (array i64) := [
+    private pow5_inv_split_cache_key(val array (array i64)) is
+    pow5_inv_split array (array i64) := (cache pow5_inv_split_cache_key (()->pow5_inv_split_cache_key [
         [536870912,0,0,1],
         [429496729,1288490188,1717986918,858993460],
         [343597383,1460288880,1374389534,1546188227],
@@ -759,7 +761,7 @@ public ryū is
         [326998476,674671703,980884287,1695296433],
         [523197562,220481266,710421401,564990645],
         [418558049,1464875201,1856827309,1740482705]
-      ]
+      ])).val
 
 
     private actual_shift(j i64) =>


### PR DESCRIPTION
This reduces the number of calls to `malloc` in step 3, as reported by valgrind, to drop from around 13000 to just around 90, in the following example:
```
float_as_string =>

  min_subnormal := 4.9406564584124654E-324
  max_subnormal := 2.2250738585072009E-308
  min_positive  := 2.2250738585072014E-308
  max_positive  := 1.7976931348623157E308
  zero          := 0.0

  numbers := [ zero,
              -zero,
              f64.type.positive_infinity,
              f64.type.negative_infinity,
              f64.type.quiet_NaN,
              0.3,
              1.0,
              1.5,
              f64.type.π,
              min_subnormal,
              max_subnormal,
              min_positive,
              max_positive,

              # these numbers are taken from test cases in
              # https://github.com/ulfjack/ryu

              1.8531501765868567E21,
              -3.347727380279489E33,
              1.9430376160308388E16,
              -6.9741824662760956E19,
              4.3816050601147837E18,
              -2.1098088986959632E16,
              -2.109808898695963E16,
              4.940656E-318,
              1.18575755E-316,
              2.989102097996E-312,
              9.0608011534336E15,
              4.708356024711512E18,
              9.409340012568248E18,
              ]

  for num0 in numbers
  do
    say (num.ryū.as_string num0 false num.ryū.rounding_conservative)
```