### PR TITLE
Expr as string

### DIFF
--- a/src/dev/flang/ast/AbstractFeature.java
+++ b/src/dev/flang/ast/AbstractFeature.java
@@ -830,7 +830,7 @@ public abstract class AbstractFeature extends Expr implements Comparable<Abstrac
         var typeFeature = new Feature(p, visibility().typeVisibility(), 0, NoType.INSTANCE, new List<>(name), typeArgs,
                                       inh,
                                       Contract.EMPTY_CONTRACT,
-                                      new Impl(p, new Block(p, new List<>()), Impl.Kind.Routine));
+                                      new Impl(p, new Block(new List<>()), Impl.Kind.Routine));
         typeFeature._typeFeatureOrigin = this;
         res._module.addTypeFeature(outerType, typeFeature);
         result = typeFeature;

--- a/src/dev/flang/ast/AstErrors.java
+++ b/src/dev/flang/ast/AstErrors.java
@@ -123,11 +123,7 @@ public class AstErrors extends ANY
   }
   static String s(Expr e)
   {
-    return expr(e.toString());
-  }
-  static String sle(List<Expr> e)
-  {
-    return expr(e.toString());
+    return expr(e.pos().sourceText());
   }
   static String s(AbstractAssign a)
   {

--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -604,7 +604,7 @@ public class Call extends AbstractCall
             as = res.resolveType(as    , thiz);
             result = res.resolveType(result, thiz);
             cb._actuals.set(cb._actuals.size()-1,
-                            new Block(b.pos(),new List<Expr>(as, t1)));
+                            new Block(new List<Expr>(as, t1)));
             _actuals = new List<Expr>(result);
             _calledFeature = Types.resolved.f_bool_AND;
             _name = _calledFeature.featureName().baseName();

--- a/src/dev/flang/ast/Destructure.java
+++ b/src/dev/flang/ast/Destructure.java
@@ -146,7 +146,7 @@ public class Destructure extends Expr
           }
       }
     exprs.add(this);
-    return new Block(_pos,exprs);
+    return new Block(exprs);
   }
 
 
@@ -342,7 +342,7 @@ public class Destructure extends Expr
             ((Feature) f)._returnType = new FunctionReturnType(Types.t_ERROR);
           }
       }
-    return new Block(_pos, exprs);
+    return new Block(exprs);
   }
 
 

--- a/src/dev/flang/ast/Expr.java
+++ b/src/dev/flang/ast/Expr.java
@@ -399,7 +399,7 @@ public abstract class Expr extends ANY implements HasSourcePosition
                                 outer);
         r.scheduleForResolution(res);
         res.resolveTypes();
-        result = new Block(pos, pos, new List<>(assignToField(res, outer, r),
+        result = new Block(pos, new List<>(assignToField(res, outer, r),
                                                     new Call(pos, new Current(pos, outer), r).resolveTypes(res, outer)));
       }
     return result;

--- a/src/dev/flang/ast/Feature.java
+++ b/src/dev/flang/ast/Feature.java
@@ -324,8 +324,7 @@ public class Feature extends AbstractFeature
          new List<>(),
          Contract.EMPTY_CONTRACT,
          new Impl(SourcePosition.builtIn,
-                  new Block(SourcePosition.builtIn,
-                            new List<Expr>()),
+                  new Block(new List<Expr>()),
                   Impl.Kind.Routine));
   }
 
@@ -1948,7 +1947,7 @@ public class Feature extends AbstractFeature
       {
         /* add assignment of initial value: */
         result = new Block
-          (_pos, new List<>
+          (new List<>
            (this,
             new Assign(res, _pos, this, _impl._initialValue, outer)
             {

--- a/src/dev/flang/ast/Function.java
+++ b/src/dev/flang/ast/Function.java
@@ -272,7 +272,7 @@ public class Function extends ExprWithPos
                                    NO_FEATURES,
                                    new List<>(_inheritsCall),
                                    Contract.EMPTY_CONTRACT,
-                                   new Impl(pos(), new Block(pos(), expressions), Impl.Kind.Routine));
+                                   new Impl(pos(), new Block(expressions), Impl.Kind.Routine));
             res._module.findDeclarations(_wrapper, outer);
             if (inferResultType)
               {
@@ -523,7 +523,7 @@ public class Function extends ExprWithPos
                                            NO_FEATURES,
                                            inherits,
                                            Contract.EMPTY_CONTRACT,
-                                           new Impl(pos(), new Block(pos(), expressions), Impl.Kind.Routine));
+                                           new Impl(pos(), new Block(expressions), Impl.Kind.Routine));
             res._module.findDeclarations(function, call.target().type().featureOfType());
             result = new Call(pos(),
                               call.target(),

--- a/src/dev/flang/ast/If.java
+++ b/src/dev/flang/ast/If.java
@@ -383,7 +383,7 @@ public class If extends ExprWithPos
     if (elseBlock == null && elseIf == null)
       {
         var unit = new Call(pos(), "unit");
-        elseBlock = new Block(pos(), new List<>(unit));
+        elseBlock = new Block(new List<>(unit));
       }
   }
 

--- a/src/dev/flang/ast/Impl.java
+++ b/src/dev/flang/ast/Impl.java
@@ -394,9 +394,7 @@ public class Impl extends ANY
                                 this._code,
                                 outer);
         ass._value = this._code.box(ass._assignedField.resultType());  // NYI: move to constructor of Assign?
-        this._code = new Block (this._code.pos(),
-                                endPos,
-                                new List<Expr>(ass));
+        this._code = new Block (new List<Expr>(ass));
       }
   }
 

--- a/src/dev/flang/ast/InlineArray.java
+++ b/src/dev/flang/ast/InlineArray.java
@@ -353,7 +353,7 @@ public class InlineArray extends ExprWithPos
                                                new Actual(unit3));
         var arrayCall       = new Call(pos(), null, "array"     , sysArrArgs).resolveTypes(res, outer);
         exprs.add(arrayCall);
-        result = new Block(pos(), exprs);
+        result = new Block(exprs);
       }
     return result;
   }

--- a/src/dev/flang/ast/Loop.java
+++ b/src/dev/flang/ast/Loop.java
@@ -274,13 +274,11 @@ public class Loop extends ANY
        sb == null || untilCond != null,
        eb0 == null || eb0 instanceof Block || eb0 instanceof If);
 
-    var prologPos = pos;
-    var nextItPos = pos;
     var succPos = pos; // NYI: if present, use position of success block, otherwise of "until" condition
     _elsePos   = pos;  // NYI: if present, use position of "else" keyword
     _indexVars = iv;
     _nextValues = nv;
-    block = Block.newIfNull(pos, block);
+    block = Block.newIfNull(block);
     _successBlock = sb;
     _elseBlock0 = eb0;
     _elseBlock1 = eb1;
@@ -299,11 +297,11 @@ public class Loop extends ANY
       }
 
     _prologSuccessBlock = new List<>();
-    _prolog             = new Block(prologPos, _prologSuccessBlock, hasImplicitResult);
+    _prolog             = new Block(_prologSuccessBlock, hasImplicitResult);
     if (!_indexVars.isEmpty())
       {
         _nextItSuccessBlock = new List<>();
-        _nextIteration = new Block(nextItPos, _nextItSuccessBlock, hasImplicitResult);
+        _nextIteration = new Block(_nextItSuccessBlock, hasImplicitResult);
         addIterators();
       }
 
@@ -326,7 +324,7 @@ public class Loop extends ANY
       {
         _nextIteration = new If(untilCond.pos(),
                                 untilCond,
-                                Block.newIfNull(succPos, _successBlock),
+                                Block.newIfNull(_successBlock),
                                 _nextIteration);
       }
     block._expressions.add(_nextIteration);
@@ -442,7 +440,7 @@ public class Loop extends ANY
       }
     else if (booleanAsImplicitResult(whileCond, untilCond))
       { /* add implicit TRUE / FALSE results to success and else blocks: */
-        _successBlock = Block.newIfNull(succPos, _successBlock);
+        _successBlock = Block.newIfNull(_successBlock);
         _successBlock._expressions.add(BoolConst.TRUE );
         if (_elseBlock0 == null)
           {
@@ -574,7 +572,7 @@ public class Loop extends ANY
                 mustDeclareLoopElse = false;
               }
             var streamName = _rawLoopName + "stream" + (iteratorCount++);
-            var p = f.pos();
+            var p = SourcePosition.notAvailable;
             Call asStream = new Call(p, f.impl()._initialValue, "as_stream");
             Feature stream = new Feature(p,
                                          Visi.PRIV,
@@ -593,8 +591,8 @@ public class Loop extends ANY
             Call next2    = new Call(p, new Call(p, streamName), "next");
             List<Expr> prolog2 = new List<>();
             List<Expr> nextIt2 = new List<>();
-            If ifHasNext1 = new If(p, hasNext1, new Block(p, prolog2));
-            If ifHasNext2 = new If(p, hasNext2, new Block(p, nextIt2));
+            If ifHasNext1 = new If(p, hasNext1, new Block(prolog2));
+            If ifHasNext2 = new If(p, hasNext2, new Block(nextIt2));
             if (_loopElse != null)
               {
                 ifHasNext1.setElse(Block.fromExpr(callLoopElse(true )));

--- a/src/dev/flang/fe/LibraryOut.java
+++ b/src/dev/flang/fe/LibraryOut.java
@@ -749,7 +749,7 @@ class LibraryOut extends ANY
           }
         else
           {
-            code(new Block(i.pos(), new List<>()));
+            code(new Block(new List<>()));
           }
       }
     else if (e instanceof Call c)

--- a/src/dev/flang/fe/Module.java
+++ b/src/dev/flang/fe/Module.java
@@ -316,12 +316,14 @@ public abstract class Module extends ANY
     var definedIn = af.pos()._sourceFile;
     var v = af.visibility();
 
-          // in same file
-    return ((usedIn.sameAs(definedIn)
-          // at least module visible and in same module
-          || v.ordinal() >= Visi.MOD.ordinal() && this == m
-          // publicly visible
-          || v == Visi.PUB));
+    return  // built-in or generated features like #loop0
+            af.pos().isBuiltIn()
+            // in same file
+            || ((usedIn.sameAs(definedIn)
+            // at least module visible and in same module
+            || v.ordinal() >= Visi.MOD.ordinal() && this == m
+            // publicly visible
+            || v == Visi.PUB));
   }
 
 

--- a/src/dev/flang/fe/SourceModule.java
+++ b/src/dev/flang/fe/SourceModule.java
@@ -587,6 +587,7 @@ public class SourceModule extends Module implements SrcModule, MirModule
     if (inner.impl().initialValue() != null &&
         !outer.pos()._sourceFile.sameAs(inner.pos()._sourceFile) &&
         (!outer.isUniverse() || !inner.isLegalPartOfUniverse()) &&
+        (outer.isUniverse() || !outer.pos().isBuiltIn()) && // some generated features in loops do not have source position
         !inner.isIndexVarUpdatedByLoop() /* required for loop in universe, e.g.
                                           *
                                           *   echo "for i in 1..10 do stdout.println(i)" | fz -

--- a/src/dev/flang/parser/Parser.java
+++ b/src/dev/flang/parser/Parser.java
@@ -358,7 +358,7 @@ field       : returnType
             addFeaturesFromBlock(first, l, p._code, ng, p, v);
             c._generics = ng;
           }
-        p = new Impl(p.pos, new Block(p.pos, new List<>()), Impl.Kind.Routine);
+        p = new Impl(p.pos, new Block(new List<>()), Impl.Kind.Routine);
       }
     return p;
   }
@@ -1962,7 +1962,7 @@ klammerLambd: LPAREN argNamesOpt RPAREN lambda
         // s9a := i16 -(32768)
         return (actual instanceof NumLiteral)
           ? actual
-          : new Block(pos, tokenSourcePos(), new List<>(actual));
+          : new Block(tokenSourcePos(), new List<>(actual));
       }
     // a tuple
     else
@@ -2150,14 +2150,15 @@ simpleterm  : bracketTerm
           case t_lbrace    :
           case t_lparen    :
           case t_lcrochet  :         result = bracketTerm();                            break;
-          case t_numliteral: var l = skipNumLiteral();
+          case t_numliteral: var endPos = tokenEndPos();
+                             var l = skipNumLiteral();
                              var m = l.mantissaValue();
                              var b = l.mantissaBase();
                              var d = l.mantissaDotAt();
                              var e = l.exponent();
                              var eb = l.exponentBase();
                              var o = l._originalString;
-                             result = new NumLiteral(sourcePos(p1), o, b, m, d, e, eb); break;
+                             result = new NumLiteral(sourcePos(p1).rangeTo(endPos), o, b, m, d, e, eb); break;
           case t_match     :         result = match();                                  break;
           case t_for       :
           case t_variant   :
@@ -2439,8 +2440,7 @@ caseBlock   : ARROW          // if followed by '|'
     sameLine(oldLine);
     if (bar)
       {
-        SourcePosition pos1 = tokenSourcePos();
-        result = new Block(pos1, pos1, new List<>());
+        result = new Block(tokenSourcePos(), new List<>());
       }
     else
       {
@@ -2529,7 +2529,7 @@ block       : exprs
         //
         // so there is an empty block.
         //
-        return new Block(pos1, pos1, new List<>());
+        return new Block(pos1, new List<>());
       }
     else if (currentAtMinIndent() != Token.t_lbrace)
       {
@@ -2546,7 +2546,7 @@ block       : exprs
             pos1 = sourcePos(lineEndPos(lineNum(p1)-1));
             pos2 = pos1;
           }
-        return new Block(pos1, pos2, l);
+        return new Block(pos2, l);
       }
     else
       {
@@ -2568,7 +2568,7 @@ brblock     : BRACEL exprs BRACER
                               () -> {
                                 var l = exprs();
                                 var pos2 = tokenSourcePos();
-                                return new Block(pos1, pos2, l);
+                                return new Block(l);
                               });
   }
 
@@ -3259,7 +3259,7 @@ anonymous   : "ref"
     // does not work yet, probably because of too much that is done explicitly
     // for anonymous features.
     //
-    // return new Block(pos, b.closingBracePos_, new List<>(f, ca));
+    // return new Block(b.closingBracePos_, new List<>(f, ca));
   }
 
 
@@ -3591,7 +3591,7 @@ implRout    : block
                                                 new Impl(pos, block()       , Impl.Kind.Routine   ); }
     else if (skip(true, "=>"      )) { result = new Impl(pos, block()       , Impl.Kind.RoutineDef); }
     else if (skip(true, Token.t_of)) { result = new Impl(pos, block()       , Impl.Kind.Of        ); }
-    else if (skipFullStop()        ) { result = new Impl(pos, new Block(pos), Impl.Kind.Routine   ); }
+    else if (skipFullStop()        ) { result = new Impl(pos, new Block()   , Impl.Kind.Routine   ); }
     else
       {
         syntaxError(tokenPos(), "'is', '{' or '=>' in routine declaration", "implRout");

--- a/src/dev/flang/util/SourcePosition.java
+++ b/src/dev/flang/util/SourcePosition.java
@@ -291,6 +291,18 @@ public class SourcePosition extends ANY implements Comparable<SourcePosition>, H
 
 
   /**
+   * The actual text in the source code this source position points to.
+   * If this SourcePosition instance is not a SourceRange this returns an emtpy string.
+   *
+   * @return
+   */
+  public String sourceText()
+  {
+    return _sourceFile.asString(bytePos(), byteEndPos());
+  }
+
+
+  /**
    * Convert this position to a string of the form
    * "<filename>:<line>:<column>:".
    */
@@ -305,41 +317,34 @@ public class SourcePosition extends ANY implements Comparable<SourcePosition>, H
     int result = fileName().compareTo(o.fileName());
     if (result == 0)
       {
-        result = _bytePos - o._bytePos;
+        result = bytePos() - o.bytePos();
+      }
+    if (result == 0)
+      {
+        result = byteEndPos() - o.byteEndPos();
       }
     return result;
   }
 
 
   /**
-   * Create a SourcePosition or SourceRange that extends form this position's
-   * start to end's end.
+   * Create a SourcePosition or SourceRange that extends from this position's
+   * start to byteEndPos.
    *
-   * @param end a second position that must refer to the same source file and
-   * not be before this.
+   * @param byteEndPos a second position not be before this.
    */
-  public SourcePosition rangeTo(SourcePosition end)
+  public SourcePosition rangeTo(int byteEndPos)
   {
     if (PRECONDITIONS) require
-      (_sourceFile == end._sourceFile,
-       bytePos() <= end.byteEndPos());
+      (bytePos() <= byteEndPos);
 
-    if (this == end)
+    if (byteEndPos() == byteEndPos)
       {
         return this;
       }
     else
       {
-        var p = bytePos();
-        var e = byteEndPos();
-        if (p == e)
-          {
-            return this;
-          }
-        else
-          {
-            return new SourceRange(_sourceFile, p, e);
-          }
+        return new SourceRange(_sourceFile, bytePos(), byteEndPos);
       }
   }
 
@@ -355,7 +360,7 @@ public class SourcePosition extends ANY implements Comparable<SourcePosition>, H
     if (PRECONDITIONS) require
       (list.size() > 0);
 
-    return list.getFirst().pos().rangeTo(list.getLast().pos());
+    return list.getFirst().pos().rangeTo(list.getLast().pos().byteEndPos());
   }
 
 }

--- a/tests/free_types_negative/test_free_types_negative.fz.expected_err
+++ b/tests/free_types_negative/test_free_types_negative.fz.expected_err
@@ -8,7 +8,7 @@ Types inferred for first type parameter 'T':
 ----------^
 'f64' found at --CURDIR--/test_free_types_negative.fz:49:6:
   c1 3.14 "e"        # 2. should flag an error, incompatible types inferred for `T`
------^
+-----^^^^
 
 
 --CURDIR--/test_free_types_negative.fz:52:3: error 2: Incompatible types found during type inference for type parameters
@@ -20,7 +20,7 @@ Types inferred for first type parameter 'T':
 ----------^
 'f64' found at --CURDIR--/test_free_types_negative.fz:52:6:
   c2 3.14 "e"        # 3. should flag an error, incompatible types inferred for `T`
------^
+-----^^^^
 
 
 --CURDIR--/test_free_types_negative.fz:61:3: error 3: Incompatible types found during type inference for type parameters
@@ -32,7 +32,7 @@ Types inferred for first type parameter '#_0':
 ---------^
 'f64' found at --CURDIR--/test_free_types_negative.fz:61:5:
   d 3.14 "e"         # 4. should flag an error, incompatible types inferred for same anonymous type
-----^
+----^^^^
 
 
 --CURDIR--/test_free_types_negative.fz:115:17: error 4: Could not find called feature
@@ -40,7 +40,7 @@ Types inferred for first type parameter '#_0':
 ----------------^
 Feature not found: 'prefix -' (no arguments)
 Target feature: 'Any'
-In call: 'neg.this.x.prefix -'
+In call: '-'
 To solve this, you might replace the free type 'test_free_type_negative.neg.i33' by a different type.  Is the type name spelled correctly?  The free type is declared at --CURDIR--/test_free_types_negative.fz:115:9:
   neg(x i33) => -x   # 8. should flag an error that is not too confusing
 --------^^^
@@ -95,7 +95,7 @@ actual is value of type 'String' at --CURDIR--/test_free_types_negative.fz:75:5:
 ----^
 actual is value of type 'f64' at --CURDIR--/test_free_types_negative.fz:76:5:
   f 3.14 "e"         # 5.b should flag an error since two calls with incompatible actual argument types
-----^
+----^^^^
 
 
 --CURDIR--/test_free_types_negative.fz:105:35: error 11: Incompatible types when passing argument in a call
@@ -107,7 +107,7 @@ expected formal type: 'Sequence test_free_type_negative.x2.U'
 actual type found   : 'Sequence test_free_type_negative.x2.T'
 assignable to       : 'Any',
                       'Sequence test_free_type_negative.x2.T'
-for value assigned  : 'x2.this.s'
+for value assigned  : 's'
 To solve this, you could change the type of the target 's' to 'Sequence test_free_type_negative.x2.T' or convert the type of the assigned value to 'Sequence test_free_type_negative.x2.U'.
 
 11 errors.

--- a/tests/nested_lazy/ex_nested_lazy.fz.expected_err
+++ b/tests/nested_lazy/ex_nested_lazy.fz.expected_err
@@ -16,13 +16,13 @@ assignable to       : 'Any',
                       'ref i32',
                       'ref integer',
                       'ref numeric'
-for value assigned  : 'box(ex_nested_lazy.this.x1.call)'
+for value assigned  : 'x1'
 To solve this, you could change the type of the target 'f' to 'ref i32' or convert the type of the assigned value to 'Function (Lazy i32)'.
 
 
 --CURDIR--/ex_nested_lazy.fz:39:18: error 2: Incompatible types in assignment
   say (lazy0 ()->42)
------------------^
+-----------------^^
 assignment to field : 'ex_nested_lazy.#fun1.call.result'
 expected formal type: 'Function i32'
 actual type found   : 'ref i32'
@@ -36,17 +36,13 @@ assignable to       : 'Any',
                       'ref i32',
                       'ref integer',
                       'ref numeric'
-for value assigned  : 
-{
-  box(42)
-}
-
+for value assigned  : '42'
 To solve this, you could change the type of the target 'ex_nested_lazy.#fun1.call.result' to 'ref i32' or convert the type of the assigned value to 'Function i32'.
 
 
 --CURDIR--/ex_nested_lazy.fz:47:18: error 3: Incompatible types in assignment
   say (lazy1 ()->42)
------------------^
+-----------------^^
 assignment to field : 'ex_nested_lazy.#fun3.call.result'
 expected formal type: 'Lazy i32'
 actual type found   : 'ref i32'
@@ -60,11 +56,7 @@ assignable to       : 'Any',
                       'ref i32',
                       'ref integer',
                       'ref numeric'
-for value assigned  : 
-{
-  box(42)
-}
-
+for value assigned  : '42'
 To solve this, you could change the type of the target 'ex_nested_lazy.#fun3.call.result' to 'ref i32' or convert the type of the assigned value to 'Lazy i32'.
 
 3 errors.

--- a/tests/reg_issue1945_ambiguity_for_lambda_result_neg/issue1945neg.fz.expected_err
+++ b/tests/reg_issue1945_ambiguity_for_lambda_result_neg/issue1945neg.fz.expected_err
@@ -10,7 +10,7 @@ While parsing: semicolon or flat line break, parse stack: semiOrFlatLF, exprs, b
 --^
 Feature not found: 'd' (one argument)
 Target feature: 'ambiguous_declaration'
-In call: 'd tuple'
+In call: 'd'
 
 
 --CURDIR--/issue1945neg.fz:51:3: error 3: Could not find called feature
@@ -18,6 +18,6 @@ In call: 'd tuple'
 --^
 Feature not found: 'l' (one argument)
 Target feature: 'ambiguous_declaration'
-In call: 'l tuple'
+In call: 'l'
 
 3 errors.

--- a/tests/typeinference_for_formal_args_negative/typeinference_for_args_negative.fz.expected_err
+++ b/tests/typeinference_for_formal_args_negative/typeinference_for_args_negative.fz.expected_err
@@ -8,13 +8,13 @@ actual is value of type 'String' at --CURDIR--/typeinference_for_args_negative.f
 ----------^
 actuals are values of type 'f64' at --CURDIR--/typeinference_for_args_negative.fz:42:11:
   say (a3 1.0         " world!")
-----------^
+----------^^^
 and at --CURDIR--/typeinference_for_args_negative.fz:43:14:
   say (a3 10.as_f64   " world!")
 -------------^^^^^^
 and at --CURDIR--/typeinference_for_args_negative.fz:44:11:
   say (a3 1.1         " world!")
-----------^
+----------^^^
 
 
 --CURDIR--/typeinference_for_args_negative.fz:31:9: error 2: Type inference from actual arguments failed due to incompatible types of actual arguments
@@ -29,7 +29,7 @@ actual is value of type 'i32' at --CURDIR--/typeinference_for_args_negative.fz:4
 --------------------------------^^^^^^^^^^^
 actual is value of type 'f64' at --CURDIR--/typeinference_for_args_negative.fz:48:23:
   say (a4 "10.as_f64" 3.14)
-----------------------^
+----------------------^^^^
 actual is value of type 'bool' at --CURDIR--/typeinference_for_args_negative.fz:49:32:
   say (a4 "1.1"       " world!"=" monde!")
 -------------------------------^

--- a/tests/visibility_modules_negative/main.fz.expected_err
+++ b/tests/visibility_modules_negative/main.fz.expected_err
@@ -4,7 +4,7 @@
 ----^^^^^^^
 Feature not found: 'mod_pub' (no arguments)
 Target feature: 'b'
-In call: 'b.mod_pub'
+In call: 'mod_pub'
 To solve this, you might change the visibility of this feature: 'mod_pub' (no arguments)
 
 


### PR DESCRIPTION
In error messages, use source text of expressions not a string representation of the expression like it was done before.
fixes #1670 

Blocks do not have a source position themselves anymore but return the range from beginning of first to end of last expression.
