### PR TITLE
ast: use `Expr` instead of `Stmnt`

### DIFF
--- a/src/dev/flang/air/Clazzes.java
+++ b/src/dev/flang/air/Clazzes.java
@@ -818,8 +818,9 @@ public class Clazzes extends ANY
     else if (e instanceof AbstractBlock b)
       {
         var s = b._statements;
-        if (!s.isEmpty() && s.get(s.size()-1) instanceof Expr e0)
+        if (!s.isEmpty() && s.get(s.size()-1).producesResult())
           {
+            var e0 = s.get(s.size()-1);
             propagateExpectedClazz(e0, ec, outerClazz);
           }
       }

--- a/src/dev/flang/ast/AbstractAssign.java
+++ b/src/dev/flang/ast/AbstractAssign.java
@@ -26,7 +26,6 @@ Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
 
 package dev.flang.ast;
 
-import dev.flang.util.ANY;
 import dev.flang.util.Errors;
 
 
@@ -36,7 +35,7 @@ import dev.flang.util.Errors;
  *
  * @author Fridtjof Siebert (siebert@tokiwa.software)
  */
-public abstract class AbstractAssign extends ANY implements Stmnt
+public abstract class AbstractAssign extends Expr
 {
 
 
@@ -138,7 +137,7 @@ public abstract class AbstractAssign extends ANY implements Stmnt
   {
     _value.visitStatements(v);
     _target.visitStatements(v);
-    Stmnt.super.visitStatements(v);
+    super.visitStatements(v);
   }
 
 
@@ -279,6 +278,16 @@ public abstract class AbstractAssign extends ANY implements Stmnt
    * code that actually would be executed at runtime.
    */
   public boolean containsOnlyDeclarations()
+  {
+    return false;
+  }
+
+
+  /**
+   * Some Expressions do not produce a result, e.g., a Block that is empty or
+   * whose last statement is not an expression that produces a result.
+   */
+  public boolean producesResult()
   {
     return false;
   }

--- a/src/dev/flang/ast/AbstractBlock.java
+++ b/src/dev/flang/ast/AbstractBlock.java
@@ -43,7 +43,7 @@ public abstract class AbstractBlock extends Expr
   /*----------------------------  variables  ----------------------------*/
 
 
-  public List<Stmnt> _statements;
+  public List<Expr> _statements;
 
 
   /*--------------------------  constructors  ---------------------------*/
@@ -54,7 +54,7 @@ public abstract class AbstractBlock extends Expr
    *
    * @param s the list of statements
    */
-  public AbstractBlock(List<Stmnt> s)
+  public AbstractBlock(List<Expr> s)
   {
     this._statements = s;
   }
@@ -75,10 +75,10 @@ public abstract class AbstractBlock extends Expr
    */
   public AbstractBlock visit(FeatureVisitor v, AbstractFeature outer)
   {
-    ListIterator<Stmnt> i = _statements.listIterator();
+    ListIterator<Expr> i = _statements.listIterator();
     while (i.hasNext())
       {
-        Stmnt s = i.next();
+        Expr s = i.next();
         i.set(s.visit(v, outer));
       }
     return this;
@@ -130,7 +130,7 @@ public abstract class AbstractBlock extends Expr
       {
         i--;
       }
-    return (i >= 0 && (_statements.get(i) instanceof Expr))
+    return (i >= 0 && (_statements.get(i).producesResult()))
       ? i
       : -1;
   }

--- a/src/dev/flang/ast/AbstractFeature.java
+++ b/src/dev/flang/ast/AbstractFeature.java
@@ -44,7 +44,7 @@ import dev.flang.util.SourcePosition;
  *
  * @author Fridtjof Siebert (siebert@tokiwa.software)
  */
-public abstract class AbstractFeature extends ANY implements Comparable<AbstractFeature>, HasSourcePosition
+public abstract class AbstractFeature extends Expr implements Comparable<AbstractFeature>
 {
 
 
@@ -1714,6 +1714,46 @@ public abstract class AbstractFeature extends ANY implements Comparable<Abstract
         result++;
       }
     throw new Error("AbstractFeature.typeParameterIndex() failed for " + this);
+  }
+
+
+  /**
+   * Some Expressions do not produce a result, e.g., a Block that is empty or
+   * whose last statement is not an expression that produces a result.
+   */
+  public boolean producesResult()
+  {
+    return false;
+  }
+
+
+  /**
+   * typeIfKnown returns the type of this expression or null if the type is
+   * still unknown, i.e., before or during type resolution.  This is redefined
+   * by sub-classes of Expr to provide type information.
+   *
+   * @return this Expr's type or null if not known.
+   */
+  AbstractType typeIfKnown()
+  {
+    return Types.resolved.t_unit;
+  }
+
+
+  /**
+   * visit all the features, expressions, statements within this feature.
+   *
+   * @param v the visitor instance that defines an action to be performed on
+   * visited objects.
+   *
+   * @param outer the feature surrounding this expression.
+   *
+   * @return this or an alternative Expr if the action performed during the
+   * visit replaces this by the alternative.
+   */
+  public Expr visit(FeatureVisitor v, AbstractFeature outer)
+  {
+    throw new RuntimeException("not meant to be used...");
   }
 
 

--- a/src/dev/flang/ast/Block.java
+++ b/src/dev/flang/ast/Block.java
@@ -83,7 +83,7 @@ public class Block extends AbstractBlock
    */
   private Block(SourcePosition pos,
                 SourcePosition closingBracePos,
-                List<Stmnt> s,
+                List<Expr> s,
                 boolean newScope)
   {
     super(s);
@@ -108,7 +108,7 @@ public class Block extends AbstractBlock
    */
   public Block(SourcePosition pos,
                SourcePosition closingBracePos,
-               List<Stmnt> s)
+               List<Expr> s)
   {
     this(pos, closingBracePos, s, true);
   }
@@ -123,7 +123,7 @@ public class Block extends AbstractBlock
    * @param s the list of statements
    */
   public Block(SourcePosition pos,
-               List<Stmnt> s)
+               List<Expr> s)
   {
     this(pos, pos, s, false);
   }
@@ -141,7 +141,7 @@ public class Block extends AbstractBlock
    * that can be ignored if assigned to unit type.
    */
   public Block(SourcePosition pos,
-               List<Stmnt> s,
+               List<Expr> s,
                boolean hasImplicitResult)
   {
     this(pos, s);
@@ -173,7 +173,7 @@ public class Block extends AbstractBlock
       }
     else
       {
-        result = new Block(e.pos(), new List<Stmnt>(e));
+        result = new Block(e.pos(), new List<Expr>(e));
       }
     return result;
   }
@@ -219,10 +219,10 @@ public class Block extends AbstractBlock
   public Block visit(FeatureVisitor v, AbstractFeature outer)
   {
     v.actionBefore(this, outer);
-    ListIterator<Stmnt> i = _statements.listIterator();
+    ListIterator<Expr> i = _statements.listIterator();
     while (i.hasNext())
       {
-        Stmnt s = i.next();
+        Expr s = i.next();
         i.set(s.visit(v, outer));
       }
     v.actionAfter(this, outer);
@@ -404,7 +404,7 @@ public class Block extends AbstractBlock
    * Some Expressions do not produce a result, e.g., a Block that is empty or
    * whose last statement is not an expression that produces a result.
    */
-  boolean producesResult()
+  public boolean producesResult()
   {
     var expr = resultExpression();
     return expr != null && expr.producesResult();

--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -593,12 +593,12 @@ public class Call extends AbstractCall
               {
                 boolean isChainedBoolRHS() { return true; }
               };
-            Stmnt as = new Assign(res, pos(), tmp, b, thiz);
+            Expr as = new Assign(res, pos(), tmp, b, thiz);
             t1 = res.resolveType(t1    , thiz);
             as = res.resolveType(as    , thiz);
             result = res.resolveType(result, thiz);
             cb._actuals.set(cb._actuals.size()-1,
-                            new Block(b.pos(),new List<Stmnt>(as, t1)));
+                            new Block(b.pos(),new List<Expr>(as, t1)));
             _actuals = new List<Expr>(result);
             _calledFeature = Types.resolved.f_bool_AND;
             _name = _calledFeature.featureName().baseName();

--- a/src/dev/flang/ast/Check.java
+++ b/src/dev/flang/ast/Check.java
@@ -34,7 +34,7 @@ import dev.flang.util.SourcePosition;
  *
  * @author Fridtjof Siebert (siebert@tokiwa.software)
  */
-public class Check implements Stmnt
+public class Check extends Expr
 {
 
 
@@ -106,7 +106,7 @@ public class Check implements Stmnt
    */
   public void visitStatements(StatementVisitor v)
   {
-    Stmnt.super.visitStatements(v);
+    super.visitStatements(v);
     cond.visitStatements(v);
   }
 
@@ -119,6 +119,16 @@ public class Check implements Stmnt
   {
     return false;
   };
+
+
+  /**
+   * Some Expressions do not produce a result, e.g., a Block that is empty or
+   * whose last statement is not an expression that produces a result.
+   */
+  public boolean producesResult()
+  {
+    return false;
+  }
 
 
   /**

--- a/src/dev/flang/ast/Destructure.java
+++ b/src/dev/flang/ast/Destructure.java
@@ -48,7 +48,7 @@ import dev.flang.util.SourcePosition;
  *
  * @author Fridtjof Siebert (siebert@tokiwa.software)
  */
-public class Destructure extends ANY implements Stmnt
+public class Destructure extends Expr
 {
 
 
@@ -136,9 +136,9 @@ public class Destructure extends ANY implements Stmnt
   /**
    * Helper routine for create to expand this into a block of statements.
    */
-  private Stmnt expand()
+  private Expr expand()
   {
-    List<Stmnt> stmnts = new List<Stmnt>();
+    List<Expr> stmnts = new List<Expr>();
     if (_fields != null)
       {
         for (var f : _fields)
@@ -168,7 +168,7 @@ public class Destructure extends ANY implements Stmnt
    *
    * @return a statement that implements the destructuring.
    */
-  public static Stmnt create(SourcePosition pos, List<AbstractFeature> fields, List<ParsedName> names, boolean def, Expr v)
+  public static Expr create(SourcePosition pos, List<AbstractFeature> fields, List<ParsedName> names, boolean def, Expr v)
   {
     if (PRECONDITIONS) require
       ((fields == null) != (names == null),
@@ -217,7 +217,7 @@ public class Destructure extends ANY implements Stmnt
    *
    * @return this
    */
-  public Stmnt visit(FeatureVisitor v, AbstractFeature outer)
+  public Expr visit(FeatureVisitor v, AbstractFeature outer)
   {
     _value = _value.visit(v, outer);
     return v.action(this, outer);
@@ -231,7 +231,7 @@ public class Destructure extends ANY implements Stmnt
    */
   private void addAssign(Resolution res,
                          AbstractFeature outer,
-                         List<Stmnt> stmnts,
+                         List<Expr> stmnts,
                          Feature tmp,
                          AbstractFeature f,
                          Iterator<ParsedName> names,
@@ -276,9 +276,9 @@ public class Destructure extends ANY implements Stmnt
    *
    * @param outer the root feature that contains this statement.
    */
-  public Stmnt resolveTypes(Resolution res, AbstractFeature outer)
+  public Expr resolveTypes(Resolution res, AbstractFeature outer)
   {
-    List<Stmnt> stmnts = new List<>();
+    List<Expr> stmnts = new List<>();
     // NYI: This might fail in conjunction with type inference.  We should maybe
     // create the decomposition code later, after resolveTypes is done.
     var t = _value.type();
@@ -354,6 +354,16 @@ public class Destructure extends ANY implements Stmnt
   public boolean containsOnlyDeclarations()
   {
     throw new Error("Destructure should have disappeared after resolveTypes");
+  }
+
+
+  /**
+   * Some Expressions do not produce a result, e.g., a Block that is empty or
+   * whose last statement is not an expression that produces a result.
+   */
+  public boolean producesResult()
+  {
+    return false;
   }
 
 

--- a/src/dev/flang/ast/Expr.java
+++ b/src/dev/flang/ast/Expr.java
@@ -229,10 +229,10 @@ public abstract class Expr extends ANY implements Stmnt
    *
    * @param r the field this should be assigned to.
    *
-   * @return the Stmnt this Expr is to be replaced with, typically an Assign
+   * @return the Expr this Expr is to be replaced with, typically an Assign
    * that performs the assignment to r.
    */
-  Stmnt assignToField(Resolution res, AbstractFeature outer, Feature r)
+  Expr assignToField(Resolution res, AbstractFeature outer, Feature r)
   {
     return new Assign(res, pos(), r, this, outer);
   }
@@ -280,7 +280,7 @@ public abstract class Expr extends ANY implements Stmnt
         var declarationsInLazy = new List<Feature>();
         visit(new FeatureVisitor()
           {
-            public Stmnt action (Feature f, AbstractFeature outer)
+            public Expr action (Feature f, AbstractFeature outer)
             {
               declarationsInLazy.add(f);
               return f;
@@ -588,7 +588,7 @@ public abstract class Expr extends ANY implements Stmnt
    * Some Expressions do not produce a result, e.g., a Block that is empty or
    * whose last statement is not an expression that produces a result.
    */
-  boolean producesResult()
+  public boolean producesResult()
   {
     return true;
   }

--- a/src/dev/flang/ast/Feature.java
+++ b/src/dev/flang/ast/Feature.java
@@ -47,7 +47,7 @@ import dev.flang.util.SourcePosition;
  *
  * @author Fridtjof Siebert (siebert@tokiwa.software)
  */
-public class Feature extends AbstractFeature implements Stmnt
+public class Feature extends AbstractFeature
 {
 
 
@@ -316,7 +316,7 @@ public class Feature extends AbstractFeature implements Stmnt
          Contract.EMPTY_CONTRACT,
          new Impl(SourcePosition.builtIn,
                   new Block(SourcePosition.builtIn,
-                            new List<Stmnt>()),
+                            new List<Expr>()),
                   Impl.Kind.Routine));
   }
 
@@ -1282,8 +1282,8 @@ public class Feature extends AbstractFeature implements Stmnt
     public void         action      (AbstractAssign a, AbstractFeature outer) {        a.resolveTypes   (res,   outer); }
     public Call         action      (Call           c, AbstractFeature outer) { return c.resolveTypes   (res,   outer); }
     public Expr         action      (DotType        d, AbstractFeature outer) { return d.resolveTypes   (res,   outer); }
-    public Stmnt        action      (Destructure    d, AbstractFeature outer) { return d.resolveTypes   (res,   outer); }
-    public Stmnt        action      (Feature        f, AbstractFeature outer) { /* use f.outer() since qualified feature name may result in different outer! */
+    public Expr         action      (Destructure    d, AbstractFeature outer) { return d.resolveTypes   (res,   outer); }
+    public Expr         action      (Feature        f, AbstractFeature outer) { /* use f.outer() since qualified feature name may result in different outer! */
                                                                                 return f.resolveTypes   (res, f.outer() ); }
     public Function     action      (Function       f, AbstractFeature outer) {        f.resolveTypes   (res,   outer); return f; }
     public void         action      (Match          m, AbstractFeature outer) {        m.resolveTypes   (res,   outer); }
@@ -1862,7 +1862,7 @@ public class Feature extends AbstractFeature implements Stmnt
         _state = State.RESOLVING_SUGAR2;
 
         visit(new FeatureVisitor() {
-            public Stmnt action(Feature     f, AbstractFeature outer) { return new Nop(_pos);                        }
+            public Expr  action(Feature     f, AbstractFeature outer) { return new Nop(_pos);                        }
             public Expr  action(Function    f, AbstractFeature outer) { return f.resolveSyntacticSugar2(res, outer); }
             public Expr  action(InlineArray i, AbstractFeature outer) { return i.resolveSyntacticSugar2(res, outer); }
             public void  action(Impl        i, AbstractFeature outer) {        i.resolveSyntacticSugar2(res, outer); }
@@ -1887,7 +1887,7 @@ public class Feature extends AbstractFeature implements Stmnt
    *
    * @return this.
    */
-  public Stmnt visit(FeatureVisitor v, AbstractFeature outer)
+  public Expr visit(FeatureVisitor v, AbstractFeature outer)
   {
     // impl.initialValue is code executed by outer, not by this. So we visit it
     // here, while impl.code is visited when impl.visit is called with this as
@@ -1912,9 +1912,9 @@ public class Feature extends AbstractFeature implements Stmnt
    *
    * @param outer the root feature that contains this statement.
    */
-  public Stmnt resolveTypes(Resolution res, AbstractFeature outer)
+  public Expr resolveTypes(Resolution res, AbstractFeature outer)
   {
-    Stmnt result = this;
+    Expr result = this;
 
     if (CHECKS) check
       (this.outer() == outer,
@@ -2039,7 +2039,7 @@ public class Feature extends AbstractFeature implements Stmnt
               found();
             }
         }
-        public Stmnt action(Destructure d, AbstractFeature outer)
+        public Expr action(Destructure d, AbstractFeature outer)
         {
           if (d == use)
             { // Found the assign, so we got the result!
@@ -2069,7 +2069,7 @@ public class Feature extends AbstractFeature implements Stmnt
         {
           curres[0] = stack.pop();
         }
-        public Stmnt action(Feature f, AbstractFeature outer)
+        public Expr action(Feature f, AbstractFeature outer)
         {
           if (f == inner)
             {

--- a/src/dev/flang/ast/FeatureVisitor.java
+++ b/src/dev/flang/ast/FeatureVisitor.java
@@ -64,8 +64,8 @@ public abstract class FeatureVisitor extends ANY
   public void         actionBefore(AbstractCase   c                       ) { }
   public void         actionAfter (AbstractCase   c                       ) { }
   public void         action      (Cond           c, AbstractFeature outer) { }
-  public Stmnt        action      (Destructure    d, AbstractFeature outer) { return d; }
-  public Stmnt        action      (Feature        f, AbstractFeature outer) { return f; }
+  public Expr         action      (Destructure    d, AbstractFeature outer) { return d; }
+  public Expr         action      (Feature        f, AbstractFeature outer) { return f; }
   public Expr         action      (Function       f, AbstractFeature outer) { return f; }
   public void         action      (If             i, AbstractFeature outer) { }
   public void         action      (Impl           i, AbstractFeature outer) { }

--- a/src/dev/flang/ast/Function.java
+++ b/src/dev/flang/ast/Function.java
@@ -262,7 +262,7 @@ public class Function extends ExprWithPos
             // inherits clause for wrapper feature: Function<R,A,B,C,...>
             _inheritsCall = new Call(pos(), null, inheritsName);
             _inheritsCall._generics = gs;
-            List<Stmnt> statements = new List<Stmnt>(f);
+            List<Expr> statements = new List<Expr>(f);
             String wrapperName = FuzionConstants.LAMBDA_PREFIX + id++;
             _wrapper = new Feature(pos(),
                                    Visi.PRIV,
@@ -512,7 +512,7 @@ public class Function extends ExprWithPos
               }
             List<AbstractCall> inherits = new List<>(new Call(pos(), null, fr.featureName().baseName(), args));
 
-            List<Stmnt> statements = new List<Stmnt>(fcall);
+            List<Expr> statements = new List<Expr>(fcall);
 
             String wrapperName = FuzionConstants.LAMBDA_PREFIX + id++;
             Feature function = new Feature(pos(),

--- a/src/dev/flang/ast/Impl.java
+++ b/src/dev/flang/ast/Impl.java
@@ -391,7 +391,7 @@ public class Impl extends ANY
         ass._value = this._code.box(ass._assignedField.resultType());  // NYI: move to constructor of Assign?
         this._code = new Block (this._code.pos(),
                                 endPos,
-                                new List<Stmnt>(ass));
+                                new List<Expr>(ass));
       }
   }
 

--- a/src/dev/flang/ast/InlineArray.java
+++ b/src/dev/flang/ast/InlineArray.java
@@ -314,7 +314,7 @@ public class InlineArray extends ExprWithPos
         res.resolveDeclarations(sysArrayVar);
         res.resolveTypes();
         var sysArrayAssign = new Assign(res, pos(), sysArrayVar, sysArrayCall, outer);
-        var stmnts = new List<Stmnt>(sysArrayAssign);
+        var stmnts = new List<Expr>(sysArrayAssign);
         for (var i = 0; i < _elements.size(); i++)
           {
             var e = _elements.get(i);

--- a/src/dev/flang/ast/Loop.java
+++ b/src/dev/flang/ast/Loop.java
@@ -185,7 +185,7 @@ public class Loop extends ANY
    * initial values. May be null if none.
    */
   private final Block _prolog;
-  private List<Stmnt> _prologSuccessBlock;
+  private List<Expr> _prologSuccessBlock;
 
 
   /**
@@ -193,7 +193,7 @@ public class Loop extends ANY
    * to be false.
    */
   private Expr _nextIteration = null;
-  private List<Stmnt> _nextItSuccessBlock = null;
+  private List<Expr> _nextItSuccessBlock = null;
 
 
   /**
@@ -592,8 +592,8 @@ public class Loop extends ANY
             Call hasNext2 = new Call(p, new Call(p, streamName), "has_next" );
             Call next1    = new Call(p, new Call(p, streamName), "next");
             Call next2    = new Call(p, new Call(p, streamName), "next");
-            List<Stmnt> prolog2 = new List<>();
-            List<Stmnt> nextIt2 = new List<>();
+            List<Expr> prolog2 = new List<>();
+            List<Expr> nextIt2 = new List<>();
             If ifHasNext1 = new If(p, hasNext1, new Block(p, prolog2));
             If ifHasNext2 = new If(p, hasNext2, new Block(p, nextIt2));
             if (_loopElse != null)

--- a/src/dev/flang/ast/Nop.java
+++ b/src/dev/flang/ast/Nop.java
@@ -26,7 +26,6 @@ Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
 
 package dev.flang.ast;
 
-import dev.flang.util.ANY;
 import dev.flang.util.SourcePosition;
 
 
@@ -35,7 +34,7 @@ import dev.flang.util.SourcePosition;
  *
  * @author Fridtjof Siebert (siebert@tokiwa.software)
  */
-public class Nop extends ANY implements Stmnt
+public class Nop extends Expr
 {
 
 
@@ -95,6 +94,16 @@ public class Nop extends ANY implements Stmnt
   public boolean containsOnlyDeclarations()
   {
     return true;
+  }
+
+
+  /**
+   * Some Expressions do not produce a result, e.g., a Block that is empty or
+   * whose last statement is not an expression that produces a result.
+   */
+  public boolean producesResult()
+  {
+    return false;
   }
 
 

--- a/src/dev/flang/ast/Stmnt.java
+++ b/src/dev/flang/ast/Stmnt.java
@@ -51,7 +51,7 @@ public interface Stmnt extends HasSourcePosition
    * @return this or an alternative Stmnt if the action performed during the
    * visit replaces this by the alternative.
    */
-  public Stmnt visit(FeatureVisitor v, AbstractFeature outer);
+  public Expr visit(FeatureVisitor v, AbstractFeature outer);
 
 
   /**

--- a/src/dev/flang/fe/LibraryFeature.java
+++ b/src/dev/flang/fe/LibraryFeature.java
@@ -27,9 +27,7 @@ Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
 package dev.flang.fe;
 
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Path;
 
-import java.util.Collection;
 import java.util.Set;
 import java.util.Stack;
 import java.util.TreeSet;
@@ -43,7 +41,6 @@ import dev.flang.ast.AbstractCurrent;
 import dev.flang.ast.AbstractFeature;
 import dev.flang.ast.AbstractMatch;
 import dev.flang.ast.AbstractType;
-import dev.flang.ast.BoolConst;
 import dev.flang.ast.Box;
 import dev.flang.ast.Cond;
 import dev.flang.ast.Consts;
@@ -54,9 +51,6 @@ import dev.flang.ast.Feature;
 import dev.flang.ast.FeatureName;
 import dev.flang.ast.FeatureVisitor;
 import dev.flang.ast.FormalGenerics;
-import dev.flang.ast.Generic;
-import dev.flang.ast.Impl;
-import dev.flang.ast.Stmnt;
 import dev.flang.ast.Tag;
 import dev.flang.ast.Types;
 import dev.flang.ast.Unbox;
@@ -565,8 +559,6 @@ public class LibraryFeature extends AbstractFeature
       {
         var s = new Stack<Expr>();
         res = code(at, s, -1);
-        if (CHECKS) check
-          (s.size() == 0);
         _libModule._code.put(at, res);
       }
     return res;
@@ -584,7 +576,7 @@ public class LibraryFeature extends AbstractFeature
    */
   AbstractBlock code(int at, Stack<Expr> s, int pos)
   {
-    var l = new List<Stmnt>();
+    var l = new List<Expr>();
     var sz = _libModule.codeSize(at);
     var eat = _libModule.codeExpressionsPos(at);
     var e = eat;
@@ -594,8 +586,7 @@ public class LibraryFeature extends AbstractFeature
         var iat = _libModule.expressionExprPos(e);
         pos = _libModule.expressionHasPosition(e) ? _libModule.expressionPosition(e) : pos;
         var fpos = pos;
-        Expr ex = null;
-        Stmnt c = null;
+        Expr c = null;
         Expr x = null;
         switch (k)
           {

--- a/src/dev/flang/fe/LibraryOut.java
+++ b/src/dev/flang/fe/LibraryOut.java
@@ -716,7 +716,7 @@ class LibraryOut extends ANY
             else
               {
                 lastPos = expressions(st, dumpResult, lastPos);
-                dumpResult = dumpResult || st instanceof Expr;
+                dumpResult = dumpResult || st.producesResult();
               }
           }
         if (!dumpResult)

--- a/src/dev/flang/fe/SourceModule.java
+++ b/src/dev/flang/fe/SourceModule.java
@@ -46,6 +46,7 @@ import dev.flang.ast.AbstractType;
 import dev.flang.ast.AstErrors;
 import dev.flang.ast.Call;
 import dev.flang.ast.Consts;
+import dev.flang.ast.Expr;
 import dev.flang.ast.Feature;
 import dev.flang.ast.FeatureName;
 import dev.flang.ast.FeatureAndOuter;
@@ -192,7 +193,7 @@ public class SourceModule extends Module implements SrcModule, MirModule
    *
    * @return the features found in source file p, may be empty, never null.
    */
-  List<Stmnt> parseFile(Path p)
+  List<Expr> parseFile(Path p)
   {
     _options.verbosePrintln(2, " - " + p);
     return new Parser(p).unit();

--- a/src/dev/flang/me/MiddleEnd.java
+++ b/src/dev/flang/me/MiddleEnd.java
@@ -282,7 +282,7 @@ public class MiddleEnd extends ANY
         // it does not seem to be necessary to mark all features in types as used:
         // public Type  action(Type    t, AbstractFeature outer) { t.findUsedFeatures(res, pos); return t; }
         public void action(AbstractCall c               ) { findUsedFeatures(c); }
-        //        public Stmnt action(Feature f, AbstractFeature outer) { markUsed(res, pos);      return f; } // NYI: this seems wrong ("f." missing) or unnecessary
+        //        public Expr action(Feature f, AbstractFeature outer) { markUsed(res, pos);      return f; } // NYI: this seems wrong ("f." missing) or unnecessary
         public void action(Tag     t, AbstractFeature outer) { findUsedFeatures(t._taggedType, t); }
       };
     f.visitCode(fv);

--- a/src/dev/flang/parser/FList.java
+++ b/src/dev/flang/parser/FList.java
@@ -31,9 +31,8 @@ import java.util.LinkedList;
 import dev.flang.ast.AbstractFeature;
 import dev.flang.ast.Feature;
 import dev.flang.ast.FeatureVisitor;
-import dev.flang.ast.Stmnt;
+import dev.flang.ast.Expr;
 
-import dev.flang.util.ANY;
 import dev.flang.util.List;
 import dev.flang.util.SourcePosition;
 
@@ -44,7 +43,7 @@ import dev.flang.util.SourcePosition;
  *
  * @author Fridtjof Siebert (siebert@tokiwa.software)
  */
-public class FList extends ANY implements Stmnt
+public class FList extends Expr
 {
 
 

--- a/src/dev/flang/parser/OpExpr.java
+++ b/src/dev/flang/parser/OpExpr.java
@@ -234,7 +234,7 @@ public class OpExpr extends ANY
    */
   boolean isExpr(int i)
   {
-    return (i>=0) && (i<els.size()) && (els.get(i) instanceof Expr);
+    return (i>=0) && (i<els.size()) && (els.get(i) instanceof Expr e && e.producesResult());
   }
 
 

--- a/src/dev/flang/parser/Parser.java
+++ b/src/dev/flang/parser/Parser.java
@@ -195,7 +195,7 @@ public class Parser extends Lexer
 unit        : stmnts EOF
             ;
    */
-  public List<Stmnt> unit()
+  public List<Expr> unit()
   {
     var result = stmnts();
     if (Errors.count() == 0)
@@ -2620,13 +2620,13 @@ stmnts      : stmnt semiOrFlatLF stmnts (semiOrFlatLF | )
             |
             ;
    */
-  List<Stmnt> stmnts()
+  List<Expr> stmnts()
   {
-    List<Stmnt> l = new List<>();
+    List<Expr> l = new List<>();
     var in = new Indentation();
     while (!endOfStmnts() && in.ok())
       {
-        Stmnt s = stmnt();
+        Expr s = stmnt();
         if (s instanceof FList fl)
           {
             l.addAll(fl._list);
@@ -2777,7 +2777,7 @@ stmnt       : feature
             | checkstmnt
             ;
    */
-  Stmnt stmnt()
+  Expr stmnt()
   {
     return
       isCheckPrefix()       ? checkstmnt()  :
@@ -3024,7 +3024,7 @@ elseBlock   : "else" block
 checkstmnt   : "check" cond
             ;
    */
-  Stmnt checkstmnt()
+  Expr checkstmnt()
   {
     match(Token.t_check, "checkstmnt");
     return new Check(tokenSourcePos(), cond());
@@ -3049,7 +3049,7 @@ checkstmnt   : "check" cond
 assign      : "set" name ":=" exprInLine
             ;
    */
-  Stmnt assign()
+  Expr assign()
   {
     if (!ENABLE_SET_KEYWORD)
       {
@@ -3101,7 +3101,7 @@ destructrDcl: formArgs               ":=" exprInLine
 destructrSet: "set" "(" argNames ")" ":=" exprInLine
             ;
    */
-  Stmnt destructure()
+  Expr destructure()
   {
     if (fork().skipFormArgs())
       {


### PR DESCRIPTION
This PR does not remove `Stmnt` just yet. Could be done in a successive PR.