### PR TITLE
tests/simple_inp: add `jvm`, `record_jvm` targets

### DIFF
--- a/tests/simple_inp.mk
+++ b/tests/simple_inp.mk
@@ -43,8 +43,14 @@ int:
 c:
 	cat $(STDIN) | ../check_simple_example_c.sh "$(FUZION_RUN)" $(FILE) || exit 1
 
+jvm:
+	cat $(STDIN) | ../check_simple_example_jvm.sh "$(FUZION_RUN)" $(FILE) || exit 1
+
 record:
 	cat $(STDIN) | ../record_simple_example.sh "$(FUZION_RUN)" $(FILE)
 
 record_c:
 	cat $(STDIN) | ../record_simple_example_c.sh "$(FUZION_RUN)" $(FILE)
+
+record_jvm:
+	cat $(STDIN) | ../record_simple_example_jvm.sh "$(FUZION_RUN)" $(FILE)


### PR DESCRIPTION
test does not succeed though:

`> error 1: java.lang.VerifyError: (class: fzC_1i32__1infix_____2reduce_or_error_String, method: fzRoutine signature: (LfzC_1i32__1infix___;LfzI_String;LfzI__L338_Function____g___abort__outcome_String____String____i32;)LfzC_outcome_String;) Bad type in putfield/putstatic`

fixes #1889