### PR TITLE
fe: fix #1943: Using type parameter as outer type

### DIFF
--- a/src/dev/flang/ast/UnresolvedType.java
+++ b/src/dev/flang/ast/UnresolvedType.java
@@ -722,7 +722,8 @@ public abstract class UnresolvedType extends AbstractType implements HasSourcePo
         if (o != null && !isThisType() && !o.isThisType())
           {
             o = o.resolve(res, of);
-            var ot = o.isGenericArgument() ? o.genericArgument().constraint() : o;  // NYI: check: do we really want the constraint here?
+            var ot = o.isGenericArgument() ? o.genericArgument().constraint(res) // see tests/reg_issue1943 for examples
+                                           : o;
             of = ot.featureOfType();
           }
         AbstractFeature f = Types.f_ERROR;

--- a/tests/reg_issue1943_type_parameter_as_outer_type/Makefile
+++ b/tests/reg_issue1943_type_parameter_as_outer_type/Makefile
@@ -1,0 +1,27 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test Makefile
+#
+#  Author: Fridtjof Siebert (siebert@tokiwa.software)
+#
+# -----------------------------------------------------------------------
+
+override NAME = issue1943
+include ../simple.mk

--- a/tests/reg_issue1943_type_parameter_as_outer_type/issue1943.fz
+++ b/tests/reg_issue1943_type_parameter_as_outer_type/issue1943.fz
@@ -1,0 +1,57 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test issue1943
+#
+#  Author: Fridtjof Siebert (siebert@tokiwa.software)
+#
+# -----------------------------------------------------------------------
+
+# this uses type parameters as outer types.
+#
+test_outer_as_type_parameter is
+
+  # here the test from #1943
+  x is
+    y is
+      redef as_string => "y in {x.this}"
+
+  z : x is
+
+  test(T type : x,
+       v T.y) =>
+    say "T is $T v is $v"
+
+  test x x.y
+  test z z.y
+
+  # here the code in an example from the Fuzion presentation at TyDe'23
+  count(n (M : mutate).new i32,
+        l Sequence T) ! M =>
+    l.for_each x->
+      n <- n.get + 1
+    n
+
+  mm : mutate.
+  mm.use ()->
+    {
+      cnt := mm.env.new 100
+      cnt := count mm i32 cnt [1,2,3]
+      say cnt
+    }

--- a/tests/reg_issue1943_type_parameter_as_outer_type/issue1943.fz.expected_out
+++ b/tests/reg_issue1943_type_parameter_as_outer_type/issue1943.fz.expected_out
@@ -1,0 +1,3 @@
+T is Type of 'test_outer_as_type_parameter.x' v is y in instance[test_outer_as_type_parameter.x]
+T is Type of 'test_outer_as_type_parameter.z' v is y in instance[test_outer_as_type_parameter.z]
+103


### PR DESCRIPTION
I was unsure when I wrote this code if using a type parameter as an outer type actually makes sense, but it does as shown in the examples of the regression test.

The bug that is patch fixes was that the constraint type of the type parameter was not resolved yet and hence not usable.