### PR TITLE
be/jvm: fix creating tagging code for non-instantiated features

### DIFF
--- a/src/dev/flang/be/jvm/Choices.java
+++ b/src/dev/flang/be/jvm/Choices.java
@@ -698,9 +698,6 @@ public class Choices extends ANY implements ClassFileConstants
     Expr res;
     var tc = _fuir.clazzChoice(newcl, tagNum);
 
-    if (CHECKS) check
-      (!_fuir.clazzIsVoidType(tc));
-
     switch (kind(newcl))
       {
       case voidlike:


### PR DESCRIPTION
tagging code for never instantiated features has to be created currently. so the assumption for the check is false.
e.g.:
```
a : choice b c is
d a := b  # c is never instantiated

e a is
  match d
     b => ...
     c0 c => c0 # but tagging code is created here

```