### PR TITLE
tests: override `NAME` variable in `visibility_modules*` tests

### DIFF
--- a/tests/loop_negative/looptest_negative.fz
+++ b/tests/loop_negative/looptest_negative.fz
@@ -34,7 +34,7 @@ looptest_negative is
       say "FAILED: $msg"
       exit_code <- 1
 
-  a := array i32 100 (i -> if (i % 23 == 0) -2*i else i*i)
+  a := array i32 100 (i -> if (i % 23 = 0) (-2)*i else i*i)
 
   say "testLoop_neg1: loop return 3333 on success and 4444 in else branch"
   testLoop_neg1(data array i32, isWhatWeWant i32 -> bool) =>

--- a/tests/visibility_modules/Makefile
+++ b/tests/visibility_modules/Makefile
@@ -24,7 +24,7 @@
 #  NAME -- the name of the main feature to be tested
 #  FUZION -- the fz command
 #  FUZION_OPTIONS -- options to be passed to $(FUZION)
-NAME = main
+override NAME = main
 FUZION_OPTIONS = -modules=mod -moduleDirs=modules
 FUZION ?= ../../bin/fz
 FUZION_RUN = $(FUZION) $(FUZION_OPTIONS)

--- a/tests/visibility_modules_negative/Makefile
+++ b/tests/visibility_modules_negative/Makefile
@@ -24,7 +24,7 @@
 #  NAME -- the name of the main feature to be tested
 #  FUZION -- the fz command
 #  FUZION_OPTIONS -- options to be passed to $(FUZION)
-NAME = main
+override NAME = main
 FUZION_OPTIONS = -XmaxErrors=-1 -modules=mod -moduleDirs=modules
 FUZION ?= ../../bin/fz
 FUZION_RUN = $(FUZION) $(FUZION_OPTIONS)


### PR DESCRIPTION
See #473, #481, #1420, #1597 for the reason.

Additionally, fix an error in the `looptest_negative` test that is not in the scope of the test.