### PR TITLE
fe: Suppress third subsequent error reported in #1945

### DIFF
--- a/src/dev/flang/ast/ResolvedNormalType.java
+++ b/src/dev/flang/ast/ResolvedNormalType.java
@@ -558,7 +558,8 @@ public class ResolvedNormalType extends ResolvedType
     this._generics.freeze();
     if (CHECKS) check
       (Errors.any() || _feature != null);
-    if (_feature != null &&
+    if (result.containsError() ||
+        _feature != null &&
         !_feature.generics().errorIfSizeOrTypeDoesNotMatch(_generics,
                                                            pos.pos(),
                                                            "type",


### PR DESCRIPTION
The problem was that an argument type ended up being `Function **error**`, while the error is suppressed automatically for `**error**`, i.e. `Types.t_ERROR`.