### PR TITLE
lib/list: jump to `concat_eagerly` in `concat_eagerly`

### DIFF
--- a/lib/list.fz
+++ b/lib/list.fz
@@ -286,7 +286,7 @@ public list(A type) : choice nil (Cons A (list A)), Sequence A is
   #
   public concat_eagerly (t list A) list A is
     list.this ? nil    => t
-              | c Cons => cons A (list A) c.head (c.tail.concat t)
+              | c Cons => cons A (list A) c.head (c.tail.concat_eagerly t)
 
 
   # Lazy list concatenation, O(1)


### PR DESCRIPTION
The eager and lazy variants shouldn't mix up themselves. Supersedes #1757.