### PR TITLE
be/c: add method for calling reasonably simple C functions

### DIFF
--- a/include/fz.h
+++ b/include/fz.h
@@ -412,5 +412,14 @@ int fzE_munmap(void * mapped_address, const int file_size){
 }
 
 
+// used to return a string as is; in Fuzion with
+//   fzE_return_string (input Any) String is native
+// this can be used to cast a c_string from type Any
+// to a String.
+char * fzE_return_string(void * in) {
+  return in;
+}
+
+
 
 #endif /* fz.h  */

--- a/src/dev/flang/ast/AbstractFeature.java
+++ b/src/dev/flang/ast/AbstractFeature.java
@@ -62,7 +62,8 @@ public abstract class AbstractFeature extends ANY implements Comparable<Abstract
     OpenTypeParameter,
     Intrinsic,
     Abstract,
-    Choice;
+    Choice,
+    Native;
 
     /**
      * get the Kind that corresponds to the given ordinal number.

--- a/src/dev/flang/ast/Feature.java
+++ b/src/dev/flang/ast/Feature.java
@@ -808,6 +808,7 @@ public class Feature extends AbstractFeature implements Stmnt
           case Routine, RoutineDef, Of                            -> Kind.Routine;
           case Abstract                                           -> Kind.Abstract;
           case Intrinsic                                          -> Kind.Intrinsic;
+          case Native                                             -> Kind.Native;
         };
   }
 

--- a/src/dev/flang/ast/Impl.java
+++ b/src/dev/flang/ast/Impl.java
@@ -56,6 +56,8 @@ public class Impl extends ANY
 
   public static final Impl INTRINSIC_CONSTRUCTOR = new Impl(Kind.Intrinsic);
 
+  public static final Impl NATIVE = new Impl(Kind.Native);
+
   /**
    * A dummy Impl instance used in case of parsing error.
    */
@@ -114,7 +116,8 @@ public class Impl extends ANY
     Routine,      // normal feature with code
     Abstract,     // an abstract feature
     Intrinsic,    // an intrinsic feature
-    Of;           // Syntactic sugar 'enum : choice of red, green, blue is', exists only during parsing
+    Of,           // Syntactic sugar 'enum : choice of red, green, blue is', exists only during parsing
+    Native;       // a native feature
 
     public String toString(){
       return switch(this)
@@ -130,6 +133,7 @@ public class Impl extends ANY
           case Routine           : yield "routine";
           case Abstract          : yield "abstract";
           case Intrinsic         : yield "intrinsic";
+          case Native            : yield "native";
           case Of                : yield "choice of";
         };
     }

--- a/src/dev/flang/be/interpreter/Interpreter.java
+++ b/src/dev/flang/be/interpreter/Interpreter.java
@@ -768,6 +768,8 @@ public class Interpreter extends ANY
           case Intrinsic:
             result = Intrinsics.call(this, innerClazz);
             break;
+          case Native:
+            throw new Error("Java backend does not support native features");
           case Choice: // NYI: why choice here?
           case Routine:
             if (innerClazz == Clazzes.universe.get())

--- a/src/dev/flang/fuir/FUIR.java
+++ b/src/dev/flang/fuir/FUIR.java
@@ -513,6 +513,7 @@ public class FUIR extends IR
       case Abstract   -> FeatureKind.Abstract;
       case Choice     -> FeatureKind.Choice;
       case TypeParameter -> FeatureKind.Intrinsic;
+      case Native     -> FeatureKind.Native;
       default         -> throw new Error ("Unexpected feature kind: "+ff.kind());
       };
   }
@@ -539,7 +540,8 @@ public class FUIR extends IR
   public String clazzIntrinsicName(int cl)
   {
     if (PRECONDITIONS) require
-      (clazzKind(cl) == FeatureKind.Intrinsic);
+      (clazzKind(cl) == FeatureKind.Intrinsic ||
+       clazzKind(cl) == FeatureKind.Native);
 
     var cc = clazz(cl);
     return cc.feature().qualifiedName();
@@ -976,7 +978,8 @@ hw25 is
       (clazzKind(cl) == FeatureKind.Routine   ||
        clazzKind(cl) == FeatureKind.Field     ||
        clazzKind(cl) == FeatureKind.Intrinsic ||
-       clazzKind(cl) == FeatureKind.Abstract     ,
+       clazzKind(cl) == FeatureKind.Abstract  ||
+       clazzKind(cl) == FeatureKind.Native       ,
        ix >= 0);
 
     var cc = clazz(cl);
@@ -1052,7 +1055,7 @@ hw25 is
         var result = switch (clazzKind(cc))
           {
           case Abstract, Choice -> false;
-          case Intrinsic, Routine, Field ->
+          case Intrinsic, Routine, Field, Native ->
             (cc.isInstantiated() || cc.feature().isOuterRef() || cc.feature().isTypeFeature())
             && cc != Clazzes.Const_String.getIfCreated()
             && !cc.isAbsurd()
@@ -1119,6 +1122,7 @@ hw25 is
                case Intrinsic -> LifeTime.Unknown;
                case Field     -> LifeTime.Unknown;
                case Routine   -> LifeTime.Unknown;
+               case Native    -> LifeTime.Unknown;
                })
           : (switch (clazzKind(cl))
                {
@@ -1127,6 +1131,7 @@ hw25 is
                case Intrinsic -> LifeTime.Undefined;
                case Field     -> LifeTime.Call;
                case Routine   -> LifeTime.Unknown;
+               case Native    -> LifeTime.Unknown;
                });
 
       return result;

--- a/src/dev/flang/fuir/analysis/dfa/Call.java
+++ b/src/dev/flang/fuir/analysis/dfa/Call.java
@@ -29,6 +29,9 @@ package dev.flang.fuir.analysis.dfa;
 import java.nio.charset.StandardCharsets;
 
 import dev.flang.fuir.FUIR;
+import dev.flang.fuir.FUIR.SpecialClazzes;
+
+import dev.flang.fuir.analysis.dfa.DFA.IntrinsicDFA;
 
 import dev.flang.ir.IR;
 
@@ -222,6 +225,38 @@ public class Call extends ANY implements Comparable<Call>, Context
                 var msg = "DFA: code to handle intrinsic '" + name + "' is missing";
                 Errors.warning(msg);
               }
+          }
+      }
+    else if (_dfa._fuir.clazzKind(_cc) == IR.FeatureKind.Native)
+      {
+        var rc = _dfa._fuir.clazzResultClazz(_cc);
+        IntrinsicDFA val = null;
+
+        if (_dfa._fuir.clazzIs(rc, SpecialClazzes.c_i8)  ||
+            _dfa._fuir.clazzIs(rc, SpecialClazzes.c_i16) ||
+            _dfa._fuir.clazzIs(rc, SpecialClazzes.c_i32) ||
+            _dfa._fuir.clazzIs(rc, SpecialClazzes.c_i64) ||
+            _dfa._fuir.clazzIs(rc, SpecialClazzes.c_u8)  ||
+            _dfa._fuir.clazzIs(rc, SpecialClazzes.c_u16) ||
+            _dfa._fuir.clazzIs(rc, SpecialClazzes.c_u32) ||
+            _dfa._fuir.clazzIs(rc, SpecialClazzes.c_u64) ||
+            _dfa._fuir.clazzIs(rc, SpecialClazzes.c_f32) ||
+            _dfa._fuir.clazzIs(rc, SpecialClazzes.c_f64))
+          {
+            val = cl -> new NumericValue(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc));
+          }
+        else if (_dfa._fuir.clazzBaseName(rc).equals("String"))
+          {
+            val = cl -> cl._dfa.newConstString(null, cl);
+          }
+
+        if (val != null)
+          {
+            result = val.analyze(this);
+          }
+        else
+          {
+            Errors.warning("DFA: cannot handle native feature " + _dfa._fuir.clazzIntrinsicName(_cc));
           }
       }
     else if (_returns)

--- a/src/dev/flang/fuir/analysis/dfa/DFA.java
+++ b/src/dev/flang/fuir/analysis/dfa/DFA.java
@@ -367,6 +367,7 @@ public class DFA extends ANY
                        "Found call to  " + _fuir.clazzAsString(cc));
         case Routine  :
         case Intrinsic:
+        case Native   :
           {
             if (_fuir.clazzNeedsCode(cc))
               {
@@ -824,7 +825,8 @@ public class DFA extends ANY
           return super.clazzNeedsCode(cl) &&
             switch (_fuir.clazzKind(cl))
             {
-            case Routine, Intrinsic -> called.contains(cl);
+            case Routine, Intrinsic,
+                 Native             -> called.contains(cl);
             case Field              -> isBuiltInNumeric(_fuir.clazzOuterClazz(cl)) || _readFields.contains(cl);
             case Abstract           -> true;
             case Choice             -> true;
@@ -853,7 +855,8 @@ public class DFA extends ANY
                      case Abstract  ,
                           Intrinsic ,
                           Field     ,
-                          Routine   -> currentEscapes(cl, pre) ? LifeTime.Unknown :
+                          Routine   ,
+                          Native    -> currentEscapes(cl, pre) ? LifeTime.Unknown :
                                                                  LifeTime.Call;
                      })
                 : (switch (clazzKind(cl))
@@ -864,6 +867,7 @@ public class DFA extends ANY
                      case Field     -> LifeTime.Call;
                      case Routine   -> currentEscapes(cl, pre) ? LifeTime.Unknown :
                                                                  LifeTime.Call;
+                     case Native    -> LifeTime.Undefined;
                      });
 
           return result;

--- a/src/dev/flang/ir/IR.java
+++ b/src/dev/flang/ir/IR.java
@@ -95,7 +95,8 @@ public class IR extends ANY
     Field,
     Intrinsic,
     Abstract,
-    Choice
+    Choice,
+    Native
   }
 
 

--- a/src/dev/flang/parser/Lexer.java
+++ b/src/dev/flang/parser/Lexer.java
@@ -177,6 +177,7 @@ public class Lexer extends SourceFile
     t_abstract("abstract"),
     t_intrinsic("intrinsic"),
     t_intrinsic_constructor("intrinsic_constructor"),
+    t_native("native"),
     t_for("for"),
     t_in("in"),
     t_do("do"),

--- a/src/dev/flang/parser/Parser.java
+++ b/src/dev/flang/parser/Parser.java
@@ -3586,6 +3586,7 @@ implRout    : block
             | "is" "abstract"
             | "is" "intrinsic"
             | "is" "intrinsic_constructor"
+            | "is" "native"
             | "is" block
             | ARROW block
             | "of" block
@@ -3600,6 +3601,7 @@ implRout    : block
     if      (startRoutine    ) { result = skip(Token.t_abstract             ) ? Impl.ABSTRACT              :
                                           skip(Token.t_intrinsic            ) ? Impl.INTRINSIC             :
                                           skip(Token.t_intrinsic_constructor) ? Impl.INTRINSIC_CONSTRUCTOR :
+                                          skip(Token.t_native               ) ? Impl.NATIVE                :
                                           new Impl(pos, block()      , Impl.Kind.Routine   ); }
     else if (skip("=>")      ) { result = new Impl(pos, block()      , Impl.Kind.RoutineDef); }
     else if (skip(Token.t_of)) { result = new Impl(pos, block()      , Impl.Kind.Of        ); }

--- a/src/dev/flang/util/FuzionConstants.java
+++ b/src/dev/flang/util/FuzionConstants.java
@@ -225,8 +225,8 @@ public class FuzionConstants extends ANY
   /**
    * feature kind value for constructor routines
    */
-  public static final int MIR_FILE_KIND_CONSTRUCTOR_VALUE = 7;
-  public static final int MIR_FILE_KIND_CONSTRUCTOR_REF   = 8;
+  public static final int MIR_FILE_KIND_CONSTRUCTOR_VALUE = 8;
+  public static final int MIR_FILE_KIND_CONSTRUCTOR_REF   = 9;
 
   /**
    * The bits of feature kind that encode the kind.


### PR DESCRIPTION
Reasonably simple means that the C functions only take integer, floating-point and string arguments, and also only return a result of one of these types.

The DFA is adjusted to automatically handle these calls, as well.