### PR TITLE
`checkTypes` use `isDirectlyAssignable`

### DIFF
--- a/src/dev/flang/ast/Box.java
+++ b/src/dev/flang/ast/Box.java
@@ -95,7 +95,7 @@ public class Box extends Expr
   {
     if (PRECONDITIONS) require
       (value != null,
-       true /* NYI */ || !value.type().isRef() || value.isCallToOuterRef());
+       !value.type().isRef() || value.isCallToOuterRef());
 
     this._value = value;
     var t = value.type();

--- a/src/dev/flang/ast/If.java
+++ b/src/dev/flang/ast/If.java
@@ -229,7 +229,7 @@ public class If extends ExprWithPos
       (elseBlock != null || elseIf != null);
 
     var t = cond.type();
-    if (!Types.resolved.t_bool.isAssignableFrom(t))
+    if (!Types.resolved.t_bool.isDirectlyAssignableFrom(t))
       {
         AstErrors.ifConditionMustBeBool(cond.pos(), t);
       }

--- a/src/dev/flang/ast/InlineArray.java
+++ b/src/dev/flang/ast/InlineArray.java
@@ -277,7 +277,7 @@ public class InlineArray extends ExprWithPos
 
     for (var e : _elements)
       {
-        if (!elementType.isAssignableFrom(e.type()))
+        if (!elementType.isDirectlyAssignableFrom(e.type()))
           {
             AstErrors.incompatibleTypeInArrayInitialization(e.pos(), _type, elementType, e);
           }


### PR DESCRIPTION
instead of `isAssignable`