### PR TITLE
lib: define `void` as an empty `choice` type, add identity routine `id T x` and function `id T`

### DIFF
--- a/lib/id.fz
+++ b/lib/id.fz
@@ -28,12 +28,7 @@
 # When called, this feature returns its argument
 #
 #
-public id(T type, x T) T =>
-
-  x
-
-  # human readable string
-  public redef as_string => "id $T"
+public id(T type, x T) T => x
 
 
 # id -- feature returing the unary identity function

--- a/lib/id.fz
+++ b/lib/id.fz
@@ -1,0 +1,45 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion standard library feature id
+#
+#  Author: Fridtjof Siebert (siebert@tokiwa.software)
+#
+# -----------------------------------------------------------------------
+
+# id -- routine implementing the identity function
+#
+# When called, this feature returns its argument
+#
+#
+public id(T type, x T) T =>
+
+  x
+
+  # human readable string
+  public redef as_string => "id $T"
+
+
+# id -- feature returing the unary identity function
+#
+# When called, this feature returns a unary function that implements the
+# identity for the given type.
+#
+#
+public id(T type) T->T => x->x

--- a/lib/void.fz
+++ b/lib/void.fz
@@ -72,5 +72,5 @@
 # a feature call that returns void.
 #
 #
-public void : choice ()  # an empty union, so this type has no value
+public void : choice  # an empty union, so this type has no value
 is

--- a/lib/void.fz
+++ b/lib/void.fz
@@ -72,11 +72,5 @@
 # a feature call that returns void.
 #
 #
-public void(absurd void) is absurd
-
-# NYI: possible alternative definitions base on choice types
-#
-# void : choice is
-#
-# void (absurd choice) is absurd
-#
+public void : choice ()  # an empty union, so this type has no value
+is

--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -1692,8 +1692,7 @@ public class Call extends AbstractCall
     for (Generic g : cf.generics().list)
       {
         int i = g.index();
-        if ( g.isOpen() && foundAt.get(i) == null ||
-            !g.isOpen() && _generics.get(i) == Types.t_UNDEFINED)
+        if (!g.isOpen() && _generics.get(i) == Types.t_UNDEFINED)
           {
             missing.add(g);
             if (CHECKS) check

--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -2157,14 +2157,14 @@ public class Call extends AbstractCall
     if (!loadCalledFeatureUnlessTargetVoid(res, outer))
       { // target of this call results in `void`, so we replace this call by the
         // target. However, we have to return a `Call` and `_target` is
-        // `Expr`. Solution: we wrap `_target` into a call `universe.void
+        // `Expr`. Solution: we wrap `_target` into a call `universe.id void
         // _target`.
         result = new Call(pos(),
                           new Universe(),
                           new List<>(new Actual(_target)),
-                          NO_GENERICS,
+                          new List<>(Types.resolved.t_void),
                           new List<>(_target),
-                          Types.resolved.f_void,
+                          Types.resolved.f_id,
                           Types.resolved.t_void);
         result.resolveTypes(res, outer);
       }

--- a/src/dev/flang/ast/Types.java
+++ b/src/dev/flang/ast/Types.java
@@ -154,6 +154,7 @@ public class Types extends ANY
     public final AbstractType t_array_u64;
     public final AbstractType t_array_f32;
     public final AbstractType t_array_f64;
+    public final AbstractFeature f_id;
     public final AbstractFeature f_void;
     public final AbstractFeature f_choice;
     public final AbstractFeature f_TRUE;
@@ -210,6 +211,7 @@ public class Types extends ANY
       t_any           = ct.type(FuzionConstants.ANY_NAME);
       t_unit          = ct.type(FuzionConstants.UNIT_NAME);
       t_void          = ct.type("void");
+      f_id            = universe.get(mod, "id", 2);
       f_void          = universe.get(mod, "void");
       f_choice        = universe.get(mod, "choice");
       f_TRUE          = universe.get(mod, "TRUE");

--- a/tests/reg_issue356_check_condition_failure_in_call_inferGenericsFromArgs/issue356.fz.expected_err
+++ b/tests/reg_issue356_check_condition_failure_in_call_inferGenericsFromArgs/issue356.fz.expected_err
@@ -1,9 +1,0 @@
-
---CURDIR--/issue356.fz:27:7: error 1: Failed to infer actual type parameters
-  a : choice is
-------^^^^^^
-In call to 'choice', no actual type parameters are given and inference of the type parameters failed.
-Expected type parameters: 'CHOICE_ELEMENT_TYPE...'
-Type inference failed for one type parameter 'CHOICE_ELEMENT_TYPE'
-
-one error.


### PR DESCRIPTION
This makes more sense than declaring it as an absurd constructor since you cannot call a choice at all and you cannot create a value by assigning one of the choice types since there are none.