### PR TITLE
lib: `Const_String` remove arg, change visibility

### DIFF
--- a/lib/conststring.fz
+++ b/lib/conststring.fz
@@ -28,7 +28,7 @@
 # Const_String cannot be called directly, instances are created implicitly by the
 # backend.
 #
-public Const_String (cannot_be_called void) ref : String, array u8 (fuzion.sys.internal_array_init u8 -1) unit unit unit is
+private:public Const_String ref : String, array u8 (fuzion.sys.internal_array_init u8 -1) unit unit unit is
 
   redef utf8 Sequence u8 is Const_String.this
 


### PR DESCRIPTION
with visibility working there is no need for the workaround of arg `cannot_be_called void` anymore.