### PR TITLE
fuir/analysis: Evaluate target and value for assginment to unused field.

### DIFF
--- a/src/dev/flang/air/Clazzes.java
+++ b/src/dev/flang/air/Clazzes.java
@@ -742,7 +742,7 @@ public class Clazzes extends ANY
       {
         if (a._tid < 0)
           {
-            a._tid = getRuntimeClazzIds(2);
+            a._tid = getRuntimeClazzIds(3);
           }
 
         Clazz sClazz = clazz(a._target, outerClazz);
@@ -754,6 +754,7 @@ public class Clazzes extends ANY
           {
             outerClazz.setRuntimeClazz(a._tid + 1, fc);
           }
+        outerClazz.setRuntimeClazz(a._tid + 2, fc.resultClazz());
       }
   }
 

--- a/src/dev/flang/fuir/FUIR.java
+++ b/src/dev/flang/fuir/FUIR.java
@@ -1475,6 +1475,36 @@ hw25 is
 
 
   /**
+   * Get the type of an assigned value. This returns the type even if the
+   * assigned field has been removed and accessedClazz() returns -1.
+   *
+   * @param cl index of clazz containing the assignment
+   *
+   * @param c code block containing the assignment
+   *
+   * @param ix index of the assignment
+   *
+   * @return the type of the assigned value.
+   */
+  public int assignedType(int cl, int c, int ix)
+  {
+    if (PRECONDITIONS) require
+      (ix >= 0,
+       withinCode(c, ix),
+       codeAt(c, ix) == ExprKind.Assign    );
+
+    var outerClazz = clazz(cl);
+    var s = _codeIds.get(c).get(ix);
+    var t =
+      (s instanceof AbstractAssign a   ) ? (Clazz) outerClazz.getRuntimeData(a   ._tid + 2) :
+      (s instanceof Clazz          fld ) ? fld.resultClazz() :
+      (Clazz) (Object) new Object() { { if (true) throw new Error("assignedType found unexpected Expr."); } } /* Java is ugly... */;
+
+    return id(t);
+  }
+
+
+  /**
    * Get the possible inner clazzes for a dynamic call or assignment to a field
    *
    * @param cl index of clazz containing the access

--- a/src/dev/flang/fuir/analysis/AbstractInterpreter.java
+++ b/src/dev/flang/fuir/analysis/AbstractInterpreter.java
@@ -570,18 +570,19 @@ public class AbstractInterpreter<VALUE, RESULT> extends ANY
       case Assign:
         {
           // NYI: pop the stack values even in case field is unused.
-          if (_fuir.accessedClazz(cl, c, i) != -1)  // field we are assigning to may be unused, i.e., -1
+          var ft = _fuir.assignedType(cl, c, i);
+          var tc = _fuir.accessTargetClazz(cl, c, i);
+          var tvalue = pop(stack, tc);
+          var avalue = pop(stack, ft);
+          var f = _fuir.accessedClazz  (cl, c, i);
+          if (f != -1)  // field we are assigning to may be unused, i.e., -1
             {
-              var f = _fuir.accessedClazz  (cl, c, i);
-              var ft = _fuir.clazzResultClazz(f);
-              var tc = _fuir.accessTargetClazz(cl, c, i);
-              var tvalue = pop(stack, tc);
-              var avalue = pop(stack, ft);
               return _processor.assign(cl, pre, c, i, tvalue, avalue);
             }
           else
             {
-              return _processor.nop();
+              return _processor.sequence(new List<>(_processor.drop(tvalue, tc),
+                                                    _processor.drop(avalue, ft)));
             }
         }
       case Box:


### PR DESCRIPTION
This is required by the JVM backen: For an assignment `t.f := v` for a field `f` that is unused, we must still evaluate `t` and `v`.  To do this, FUIR has been extended to obtain the type of the assigned value in case the assigned field is removed.