### PR TITLE
visibility: make `outcome.err` public

### DIFF
--- a/lib/outcome.fz
+++ b/lib/outcome.fz
@@ -99,9 +99,9 @@ is
   # error of an outcome that is known to contain an error
   #
   # This can only be called in cases where it is known for sure that this
-  # outcomee is an error.  A runtime error will be created otherwise.
+  # outcome is an error.  A runtime error will be created otherwise.
   #
-  err error
+  public err error
     pre
       safety: outcome.this!!
   is


### PR DESCRIPTION
- this fixes currently broken examples/webserver.fz