### PR TITLE
feature visitor, option to continue/abort visit on error

### DIFF
--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -2217,7 +2217,7 @@ public class Call extends AbstractCall
     if (POSTCONDITIONS) ensure
       (Errors.count() > 0 || result.typeIfKnown() != Types.t_ERROR);
 
-    return result.typeIfKnown() == Types.t_ERROR
+    return result.typeIfKnown() == Types.t_ERROR && !res._options.isLanguageServer()
       ? Call.ERROR // short circuit this call
       : result;
   }

--- a/src/dev/flang/util/FuzionOptions.java
+++ b/src/dev/flang/util/FuzionOptions.java
@@ -193,6 +193,11 @@ public class FuzionOptions extends ANY
     return _fuzionHome;
   }
 
+  public boolean isLanguageServer()
+  {
+    return false;
+  }
+
 
 }
 


### PR DESCRIPTION
I did not think of it at the time I made the change but the short circuit of a call in case of errors broke a lot of tests in the language server. So this is my new suggestion to have an option in the visitor to continue/abort visitation of AST-items on known errors.