### PR TITLE
tests: in simple tests, if unexpected error was produced, supress diff on stdout

### DIFF
--- a/tests/check_simple_example_c.sh
+++ b/tests/check_simple_example_c.sh
@@ -76,19 +76,15 @@ else
         experr=$2.expected_err_c
     fi
     head -n 100 "$expout" >tmp_exp_out.txt
-    if diff tmp_exp_out.txt tmp_out.txt; then
-        if diff "$experr" tmp_err.txt >/dev/null; then
-            echo -ne "\033[32;1mPASSED\033[0m."
-        else
-            diff "$experr" tmp_err.txt
-            echo -e "\033[31;1m*** FAILED\033[0m err on $2"
-            RC=1
-        fi
-    else
-        diff "$experr" tmp_err.txt
-        echo -e "\033[31;1m*** FAILED\033[0m out on $2"
-        RC=1
+    expout=tmp_exp_out.txt
+
+    # show diff in stdout unless an unexpected output occured to stderr
+    if [ ! -s tmp_err.txt  ] && [ -s "$experr" ]; then
+        diff "$expout" tmp_out.txt || (echo -e "\033[31;1m*** FAILED\033[0m out on $2")
     fi
+    diff "$experr" tmp_err.txt || (echo -e "\033[31;1m*** FAILED\033[0m err on $2")
+    diff "$expout" tmp_out.txt >/dev/null && diff "$experr" tmp_err.txt >/dev/null && echo -e "\033[32;1mPASSED\033[0m."
+    RC=$?
     if [ -f testbin ]; then
         echo " (binary)"
     else


### PR DESCRIPTION
This avoids long output that makes it hard to see the actual error.

Also simplifies the scripts such that they contain the same code to output the restuls.  Aadded support for expected_out_int/expected_err_int to prepare for the interpreter no longer being the default.