### PR TITLE
lib: make `val` field of numeric features public

### DIFF
--- a/lib/f128.fz
+++ b/lib/f128.fz
@@ -25,7 +25,7 @@
 
 # f128 -- 128 bit floating point values
 #
-public f128(val f128) is
+public f128(public val f128) is
   public infix + (other f128) f128 is panic "NYI: f128 is not supported"
   public infix - (other f128) f128 is panic "NYI: f128 is not supported"
   public infix * (other f128) f128 is panic "NYI: f128 is not supported"

--- a/lib/f16.fz
+++ b/lib/f16.fz
@@ -25,7 +25,7 @@
 
 # f16 -- 16 bit floating point values
 #
-public f16(val f16) is
+public f16(public val f16) is
   public infix + (other f16) f16 is panic "NYI: f16 is not supported"
   public infix - (other f16) f16 is panic "NYI: f16 is not supported"
   public infix * (other f16) f16 is panic "NYI: f16 is not supported"

--- a/lib/f32.fz
+++ b/lib/f32.fz
@@ -29,7 +29,7 @@
 # f32 are binary32-numbers as defined in the IEEE 754-2019 standard, see
 # https://ieeexplore.ieee.org/servlet/opac?punumber=8766227
 #
-public f32(val f32) : float is
+public f32(public val f32) : float is
 
 
   # basic operations: 'prefix -' (negation)

--- a/lib/f64.fz
+++ b/lib/f64.fz
@@ -29,7 +29,7 @@
 # f64 are binary64-numbers as defined in the IEEE 754-2019 standard, see
 # https://ieeexplore.ieee.org/servlet/opac?punumber=8766227
 #
-public f64(val f64) : float is
+public f64(public val f64) : float is
 
   public thiz => f64.this.val
 

--- a/lib/i128.fz
+++ b/lib/i128.fz
@@ -25,7 +25,7 @@
 
 # i128 -- 128-bit signed integer values
 #
-public i128(hi i64, lo u64) : num.wrap_around, has_interval is
+public i128(public hi i64, public lo u64) : num.wrap_around, has_interval is
   fixed redef infix + (other i128) i128 is panic "NYI: i128 is not supported"
   fixed redef infix - (other i128) i128 is panic "NYI: i128 is not supported"
   fixed redef infix * (other i128) i128 is panic "NYI: i128 is not supported"

--- a/lib/i16.fz
+++ b/lib/i16.fz
@@ -25,7 +25,7 @@
 
 # i16 -- 16-bit signed integer values
 #
-public i16(val i16) : num.wrap_around, has_interval is
+public i16(public val i16) : num.wrap_around, has_interval is
 
   public thiz => i16.this.val
 

--- a/lib/i32.fz
+++ b/lib/i32.fz
@@ -25,7 +25,7 @@
 
 # i32 -- 32-bit signed integer values
 #
-public i32(val i32) : num.wrap_around, has_interval is
+public i32(public val i32) : num.wrap_around, has_interval is
 
   public thiz => i32.this.val
 

--- a/lib/i64.fz
+++ b/lib/i64.fz
@@ -25,7 +25,7 @@
 
 # i64 -- 64-bit signed integer values
 #
-public i64(val i64) : num.wrap_around, has_interval is
+public i64(public val i64) : num.wrap_around, has_interval is
 
   public thiz => i64.this.val
 

--- a/lib/i8.fz
+++ b/lib/i8.fz
@@ -25,7 +25,7 @@
 
 # i8 -- 8-bit signed integer values
 #
-public i8(val i8) : num.wrap_around, has_interval is
+public i8(public val i8) : num.wrap_around, has_interval is
 
   public thiz => i8.this.val
 

--- a/lib/int.fz
+++ b/lib/int.fz
@@ -25,7 +25,7 @@
 
 # int -- signed integer values of arbitrary size
 #
-module:public int (s num.sign, n uint) : has_interval
+module:public int (public s num.sign, public n uint) : has_interval
 is
 
   # normalize the sign => no minus zero

--- a/lib/num/minus.fz
+++ b/lib/num/minus.fz
@@ -25,4 +25,4 @@
 #
 # note that this value is of unit type minus, not of type sign
 #
-module minus is
+public minus is

--- a/lib/num/plus.fz
+++ b/lib/num/plus.fz
@@ -25,4 +25,4 @@
 #
 # note that this value is of unit type plus, not of type sign
 #
-module plus is
+public plus is

--- a/lib/num/sign.fz
+++ b/lib/num/sign.fz
@@ -25,7 +25,7 @@
 #
 # this can be plus or minus
 #
-module sign : choice num.plus num.minus, property.equatable is
+public sign : choice num.plus num.minus, property.equatable is
 
   module is_plus =>
     match sign.this

--- a/lib/u128.fz
+++ b/lib/u128.fz
@@ -25,7 +25,7 @@
 
 # u128 -- 128-bit unsigned integer values
 #
-public u128(hi, lo u64) : num.wrap_around, has_interval is
+public u128(public hi u64, public lo u64) : num.wrap_around, has_interval is
 
   public thiz => u128 hi lo
 

--- a/lib/u16.fz
+++ b/lib/u16.fz
@@ -25,7 +25,7 @@
 
 # u16 -- 16-bit unsigned integer values
 #
-public u16(val u16) : num.wrap_around, has_interval is
+public u16(public val u16) : num.wrap_around, has_interval is
 
   public thiz => u16.this.val
 

--- a/lib/u32.fz
+++ b/lib/u32.fz
@@ -25,7 +25,7 @@
 
 # u32 -- 32-bit unsigned integer values
 #
-public u32(val u32) : num.wrap_around, has_interval is
+public u32(public val u32) : num.wrap_around, has_interval is
 
   public thiz => u32.this.val
 

--- a/lib/u64.fz
+++ b/lib/u64.fz
@@ -25,7 +25,7 @@
 
 # u64 -- 64-bit unsigned integer values
 #
-public u64(val u64) : num.wrap_around, has_interval is
+public u64(public val u64) : num.wrap_around, has_interval is
 
   public thiz => u64.this.val
 

--- a/lib/u8.fz
+++ b/lib/u8.fz
@@ -25,7 +25,7 @@
 
 # u8 -- 8-bit unsigned integer values
 #
-public u8(val u8) : num.wrap_around, has_interval is
+public u8(public val u8) : num.wrap_around, has_interval is
 
   public thiz => u8.this.val
 

--- a/lib/uint.fz
+++ b/lib/uint.fz
@@ -25,7 +25,7 @@
 
 # unsigned integer of arbitrary size, including zero
 # represented by its bit sequence
-private:public uint (b Sequence u32, _ unit) : has_interval
+private:public uint (public b Sequence u32, _ unit) : has_interval
 is
 
   # the actually relevant data of this uint.


### PR DESCRIPTION
In particular, this allows user-supplied code such as
```
i32.factors => 1..val & x -> val %% x
```
to keep working.