### PR TITLE
fe: Fix .fum file for free types, #1656, modifications forgot in #1774

### DIFF
--- a/src/dev/flang/ast/Feature.java
+++ b/src/dev/flang/ast/Feature.java
@@ -2336,7 +2336,7 @@ public class Feature extends AbstractFeature implements Stmnt
   /**
    * Number of free types amoung the type parameters.
    */
-  int freeTypesCount()
+  public int freeTypesCount()
   {
     var result = 0;
     for (var tp : _arguments)

--- a/src/dev/flang/fe/LibraryOut.java
+++ b/src/dev/flang/fe/LibraryOut.java
@@ -460,7 +460,8 @@ class LibraryOut extends ANY
         bn = "";
       }
     _data.writeName(bn);
-    _data.writeInt (n.argCount());  // NYI: use better integer encoding
+    var argCount = n.argCount() + f.freeTypesCount();
+    _data.writeInt (argCount);      // NYI: use better integer encoding
     _data.writeInt (n._id);         // NYI: id /= 0 only if argCount = 0, so join these two values.
     pos(f.pos());
     featureIndexOrZeroForUniverse(f.outer());
@@ -469,7 +470,7 @@ class LibraryOut extends ANY
         _data.writeOffset(f.typeFeature());
       }
     if (CHECKS) check
-      (f.arguments().size() == f.featureName().argCount());
+      (f.arguments().size() == argCount);
     if (!f.isConstructor() && !f.isChoice())
       {
         type(f.resultType());


### PR DESCRIPTION
Write correct argument count to fum file, i.e., include free types that were added.

With this, @maxteufel 's changes to `Sequence.zip` can be sabed to `base.fum` without failing checks, and the example runs. 