### PR TITLE
lib/exit: make `Exit_Handler` public

### DIFF
--- a/lib/exit.fz
+++ b/lib/exit.fz
@@ -137,7 +137,7 @@ public exit(handler Exit_Handler, code ()->unit) =>
 
 # Exit_Handler -- abstract exit
 #
-private:public Exit_Handler ref is
+public Exit_Handler ref is
 
   # exit with the given code
   #


### PR DESCRIPTION
Just like for `Panic_Handler` and `Print_Handler`, the user might want to specify a custom behavior. This is not possible unless `Exit_Handler` is public (a "Could not find called feature" message is returned otherwise).