### PR TITLE
ast: handle boxing of erroneous and empty values gracefully

### DIFF
--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -2469,6 +2469,11 @@ public class Call extends AbstractCall
     ERROR = new Call(SourcePosition.builtIn, Errors.ERROR_STRING)
     {
       { _type = Types.t_ERROR; }
+      @Override
+      Expr box(AbstractType frmlT)
+      {
+        return this;
+      }
     };
   }
 

--- a/src/dev/flang/ast/Expr.java
+++ b/src/dev/flang/ast/Expr.java
@@ -505,6 +505,9 @@ public abstract class Expr extends ANY implements Stmnt
             AstErrors.ambiguousAssignmentToChoice(frmlT, value);
           }
 
+        if (CHECKS) check
+          (Errors.count() > 0 || cgs.size() == 1);
+
         return tag(frmlT, tag(cgs.get(0), value));
       }
   }
@@ -602,6 +605,11 @@ public abstract class Expr extends ANY implements Stmnt
     NO_VALUE = new Call(SourcePosition.builtIn, Errors.ERROR_STRING)
     {
       { _type = Types.t_ERROR; }
+      @Override
+      Expr box(AbstractType frmlT)
+      {
+        return this;
+      }
     };
   }
 


### PR DESCRIPTION
Fixes #1765.