### PR TITLE
Call.resolveTypes: return Call.NO_VALUE in case of error

### DIFF
--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -377,6 +377,8 @@ public class Call extends AbstractCall
                AbstractFeature calledFeature,
                AbstractType type)
   {
+    if (PRECONDITIONS)
+      require(generics.stream().allMatch(g -> !g.containsError()));
     this._pos = pos;
     this._name = name;
     this._select = select;
@@ -2198,7 +2200,13 @@ public class Call extends AbstractCall
       {
         _type = _type.replace_type_parameters_of_type_feature_origin(outer);
       }
-    return result;
+
+    if (POSTCONDITIONS)
+      ensure(Errors.count() > 0 || _type != Types.t_ERROR);
+
+    return _type == Types.t_ERROR
+      ? Call.NO_VALUE // short circuit this call
+      : result;
   }
 
 

--- a/src/dev/flang/ast/Expr.java
+++ b/src/dev/flang/ast/Expr.java
@@ -53,7 +53,7 @@ public abstract class Expr extends ANY implements Stmnt
 
 
   /**
-   * Dummy Expr value. Used in 'Actual' to represent non-existing value version
+   * Dummy Expr value. Used e.g. in 'Actual' to represent non-existing value version
    * of the actual.
    */
   public static Call NO_VALUE;

--- a/src/dev/flang/ast/Feature.java
+++ b/src/dev/flang/ast/Feature.java
@@ -37,7 +37,6 @@ import java.util.stream.Collectors;
 
 import dev.flang.util.Errors;
 import dev.flang.util.FuzionConstants;
-import dev.flang.util.HasSourcePosition;
 import dev.flang.util.List;
 import dev.flang.util.SourcePosition;
 
@@ -337,6 +336,7 @@ public class Feature extends AbstractFeature implements Stmnt
   {
     this();
     _state = State.ERROR;
+    _featureName = FeatureName.get(Types.ERROR_NAME, arguments().size());
   }
 
 
@@ -1041,7 +1041,7 @@ public class Feature extends AbstractFeature implements Stmnt
       {
         Expr nc = c.visit(v, this);
         if (CHECKS) check
-          (c == nc); // NYI: This will fail when doing funny stuff like inherit from bool.infix &&, need to check and handle explicitly
+          (Errors.count() > 0 || c == nc); // NYI: This will fail when doing funny stuff like inherit from bool.infix &&, need to check and handle explicitly
       }
     _impl.visit(v, this);
     _returnType.visit(v, this);

--- a/src/dev/flang/ast/FormalGenerics.java
+++ b/src/dev/flang/ast/FormalGenerics.java
@@ -29,7 +29,6 @@ package dev.flang.ast;
 import java.util.Iterator;
 
 import dev.flang.util.ANY;
-import dev.flang.util.HasSourcePosition;
 import dev.flang.util.List;
 import dev.flang.util.SourcePosition;
 

--- a/src/dev/flang/ast/ResolvedParametricType.java
+++ b/src/dev/flang/ast/ResolvedParametricType.java
@@ -217,8 +217,6 @@ public class ResolvedParametricType extends ResolvedType
    */
   public String toString()
   {
-    String result;
-
     String n;
     if (_generic.isThisTypeInTypeFeature())
       {


### PR DESCRIPTION
this fixes an unjustified error: "Incompatible type parameter" when
the type parameter of an inheritance call was found to an error e.g. a : `Sequence **error**`