### PR TITLE
improve error message when using type feature as field

### DIFF
--- a/src/dev/flang/ast/AstErrors.java
+++ b/src/dev/flang/ast/AstErrors.java
@@ -991,6 +991,13 @@ public class AstErrors extends ANY
           ".  Alternatively, you can declare a routine instead.");
   }
 
+  public static void typeFeaturesMustNotBeFields(Feature f)
+  {
+    error(f.pos(),
+          "Type features must not be fields.",
+          "To solve this, you could declare a routine instead.");
+  }
+
   static void cannotRedefine(SourcePosition pos, AbstractFeature f, AbstractFeature existing, String msg, String solution)
   {
     error(pos,

--- a/src/dev/flang/fe/SourceModule.java
+++ b/src/dev/flang/fe/SourceModule.java
@@ -466,7 +466,15 @@ public class SourceModule extends Module implements SrcModule, MirModule
 
     if (inner.isField())
       {
-        AstErrors.qualifiedDeclarationNotAllowedForField(inner);
+        // NYI inner.isTypeFeature() does not work currently
+        if (inner._qname.getFirst().equals(FuzionConstants.TYPE_NAME))
+          {
+            AstErrors.typeFeaturesMustNotBeFields(inner);
+          }
+        else
+          {
+            AstErrors.qualifiedDeclarationNotAllowedForField(inner);
+          }
       }
 
     setOuterAndAddInnerForQualifiedRec(inner, 0, outer);


### PR DESCRIPTION
```
/home/not_synced/fuzion (type_feature_field_error)130$ cat ~/playground/test.fz
ex is

  type.some_field i32 := 1
/home/not_synced/fuzion (type_feature_field_error)$ fz  ~/playground/test.fz

/home/sam/playground/test.fz:3:8: error 1: Type features must not be fields.
  type.some_field i32 := 1
-------^^^^^^^^^^
To solve this, you could declare a routine instead.

one error.
```