### PR TITLE
fuir/C: Add new method `FUIR.clazzid2num`

### DIFF
--- a/src/dev/flang/be/c/CNames.java
+++ b/src/dev/flang/be/c/CNames.java
@@ -453,11 +453,14 @@ public class CNames extends ANY
 
 
   /**
-   * NYI: Documentation, just discard the sign?
+   * Convert a clazz id into a number 0, 1, 2, 3, ...
+   *
+   * The clazz id is intentionally large to detect accidental usage of a clazz
+   * id in a wrong context.
    */
   private int clazzId2num(int cl)
   {
-    return cl & 0xFFFffff; // NYI: give a name to this constant
+    return _fuir.clazzId2num(cl);
   }
 
 

--- a/src/dev/flang/fuir/FUIR.java
+++ b/src/dev/flang/fuir/FUIR.java
@@ -304,6 +304,29 @@ public class FUIR extends IR
     return id(_main);
   }
 
+
+  /**
+   * Convert a clazz id into a number 0, 1, 2, 3, ...
+   *
+   * The clazz id is intentionally large to detect accidental usage of a clazz
+   * id in a wrong context.
+   *
+   * @param cl a clazz id
+   */
+  public int clazzId2num(int cl)
+  {
+    if (PRECONDITIONS) require
+      (cl >= firstClazz() && cl <= lastClazz());
+
+    var result = cl - FUIR.CLAZZ_BASE;
+
+    if (POSTCONDITIONS) ensure
+      (result >= 0 && result <= lastClazz() - firstClazz());
+
+    return result;
+  }
+
+
   public int clazzNumFields(int cl)
   {
     return clazz(cl).fields().length;


### PR DESCRIPTION
This avoids some ugly inline constants in the backends.