### PR TITLE
add badges of testruns to readme

### DIFF
--- a/.github/workflows/apple.yml
+++ b/.github/workflows/apple.yml
@@ -28,6 +28,8 @@ permissions:
 
 on:
   workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * 0' # every sunday
 
 env:
   PRECONDITIONS: true

--- a/.github/workflows/syntax_check_fuzion.yml
+++ b/.github/workflows/syntax_check_fuzion.yml
@@ -17,7 +17,7 @@
 #
 #  Tokiwa Software GmbH, Germany
 #
-#  GitHub Actions workflow to build and test Fuzion on Ubuntu.
+#  GitHub Actions workflow to syntax check fz files.
 #
 # -----------------------------------------------------------------------
 
@@ -29,8 +29,7 @@ permissions:
 on:
   workflow_dispatch:
   schedule:
-    # weekly
-    - cron: '0 0 * * 0'
+    - cron: '0 0 * * 0' # every sunday
 
 env:
   PRECONDITIONS: true

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,3 +1,26 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  GitHub Actions workflow to build and test Fuzion on Windows.
+#
+# -----------------------------------------------------------------------
+
 name: run tests on windows
 
 permissions:
@@ -6,7 +29,7 @@ permissions:
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 0 * * 0'
+    - cron: '0 0 * * 0' # every sunday
 
 jobs:
   run_tests:

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 [![OpenSSF
 Scorecard](https://api.securityscorecards.dev/projects/github.com/tokiwa-software/fuzion/badge)](https://api.securityscorecards.dev/projects/github.com/tokiwa-software/fuzion)
+[![syntax check fz files](https://github.com/tokiwa-software/fuzion/actions/workflows/syntax_check_fuzion.yml/badge.svg)](https://github.com/tokiwa-software/fuzion/actions/workflows/syntax_check_fuzion.yml)
+[![run tests on macOS](https://github.com/tokiwa-software/fuzion/actions/workflows/apple.yml/badge.svg)](https://github.com/tokiwa-software/fuzion/actions/workflows/apple.yml)
+[![run tests on windows](https://github.com/tokiwa-software/fuzion/actions/workflows/windows.yml/badge.svg)](https://github.com/tokiwa-software/fuzion/actions/workflows/windows.yml)
+
 
 ## A language with a focus on simplicity, safety and correctness.
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![OpenSSF
 Scorecard](https://api.securityscorecards.dev/projects/github.com/tokiwa-software/fuzion/badge)](https://api.securityscorecards.dev/projects/github.com/tokiwa-software/fuzion)
 [![syntax check fz files](https://github.com/tokiwa-software/fuzion/actions/workflows/syntax_check_fuzion.yml/badge.svg)](https://github.com/tokiwa-software/fuzion/actions/workflows/syntax_check_fuzion.yml)
+[![run tests on linux](https://github.com/tokiwa-software/fuzion/actions/workflows/linux.yml/badge.svg)](https://github.com/tokiwa-software/fuzion/actions/workflows/linux.yml)
 [![run tests on macOS](https://github.com/tokiwa-software/fuzion/actions/workflows/apple.yml/badge.svg)](https://github.com/tokiwa-software/fuzion/actions/workflows/apple.yml)
 [![run tests on windows](https://github.com/tokiwa-software/fuzion/actions/workflows/windows.yml/badge.svg)](https://github.com/tokiwa-software/fuzion/actions/workflows/windows.yml)
 


### PR DESCRIPTION
also changed to run the tests weekly on apple

![image](https://github.com/tokiwa-software/fuzion/assets/88769212/afb8acda-e5d9-4df5-b073-1deb2268387d)

on windows, mmap test fails because required stack size is larger than windows default and `list.concat` can not be tail call optimized. this can be reproduced on linux easily by decreasing stack size e.g. `ulimit -s 512`
on apple, floating point test fails probably due to a rounding error.