### PR TITLE
jvm: Add a check that the value returned by code for assign is Expr.UNIT

### DIFF
--- a/src/dev/flang/be/jvm/CodeGen.java
+++ b/src/dev/flang/be/jvm/CodeGen.java
@@ -251,7 +251,12 @@ class CodeGen
    */
   public Expr assign(int cl, boolean pre, int c, int i, Expr tvalue, Expr avalue)
   {
-    return access(cl, pre, c, i, tvalue, new List<>(avalue))._v1;
+    var p = access(cl, pre, c, i, tvalue, new List<>(avalue));
+
+    if (CHECKS) check
+      (p._v0 == Expr.UNIT);
+
+    return p._v1;
   }
 
 


### PR DESCRIPTION
Just to make sure that it can be dumped savel.