### PR TITLE
be/c: add option `-Wno-tripraphs`

### DIFF
--- a/src/dev/flang/be/c/C.java
+++ b/src/dev/flang/be/c/C.java
@@ -559,6 +559,7 @@ public class C extends ANY
           "-Wno-unused-variable",
           "-Wno-unused-label",
           "-Wno-unused-function",
+          "-Wno-trigraphs",
           // allow infinite recursion
           "-Wno-infinite-recursion");
 


### PR DESCRIPTION
example error:
```
test_hash_map.c:36073:123: error: trigraph converted to ']' character [-Werror,-Wtrigraphs]
    fprintf(stderr,"*** %s:%d: no targets for access of %s within %s\012",__FILE__,__LINE__,"((option (list i32)).postfix ??).#^option.postfix ??","(option (list i32)).postfix ??");
```