### PR TITLE
fuir: Improve stack cleanup witihin basic block, #1875

### DIFF
--- a/src/dev/flang/fuir/FUIR.java
+++ b/src/dev/flang/fuir/FUIR.java
@@ -599,7 +599,7 @@ public class FUIR extends IR
    *
    * @param cl a clazz id
    *
-   * @return clazz id  of corresponding value clazz.
+   * @return clazz id of corresponding value clazz.
    */
   public int clazzAsValue(int cl)
   {
@@ -826,8 +826,10 @@ public class FUIR extends IR
 
 
   /**
-   * Are values of this clazz all the same, so they are essentially C/Java void
-   * values?
+   * Is there just one single value of this class, so this type is essentially a
+   * C/Java `void` type?
+   *
+   * NOTE: This is false for Fuzion's `void` type!
    */
   public boolean clazzIsUnitType(int cl)
   {
@@ -916,14 +918,14 @@ hw25 is
         var pf = p.calledFeature();
         var of = pf.outerRef();
         var or = (of == null) ? null : (Clazz) cc._inner.get(new FeatureAndActuals(of, new List<>(), false));  // NYI: ugly cast
-        toStack(code, p.target());
-        if (or != null && !or.resultClazz().isUnitType())
+        var needsOuterRef = (or != null && !or.resultClazz().isUnitType());
+        toStack(code, p.target(), !needsOuterRef /* dump result if not needed */);
+        if (needsOuterRef)
           {
             if (clazzFieldIsAdrOfValue(or))
               {
                 code.add(ExprKind.AdrOf);
               }
-            code.add(ExprKind.Dup);
             code.add(ExprKind.Current);
             code.add(or);  // field clazz means assignment to field
           }
@@ -1979,7 +1981,6 @@ hw25 is
       case Current -> "Current";
       case Comment -> "Comment: " + comment(c, ix);
       case Const   -> "Const";
-      case Dup     -> "Dup";
       case Match   -> {
                         var sb = new StringBuilder("Match");
                         for (var cix = 0; cix < matchCaseCount(c, ix); cix++)
@@ -2246,7 +2247,6 @@ hw25 is
       case Current -> codeIndex(c, ix, -1);
       case Comment -> skipBack(cl, c, codeIndex(c, ix, -1));
       case Const   -> codeIndex(c, ix, -1);
-      case Dup     -> codeIndex(c, ix, -1);
       case Match   ->
         {
           ix = codeIndex(c, ix, -1);

--- a/src/dev/flang/fuir/analysis/dfa/DFA.java
+++ b/src/dev/flang/fuir/analysis/dfa/DFA.java
@@ -272,7 +272,7 @@ public class DFA extends ANY
           var cc = ccs[cci+1];
           tvalue.value().forAll(t -> {
               check
-                (t != Value.UNIT || AbstractInterpreter.ignoredOnStack(_fuir, tt));
+                (t != Value.UNIT || AbstractInterpreter.clazzHasUniqueValue(_fuir, tt));
               if (t == Value.UNIT ||
                   t._clazz == tt ||
                   _fuir.clazzAsValue(t._clazz) == tt)

--- a/src/dev/flang/fuir/cfg/CFG.java
+++ b/src/dev/flang/fuir/cfg/CFG.java
@@ -582,7 +582,6 @@ public class CFG extends ANY
           addEffect(cl, ecl);
           break;
         }
-      case Dup: break;
       case Pop: break;
       default:
         {

--- a/src/dev/flang/ir/IR.java
+++ b/src/dev/flang/ir/IR.java
@@ -105,7 +105,6 @@ public class IR extends ANY
     Current,
     Comment,
     Const,
-    Dup,
     Match,
     Tag,
     Env,
@@ -193,7 +192,7 @@ public class IR extends ANY
    *
    * @param dumpResult flag indicating that we are not interested in the result.
    */
-  private void toStack(List<Object> l, Expr e, boolean dumpResult)
+  protected void toStack(List<Object> l, Expr e, boolean dumpResult)
   {
     if (PRECONDITIONS) require
       (l != null,
@@ -207,16 +206,19 @@ public class IR extends ANY
       }
     else if (e instanceof Unbox u)
       {
-        toStack(l, u._adr);
-        if (u._needed)
+        toStack(l, u._adr, dumpResult);
+        if (!dumpResult && u._needed)
           {
             l.add(u);
           }
       }
     else if (e instanceof Box b)
       {
-        toStack(l, b._value);
-        l.add(b);
+        toStack(l, b._value, dumpResult);
+        if (!dumpResult)
+          {
+            l.add(b);
+          }
       }
     else if (e instanceof AbstractBlock b)
       {
@@ -229,11 +231,17 @@ public class IR extends ANY
       }
     else if (e instanceof AbstractConstant)
       {
-        l.add(e);
+        if (!dumpResult)
+          {
+            l.add(e);
+          }
       }
     else if (e instanceof AbstractCurrent)
       {
-        l.add(ExprKind.Current);
+        if (!dumpResult)
+          {
+            l.add(ExprKind.Current);
+          }
       }
     else if (e instanceof If i)
       {
@@ -268,12 +276,18 @@ public class IR extends ANY
       }
     else if (e instanceof Tag t)
       {
-        toStack(l, t._value);
-        l.add(t);
+        toStack(l, t._value, dumpResult);
+        if (!dumpResult)
+          {
+            l.add(t);
+          }
       }
     else if (e instanceof Env v)
       {
-        l.add(v);
+        if (!dumpResult)
+          {
+            l.add(v);
+          }
       }
     else if (e instanceof Nop)
       {


### PR DESCRIPTION
This patch removes the only use of the `Dup` intermediate instruction and removes the instruction as well.  The duplication was not neccessary and resulted in a value left on the stack.

This patch also contains some cleanup:

- Rename `AbstractInterpreter.clazzHasUniqueValue` as `ignoredOnStack`,
- Remove unused handlign of InlinedArray in IR, and
- enhanced some comments.