### PR TITLE
lib/fuir: Add backend-dependend pointer type fuzion.sys.Pointer

### DIFF
--- a/lib/fuzion/sys/Pointer.fz
+++ b/lib/fuzion/sys/Pointer.fz
@@ -17,41 +17,19 @@
 #
 #  Tokiwa Software GmbH, Germany
 #
-#  Source code of Fuzion standard library feature sys.internal_array
+#  Source code of Fuzion standard library feature sys.Pointer
 #
 #  Author: Fridtjof Siebert (siebert@tokiwa.software)
 #
 # -----------------------------------------------------------------------
 
-# helper to allocate memory for an internal_array.
-# returns an internal_array.
+# backend-specific pointer type used, e.g., to refer to the actual data in an
+# array
 #
-public internal_array_init(T type, private length i32) =>
+# This must not be used for anything except assignments to other pointers, no
+# calls on this value are permitted, not even `p.as_string`, this will lead to
+# undefined behaviour.
+#
+public /* NYI: private */ Pointer ref is
 
-  private alloc(X type, l i32) Pointer is intrinsic
-
-  internal_array T (alloc T length) length
-
-
-# fuzion.sys.internal_array_init -- one-dimensional low-level array
-module:public internal_array(T type, module data Pointer, public length i32) is
-
-  private get  (X type, d Pointer, i i32) X is intrinsic
-  private setel(X type, d Pointer, i i32, o X) unit is intrinsic
-
-
-  module indices => 0..length-1
-
-  public index [ ] (i i32) T
-    pre
-      safety: 0 ≤ i < length
-  is
-    get T data i
-
-  public set [ ] (i i32, o T) unit
-    pre
-      safety: 0 ≤ i < length
-  # post   NYI
-    #array.this[i] == o
-  is
-    setel T data i o
+  # this must not contain any declarations.

--- a/lib/fuzion/sys/fileio.fz
+++ b/lib/fuzion/sys/fileio.fz
@@ -305,7 +305,7 @@ module fileio is
   # note: offset+size must not exceed file size.
   # note: returning allocated memory - instead of error code - simplifies handling in DFA.
   #
-  module mmap(fd i64, offset, size i64, res Any) Any is intrinsic
+  module mmap(fd i64, offset, size i64, res Any) Pointer is intrinsic
 
 
   # close a memory mapped file

--- a/src/dev/flang/air/Clazzes.java
+++ b/src/dev/flang/air/Clazzes.java
@@ -188,6 +188,7 @@ public class Clazzes extends ANY
       }
     };
   public static Clazz constStringInternalArray;  // field Const_String.internal_array
+  public static Clazz fuzionSysPtr;              // internal pointer type
   public static Clazz fuzionSysArray_u8;         // result clazz of Const_String.internal_array
   public static Clazz fuzionSysArray_u8_data;    // field fuzion.sys.array<u8>.data
   public static Clazz fuzionSysArray_u8_length;  // field fuzion.sys.array<u8>.length
@@ -436,6 +437,7 @@ public class Clazzes extends ANY
     fuzionSysArray_u8.instantiated(SourcePosition.builtIn);
     fuzionSysArray_u8_data   = fuzionSysArray_u8.lookup(Types.resolved.f_fuzion_sys_array_data  , SourcePosition.builtIn);
     fuzionSysArray_u8_length = fuzionSysArray_u8.lookup(Types.resolved.f_fuzion_sys_array_length, SourcePosition.builtIn);
+    fuzionSysPtr = fuzionSysArray_u8_data.resultClazz();
 
     while (!clazzesToBeVisited.isEmpty())
       {

--- a/src/dev/flang/fuir/FUIR.java
+++ b/src/dev/flang/fuir/FUIR.java
@@ -119,6 +119,7 @@ public class FUIR extends IR
     c_TRUE        { Clazz getIfCreated() { return Clazzes.c_TRUE     .getIfCreated(); } },
     c_FALSE       { Clazz getIfCreated() { return Clazzes.c_FALSE    .getIfCreated(); } },
     c_Const_String{ Clazz getIfCreated() { return Clazzes.Const_String.getIfCreated(); } },
+    c_sys_ptr     { Clazz getIfCreated() { return Clazzes.fuzionSysPtr;               } },
     c_unit        { Clazz getIfCreated() { return Clazzes.c_unit     .getIfCreated(); } },
 
     // dummy entry to report failure of getSpecialId()

--- a/src/dev/flang/fuir/analysis/dfa/Call.java
+++ b/src/dev/flang/fuir/analysis/dfa/Call.java
@@ -234,6 +234,7 @@ public class Call extends ANY implements Comparable<Call>, Context
                   case c_TRUE, c_FALSE           -> Value.UNIT;
                   case c_Const_String            -> _dfa.newConstString(null, this);
                   case c_unit                    -> Value.UNIT;
+                  case c_sys_ptr                 -> new Value(_cc); // NYI: we might add a specific value for system pointers
                   case c_NOT_FOUND               -> null;
                   };
               }


### PR DESCRIPTION
This is currently used for internal array data only, but might be used at other places as well.

This will be needed in the JVM backend.