### PR TITLE
lib: Remove Any.hash_code

### DIFF
--- a/lib/Any.fz
+++ b/lib/Any.fz
@@ -27,7 +27,6 @@
 #
 public Any ref is
 
-  public hash_code i32 is intrinsic
 
   # create a String from this instance.  Unless redefined, `a.as_string` will
   # create `"instance[T]"` where `T` is the dynamic type of `a`

--- a/src/dev/flang/be/c/Intrinsics.java
+++ b/src/dev/flang/be/c/Intrinsics.java
@@ -766,14 +766,6 @@ public class Intrinsics extends ANY
     put("f32.type.tanh"        , (c,cl,outer,in) -> CExpr.call("tanhf",  new List<>(A0)).ret());
     put("f64.type.tanh"        , (c,cl,outer,in) -> CExpr.call("tanh",   new List<>(A0)).ret());
 
-    put("Any.hash_code"        , (c,cl,outer,in) ->
-        {
-          var or = c._fuir.clazzOuterRef(cl);
-          var hc = c._fuir.clazzIsRef(c._fuir.clazzResultClazz(or))
-            ? CNames.OUTER.castTo("char *").sub(new CIdent("NULL").castTo("char *")).castTo("int32_t") // NYI: This implementation of hash_code relies on non-compacting GC
-            : CExpr.int32const(42);  // NYI: This implementation of hash_code is stupid
-          return hc.ret();
-        });
     put("Any.as_string"        , (c,cl,outer,in) ->
         {
           var res = new CIdent("res");

--- a/src/dev/flang/be/interpreter/Intrinsics.java
+++ b/src/dev/flang/be/interpreter/Intrinsics.java
@@ -1223,7 +1223,6 @@ public class Intrinsics extends ANY
     put("f64.type.square_root"  , (interpreter, innerClazz) -> args -> new f64Value (                 Math.sqrt(                args.get(1).f64Value())));
     put("f64.type.tan"          , (interpreter, innerClazz) -> args -> new f64Value (                 Math.tan(                 args.get(1).f64Value())));
     put("f64.type.tanh"         , (interpreter, innerClazz) -> args -> new f64Value (                 Math.tanh(                args.get(1).f64Value())));
-    put("Any.hash_code"         , (interpreter, innerClazz) -> args -> new i32Value (args.get(0).toString().hashCode()));
     put("Any.as_string"         , (interpreter, innerClazz) -> args -> Interpreter.value("instance[" + innerClazz._outer.toString() + "]"));
     put("fuzion.std.nano_time"  , (interpreter, innerClazz) -> args -> new u64Value (System.nanoTime()));
     put("fuzion.std.nano_sleep" , (interpreter, innerClazz) -> args ->

--- a/src/dev/flang/be/jvm/Intrinsix.java
+++ b/src/dev/flang/be/jvm/Intrinsix.java
@@ -321,8 +321,7 @@ public class Intrinsix extends ANY implements ClassFileConstants
         });
 
     put(new String[]
-      { "Any.hash_code",
-        "concur.atomic.compare_and_set0",
+      { "concur.atomic.compare_and_set0",
         "concur.atomic.compare_and_swap0",
         "concur.atomic.read0",
         "concur.atomic.write0",

--- a/src/dev/flang/fuir/analysis/dfa/DFA.java
+++ b/src/dev/flang/fuir/analysis/dfa/DFA.java
@@ -1464,7 +1464,6 @@ public class DFA extends ANY
     put("f32.type.tanh"                  , cl -> new NumericValue(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc)) );
     put("f64.type.tanh"                  , cl -> new NumericValue(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc)) );
 
-    put("Any.hash_code"                  , cl -> new NumericValue(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc)) );
     put("Any.as_string"                  , cl -> cl._dfa.newConstString(null, cl) );
     put("fuzion.sys.internal_array_init.alloc", cl -> { return new SysArray(cl._dfa, new byte[0]); } ); // NYI: get length from args
     put("fuzion.sys.internal_array.setel", cl ->

--- a/src/dev/flang/fuir/cfg/CFG.java
+++ b/src/dev/flang/fuir/cfg/CFG.java
@@ -451,7 +451,6 @@ public class CFG extends ANY
     put("f32.type.tanh"                  , (cfg, cl) -> { } );
     put("f64.type.tanh"                  , (cfg, cl) -> { } );
 
-    put("Any.hash_code"                  , (cfg, cl) -> { } );
     put("Any.as_string"                  , (cfg, cl) -> { } );
     put("fuzion.sys.internal_array_init.alloc", (cfg, cl) -> { } );
     put("fuzion.sys.internal_array.setel", (cfg, cl) -> { } );

--- a/tests/functions/functions.fz
+++ b/tests/functions/functions.fz
@@ -25,6 +25,14 @@
 
 functions is
 
+    # this test uses Any.hash_code, which no longer exists. So we provide it here:
+    Any.hash_code =>
+      for
+        r := 4711, r *° 257 +° c.as_i32
+        c in Any.this.as_string.utf8
+      else
+        r
+
     y(f ()->i32){}
     x0(f0 Function i32 Any i32) is
       say "here 1x0---------------"


### PR DESCRIPTION
Just like equality, the hash_code function should be a type feature and not be defined for Any and inherited.

For hash_code to be useful, the following invariant should hold:
```
  (hash_code a != hash_code b) || (a = b)
```
So the semantics of `hash_code` depends on `type.equality`, so `hash_code` should be a type feature as well.