### PR TITLE
fe: remove unnecessary calls performed by Feature.findGenerics visitor

### DIFF
--- a/src/dev/flang/ast/Feature.java
+++ b/src/dev/flang/ast/Feature.java
@@ -1204,9 +1204,7 @@ public class Feature extends AbstractFeature implements Stmnt
 
   static FeatureVisitor findGenerics = new FeatureVisitor()
     {
-      public Function     action(Function     f, AbstractFeature outer) {        f.findGenerics(this, outer); return f; }
-      public This         action(This         t, AbstractFeature outer) {        t.findGenerics(      outer); return t; }
-      public AbstractType action(AbstractType t, AbstractFeature outer) { return t.findGenerics(      outer);           }
+      public AbstractType action(AbstractType t, AbstractFeature outer) { return t.findGenerics(outer); }
     };
 
   /*

--- a/src/dev/flang/ast/Function.java
+++ b/src/dev/flang/ast/Function.java
@@ -313,30 +313,6 @@ public class Function extends ExprWithPos
   }
 
 
-  /**
-   * Find all the types used in this that refer to formal generic arguments of
-   * this or any of this' outer classes.
-   *
-   * @param outer the root feature that contains this statement.
-   */
-  public void findGenerics(FeatureVisitor v, AbstractFeature outer)
-  {
-    if (this._feature != null)
-      { /* NYI: Needed? The following comment seems wrong: */
-        // directly process generics in _feature's arguments and return type,
-        // while visit() skips the _feature.
-        var f = this._feature;
-        for (var a : f.arguments())
-          {
-            var rt = ((Feature)a).returnType(); // NYI: Cast!
-            rt.visit(v, outer);
-          }
-        var rt = ((Feature)f).returnType(); // NYI: Cast!
-        rt.visit(v, outer);
-      }
-  }
-
-
   private AbstractFeature functionOrRoutine()
   {
     var f = this._feature == null ? this._call.calledFeature()

--- a/src/dev/flang/ast/This.java
+++ b/src/dev/flang/ast/This.java
@@ -186,19 +186,6 @@ public class This extends ExprWithPos
 
 
   /**
-   * Find all the types used in this that refer to formal generic arguments of
-   * this or any of this' outer classes.
-   *
-   * @param outer the root feature that contains this statement.
-   */
-  public void findGenerics(AbstractFeature outer)
-  {
-    // NYI: Check if qual starts with the name of a formal generic in outer or
-    // outer.outer..., flag an error if this is the case.
-  }
-
-
-  /**
    * determine the static type of all expressions and declared features in this feature
    *
    * @param res this is called during type resolution, res gives the resolution


### PR DESCRIPTION
Ideally, I would like to get rid of this visitor altogether and join `UnresolvedType.findGenerics` with `UnresolvedType.resolve`.