### PR TITLE
fe: Allow result type in declaration using `=>`

### DIFF
--- a/src/dev/flang/ast/AstErrors.java
+++ b/src/dev/flang/ast/AstErrors.java
@@ -1687,15 +1687,6 @@ public class AstErrors extends ANY
           "Field declared: " + s(f));
   }
 
-  static void illegalResultTypeRoutineDef(AbstractFeature f, ReturnType rt)
-  {
-    error(f.pos(),
-          "Illegal result type " + s(rt) + " in feature definition using " + ss("=>"),
-          "For function definition using " + ss("=>") + ", the type is determined automatically, " +
-          "it must not be given explicitly.\n" +
-          "Feature declared: " + s(f));
-  }
-
   static void illegalResultTypeRefTypeRoutineDef(Feature f)
   {
     error(f.pos(),

--- a/src/dev/flang/ast/Impl.java
+++ b/src/dev/flang/ast/Impl.java
@@ -259,21 +259,17 @@ public class Impl extends ANY
       case RoutineDef:
         // Function definition of the form
         //
-        //   f => 0;
+        //   f => 0
+        //   f i32 => 0
         //
-        // requires no return type
+        // may or may not have a return type but must not be
+        // `ref` type:
         //
-        if (rt != NoType.INSTANCE)
+        //   f ref => x
+        //
+        if (rt == RefType.INSTANCE)
           {
-            if (rt != RefType.INSTANCE)
-              {
-                AstErrors.illegalResultTypeRoutineDef(f, rt);
-                rt = NoType.INSTANCE;
-              }
-            else
-              {
-                AstErrors.illegalResultTypeRefTypeRoutineDef(f);
-              }
+            AstErrors.illegalResultTypeRefTypeRoutineDef(f);
           }
         break;
 
@@ -287,6 +283,15 @@ public class Impl extends ANY
         if (rt == NoType.INSTANCE)
           {
             rt = ValueType.INSTANCE;
+          }
+        else if (rt instanceof FunctionReturnType)
+          {
+            // NYI: function declaration using `is` should be forbidden
+            //
+            //   f type is ...
+            //   f type { ... }
+            //
+            // AstErrors.illegalResultTypeInConstructorDeclaration(f);  -- NYI
           }
         break;
       }


### PR DESCRIPTION
This would make `=>` behave the same as `:=`, both allow but do not require the result type.

A constructor declaration with `is` or `{ .. }` should eventually be required not to define a function result type.