### PR TITLE
be/jvm/runtime: throw an Error in case of a contract failure

### DIFF
--- a/src/dev/flang/be/jvm/runtime/Runtime.java
+++ b/src/dev/flang/be/jvm/runtime/Runtime.java
@@ -395,7 +395,7 @@ public class Runtime extends ANY
    */
   public static void contract_fail(String msg)
   {
-    Errors.fatal("CONTRACT FAILED: " + msg);
+    Errors.fatal(new Error("CONTRACT FAILED: " + msg));
   }
 
 


### PR DESCRIPTION
Without any extra work, this also provides a stack trace, which due to the name mangling also contains a readable stack trace for the Fuzion part of the code.