### PR TITLE
add intrinsics stdin, stderr, stdout, fileio.flush

### DIFF
--- a/lib/fuzion/sys/err.fz
+++ b/lib/fuzion/sys/err.fz
@@ -36,8 +36,7 @@ public err: character_encodings is
   public println =>
     write [ascii.lf]
 
-  private write(arr array u8) =>
-    write arr.internal_array.data arr.length
+  private stderr i64 is intrinsic
 
-  private write(array_data Any, length i32) unit is intrinsic
-  private flush unit is intrinsic
+  private write(arr array u8) =>
+    _ := fuzion.sys.fileio.write stderr arr

--- a/lib/fuzion/sys/fileio.fz
+++ b/lib/fuzion/sys/fileio.fz
@@ -37,16 +37,21 @@ module fileio is
     buf := array n.as_i32 i->(u8 0)
     res := read fd buf.internal_array.data buf.length
 
-    if res < i64 0
+    if res < -1
       error "unspecified read error: {res}"
-    else if res < n.as_i64 || res = n.as_i64
-      (buf.slice 0 res.as_i32).as_array
+    else if res < 0
+      r array u8 := [] # NYI type inference assigning array to choice
+      r
     else
-      error "read more than expected"
+      (buf.slice 0 res).as_array
 
 
   # intrinsic that fills an array u8 with the file bytes that is represented by the file descriptor
-  # returns i8 0 in case of success and the error number/ -1 for the interpreter in case of failure
+  #
+  # returns:
+  # 0 or greater on success
+  # -1 at end of file
+  # -2 for any other error
   #
   private read(
                # the file descriptor
@@ -54,7 +59,7 @@ module fileio is
                # the internal array data representing the container for the bytes to be read from the file
                file_array Any,
                # the length of the array that represents the file bytes
-               file_array_length i32) i64 is intrinsic
+               file_array_length i32) i32 is intrinsic
 
 
   # retrieves the file size in bytes and returns an outcome of error in case of an error
@@ -75,14 +80,13 @@ module fileio is
   module write(fd i64, content array u8) outcome unit is
     res := write fd content.internal_array.data content.length
 
-    if res = i8 0
+    if res = 0
       unit
     else
       error "write error: {res}"
 
   # intrinsic to write bytes (internal array data) in a file using the file descriptor
-  # returns i8 0 in case of success
-  # and the error number/ -1 in the interpreter in case of failure
+  # returns 0 in case of success, -1 in case of failure
   #
   private write(
                 # the file descriptor
@@ -90,7 +94,7 @@ module fileio is
                 # the internal array data representing the content bytes to insert in file
                 content Any,
                 # the length of the internal array representing the content
-                content_length i32) i8 is intrinsic
+                content_length i32) i32 is intrinsic
 
 
   # deletes the file/dir found in the path
@@ -310,3 +314,9 @@ module fileio is
   #
   module munmap(address Any, size i64) i32 is intrinsic
 
+
+  # flush user-space buffers of file descriptor
+  #
+  # return: 0 on success everything else is an error
+  #
+  module flush(fd i64) i32 is intrinsic

--- a/lib/fuzion/sys/out.fz
+++ b/lib/fuzion/sys/out.fz
@@ -36,8 +36,7 @@ public out : character_encodings is
   public println =>
     write [ascii.lf]
 
-  private write(arr array u8) =>
-    write arr.internal_array.data arr.length
+  module stdout i64 is intrinsic
 
-  private write(array_data Any, length i32) unit is intrinsic
-  private flush unit is intrinsic
+  private write(arr array u8) =>
+    _ := fuzion.sys.fileio.write stdout arr

--- a/lib/fuzion/sys/stdin.fz
+++ b/lib/fuzion/sys/stdin.fz
@@ -27,11 +27,5 @@
 # NYI name in does not work right now since in is reserved keyword
 public stdin is
 
-  # read next byte from stdin
-  #
-  # returns:
-  # 0 or greater on success
-  # -1 at end of file
-  # -2 for any other error
-  #
-  module next_byte i32 is intrinsic
+  private stdin0 i64 is intrinsic
+

--- a/lib/io/file/write.fz
+++ b/lib/io/file/write.fz
@@ -54,6 +54,9 @@ public write(fwh Write_Handler) : simple_effect is
     # dummy parameter for overloading
     write(fd i64, content array u8, _ unit) =>
       fuzion.sys.fileio.write fd content
+        .bind unit r->
+          if fuzion.sys.fileio.flush fd = 0 then r else error "flushing failed"
+
 
     mkdir(path String) =>
       fuzion.sys.fileio.create_dir path

--- a/lib/io/stdin.fz
+++ b/lib/io/stdin.fz
@@ -170,15 +170,18 @@ public stdin(ip io.Byte_Input_Handler) : simple_effect is
   #
   type.default_input_handler(r choice u8 io.end_of_file error) : io.Byte_Input_Handler is
 
+    stdin := fuzion.sys.stdin.stdin0
 
     next io.Byte_Input_Handler is
-      v := fuzion.sys.stdin.next_byte
-      if v = -1
-        default_input_handler io.end_of_file
-      else if v < -1
+      res := [u8 0]
+      v := fuzion.sys.fileio.read stdin res.internal_array.data 1
+
+      if v < -1
         default_input_handler (error "an error occurred while reading stdin")
+      else if v <= 0
+          default_input_handler io.end_of_file
       else
-        default_input_handler v.as_u8
+        default_input_handler res[0]
 
 
     get => r

--- a/src/dev/flang/be/c/Intrinsics.java
+++ b/src/dev/flang/be/c/Intrinsics.java
@@ -316,56 +316,33 @@ public class Intrinsics extends ANY
                             tmp.castTo(c._types.clazz(rc)).ret());
         });
     put("fuzion.std.exit"      , (c,cl,outer,in) -> CExpr.call("exit", new List<>(A0)));
-    put("fuzion.sys.out.write" ,
-        "fuzion.sys.err.write" , (c,cl,outer,in) ->
-        {
-          // How do I print a non-null-terminated strings: https://stackoverflow.com/a/25111267
-          return CExpr.call("fwrite",
-                              new List<>(
-                                A0.castTo("void *"),
-                                CExpr.sizeOfType("char"),
-                                A1,
-                                outOrErr(in)
-                              ));
-        });
     put("fuzion.sys.fileio.read"         , (c,cl,outer,in) ->
         {
-          var readingIdent = new CIdent("reading");
-          var resultIdent = new CIdent("result");
+          var result = new CIdent("result");
           var zero = new CIdent("0");
           return CStmnt.seq(
-            CExpr.call("clearerr", new List<>(A0.castTo("FILE *"))),
-            CExpr.decl("size_t", readingIdent, CExpr.call("fread", new List<>(A1, CExpr.int8const(1), A2, A0.castTo("FILE *")))),
-            CExpr.decl("fzT_1i64", resultIdent, readingIdent.castTo("fzT_1i64")),
-            CExpr.iff(
-              CExpr.notEq(readingIdent, A2.castTo("size_t")),
-              CStmnt.seq(
-                CExpr.iff(CExpr.notEq(CExpr.call("feof", new List<>(A0.castTo("FILE *"))), zero),
-                  resultIdent.assign(readingIdent.castTo("fzT_1i64"))),
-                CExpr.iff(CExpr.notEq(CExpr.call("ferror", new List<>(A0.castTo("FILE *"))), zero),
-                  resultIdent.assign(CExpr.int64const(-1))),
-                CExpr.call("clearerr", new List<>(A0.castTo("FILE *"))))),
-            resultIdent.ret());
+            CExpr.decl("int", result, CExpr.call("fread", new List<>(A1, CExpr.int8const(1), A2, A0.castTo("FILE *")))),
+            CExpr.iff(CExpr.notEq(CExpr.call("ferror", new List<>(A0.castTo("FILE *"))), zero),
+              CExpr.int32const(-2).ret()),
+            CExpr.iff(result.eq(zero).and(CExpr.notEq(CExpr.call("feof", new List<>(A0.castTo("FILE *"))), zero)),
+              CExpr.int32const(-1).ret()),
+            result.castTo("fzT_1i32").ret()
+          );
         });
     put("fuzion.sys.fileio.write"        , (c,cl,outer,in) ->
         {
-          var writingIdent = new CIdent("writing");
-          var flushingIdent = new CIdent("flushing");
-          var resultIdent = new CIdent("result");
-          var zero = new CIdent("0");
           return CStmnt.seq(
-            CExpr.call("clearerr", new List<>(A0.castTo("FILE *"))),
-            CExpr.decl("size_t", writingIdent, CExpr.call("fwrite", new List<>(A1, CExpr.int8const(1), A2, A0.castTo("FILE *")))),
-            CExpr.decl("fzT_1i8", resultIdent, CExpr.int8const(0)),
-            CExpr.iff(
-              CExpr.notEq(writingIdent, A2.castTo("size_t")),
-              CStmnt.seq(
-                CExpr.iff(CExpr.notEq(CExpr.call("ferror", new List<>(A0.castTo("FILE *"))), zero),
-                  resultIdent.assign(CExpr.int8const(-1))),
-                CExpr.call("clearerr", new List<>(A0.castTo("FILE *"))))),
-            CExpr.decl("bool", flushingIdent, CExpr.call("fflush", new List<>(A0.castTo("FILE *"))).eq(CExpr.int8const(0))),
-            CExpr.iff(flushingIdent.not(), resultIdent.assign(errno.castTo("fzT_1i8"))),
-            resultIdent.ret());
+            CExpr.call("fwrite",
+                            new List<>(
+                              A1.castTo("void *"),      // the data
+                              CExpr.sizeOfType("char"), //
+                              A2,                       // how many bytes to write
+                              A0.castTo("FILE *")       // the file descriptor
+                            )),
+            CExpr.iff(CExpr.notEq(CExpr.call("ferror", new List<>(A0.castTo("FILE *"))), new CIdent("0")),
+              CExpr.int32const(-1).ret()),
+            CExpr.int32const(0).ret()
+          );
         });
     put("fuzion.sys.fileio.delete"       ,  (c,cl,outer,in) ->
         {
@@ -556,24 +533,14 @@ public class Intrinsics extends ANY
       A1.castTo("size_t")     // size
     )).ret());
 
-    put("fuzion.sys.out.flush"      ,
-        "fuzion.sys.err.flush"      , (c,cl,outer,in) -> CExpr.call("fflush", new List<>(outOrErr(in))));
-    put("fuzion.sys.stdin.next_byte", (c,cl,outer,in) ->
-        {
-          var cIdent = new CIdent("c");
-          return CStmnt.seq(
-            CExpr.decl("int", cIdent, CExpr.call("getchar", new List<>())),
-            CExpr.iff(cIdent.eq(new CIdent("EOF")),
-              CStmnt.seq(
-                // -1 EOF
-                CExpr.iff(CExpr.call("feof", new List<>(CExpr.ident("stdin"))), CExpr.int32const(-1).ret()),
-                // -2 some other error
-                CExpr.int32const(-2).ret()
-              )
-            ),
-            cIdent.castTo("fzT_1i32").ret()
-          );
-        });
+    put("fuzion.sys.fileio.flush"      , (c,cl,outer,in) ->
+      CExpr.call("fflush", new List<>(A0.castTo("FILE *"))).ret());
+    put("fuzion.sys.stdin.stdin0"      , (c,cl,outer,in) ->
+      new CIdent("stdin").castTo("fzT_1i64").ret());
+    put("fuzion.sys.out.stdout"      , (c,cl,outer,in) ->
+      new CIdent("stdout").castTo("fzT_1i64").ret());
+    put("fuzion.sys.err.stderr"      , (c,cl,outer,in) ->
+      new CIdent("stderr").castTo("fzT_1i64").ret());
 
         /* NYI: The C standard does not guarantee wrap-around semantics for signed types, need
          * to check if this is the case for the C compilers used for Fuzion.
@@ -1162,22 +1129,6 @@ public class Intrinsics extends ANY
 
 
   /*-----------------------------  methods  -----------------------------*/
-
-
-  /**
-   * Get the proper output file handle 'stdout' or 'stderr' depending on the
-   * prefix of the intrinsic feature name in.
-   *
-   * @param in name of an intrinsic feature in fuzion.sys.out or fuzion.sys.err.
-   *
-   * @return CIdent of 'stdout' or 'stderr'
-   */
-  private static CIdent outOrErr(String in)
-  {
-    if      (in.startsWith("fuzion.sys.out.")) { return new CIdent("stdout"); }
-    else if (in.startsWith("fuzion.sys.err.")) { return new CIdent("stderr"); }
-    else                                       { throw new Error("outOrErr called on "+in); }
-  }
 
 
   /**

--- a/src/dev/flang/fuir/analysis/dfa/DFA.java
+++ b/src/dev/flang/fuir/analysis/dfa/DFA.java
@@ -1243,8 +1243,6 @@ public class DFA extends ANY
     put("fuzion.sys.args.count"          , cl -> new NumericValue(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc)) );
     put("fuzion.sys.args.get"            , cl -> cl._dfa.newConstString(null, cl) );
     put("fuzion.std.exit"                , cl -> null );
-    put("fuzion.sys.out.write"           , cl -> Value.UNIT );
-    put("fuzion.sys.err.write"           , cl -> Value.UNIT );
     put("fuzion.sys.fileio.read"         , cl -> new NumericValue(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc)) ); // NYI : manipulation of an array passed as argument needs to be tracked and recorded
     put("fuzion.sys.fileio.write"        , cl -> new NumericValue(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc)) );
     put("fuzion.sys.fileio.delete"       , cl -> cl._dfa._bool );
@@ -1258,9 +1256,11 @@ public class DFA extends ANY
     put("fuzion.sys.fileio.file_position", cl -> Value.UNIT ); // NYI : manipulation of an array passed as argument needs to be tracked and recorded
     put("fuzion.sys.fileio.mmap"         , cl -> new SysArray(cl._dfa, new byte[0])); // NYI: length wrong, get from arg
     put("fuzion.sys.fileio.munmap"       , cl -> new NumericValue(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc)) );
-    put("fuzion.sys.out.flush"           , cl -> Value.UNIT );
-    put("fuzion.sys.err.flush"           , cl -> Value.UNIT );
-    put("fuzion.sys.stdin.next_byte"     , cl -> new NumericValue(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc)) );
+    put("fuzion.sys.fileio.flush"        , cl -> new NumericValue(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc)) );
+    put("fuzion.sys.stdin.stdin0"        , cl -> new NumericValue(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc)) );
+    put("fuzion.sys.out.stdout"          , cl -> new NumericValue(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc)) );
+    put("fuzion.sys.err.stderr"          , cl -> new NumericValue(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc)) );
+
     put("i8.prefix -°"                   , cl -> { return new NumericValue(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc)); } );
     put("i16.prefix -°"                  , cl -> { return new NumericValue(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc)); } );
     put("i32.prefix -°"                  , cl -> { return new NumericValue(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc)); } );

--- a/src/dev/flang/fuir/cfg/CFG.java
+++ b/src/dev/flang/fuir/cfg/CFG.java
@@ -231,8 +231,6 @@ public class CFG extends ANY
     put("fuzion.sys.args.count"          , (cfg, cl) -> { } );
     put("fuzion.sys.args.get"            , (cfg, cl) -> { } );
     put("fuzion.std.exit"                , (cfg, cl) -> { } );
-    put("fuzion.sys.out.write"           , (cfg, cl) -> { } );
-    put("fuzion.sys.err.write"           , (cfg, cl) -> { } );
     put("fuzion.sys.fileio.read"         , (cfg, cl) -> { } );
     put("fuzion.sys.fileio.write"        , (cfg, cl) -> { } );
     put("fuzion.sys.fileio.delete"       , (cfg, cl) -> { } );
@@ -246,9 +244,11 @@ public class CFG extends ANY
     put("fuzion.sys.fileio.file_position", (cfg, cl) -> { } );
     put("fuzion.sys.fileio.mmap"         , (cfg, cl) -> { } );
     put("fuzion.sys.fileio.munmap"       , (cfg, cl) -> { } );
-    put("fuzion.sys.out.flush"           , (cfg, cl) -> { } );
-    put("fuzion.sys.err.flush"           , (cfg, cl) -> { } );
-    put("fuzion.sys.stdin.next_byte"     , (cfg, cl) -> { } );
+    put("fuzion.sys.fileio.flush"        , (cfg, cl) -> { } );
+    put("fuzion.sys.stdin.stdin0"        , (cfg, cl) -> { } );
+    put("fuzion.sys.out.stdout"          , (cfg, cl) -> { } );
+    put("fuzion.sys.err.stderr"          , (cfg, cl) -> { } );
+
     put("i8.prefix -°"                   , (cfg, cl) -> { } );
     put("i16.prefix -°"                  , (cfg, cl) -> { } );
     put("i32.prefix -°"                  , (cfg, cl) -> { } );

--- a/tests/stdin/stdintest.fz
+++ b/tests/stdin/stdintest.fz
@@ -29,10 +29,10 @@ stdintest =>
   read_line => io.stdin.read_line
 
   a := read 1
-  # read 0 should not lead to next_byte beeing called
+  # read 0 should not lead to next_byte being called
   read 0
   b := read 1
-  # read 0 should not lead to next_byte beeing called
+  # read 0 should not lead to next_byte being called
   read 0
   # read 1 utf8
   smiley := read 1


### PR DESCRIPTION
- adjusted fileio.(read|write) to work with the new intrinsics
- remove unneeded intrinsics: (out|err).(flush|write), stdin.next_byte