### PR TITLE
fix #1928, pre-condition in `resolveTypes` is not correct anymore

### DIFF
--- a/src/dev/flang/ast/Feature.java
+++ b/src/dev/flang/ast/Feature.java
@@ -1941,8 +1941,7 @@ public class Feature extends AbstractFeature
       (this.outer() == outer,
         Errors.any() ||
         (_impl._kind != Impl.Kind.FieldDef    &&
-         _impl._kind != Impl.Kind.FieldActual &&
-         _impl._kind != Impl.Kind.RoutineDef)
+         _impl._kind != Impl.Kind.FieldActual)
         || _returnType == NoType.INSTANCE);
 
     if (_impl._initialValue != null)


### PR DESCRIPTION
since this syntax is now allowed,  `feat <type> =>`, pre-condition `_impl._kind != Impl.Kind.RoutineDef` is not correct anymore