### PR TITLE
change visibility of time.duration constructor

### DIFF
--- a/lib/time/duration.fz
+++ b/lib/time/duration.fz
@@ -32,7 +32,7 @@
 # calendars that may require time spans exceeding several centuries or millenia,
 # nor astrological time spans.
 #
-public duration (
+private:public duration (
 
   # the duration in nano seconds
   #


### PR DESCRIPTION
The constructor must not be used directly making unit mixups less likely. `durations.<unit>` should be used instead.