### PR TITLE
lib/io: use `fuzion.sys.Pointer` for references to arrays' internal data

### DIFF
--- a/lib/fuzion/sys/fileio.fz
+++ b/lib/fuzion/sys/fileio.fz
@@ -57,7 +57,7 @@ module fileio is
                # the file descriptor
                fd i64,
                # the internal array data representing the container for the bytes to be read from the file
-               file_array Any,
+               file_array fuzion.sys.Pointer,
                # the length of the array that represents the file bytes
                file_array_length i32) i32 is intrinsic
 
@@ -92,7 +92,7 @@ module fileio is
                 # the file descriptor
                 fd i64,
                 # the internal array data representing the content bytes to insert in file
-                content Any,
+                content fuzion.sys.Pointer,
                 # the length of the internal array representing the content
                 content_length i32) i32 is intrinsic
 
@@ -115,7 +115,7 @@ module fileio is
   #
   private delete(
                  # the internal array data representing the file/dir path in bytes
-                 path Any,
+                 path fuzion.sys.Pointer,
                  # dummy parameter to avoid duplicate feature name
                  _ unit) bool is intrinsic
 
@@ -140,9 +140,9 @@ module fileio is
   #
   private move(
                # the internal array data representing the old file/dir path in bytes
-               old_path Any,
+               old_path fuzion.sys.Pointer,
                # the internal array data representing the new file/dir path in bytes
-               new_path Any,
+               new_path fuzion.sys.Pointer,
                # dummy parameter for overloading
                _ unit) bool is intrinsic
 
@@ -163,7 +163,7 @@ module fileio is
   #
   private create_dir(
                      # the internal array data representing the dir path in bytes
-                     path Any,
+                     path fuzion.sys.Pointer,
                      # dummy parameter to enable overloading
                      _ unit) bool is intrinsic
 
@@ -177,9 +177,9 @@ module fileio is
   #
   module stats(
         # the internal array data representing the file/dir path in bytes
-        path Any,
+        path fuzion.sys.Pointer,
         # the internal array data representing the metadata fields [size in bytes, creation_time in seconds, regular file? 1 : 0, dir? 1 : 0]
-        meta_data Any) bool is intrinsic
+        meta_data fuzion.sys.Pointer) bool is intrinsic
 
   # intrinsic that fills an array with some metadata of the file/dir provided by the path
   # returns TRUE in case the operation was successful and FALSE in case of failure
@@ -188,10 +188,10 @@ module fileio is
   # in case an error is returned (the result of this feature is false), then the size field of
   # the meta_data array will contain the errno for the lstat call.
   #
-  module lstats(path Any, meta_data Any) bool is intrinsic # NYI behaves the same as stats in the interpreter
+  module lstats(path fuzion.sys.Pointer, meta_data fuzion.sys.Pointer) bool is intrinsic # NYI behaves the same as stats in the interpreter
 
 
-  # Opens an IO source using a Fuzion Any as path and an i8 flag to represent the opening method (Read: 0, Write: 1, Append: 2)
+  # Opens an IO source using a Fuzion Pointer as path and an i8 flag to represent the opening method (Read: 0, Write: 1, Append: 2)
   # returns outcome i64 representing the file descriptor in success
   # returns an error in failure
   #
@@ -211,10 +211,10 @@ module fileio is
   # after opening the source represented by the path parameter
   #
   private open(
-               # a Fuzion Any represention the path for the source to be opened
-               path Any,
-               # open_results[file descriptor, error number] as a Fuzion Any
-               open_results Any,
+               # a Fuzion Pointer represention the path for the source to be opened
+               path fuzion.sys.Pointer,
+               # open_results[file descriptor, error number] as a Fuzion Pointer
+               open_results fuzion.sys.Pointer,
                # opening flag (Read: 0, Write: 1, Append: 2)
                flag i8) unit is intrinsic
 
@@ -269,7 +269,7 @@ module fileio is
                # the offset to seek from the beginning of this file
                offset i64,
                # Array data [new file position, error number]
-               seek_results Any) unit is intrinsic
+               seek_results fuzion.sys.Pointer) unit is intrinsic
 
 
   # returns the current file-pointer offset as an outcome i64,
@@ -293,7 +293,7 @@ module fileio is
                         # file descriptor
                         fd i64,
                         # Array data [new file position, error number]
-                        position_results Any) unit is intrinsic
+                        position_results fuzion.sys.Pointer) unit is intrinsic
 
 
   # memory map a file
@@ -305,14 +305,14 @@ module fileio is
   # note: offset+size must not exceed file size.
   # note: returning allocated memory - instead of error code - simplifies handling in DFA.
   #
-  module mmap(fd i64, offset, size i64, res Any) Pointer is intrinsic
+  module mmap(fd i64, offset, size i64, res fuzion.sys.Pointer) Pointer is intrinsic
 
 
   # close a memory mapped file
   #
   # return: 0 on success, -1 on error
   #
-  module munmap(address Any, size i64) i32 is intrinsic
+  module munmap(address fuzion.sys.Pointer, size i64) i32 is intrinsic
 
 
   # flush user-space buffers of file descriptor

--- a/lib/io/file/stat.fz
+++ b/lib/io/file/stat.fz
@@ -75,10 +75,10 @@ public stat(ps Stat_Handler) : simple_effect is
   # the default file stat provided
   #
   type.default_stat_handler : io.file.Stat_Handler is
-    stats(path Any, meta_data_arr Any) =>
+    stats(path fuzion.sys.Pointer, meta_data_arr fuzion.sys.Pointer) =>
       fuzion.sys.fileio.stats path meta_data_arr
 
-    lstats(path Any, meta_data_arr Any) =>
+    lstats(path fuzion.sys.Pointer, meta_data_arr fuzion.sys.Pointer) =>
       fuzion.sys.fileio.lstats path meta_data_arr
 
 
@@ -115,5 +115,5 @@ public stat(
 # reference to the stats that could be provided
 #
 private:public Stat_Handler ref is
-  stats(path Any, meta_data_arr Any) bool is abstract
-  lstats(path Any, meta_data_arr Any) bool is abstract
+  stats(path fuzion.sys.Pointer, meta_data_arr fuzion.sys.Pointer) bool is abstract
+  lstats(path fuzion.sys.Pointer, meta_data_arr fuzion.sys.Pointer) bool is abstract


### PR DESCRIPTION
This will avoid accidentally supplying values other than the internal data structure of an array to these features, and thus make it a little bit safer to work on the standard library.