### PR TITLE
be/c: add option `-Wno-trigraphs`/`-fno-trigraphs`

### DIFF
--- a/src/dev/flang/be/c/C.java
+++ b/src/dev/flang/be/c/C.java
@@ -555,6 +555,7 @@ public class C extends ANY
         command.addAll(
           "-Wall",
           "-Werror",
+          "-Wno-trigraphs",
           "-Wno-gnu-empty-struct",
           "-Wno-unused-variable",
           "-Wno-unused-label",
@@ -574,7 +575,7 @@ public class C extends ANY
         command.addAll("-lgc");
       }
     // NYI link libmath, libpthread only when needed
-    command.addAll("-lm", "-lpthread", "-std=c11", "-o", name, cname);
+    command.addAll("-fno-trigraphs", "-lm", "-lpthread", "-std=c11", "-o", name, cname);
 
     if (isWindows())
       {


### PR DESCRIPTION
example error:
```
test_hash_map.c:36073:123: error: trigraph converted to ']' character [-Werror,-Wtrigraphs]
    fprintf(stderr,"*** %s:%d: no targets for access of %s within %s\012",__FILE__,__LINE__,"((option (list i32)).postfix ??).#^option.postfix ??","(option (list i32)).postfix ??");
```