### PR TITLE
be/jvm: `fieldExists` should always be true for mains result field.

### DIFF
--- a/src/dev/flang/fuir/analysis/dfa/DFA.java
+++ b/src/dev/flang/fuir/analysis/dfa/DFA.java
@@ -827,7 +827,10 @@ public class DFA extends ANY
             {
             case Routine, Intrinsic,
                  Native             -> called.contains(cl);
-            case Field              -> isBuiltInNumeric(_fuir.clazzOuterClazz(cl)) || _readFields.contains(cl);
+            case Field              -> isBuiltInNumeric(_fuir.clazzOuterClazz(cl)) ||
+                                       _readFields.contains(cl) ||
+                                       // main result field
+                                       _fuir.clazzResultField(_fuir.mainClazzId()) == cl;
             case Abstract           -> true;
             case Choice             -> true;
             };


### PR DESCRIPTION
the DFA figures out that the field is never read hence `clazzNeedsCode` is false for the result field of the main feature but we need it for assigning result in jvm backend.

fixes #1903