### PR TITLE
ast: use a unique name for `Expr.NO_VALUE`

### DIFF
--- a/src/dev/flang/ast/Expr.java
+++ b/src/dev/flang/ast/Expr.java
@@ -599,7 +599,7 @@ public abstract class Expr extends ANY implements Stmnt
    */
   public static void reset()
   {
-    NO_VALUE = new Call(SourcePosition.builtIn, Errors.ERROR_STRING)
+    NO_VALUE = new Call(SourcePosition.builtIn, FuzionConstants.NO_VALUE_STRING)
     {
       { _type = Types.t_ERROR; }
     };

--- a/src/dev/flang/util/FuzionConstants.java
+++ b/src/dev/flang/util/FuzionConstants.java
@@ -42,6 +42,12 @@ public class FuzionConstants extends ANY
   /*----------------------------  constants  ----------------------------*/
 
 
+  /**
+   * String used in the dummy Expr Expr.NO_VALUE.
+   */
+  public static final String NO_VALUE_STRING = "**no value**";
+
+
   /*----------------------  special feature names  ----------------------*/
 
 


### PR DESCRIPTION
This changes the name used by `Expr.NO_VALUE` from `**error**` to `**no value**`. This is intended to make `Expr.NO_VALUE` easily distinguishable from `Call.ERROR` in a debugger.