### PR TITLE
fix tagging of typefeaturethistype result

### DIFF
--- a/src/dev/flang/ast/Expr.java
+++ b/src/dev/flang/ast/Expr.java
@@ -531,6 +531,10 @@ public abstract class Expr extends ANY implements Stmnt
   private boolean needsBoxing(AbstractType frmlT)
   {
     var t = type();
+    if (frmlT.isThisTypeInTypeFeature())
+      {
+        return false;
+      }
     if (needsBoxingForGenericOrThis(frmlT))
       {
         return true;

--- a/src/dev/flang/ast/Generic.java
+++ b/src/dev/flang/ast/Generic.java
@@ -68,6 +68,8 @@ public class Generic extends ANY
    */
   public Generic(AbstractFeature typeParameter)
   {
+    if (PRECONDITIONS) require
+        (typeParameter.isTypeParameter());
     _typeParameter = typeParameter;
   }
 


### PR DESCRIPTION
for e.g. this example, tagging was not correctly done:
```
  public redef fixed type.empty list.this is
    nil
```
fixes #1739