### PR TITLE
fe: fix search for nontype features that match a type name

### DIFF
--- a/src/dev/flang/ast/AstErrors.java
+++ b/src/dev/flang/ast/AstErrors.java
@@ -1209,7 +1209,7 @@ public class AstErrors extends ANY
                                ? "check the spelling of the type you have used"
                                : ((hasAbstract ? "implement (make non-abstract) " : "") +
                                   (hasAbstract && hasReturnType ? "and " : "") +
-                                  (hasReturnType ? "remove the return type (or replace it by " + skw("ref") +") of " : "") + "one of these features")
+                                  (hasReturnType ? "remove the return type (or replace it by " + skw("ref") +") of " : "") + ((n > 1) ? "one of these features" : "this feature"))
                                ) + ".");
   }
 

--- a/src/dev/flang/fe/Module.java
+++ b/src/dev/flang/fe/Module.java
@@ -278,11 +278,27 @@ public abstract class Module extends ANY
    */
   protected boolean typeVisible(SourceFile usedIn, AbstractFeature af)
   {
+    return typeVisible(usedIn, af, false);
+  }
+
+
+  /**
+   * Is type defined by feature `af` visible in file `usedIn`?
+   * If `af` does not define a type, result is false.
+   *
+   * @param usedIn
+   * @param af
+   * @param ignoreDefinesType leave checking whethere `af` defines a type to the caller
+   * @return
+   */
+  protected boolean typeVisible(SourceFile usedIn, AbstractFeature af, boolean ignoreDefinesType)
+  {
     var m = (af instanceof LibraryFeature lf) ? lf._libModule : this;
     var definedIn = af.pos()._sourceFile;
     var v = af.visibility();
+    var definesType = af.definesType() || ignoreDefinesType;
 
-    return af.definesType() && (usedIn.sameAs(definedIn)
+    return definesType && (usedIn.sameAs(definedIn)
       || (v == Visi.PRIVMOD || v == Visi.MOD) && this == m
       || v == Visi.PRIVPUB || v == Visi.MODPUB ||  v == Visi.PUB);
   }

--- a/src/dev/flang/fe/SourceModule.java
+++ b/src/dev/flang/fe/SourceModule.java
@@ -1120,7 +1120,7 @@ public class SourceModule extends Module implements SrcModule, MirModule
         for (var fo : fs)
           {
             var f = fo._feature;
-            if (typeVisible(pos._sourceFile, f))
+            if (typeVisible(pos._sourceFile, f, true))
               {
                 (f.definesType() ? type_fs
                                  : nontype_fs).add(f);


### PR DESCRIPTION
A minimal example,
```
ex_tnf is

  foo void is
    do

  f foo := foo
```
which previously generated the following error:
```
ex_tnf.fz:6:5: error 1: Type not found
  f foo := foo
----^^^
Type 'foo' was not found, no corresponding feature nor formal type parameter exists
Type that was not found: 'foo'
in feature: 'ex_tnf.f'
However, one feature has been found that matches the type name but that does not define a type:
'ex_tnf.foo' defined at ex_tnf.fz:3:3:
  foo void is
--^^^

To solve this, remove the return type (or replace it by 'ref') of one of these features.

one error.
```
started producing the following error after the visibility changes were introduced:
```
ex_tnf.fz:6:5: error 1: Type not found
  f foo := foo
----^^^
Type 'foo' was not found, no corresponding feature nor formal type parameter exists
Type that was not found: 'foo'
in feature: 'ex_tnf.f'
To solve this, check the spelling of the type you have used.

one error.
```

The list of the features in the original message comes from the `nontypes_found` argument to `dev.flang.ast.AstErrors.typeNotFound`. In `dev.flang.fe.SourceModule.lookupType`, where this error in particular is generated, this is how the `nontypes_found` list is generated:
```
if (typeVisible(pos._sourceFile, f))
  {
    (f.definesType() ? type_fs
                     : nontype_fs).add(f);
```
The problem is that `typeVisible` always returns `false` when `f.definesType()` is false. This means that the `nontypes_found` list was always empty.

Fix this by introducing a new variant of `typeVisible` which does not check whether the feature passed to it is actually a type.

Fixes #1822.