### PR TITLE
dfa: Fix crash due to Value.UNDEFINED (as a result of missing intrinsics)

### DIFF
--- a/src/dev/flang/fuir/analysis/dfa/DFA.java
+++ b/src/dev/flang/fuir/analysis/dfa/DFA.java
@@ -275,7 +275,7 @@ public class DFA extends ANY
                 (t != Value.UNIT || AbstractInterpreter.clazzHasUniqueValue(_fuir, tt));
               if (t == Value.UNIT ||
                   t._clazz == tt ||
-                  _fuir.clazzAsValue(t._clazz) == tt)
+                  t != Value.UNDEFINED && _fuir.clazzAsValue(t._clazz) == tt)
                 {
                   found[0] = true;
                   var r = access0(cl, c, i, t, args, cc, tvalue);


### PR DESCRIPTION
This caused a crash in tests/javaBase for the JVM backend since unsupported intrinsics of the Java interface produced Value.UNDEFINED that was not handledproperly when accessed.