### PR TITLE
fix negative tests on openbsd

### DIFF
--- a/tests/negative.mk
+++ b/tests/negative.mk
@@ -30,16 +30,16 @@
 
 FUZION_OPTIONS ?=
 FUZION = ../../bin/fz -XmaxErrors=-1 $(FUZION_OPTIONS)
-EXPECTED_ERRORS = `cat *.fz | grep "should.flag.an.error"  | sed "s ^.*//  g"| sort -n | uniq | wc -l`
+EXPECTED_ERRORS = `cat *.fz | grep "should.flag.an.error"  | sed "s ^.*//  g"| sort -n | uniq | wc -l | tr -d ' '`
 
 int:
 	$(FUZION) $(NAME) 2>err.txt || echo -n
-	cat err.txt  | grep "should.flag.an.error" | sed "s ^.*//  g"| sort -n | uniq | wc -l | grep ^$(EXPECTED_ERRORS)$$ && echo "test passed." || exit 1
+	cat err.txt  | grep "should.flag.an.error" | sed "s ^.*//  g"| sort -n | uniq | wc -l | tr -d ' ' | grep ^$(EXPECTED_ERRORS)$$ && echo "test passed." || exit 1
 
 c:
 	($(FUZION) -c -o=testbin $(NAME) && ./testbin) 2>err.txt || echo -n
-	cat err.txt  | grep "should.flag.an.error" | sed "s ^.*//  g"| sort -n | uniq | wc -l | grep ^$(EXPECTED_ERRORS)$$ && echo "test passed." || exit 1
+	cat err.txt  | grep "should.flag.an.error" | sed "s ^.*//  g"| sort -n | uniq | wc -l | tr -d ' ' | grep ^$(EXPECTED_ERRORS)$$ && echo "test passed." || exit 1
 
 show:
-	echo -n "Expected $(EXPECTED_ERRORS) errors, found " && cat err.txt  | grep "should.flag.an.error" | sed "s ^.*//  g"| sort -n | uniq | wc -l
+	echo -n "Expected $(EXPECTED_ERRORS) errors, found " && cat err.txt  | grep "should.flag.an.error" | sed "s ^.*//  g"| sort -n | uniq | wc -l | tr -d ' '
 	cat err.txt  | grep "should.flag.an.error" | sed "s ^.*//  g"| sort -n | uniq


### PR DESCRIPTION
output of `wc -l` is preceded by spaces on openbsd.