### PR TITLE
be/jvm: mark `Any` as abstract

### DIFF
--- a/src/dev/flang/be/jvm/runtime/Any.java
+++ b/src/dev/flang/be/jvm/runtime/Any.java
@@ -34,7 +34,7 @@ import dev.flang.util.ANY;
  *
  * @author Fridtjof Siebert (siebert@tokiwa.software)
  */
-public class Any extends ANY implements AnyI
+public abstract class Any extends ANY implements AnyI
 {
 
 


### PR DESCRIPTION
The marking is not really necessary but in JVM.java this class is referred to as an _abstract_ class so I think it is a bit more consistent with the documentation.