### PR TITLE
called feature not found, add solution if called feature hidden.

### DIFF
--- a/src/dev/flang/ast/Assign.java
+++ b/src/dev/flang/ast/Assign.java
@@ -190,7 +190,8 @@ public class Assign extends AbstractAssign
         var fo = FeatureAndOuter.filter(res._module.lookup(outer,
                                                            _name,
                                                            destructure == null ? this : destructure,
-                                                           true),
+                                                           true,
+                                                           false),
                                         pos(), FeatureAndOuter.Operation.ASSIGNMENT, FeatureName.get(_name, 0), __ -> false);
         if (fo != null)
           {

--- a/src/dev/flang/ast/AstErrors.java
+++ b/src/dev/flang/ast/AstErrors.java
@@ -1093,6 +1093,25 @@ public class AstErrors extends ANY
   }
 
   /**
+   * Suggest to a user that they are trying to call a hidden feature.
+   * Called feature could not be found but there is a feature with the same
+   * name which is not visible at call site.
+   */
+  static String solutionHidden(List<FeatureAndOuter> candidates)
+  {
+    var solution = "";
+
+    if (!candidates.isEmpty())
+      {
+        solution = "To solve this, you might change the visibility of " +
+                   (candidates.size() > 1 ? "one of these features" : "this feature") + ": " +
+                   slbn(candidates.stream().map(c -> c._feature.featureName()).collect(List.collector()));
+      }
+
+    return solution;
+  }
+
+  /**
    * Detect code patterns as follows
    *
    *   f(x some_type_with_a_typo) => x.g
@@ -1131,14 +1150,16 @@ public class AstErrors extends ANY
                                     FeatureName calledName,
                                     AbstractFeature targetFeature,
                                     Expr target,
-                                    List<FeatureAndOuter> candidates)
+                                    List<FeatureAndOuter> candidatesArgCountMismatch,
+                                    List<FeatureAndOuter> candidatesHidden)
   {
     if (!any() || !errorInOuterFeatures(targetFeature))
       {
         var solution1 = solutionDeclareReturnTypeIfResult(calledName.baseName(),
                                                           calledName.argCount());
-        var solution2 = solutionWrongArgumentNumber(candidates);
+        var solution2 = solutionWrongArgumentNumber(candidatesArgCountMismatch);
         var solution3 = solutionAccidentalFreeType(target);
+        var solution4 = solutionHidden(candidatesHidden);
         error(call.pos(),
               "Could not find called feature",
               "Feature not found: " + sbn(calledName) + "\n" +
@@ -1146,7 +1167,8 @@ public class AstErrors extends ANY
               "In call: " + s(call) + "\n" +
               (solution1 != "" ? solution1 :
                solution2 != "" ? solution2 :
-               solution3 != "" ? solution3 : ""));
+               solution3 != "" ? solution3 :
+               solution4 != "" ? solution4 : ""));
       }
   }
 

--- a/src/dev/flang/ast/SrcModule.java
+++ b/src/dev/flang/ast/SrcModule.java
@@ -67,7 +67,7 @@ public interface SrcModule
   SortedMap<FeatureName, AbstractFeature> declaredOrInheritedFeatures(AbstractFeature outer);
   AbstractFeature lookupFeature(AbstractFeature outer, FeatureName name, AbstractFeature original);
   void findDeclaredOrInheritedFeatures(Feature outer);
-  List<FeatureAndOuter> lookup(AbstractFeature thiz, String name, Expr use, boolean traverseOuter);
+  List<FeatureAndOuter> lookup(AbstractFeature thiz, String name, Expr use, boolean traverseOuter, boolean hidden);
   void checkTypes(Feature f);
   FeatureAndOuter lookupType(SourcePosition pos, AbstractFeature outer, String name, boolean traverseOuter, boolean mayBeFreeType);
 

--- a/src/dev/flang/fe/SourceModule.java
+++ b/src/dev/flang/fe/SourceModule.java
@@ -975,7 +975,7 @@ public class SourceModule extends Module implements SrcModule, MirModule
    * @return in case we found features visible in the call's scope, the features
    * together with the outer feature where they were found.
    */
-  public List<FeatureAndOuter> lookup(AbstractFeature outer, String name, Expr use, boolean traverseOuter)
+  public List<FeatureAndOuter> lookup(AbstractFeature outer, String name, Expr use, boolean traverseOuter, boolean hidden)
   {
     if (PRECONDITIONS) require
       (!(outer instanceof Feature of) || of.state().atLeast(Feature.State.LOADING));
@@ -1030,7 +1030,7 @@ public class SourceModule extends Module implements SrcModule, MirModule
         for (var e : fs.entrySet())
           {
             var v = e.getValue();
-            if ((use == null || featureVisible(use.pos()._sourceFile, v)) &&
+            if ((use == null || (hidden != featureVisible(use.pos()._sourceFile, v))) &&
                 (!v.isField() || !foundFieldInScope))
               {
                 result.add(new FeatureAndOuter(v, curOuter, inner));
@@ -1114,7 +1114,7 @@ public class SourceModule extends Module implements SrcModule, MirModule
         _res.resolveDeclarations(outer);
         var type_fs = new List<AbstractFeature>();
         var nontype_fs = new List<AbstractFeature>();
-        var fs = lookup(outer, name, null, traverseOuter);
+        var fs = lookup(outer, name, null, traverseOuter, false);
         for (var fo : fs)
           {
             var f = fo._feature;


### PR DESCRIPTION
```
/home/not_synced/fuzion (2023-09-07T12-24-48+02-00)$ cat ~/playground/test.fz
ex =>

  time.now.type.default_now
```
```
/home/not_synced/fuzion (2023-09-07T12-24-48+02-00)$ fz ~/playground/test.fz

/home/sam/playground/test.fz:3:17: error 1: Could not find called feature
  time.now.type.default_now
----------------^^^^^^^^^^^
Feature not found: 'default_now' (no arguments)
Target feature: 'time.now.type'
In call: 'Types.get time.now.default_now'
To solve this, you might change the visibility of this feature: 'default_now' (no arguments)

one error.
```