### PR TITLE
change visibility of `float.exponent` etc.

### DIFF
--- a/lib/f32.fz
+++ b/lib/f32.fz
@@ -69,7 +69,7 @@ public f32(public val f32) : float is
 
 
   # is the sign bit set?
-  is_sign_bit_set bool is
+  public is_sign_bit_set bool is
     cast_to_u32 >= 1P31
 
 
@@ -140,7 +140,7 @@ public f32(public val f32) : float is
   # is smaller than 0.001
   # or greater than 9_999_999
   #
-  module use_scientific_notation bool is
+  public use_scientific_notation bool is
     abs<1E-3 || abs>=1E7
 
 

--- a/lib/f64.fz
+++ b/lib/f64.fz
@@ -153,7 +153,7 @@ public f64(public val f64) : float is
   # is smaller than 0.001
   # or greater than 9_999_999
   #
-  module use_scientific_notation bool is
+  public use_scientific_notation bool is
     abs<1E-3 || abs>=1E7
 
 

--- a/lib/float.fz
+++ b/lib/float.fz
@@ -122,30 +122,30 @@ public float : numeric is
 
   # the biased exponent of this float
   #
-  module exponent_biased i32 is abstract
+  public exponent_biased i32 is abstract
 
 
   # the normalized exponent of this float
   #
-  module exponent i32 is abstract
+  public exponent i32 is abstract
 
 
   # the normalized mantissa of this float
-  module mantissa u64 is abstract
+  public mantissa u64 is abstract
 
 
   # is the bit denoting the sign of the number set?
   # this is different from smaller than zero since
   # there is +0, -0, NaN, etc. in floating point numbers.
   #
-  module is_sign_bit_set bool is abstract
+  public is_sign_bit_set bool is abstract
 
 
   # true when the absolute value
   # is smaller than 0.001
   # or greater than 9_999_999
   #
-  module use_scientific_notation bool is abstract
+  public use_scientific_notation bool is abstract
 
 
   # number of bytes required to store this value


### PR DESCRIPTION
this makes it possible to use ryū outside of the standard library