### PR TITLE
implement atan2 in fuzion

### DIFF
--- a/lib/f32.fz
+++ b/lib/f32.fz
@@ -192,7 +192,46 @@ public f32(val f32) : float is
   public fixed type.asin(val f32) f32 is intrinsic
   public fixed type.acos(val f32) f32 is intrinsic
   public fixed type.atan(val f32) f32 is intrinsic
-  public fixed type.atan2(y, x f32) f32 is intrinsic
+
+  # atan(y/x) with a few special cases
+  # see also: https://go.dev/src/math/atan2.go
+  #
+  public fixed type.atan2(y, x f32) f32 is
+    if is_NaN y || is_NaN x
+      NaN
+    if y = 0
+      if x > 0 || (x = 0 && x.is_sign_bit_set)
+        y
+      else
+        if y.is_sign_bit_set then -π else π
+    else if x = 0
+      if y > 0 then π/2 else -π/2
+    else if x = f32.type.positive_infinity
+      if y = f32.type.positive_infinity
+        π/4
+      else if y = f32.type.negative_infinity
+        -π/4
+      else
+        0
+    else if x = f32.type.negative_infinity
+      if y = f32.type.positive_infinity
+        (f32 3.0)*π/4
+      else if y = f32.type.negative_infinity
+        -(f32 3.0)*π/4
+      else if y > 0
+        π
+      else // y < 0
+        -π
+    else if y = f32.type.positive_infinity
+      π/2
+    else if y = f32.type.negative_infinity
+      -π/2
+    else
+      q := atan y/x
+      if x < 0
+        if q <= 0 then q+π else q-π
+      else
+        q
 
 
   public fixed type.sinh (val f32) f32 is intrinsic

--- a/lib/f64.fz
+++ b/lib/f64.fz
@@ -207,7 +207,46 @@ public f64(val f64) : float is
   public fixed type.asin(val f64) f64 is intrinsic
   public fixed type.acos(val f64) f64 is intrinsic
   public fixed type.atan(val f64) f64 is intrinsic
-  public fixed type.atan2(y, x f64) f64 is intrinsic
+
+  # atan(y/x) with a few special cases
+  # see also: https://go.dev/src/math/atan2.go
+  #
+  public fixed type.atan2(y, x f64) f64 is
+    if is_NaN y || is_NaN x
+      NaN
+    if y = 0
+      if x > 0 || (x = 0 && x.is_sign_bit_set)
+        y
+      else
+        if y.is_sign_bit_set then -π else π
+    else if x = 0
+      if y > 0 then π/2 else -π/2
+    else if x = f64.type.positive_infinity
+      if y = f64.type.positive_infinity
+        π/4
+      else if y = f64.type.negative_infinity
+        -π/4
+      else
+        0
+    else if x = f64.type.negative_infinity
+      if y = f64.type.positive_infinity
+        3.0*π/4
+      else if y = f64.type.negative_infinity
+        -3.0*π/4
+      else if y > 0
+        π
+      else // y < 0
+        -π
+    else if y = f64.type.positive_infinity
+      π/2
+    else if y = f64.type.negative_infinity
+      -π/2
+    else
+      q := atan y/x
+      if x < 0
+        if q <= 0 then q+π else q-π
+      else
+        q
 
 
   public fixed type.sinh(val f64) f64 is intrinsic

--- a/src/dev/flang/be/c/Intrinsics.java
+++ b/src/dev/flang/be/c/Intrinsics.java
@@ -792,8 +792,6 @@ public class Intrinsics extends ANY
     put("f64.type.acos"        , (c,cl,outer,in) -> CExpr.call("acos",  new List<>(A0)).ret());
     put("f32.type.atan"        , (c,cl,outer,in) -> CExpr.call("atanf", new List<>(A0)).ret());
     put("f64.type.atan"        , (c,cl,outer,in) -> CExpr.call("atan",  new List<>(A0)).ret());
-    put("f32.type.atan2"       , (c,cl,outer,in) -> CExpr.call("atan2f", new List<>(A0, A1)).ret());
-    put("f64.type.atan2"       , (c,cl,outer,in) -> CExpr.call("atan2",  new List<>(A0, A1)).ret());
     put("f32.type.sinh"        , (c,cl,outer,in) -> CExpr.call("sinhf",  new List<>(A0)).ret());
     put("f64.type.sinh"        , (c,cl,outer,in) -> CExpr.call("sinh",   new List<>(A0)).ret());
     put("f32.type.cosh"        , (c,cl,outer,in) -> CExpr.call("coshf",  new List<>(A0)).ret());

--- a/src/dev/flang/be/interpreter/Intrinsics.java
+++ b/src/dev/flang/be/interpreter/Intrinsics.java
@@ -1199,7 +1199,6 @@ public class Intrinsics extends ANY
     put("f32.type.acos"         , (interpreter, innerClazz) -> args -> new f32Value ((float)           Math.acos(               args.get(1).f32Value())));
     put("f32.type.asin"         , (interpreter, innerClazz) -> args -> new f32Value ((float)           Math.asin(               args.get(1).f32Value())));
     put("f32.type.atan"         , (interpreter, innerClazz) -> args -> new f32Value ((float)           Math.atan(               args.get(1).f32Value())));
-    put("f32.type.atan2"        , (interpreter, innerClazz) -> args -> new f32Value ((float)  Math.atan2(args.get(1).f32Value(),args.get(2).f32Value())));
     put("f32.type.cos"          , (interpreter, innerClazz) -> args -> new f32Value ((float)           Math.cos(                args.get(1).f32Value())));
     put("f32.type.cosh"         , (interpreter, innerClazz) -> args -> new f32Value ((float)           Math.cosh(               args.get(1).f32Value())));
     put("f32.type.epsilon"      , (interpreter, innerClazz) -> args -> new f32Value (                  Math.ulp(                (float)1)));
@@ -1217,7 +1216,6 @@ public class Intrinsics extends ANY
     put("f64.type.acos"         , (interpreter, innerClazz) -> args -> new f64Value (                 Math.acos(                args.get(1).f64Value())));
     put("f64.type.asin"         , (interpreter, innerClazz) -> args -> new f64Value (                 Math.asin(                args.get(1).f64Value())));
     put("f64.type.atan"         , (interpreter, innerClazz) -> args -> new f64Value (                 Math.atan(                args.get(1).f64Value())));
-    put("f64.type.atan2"        , (interpreter, innerClazz) -> args -> new f64Value (         Math.atan2(args.get(1).f64Value(),args.get(2).f64Value())));
     put("f64.type.cos"          , (interpreter, innerClazz) -> args -> new f64Value (                 Math.cos(                 args.get(1).f64Value())));
     put("f64.type.cosh"         , (interpreter, innerClazz) -> args -> new f64Value (                 Math.cosh(                args.get(1).f64Value())));
     put("f64.type.epsilon"      , (interpreter, innerClazz) -> args -> new f64Value (                 Math.ulp(                 (double)1)));

--- a/src/dev/flang/fuir/analysis/dfa/DFA.java
+++ b/src/dev/flang/fuir/analysis/dfa/DFA.java
@@ -1456,8 +1456,6 @@ public class DFA extends ANY
     put("f64.type.acos"                  , cl -> new NumericValue(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc)) );
     put("f32.type.atan"                  , cl -> new NumericValue(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc)) );
     put("f64.type.atan"                  , cl -> new NumericValue(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc)) );
-    put("f32.type.atan2"                 , cl -> new NumericValue(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc)) );
-    put("f64.type.atan2"                 , cl -> new NumericValue(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc)) );
     put("f32.type.sinh"                  , cl -> new NumericValue(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc)) );
     put("f64.type.sinh"                  , cl -> new NumericValue(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc)) );
     put("f32.type.cosh"                  , cl -> new NumericValue(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc)) );

--- a/src/dev/flang/fuir/cfg/CFG.java
+++ b/src/dev/flang/fuir/cfg/CFG.java
@@ -444,8 +444,6 @@ public class CFG extends ANY
     put("f64.type.acos"                  , (cfg, cl) -> { } );
     put("f32.type.atan"                  , (cfg, cl) -> { } );
     put("f64.type.atan"                  , (cfg, cl) -> { } );
-    put("f32.type.atan2"                 , (cfg, cl) -> { } );
-    put("f64.type.atan2"                 , (cfg, cl) -> { } );
     put("f32.type.sinh"                  , (cfg, cl) -> { } );
     put("f64.type.sinh"                  , (cfg, cl) -> { } );
     put("f32.type.cosh"                  , (cfg, cl) -> { } );


### PR DESCRIPTION
fixes inconsistency of implementations of `atan2` in glibc/musl/macos/bsd etc.