### PR TITLE
jvm: add support for abortable effects

### DIFF
--- a/src/dev/flang/be/jvm/Choices.java
+++ b/src/dev/flang/be/jvm/Choices.java
@@ -651,7 +651,7 @@ public class Choices extends ANY implements ClassFileConstants
             .andThen(Expr.POP);                                                 //          -
           break;
         }
-      default: throw new Error("Unexpeced choice kind in match of JVM backend: " + kind(subjClazz));
+      default: throw new Error("Unexpected choice kind in match of JVM backend: " + kind(subjClazz));
       }
     return code;
   }
@@ -762,7 +762,7 @@ public class Choices extends ANY implements ClassFileConstants
             }
           break;
         }
-      default: throw new Error("Unexpeced choice kind in tag of JVM backend: " + kind(newcl));
+      default: throw new Error("Unexpected choice kind in tag of JVM backend: " + kind(newcl));
       }
     return res;
   }

--- a/src/dev/flang/be/jvm/Intrinsix.java
+++ b/src/dev/flang/be/jvm/Intrinsix.java
@@ -206,7 +206,7 @@ public class Intrinsix extends ANY implements ClassFileConstants
             }
           else
             { // unreachable, call type cannot be primitive type
-              throw new Error("unexpeced type " + call_t + " for " + jvm._fuir.clazzAsString(call));
+              throw new Error("unexpected type " + call_t + " for " + jvm._fuir.clazzAsString(call));
             }
         });
 

--- a/src/dev/flang/be/jvm/Intrinsix.java
+++ b/src/dev/flang/be/jvm/Intrinsix.java
@@ -169,6 +169,47 @@ public class Intrinsix extends ANY implements ClassFileConstants
           return new Pair<>(val, code);
         });
 
+    put("effect.abort",
+        (jvm, cc, tvalue, args) ->
+        {
+          var ecl = jvm._fuir.clazzActualGeneric(cc, 0);
+          var code = Expr.iconst(jvm._fuir.clazzId2num(ecl))
+            .andThen(Expr.invokeStatic(Names.RUNTIME_CLASS,
+                                       "effect_abort",
+                                       "(I)V",
+                                       ClassFileConstants.PrimitiveType.type_void));
+          return new Pair<>(Expr.UNIT, code);
+        });
+
+    put("effect.abortable",
+        (jvm, cc, tvalue, args) ->
+        {
+          var ecl = jvm._fuir.effectType(cc);
+          var oc = jvm._fuir.clazzActualGeneric(cc, 0);
+          var call = jvm._fuir.lookupCall(oc);
+          var call_t = jvm._types.javaType(call);
+          if (call_t instanceof ClassType call_ct)
+            {
+              var result = Expr.iconst(jvm._fuir.clazzId2num(ecl))
+                .andThen(tvalue)
+                .andThen(args.get(0))
+                .andThen(Expr.classconst(call_ct))
+                .andThen(Expr.invokeStatic(Names.RUNTIME_CLASS,
+                                           "effect_abortable",
+                                           "(" + ("I" +
+                                                  Names.ANY_DESCR +
+                                                  Names.ANY_DESCR +
+                                                  JAVA_LANG_CLASS.descriptor()) +
+                                           ")V",
+                                           ClassFileConstants.PrimitiveType.type_void));
+              return new Pair<>(Expr.UNIT, result);
+            }
+          else
+            { // unreachable, call type cannot be primitive type
+              throw new Error("unexpeced type " + call_t + " for " + jvm._fuir.clazzAsString(call));
+            }
+        });
+
     put("effect.default",
         (jvm, cc, tvalue, args) ->
         {
@@ -177,7 +218,9 @@ public class Intrinsix extends ANY implements ClassFileConstants
             .andThen(tvalue)
             .andThen(Expr.invokeStatic(Names.RUNTIME_CLASS,
                                        "effect_default",
-                                       "(ILdev/flang/be/jvm/runtime/Any;)V",
+                                       "(" + ("I" +
+                                              Names.ANY_DESCR) +
+                                       ")V",
                                        ClassFileConstants.PrimitiveType.type_void));
           return new Pair<>(Expr.UNIT, result);
         });
@@ -189,7 +232,9 @@ public class Intrinsix extends ANY implements ClassFileConstants
             .andThen(tvalue)
             .andThen(Expr.invokeStatic(Names.RUNTIME_CLASS,
                                        "effect_replace",
-                                       "(ILdev/flang/be/jvm/runtime/Any;)V",
+                                       "(" + ("I" +
+                                              Names.ANY_DESCR) +
+                                       ")V",
                                        ClassFileConstants.PrimitiveType.type_void));
           return new Pair<>(Expr.UNIT, result);
         });
@@ -214,8 +259,6 @@ public class Intrinsix extends ANY implements ClassFileConstants
         "concur.atomic.write0",
         "concur.util.loadFence",
         "concur.util.storeFence",
-        "effect.abort",
-        "effect.abortable",
         "fuzion.java.Java_Object.is_null",
         "fuzion.java.array_get",
         "fuzion.java.array_length",

--- a/src/dev/flang/be/jvm/Intrinsix.java
+++ b/src/dev/flang/be/jvm/Intrinsix.java
@@ -172,7 +172,7 @@ public class Intrinsix extends ANY implements ClassFileConstants
     put("effect.abort",
         (jvm, cc, tvalue, args) ->
         {
-          var ecl = jvm._fuir.clazzActualGeneric(cc, 0);
+          var ecl = jvm._fuir.effectType(cc);
           var code = Expr.iconst(jvm._fuir.clazzId2num(ecl))
             .andThen(Expr.invokeStatic(Names.RUNTIME_CLASS,
                                        "effect_abort",

--- a/src/dev/flang/be/jvm/Names.java
+++ b/src/dev/flang/be/jvm/Names.java
@@ -69,6 +69,7 @@ public class Names extends ANY implements ClassFileConstants
    */
   static final String ANY_CLASS = Any.class.getName().replace(".","/");
   static final ClassType ANY_TYPE = new ClassType(ANY_CLASS);
+  static final String ANY_DESCR = ANY_TYPE.descriptor();
 
 
   /**
@@ -90,7 +91,7 @@ public class Names extends ANY implements ClassFileConstants
    * Name and signature of Runtime.effect_get()
    */
   static final String RUNTIME_EFFECT_GET     = "effect_get";
-  static final String RUNTIME_EFFECT_GET_SIG = "(I)Ldev/flang/be/jvm/runtime/Any;";
+  static final String RUNTIME_EFFECT_GET_SIG = "(I)" + ANY_DESCR;
 
 
   /**
@@ -109,6 +110,11 @@ public class Names extends ANY implements ClassFileConstants
 
   static final String PRECONDITION_NAME = "fzPrecondition";
   static final String ROUTINE_NAME = "fzRoutine";
+  static
+  {
+    if (CHECKS) check
+      (ROUTINE_NAME.equals(Runtime.ROUTINE_NAME));
+  }
 
   /**
    * Prefix for Java fields created for Fuzion fields

--- a/src/dev/flang/be/jvm/classfile/ClassFile.java
+++ b/src/dev/flang/be/jvm/classfile/ClassFile.java
@@ -327,6 +327,11 @@ public class ClassFile extends ANY implements ClassFileConstants
       this(cpUtf8(name));
     }
 
+    CPClass(AType t)
+    {
+      this(t.descriptor2());
+    }
+
     CPoolTag tag() { return CPoolTag.tag_class; }
 
     int compareTo2(CPEntry other)
@@ -689,6 +694,7 @@ public class ClassFile extends ANY implements ClassFileConstants
   CPNameAndType     cpNameAndType    (String name, String type  ) { return (CPNameAndType    ) (new CPNameAndType    (name, type)).add(); }
   CPClass           cpClass          (CPUtf8 name               ) { return (CPClass          ) (new CPClass          (name      )).add(); }
   CPClass           cpClass          (String name               ) { return (CPClass          ) (new CPClass          (name      )).add(); }
+  CPClass           cpClass          (AType  t                  ) { return (CPClass          ) (new CPClass          (t         )).add(); }
   CPField           cpField          (CPClass c, CPNameAndType n) { return (CPField          ) (new CPField          (c, n      )).add(); }
   CPMethod          cpMethod         (CPClass c, CPNameAndType n) { return (CPMethod         ) (new CPMethod         (c, n      )).add(); }
   CPInterfaceMethod cpInterfaceMethod(CPClass c, CPNameAndType n) { return (CPInterfaceMethod) (new CPInterfaceMethod(c, n      )).add(); }

--- a/src/dev/flang/be/jvm/classfile/ClassFileConstants.java
+++ b/src/dev/flang/be/jvm/classfile/ClassFileConstants.java
@@ -596,6 +596,7 @@ public interface ClassFileConstants
   }
 
 
+  static ClassType JAVA_LANG_CLASS  = new ClassType("java/lang/Class");
   static ClassType JAVA_LANG_OBJECT = new ClassType("java/lang/Object");
   static ClassType JAVA_LANG_STRING = new ClassType("java/lang/String");
 

--- a/src/dev/flang/be/jvm/classfile/Expr.java
+++ b/src/dev/flang/be/jvm/classfile/Expr.java
@@ -546,6 +546,19 @@ public abstract class Expr extends ByteCode
 
 
   /**
+   * Load a java.lang.Class constant given by ClassType
+   */
+  public static Expr classconst(ClassType t)
+  {
+    return new LoadConst()
+      {
+        public String toString() { return "class " + t;                 }
+        public JavaType type()   { return JAVA_LANG_CLASS;              }
+        ClassFile.CPEntry cpEntry(ClassFile cf) { return cf.cpClass(t); }
+    };
+  }
+
+  /**
    * Load int local variable from slot at given index.
    */
   public static Expr iload(int index)

--- a/src/dev/flang/be/jvm/runtime/Runtime.java
+++ b/src/dev/flang/be/jvm/runtime/Runtime.java
@@ -295,7 +295,7 @@ public class Runtime extends ANY
 
 
   /**
-   * Helper method to implement effect.abortable.  Install an instanc of effect
+   * Helper method to implement effect.abortable.  Install an instance of effect
    * type specified by id and run f.call while it is installed.  Helper to
    * implement intrinsic effect.abort.
    *

--- a/src/dev/flang/be/jvm/runtime/Runtime.java
+++ b/src/dev/flang/be/jvm/runtime/Runtime.java
@@ -30,10 +30,14 @@ import dev.flang.be.interpreter.OpenResources; // NYI: remove dependency!
 
 import dev.flang.util.ANY;
 import dev.flang.util.Errors;
+import dev.flang.util.List;
 
 import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.io.OutputStream;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 
 import java.nio.charset.StandardCharsets;
 
@@ -46,10 +50,38 @@ import java.nio.charset.StandardCharsets;
 public class Runtime extends ANY
 {
 
+  /*-----------------------------  classes  -----------------------------*/
+
+
+  /**
+   * Exception that is thrown by effect.abort
+   */
+  static class Abort extends Error
+  {
+
+    int _effect;
+
+    /**
+     * @param effect the id of the effect that is aborted.
+     */
+    Abort(int effect)
+    {
+      super();
+      this._effect = effect;
+    }
+
+  }
+
 
   /*----------------------------  constants  ----------------------------*/
 
-  static final int NYI_MAX_EFFECT_ID = 10000; // NYI: remove!
+
+  /**
+   * Copy of dev.flang.be.jvm.Names.ROUTINE_NAME without adding a dependency on
+   * that package.  We do not want to bundle the backend classes with a
+   * stand-alone application that needs the runtime classes, so this is copied.
+   */
+  public static final String ROUTINE_NAME = "fzRoutine";
 
 
   /*--------------------------  static fields  --------------------------*/
@@ -59,11 +91,8 @@ public class Runtime extends ANY
    * Currently installed effects.
    *
    * NYI: this should be thread local
-   *
-   * NYI: this should not have a static size but allocated to hold the # of
-   * effects in use
    */
-  static Any[] _installedEffects_ = new Any[NYI_MAX_EFFECT_ID];
+  static List<Any> _installedEffects_ = new List<>();
 
 
   /**
@@ -137,43 +166,218 @@ public class Runtime extends ANY
   static Thread _nyi_remove_single_thread = Thread.currentThread();
 
 
+  /**
+   * Make sure _installedEffects_ is large enough to hold effect with given id.
+   *
+   * @param id an effect id.
+   */
+  private static void ensure_effect_capacity(int id)
+  {
+    while (_installedEffects_.size() < id+1)
+      {
+        _installedEffects_.add(null);
+      }
+  }
+
+
+  /**
+   * Internal helper to load an effect instance from the given id.
+   *
+   * @param id an effect id.
+   */
+  private static Any effect_load(int id)
+  {
+    if (CHECKS) check
+      (_nyi_remove_single_thread == Thread.currentThread());
+
+    ensure_effect_capacity(id);
+    return _installedEffects_.get(id);
+  }
+
+  /**
+   * Internal helper to store an effect instance for the given id.
+   *
+   * @param id an effect id.
+   */
+  private static void effect_store(int id, Any instance)
+  {
+    if (CHECKS) check
+      (_nyi_remove_single_thread == Thread.currentThread());
+
+    ensure_effect_capacity(id);
+    _installedEffects_.set(id, instance);
+  }
+
+
   public static void effect_default(int id, Any instance)
   {
     if (CHECKS) check
       (_nyi_remove_single_thread == Thread.currentThread());
 
-    if (_installedEffects_[id] == null)
+    _installedEffects_.ensureCapacity(id + 1);
+    if (effect_load(id) == null)
       {
-        _installedEffects_[id] = instance;
+        effect_store(id, instance);
       }
   }
 
+
+  /**
+   * Helper method to implement intrinsic effect.type.is_installed.
+   *
+   * @param id an effect id.
+   *
+   * @return true iff an effect with that id was installed.
+   */
   public static boolean effect_is_installed(int id)
   {
     if (CHECKS) check
       (_nyi_remove_single_thread == Thread.currentThread());
 
-    return _installedEffects_[id] != null;
+    return effect_load(id) != null;
   }
 
+
+  /**
+   * Helper method to implement intrinsic effect.replace.
+   *
+   * @param id an effect id.
+   *
+   * @instance a new instance to replace the old one
+   */
   public static void effect_replace(int id, Any instance)
   {
     if (CHECKS) check
       (_nyi_remove_single_thread == Thread.currentThread());
 
-    _installedEffects_[id] = instance;
+    effect_store(id, instance);
   }
 
+
+  /**
+   * Helper method to handle an InvocationTargetException caused by a call to
+   * java.lang.reflect.Method.invoke.  This checks the causing exception, if
+   * that is an unchecked RuntimeException or Error, it just re-throws it to be
+   * handled by the caller.
+   *
+   * Otherwise, it causes a fatal error immediately.
+   *
+   * @param e the caught exception
+   *
+   * @return does not.
+   */
+  public static void handleInvocationTargetException(InvocationTargetException e)
+  {
+    var o = e.getCause();
+    if (o instanceof RuntimeException r) { throw r; }
+    if (o instanceof Error            r) { throw r; }
+    if (o != null)
+      {
+        Errors.fatal("Error while running JVM compiled code: " + o);
+      }
+    else
+      {
+        Errors.fatal("Error while running JVM compiled code: " + e);
+      }
+  }
+
+
+  /**
+   * Helper method to implement effect.abort.  Abort the currently installed
+   * effect with given id.  Helper to implement intrinsic effect.abort.
+   *
+   * @param id the id of the effect type that is aborted.
+   */
+  public static void effect_abort(int id)
+  {
+    throw new Abort(id);
+  }
+
+
+  /**
+   * Helper method to implement effect.abortable.  Install an instanc of effect
+   * type specified by id and run f.call while it is installed.  Helper to
+   * implement intrinsic effect.abort.
+   *
+   * @param id the id of the effect that is installed
+   *
+   * @param instance the effect instance that is installed
+   *
+   * @param code the Unary instance to be executed
+   *
+   * @param call the Java clazz of the Unary instance to be executed.
+   */
+  public static void effect_abortable(int id, Any instance, Any code, Class call)
+  {
+    if (CHECKS) check
+      (_nyi_remove_single_thread == Thread.currentThread());
+
+    var old = effect_load(id);
+    effect_store(id, instance);
+    Method r = null;
+    for (var m : call.getDeclaredMethods())
+      {
+        if (m.getName().equals("fzRoutine"))
+          {
+            r = m;
+          }
+      }
+    if (r == null)
+      {
+        Errors.fatal("in effect.abortable, missing `fzRoutine` in class `" + call + "`");
+      }
+    else
+      {
+        try
+          {
+            r.invoke(null, code);
+          }
+        catch (IllegalAccessException e)
+          {
+            Errors.fatal("effect.abortable call caused `" + e + "` when calling `" + call + "`");
+          }
+        catch (InvocationTargetException e)
+          {
+            if (e.getCause() instanceof Abort a)
+              {
+                if (a._effect != id)
+                  {
+                    throw a;
+                  }
+              }
+            else
+              {
+                handleInvocationTargetException(e);
+              }
+          }
+        finally
+          {
+            effect_store(id, old);
+          }
+      }
+  }
+
+  /**
+   * Helper method to implement `effect.env` expressions.  Returns the installed
+   * effect with the given id.  Causes an error in case no such effect exists.
+   *
+   * @param id the id of the effect that should be loaded.
+   *
+   * @return the instance that was installed for this id
+   *
+   * @throws Error in case no instance was installed.
+   */
   public static Any effect_get(int id)
   {
     if (CHECKS) check
       (_nyi_remove_single_thread == Thread.currentThread());
 
-    if (_installedEffects_[id] == null)
+    var result = effect_load(id);
+    if (result == null)
       {
         throw new Error("No effect of "+id+" installed");
       }
-    return _installedEffects_[id];
+    return result;
   }
 
 


### PR DESCRIPTION
This is similar to the way the Interpreter impelments abortable effects: An expception `Abort` is thrown and handled by a suitable installed effect handler.

What was alittle tricky for the JVM backend is to permit the callback within effect_abortable.  This is done now a little manually via passing an instance to the clazz and searching for `fzRoutine`. This willt need to be improved for better performance at some point.

Also added some comemnts and support for cpClass constants in class files.