### PR TITLE
be/jvm: determine values of debug and safety intrinsics at build time

### DIFF
--- a/src/dev/flang/be/jvm/Intrinsix.java
+++ b/src/dev/flang/be/jvm/Intrinsix.java
@@ -120,6 +120,18 @@ public class Intrinsix extends ANY implements ClassFileConstants
           return new Pair<>(Expr.UNIT, Expr.iconst(r ? 1 : 0));
         });
 
+    put("debug",
+        (jvm, cc, tvalue, args) ->
+        {
+          return new Pair<>(Expr.UNIT, Expr.iconst(jvm._options.fuzionDebug() ? 1 : 0));
+        });
+
+    put("debug_level",
+        (jvm, cc, tvalue, args) ->
+        {
+          return new Pair<>(Expr.UNIT, Expr.iconst(jvm._options.fuzionDebugLevel()));
+        });
+
     put("fuzion.std.date_time",
         (jvm, cc, tvalue, args) ->
         {
@@ -285,6 +297,12 @@ public class Intrinsix extends ANY implements ClassFileConstants
                                        "(I)Z",
                                        ClassFileConstants.PrimitiveType.type_boolean));
           return new Pair<>(val, Expr.UNIT);
+        });
+
+    put("safety",
+        (jvm, cc, tvalue, args) ->
+        {
+          return new Pair<>(Expr.UNIT, Expr.iconst(jvm._options.fuzionSafety() ? 1 : 0));
         });
 
     put(new String[]

--- a/src/dev/flang/be/jvm/runtime/Intrinsics.java
+++ b/src/dev/flang/be/jvm/runtime/Intrinsics.java
@@ -42,10 +42,6 @@ public class Intrinsics extends ANY
   /*-------------------------  static methods  --------------------------*/
 
 
-  public static boolean safety      () { return true; /* NYI: Interpreter._options_.fuzionSafety()     */ }
-  public static boolean debug       () { return true; /* NYI: Interpreter._options_.fuzionDebug()      */ }
-  public static int     debug_level () { return 0;    /* NYI: Interpreter._options_.fuzionDebugLevel() */ }
-
   public static long    fuzion_sys_stdin_stdin0 () { return Runtime._stdin;  }
   public static long    fuzion_sys_out_stdout   () { return Runtime._stdout; }
   public static long    fuzion_sys_err_stderr   () { return Runtime._stderr; }


### PR DESCRIPTION
The value of the `debug`, `debug_level` and `safety` intrinsics is now determined by the values of these options passed to the `fz` tool at build time, rather than hard-coding values in the JVM runtime.

This also fixes problems caused by the DFA and the JVM backend using different values, in case a non-default value was passed to Fuzion at the build time.