### PR TITLE
lib/io/print_effect: println: append newline to string printed

### DIFF
--- a/lib/io/print_effect.fz
+++ b/lib/io/print_effect.fz
@@ -52,8 +52,7 @@ is
 public Print_Handler ref is
 
   println(s Any) =>
-    print s
-    println
+    print (s.as_string + (codepoint 10))
 
   println =>
     print (codepoint 10)


### PR DESCRIPTION
When used in threaded environments, the previous version with the newline being printed by a second println, a println from another thread was able to print text before the newline was printed.

Fixes #1763.