### PR TITLE
jvm: Add new interface dev.flang.be.jvm.runtime.AnyI and use it for fzVref

### DIFF
--- a/src/dev/flang/be/jvm/Choices.java
+++ b/src/dev/flang/be/jvm/Choices.java
@@ -352,7 +352,7 @@ public class Choices extends ANY implements ClassFileConstants
                         {
                           cf.field(ACC_PUBLIC,
                                    Names.CHOICE_REF_ENTRY_NAME,
-                                   Names.ANY_TYPE.descriptor(),
+                                   Names.ANYI_TYPE.descriptor(),
                                    new List<>());
                         }
                     }
@@ -829,7 +829,7 @@ public class Choices extends ANY implements ClassFileConstants
        0 <= tagNum && tagNum <= _fuir.clazzNumChoices(cl));
 
     var tc = _fuir.clazzChoice(cl, tagNum);
-    var ft = _fuir.clazzIsRef(tc) ? Names.ANY_TYPE
+    var ft = _fuir.clazzIsRef(tc) ? Names.ANYI_TYPE
                                   : _types.javaType(tc);
     return ft;
   }

--- a/src/dev/flang/be/jvm/Names.java
+++ b/src/dev/flang/be/jvm/Names.java
@@ -33,6 +33,7 @@ import java.util.TreeSet;
 import dev.flang.be.jvm.classfile.ClassFileConstants;
 
 import dev.flang.be.jvm.runtime.Any;
+import dev.flang.be.jvm.runtime.AnyI;
 import dev.flang.be.jvm.runtime.Runtime;
 import dev.flang.be.jvm.runtime.Intrinsics;
 
@@ -65,11 +66,14 @@ public class Names extends ANY implements ClassFileConstants
 
 
   /**
-   * Name of JVM backend's runtime's class Any
+   * Name of JVM backend's runtime's class Any and interface AnyI
    */
-  static final String ANY_CLASS = Any.class.getName().replace(".","/");
-  static final ClassType ANY_TYPE = new ClassType(ANY_CLASS);
-  static final String ANY_DESCR = ANY_TYPE.descriptor();
+  static final String    ANY_CLASS  = Any.class.getName().replace(".","/");
+  static final ClassType ANY_TYPE   = new ClassType(ANY_CLASS);
+  static final String    ANY_DESCR  = ANY_TYPE.descriptor();
+  static final String    ANYI_CLASS = AnyI.class.getName().replace(".","/");
+  static final ClassType ANYI_TYPE  = new ClassType(ANYI_CLASS);
+  static final String    ANYI_DESCR = ANYI_TYPE.descriptor();
 
 
   /**

--- a/src/dev/flang/be/jvm/runtime/AnyI.java
+++ b/src/dev/flang/be/jvm/runtime/AnyI.java
@@ -20,7 +20,7 @@ Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
  *
  * Tokiwa Software GmbH, Germany
  *
- * Source of class Any
+ * Source of class AnyI
  *
  *---------------------------------------------------------------------*/
 
@@ -30,14 +30,13 @@ import dev.flang.util.ANY;
 
 
 /**
- * Any is used in the JVM backend as super class of all Java classes created for Fuzion features.
+ * AnyI is used in the JVM backend as implemented interface of all Java classes
+ * created for Fuzion features.
  *
  * @author Fridtjof Siebert (siebert@tokiwa.software)
  */
-public class Any extends ANY implements AnyI
+public interface AnyI
 {
-
-
 }
 
 /* end of file */


### PR DESCRIPTION
All the `refs` in a choice type are stored in the same value field. Since the type of these fields could be an interface, they are not assignable to `runtime.Any`, so we use a new interface `runtime.AnyI` that is also implemented by these interfaces.

This fixed the class verify error when running `tests/stdin` using the JVM backend.