### PR TITLE
be/jvm: Expr: consistently use `JavaType` as an argument

### DIFF
--- a/src/dev/flang/be/jvm/Choices.java
+++ b/src/dev/flang/be/jvm/Choices.java
@@ -306,7 +306,7 @@ public class Choices extends ANY implements ClassFileConstants
                                                     "(I)V"))
                         .andThen(Expr.putstatic(cf._name,
                                                 u,
-                                                uti.descriptor()));
+                                                uti));
                     }
                 }
 
@@ -316,7 +316,7 @@ public class Choices extends ANY implements ClassFileConstants
                 .andThen(Expr.iload(1))
                 .andThen(Expr.putfield(cf._name,
                                        Names.TAG_NAME,
-                                       PrimitiveType.type_int.descriptor()))
+                                       PrimitiveType.type_int))
                 .andThen(Expr.RETURN);
               var code_init = cf.codeAttribute("<init> in class for " + _fuir.clazzAsString(cl),
                                                bc_init, new List<>(), new List<>());
@@ -760,7 +760,7 @@ public class Choices extends ANY implements ClassFileConstants
             .andThen(Expr.iconst(tagNum))
             .andThen(Expr.putfield(_names.javaClass(newcl),
                                    Names.TAG_NAME,
-                                   ClassFileConstants.PrimitiveType.type_int.descriptor()));
+                                   ClassFileConstants.PrimitiveType.type_int));
           var fn = generalValueFieldName(newcl, tagNum);
           var ft = generalValueFieldType(newcl, tagNum);
           if (ft == PrimitiveType.type_void)
@@ -774,7 +774,7 @@ public class Choices extends ANY implements ClassFileConstants
                 .andThen(value)
                 .andThen(Expr.putfield(_names.javaClass(newcl),
                                        fn,
-                                       ft.descriptor()))
+                                       ft))
                 .is(_types.javaType(newcl));
             }
           break;

--- a/src/dev/flang/be/jvm/JVM.java
+++ b/src/dev/flang/be/jvm/JVM.java
@@ -761,7 +761,7 @@ should be avoided as much as possible.
           .andThen(cl == _fuir.clazzUniverse()
                    ? Expr.DUP.andThen(Expr.putstatic(_names.javaClass(cl),
                                                      _names.UNIVERSE_FIELD,
-                                                     _types.UNIVERSE_TYPE.descriptor()))
+                                                     _types.UNIVERSE_TYPE))
                    : Expr.UNIT)
           .andThen(Expr.astore(current_index(cl)));
       }
@@ -1019,7 +1019,7 @@ should be avoided as much as possible.
       Expr.comment("Setting field `" + _fuir.clazzAsString(field) + "` in `" + _fuir.clazzAsString(cl) + "`")
       .andThen(Expr.putfield(_names.javaClass(cl),
                              _names.field(field),
-                             _types.resultType(rt).descriptor()));
+                             _types.resultType(rt)));
   }
 
 }

--- a/src/dev/flang/be/jvm/Types.java
+++ b/src/dev/flang/be/jvm/Types.java
@@ -154,7 +154,7 @@ public class Types extends ANY implements ClassFileConstants
                 sig = "(" + vt.descriptor() + ")V";
                 cod = rt.load(0)
                   .andThen(vt.load(1))
-                  .andThen(Expr.putfield(cn, Names.BOXED_VALUE_FIELD_NAME, vt.descriptor()));
+                  .andThen(Expr.putfield(cn, Names.BOXED_VALUE_FIELD_NAME, vt));
               }
             var bc_box = Expr.new0(cn, rt)
               .andThen(Expr.DUP)
@@ -180,7 +180,7 @@ public class Types extends ANY implements ClassFileConstants
             var maincl = _fuir.mainClazzId();
             var bc_main =
               Expr.aload(0, JAVA_LANG_STRING.array())
-              .andThen(Expr.putstatic(Names.RUNTIME_CLASS, Names.RUNTIME_ARGS, JAVA_LANG_STRING.array().descriptor()))
+              .andThen(Expr.putstatic(Names.RUNTIME_CLASS, Names.RUNTIME_ARGS, JAVA_LANG_STRING.array()))
               .andThen(_fuir.hasPrecondition(maincl) ? invokeStatic(maincl, true) : Expr.UNIT)
               .andThen(invokeStatic(maincl, false)).drop()
               .andThen(Expr.RETURN);

--- a/src/dev/flang/be/jvm/classfile/Expr.java
+++ b/src/dev/flang/be/jvm/classfile/Expr.java
@@ -356,13 +356,13 @@ public abstract class Expr extends ByteCode
   /**
    * create putfield bytecode to write field described by cls, name and type.
    */
-  public static Expr putfield(String cls, String name, String type)
+  public static Expr putfield(String cls, String name, JavaType type)
   {
     if (PRECONDITIONS) require
       (cls != null,
        name != null,
        type != null,
-       !type.equals("V"));
+       type != ClassFileConstants.PrimitiveType.type_void);
 
     return new Expr()
       {
@@ -370,7 +370,7 @@ public abstract class Expr extends ByteCode
         public JavaType type() { return PrimitiveType.type_void;  }
         public byte[] byteCode(ClassFile cf)
         {
-          return bc(O_putfield, cf.cpField(cf.cpClass(cls), cf.cpNameAndType(name, type)));
+          return bc(O_putfield, cf.cpField(cf.cpClass(cls), cf.cpNameAndType(name, type.descriptor())));
         }
     };
   }
@@ -385,7 +385,7 @@ public abstract class Expr extends ByteCode
       (cls != null,
        name != null,
        type != null,
-       !type.equals("V"));
+       type != ClassFileConstants.PrimitiveType.type_void);
 
     return new Expr()
       {
@@ -405,13 +405,13 @@ public abstract class Expr extends ByteCode
   /**
    * create putstatic bytecode to write field described by cls, name and type.
    */
-  public static Expr putstatic(String cls, String name, String type)
+  public static Expr putstatic(String cls, String name, JavaType type)
   {
     if (PRECONDITIONS) require
       (cls != null,
        name != null,
        type != null,
-       !type.equals("V"));
+       type != ClassFileConstants.PrimitiveType.type_void);
 
     return new Expr()
       {
@@ -419,7 +419,7 @@ public abstract class Expr extends ByteCode
         public JavaType type() { return PrimitiveType.type_void;  }
         public byte[] byteCode(ClassFile cf)
         {
-          return bc(O_putstatic, cf.cpField(cf.cpClass(cls), cf.cpNameAndType(name, type)));
+          return bc(O_putstatic, cf.cpField(cf.cpClass(cls), cf.cpNameAndType(name, type.descriptor())));
         }
     };
   }


### PR DESCRIPTION
Previously some methods, such as `getstatic`, accepted a `JavaType` argument, while other methods, such as `putstatic`, accepted type information by passing a `String`. Change the latter to take a `JavaType` argument, to make the usage more consitent.