### PR TITLE
be: use atomic operations in `fuzion.sys.misc.unique_id` intrinsic

### DIFF
--- a/src/dev/flang/be/c/Intrinsics.java
+++ b/src/dev/flang/be/c/Intrinsics.java
@@ -873,15 +873,14 @@ public class Intrinsics extends ANY
                             c._names.FZ_FALSE.ret());
         });
      put("fuzion.sys.misc.unique_id",(c,cl,outer,in) ->
-         {
-           var last_id= new CIdent("last_id");
-           return CStmnt.seq(CStmnt.decl("static",
-                                         c._types.scalar(FUIR.SpecialClazzes.c_u64),
-                                         last_id,
-                                         CExpr.uint64const(0)),
-                             last_id.assign(last_id.add(CExpr.uint64const(1))),
-                             last_id.ret());
-         });
+        {
+          var last_id = new CIdent("last_id");
+          return CStmnt.seq(CStmnt.decl("static",
+                                        c._types.scalar(FUIR.SpecialClazzes.c_u64),
+                                        last_id,
+                                        CExpr.uint64const(0)),
+                            CExpr.call("__atomic_add_fetch", new List<>(last_id.adrOf(), CExpr.uint64const(1), new CIdent("__ATOMIC_SEQ_CST"))).ret());
+        });
      put("fuzion.sys.thread.spawn0", (c,cl,outer,in) ->
         {
           var oc = c._fuir.clazzActualGeneric(cl, 0);

--- a/src/dev/flang/be/interpreter/Intrinsics.java
+++ b/src/dev/flang/be/interpreter/Intrinsics.java
@@ -59,6 +59,7 @@ import java.util.Set;
 import java.util.TimeZone;
 import java.util.TreeMap;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 
 
 /**
@@ -146,7 +147,7 @@ public class Intrinsics extends ANY
   /**
    * the last unique identifier returned by `fuzion.sys.misc.unique_id`.
    */
-  private static long _last_unique_id_ = 0;
+  private static AtomicLong _last_unique_id_ = new AtomicLong();
 
 
   /*-------------------------  static methods  --------------------------*/
@@ -797,7 +798,7 @@ public class Intrinsics extends ANY
     put("fuzion.sys.env_vars.set0"  , (interpreter, innerClazz) -> args -> new boolValue(false));
     // unsetting env variable not supported in java
     put("fuzion.sys.env_vars.unset0", (interpreter, innerClazz) -> args -> new boolValue(false));
-    put("fuzion.sys.misc.unique_id",(interpreter, innerClazz) -> args -> new u64Value(++_last_unique_id_));
+    put("fuzion.sys.misc.unique_id",(interpreter, innerClazz) -> args -> new u64Value(_last_unique_id_.incrementAndGet()));
     put("fuzion.sys.thread.spawn0", (interpreter, innerClazz) -> args ->
         {
           var call = Types.resolved.f_function_call;


### PR DESCRIPTION
Fixes #1759.