### PR TITLE
jvm: Do not throw away code for dynamic call with unit type result

### DIFF
--- a/src/dev/flang/be/jvm/CodeGen.java
+++ b/src/dev/flang/be/jvm/CodeGen.java
@@ -419,9 +419,17 @@ class CodeGen
           (_fuir.hasData(_fuir.accessTargetClazz(cl, c, i)),  // would be strange if target is unit type
            _fuir.accessIsDynamic(cl, c, i));                  // or call is not dynamic
 
-        res = args(true, tvalue, args, cc0, _fuir.clazzArgCount(cc0))
+        var dynCall = args(true, tvalue, args, cc0, _fuir.clazzArgCount(cc0))
           .andThen(Expr.comment("Dynamic access of " + _fuir.clazzAsString(cc0)))
           .andThen(addDynamicFunctionAndStubs(cc0, ccs, isCall));
+        if (AbstractInterpreter.clazzHasUniqueValue(_fuir, _fuir.clazzResultClazz(cc0)))
+          {
+            s = dynCall;  // make sure we do not throw away the code even if it is of unit type
+          }
+        else
+          {
+            res = dynCall;
+          }
       }
     else
       {


### PR DESCRIPTION
For a dynamic call with more than one targets, the resulting code is just an `invokeinterface` to a method performing the actual call. If, however, this call returns a unit type value and that value, the AbstractInterpreter currently throws that code away.

This change makes sure that a unit type value is returned as a RESULT (i.e., code) not as a VALUE to the AbstractInterpreter, so it will not be ignored.

For non-unit type values, the AbstractInterpreter already makes sure that the value is drop()ped properly if it is not used.