### PR TITLE
fuir/C: FUIR.clazzChoice now returns void clazz instead of -1

### DIFF
--- a/src/dev/flang/be/c/C.java
+++ b/src/dev/flang/be/c/C.java
@@ -287,21 +287,18 @@ public class C extends ANY
           for (var tagNum : tags)
             {
               var tc = _fuir.clazzChoice(subjClazz, tagNum);
-              if (tc != -1)
+              if (!hasTag && _fuir.clazzIsRef(tc))  // do we need to check the clazzId of a ref?
                 {
-                  if (!hasTag && _fuir.clazzIsRef(tc))  // do we need to check the clazzId of a ref?
+                  for (var h : _fuir.clazzInstantiatedHeirs(tc))
                     {
-                      for (var h : _fuir.clazzInstantiatedHeirs(tc))
-                        {
-                          rtags.add(_names.clazzId(h).comment(_fuir.clazzAsString(h)));
-                        }
+                      rtags.add(_names.clazzId(h).comment(_fuir.clazzAsString(h)));
                     }
-                  else
-                    {
-                      ctags.add(CExpr.int32const(tagNum).comment(_fuir.clazzAsString(tc)));
-                      if (CHECKS) check
-                        (hasTag || !_fuir.hasData(tc));
-                    }
+                }
+              else if (!_fuir.clazzIsVoidType(tc))
+                {
+                  ctags.add(CExpr.int32const(tagNum).comment(_fuir.clazzAsString(tc)));
+                  if (CHECKS) check
+                    (hasTag || !_fuir.hasData(tc));
                 }
             }
           var sl = new List<CStmnt>();

--- a/src/dev/flang/be/c/CTypes.java
+++ b/src/dev/flang/be/c/CTypes.java
@@ -244,10 +244,7 @@ public class CTypes extends ANY
             for (int i = 0; i < _fuir.clazzNumChoices(cl); i++)
               {
                 var cc = _fuir.clazzChoice(cl, i);
-                if (cc != -1)
-                  {
-                    findDeclarationOrder(_fuir.clazzIsRef(cc) ? _fuir.clazzObject() : cc, result, visited);
-                  }
+                findDeclarationOrder(_fuir.clazzIsRef(cc) ? _fuir.clazzObject() : cc, result, visited);
               }
             if (_fuir.clazzIsRef(cl))
               {
@@ -288,7 +285,7 @@ public class CTypes extends ANY
             for (int i = 0; i < _fuir.clazzNumChoices(cl); i++)
               {
                 var cc = _fuir.clazzChoice(cl, i);
-                if (cc != -1 && !_fuir.clazzIsRef(cc))
+                if (!_fuir.clazzIsVoidType(cc) && !_fuir.clazzIsRef(cc))
                   {
                     uls.add(CStmnt.decl(clazz(cc), new CIdent(_names.CHOICE_ENTRY_NAME + i)));
                   }

--- a/src/dev/flang/fuir/FUIR.java
+++ b/src/dev/flang/fuir/FUIR.java
@@ -376,12 +376,8 @@ public class FUIR extends IR
    *
    * @param i the choice number
    *
-   * @return the clazz id of the choice type, or -1 if the clazz is never
-   * instantiated and hence does not need to be taken care for.
-   *
-   * NYI: Instead of returning -1 for non-instantiated value clazzes, it would
-   * be much nicer if those clazzes would be removed completely from the IR or
-   * replaced by something obvious like 'void'.
+   * @return the clazz id of the choice type, or void clazz if the clazz is
+   * never instantiated and hence does not need to be taken care for.
    */
   public int clazzChoice(int cl, int i)
   {
@@ -390,7 +386,10 @@ public class FUIR extends IR
 
     var cc = clazz(cl);
     var cg = cc.choiceGenerics().get(i);
-    return cg.isRef() || cg.isInstantiated() ? id(cg) : -1;
+    var res = cg.isRef()          ||
+              cg.isInstantiated()    ? cg
+                                     : Clazzes.c_void.get();
+    return id(res);
   }
 
 
@@ -687,6 +686,9 @@ public class FUIR extends IR
    */
   public int clazzChoiceTag(int cl, int valuecl)
   {
+    if (PRECONDITIONS) require
+      (!clazzIsVoidType(valuecl));
+
     var cc = clazz(cl);
     var vc = clazz(valuecl);
     return cc.getChoiceTag(vc._type);

--- a/src/dev/flang/fuir/analysis/AbstractInterpreter.java
+++ b/src/dev/flang/fuir/analysis/AbstractInterpreter.java
@@ -682,6 +682,8 @@ public class AbstractInterpreter<VALUE, RESULT> extends ANY
           var valuecl = _fuir.tagValueClazz(cl, c, i);  // static clazz of value
           var value   = pop(stack, valuecl);            // value that will be tagged
           var newcl   = _fuir.tagNewClazz  (cl, c, i);  // static clazz of result
+          if (PRECONDITIONS) check
+            (!_fuir.clazzIsVoidType(valuecl));
           int tagNum  = _fuir.clazzChoiceTag(newcl, valuecl);
           var r = _processor.tag(cl, valuecl, value, newcl, tagNum);
           push(stack, newcl, r._v0);

--- a/src/dev/flang/fuir/analysis/AbstractInterpreter.java
+++ b/src/dev/flang/fuir/analysis/AbstractInterpreter.java
@@ -682,7 +682,7 @@ public class AbstractInterpreter<VALUE, RESULT> extends ANY
           var valuecl = _fuir.tagValueClazz(cl, c, i);  // static clazz of value
           var value   = pop(stack, valuecl);            // value that will be tagged
           var newcl   = _fuir.tagNewClazz  (cl, c, i);  // static clazz of result
-          if (PRECONDITIONS) check
+          if (CHECKS) check
             (!_fuir.clazzIsVoidType(valuecl));
           int tagNum  = _fuir.clazzChoiceTag(newcl, valuecl);
           var r = _processor.tag(cl, valuecl, value, newcl, tagNum);


### PR DESCRIPTION
This avoids some special handling in the backend, in particular helps with the upcoming JVM backend.