### PR TITLE
fuir/analysis: When setting argument fields, do not force to use value instance

### DIFF
--- a/src/dev/flang/fuir/analysis/AbstractInterpreter.java
+++ b/src/dev/flang/fuir/analysis/AbstractInterpreter.java
@@ -426,14 +426,13 @@ public class AbstractInterpreter<VALUE, RESULT> extends ANY
         l.add(_processor.assignStatic(cl, or, rt, cur._v0, out._v0));
       }
 
-    var vcl = _fuir.clazzAsValue(cl);
-    var ac = _fuir.clazzArgCount(vcl);
+    var ac = _fuir.clazzArgCount(cl);
     for (int i = 0; i < ac; i++)
       {
         var cur = _processor.current(cl, pre);
         l.add(cur._v1);
-        var af = _fuir.clazzArg(vcl, i);
-        var at = _fuir.clazzArgClazz(vcl, i);
+        var af = _fuir.clazzArg(cl, i);
+        var at = _fuir.clazzArgClazz(cl, i);
         var ai = _processor.arg(cl, i);
         if (ai != null)
           {


### PR DESCRIPTION
This is a special handling that was introduced for the C backend where structs for ref types always contain an embedded corresponding value type instance, so accesses to fields are always to the fields of the value type.

This special handling in the AbstractInterpreter is no longer needed for the C backend and it is in the way for the JVM backend that does not create value types for every ref type.  SO this patch removes that special handling.