### PR TITLE
air/me: mark clazzes/feature as instantiated/used/called programmatically

### DIFF
--- a/src/dev/flang/air/Clazz.java
+++ b/src/dev/flang/air/Clazz.java
@@ -1493,6 +1493,10 @@ public class Clazz extends ANY implements Comparable<Clazz>
   private void inspectCode(ExpressionVisitor fc, AbstractFeature f)
   {
     f.visitExpressions(fc);
+    Stream
+      .concat(f.contract().req.stream(), f.contract().ens.stream())
+      .forEach(c -> c.visitExpressions(fc));
+
     for (var c: f.inherits())
       {
         AbstractFeature cf = c.calledFeature();

--- a/src/dev/flang/air/Clazzes.java
+++ b/src/dev/flang/air/Clazzes.java
@@ -95,7 +95,6 @@ public class Clazzes extends ANY
   {
     final TypF _t;
     Clazz _clazz = null;
-    Clazz _dummy = null;
     OnDemandClazz(TypF t) { _t = t; }
     OnDemandClazz() { this(null); }
 
@@ -109,16 +108,9 @@ public class Clazzes extends ANY
         {
           get();
         }
-      else if (_clazz == null)
+      else if (_clazz == null && _clazzesForTypes_.containsKey(_t.get()))
         {
-          if (_dummy == null)
-            {
-              var oldClosed = closed;
-              closed = false;
-              _dummy = new Clazz(_t.get(), -1, universe.get());
-              closed = oldClosed;
-            }
-          _clazz = clazzes.get(_dummy);
+          _clazz = clazz(_t.get());
         }
       return _clazz;
     }
@@ -128,18 +120,17 @@ public class Clazzes extends ANY
         {
           if (_t == null)
             {
-              _clazz = create(Types.resolved.universe.selfType(), null);
+              _clazz = clazz(Types.resolved.universe.selfType());
             }
           else
             {
-              _clazz = create(_t.get(), universe.get());
+              _clazz = clazz(_t.get());
             }
         }
       return _clazz;
     }
     public void clear()
     {
-      _dummy = null;
       _clazz = null;
     }
   }
@@ -423,7 +414,10 @@ public class Clazzes extends ANY
 
     // make sure internally referenced clazzes do exist:
     any.get();
-    create(Types.t_ADDRESS, universe.get());
+    var c_universe = universe.get();
+    c_universe.called(SourcePosition.builtIn);
+    c_universe.instantiated(SourcePosition.builtIn);
+    create(Types.t_ADDRESS, c_universe);
 
     // mark internally referenced clazzes as called or instantiated:
     if (CHECKS) check
@@ -433,18 +427,8 @@ public class Clazzes extends ANY
         main.called(SourcePosition.builtIn);
         main.instantiated(SourcePosition.builtIn);
       }
-    for (var c : new OnDemandClazz[] { universe, i32, u32, i64, u64, f32, f64 })
-      {
-        c.get().called(SourcePosition.builtIn);
-        c.get().instantiated(SourcePosition.builtIn);
-      }
-    for (var c : new OnDemandClazz[] { Const_String, bool, c_TRUE, c_FALSE, c_unit })
-      {
-        c.get().instantiated(SourcePosition.builtIn);
-      }
     constStringInternalArray = Const_String.get().lookup(Types.resolved.f_array_internal_array, SourcePosition.builtIn);
     fuzionSysArray_u8 = constStringInternalArray.resultClazz();
-    fuzionSysArray_u8.instantiated(SourcePosition.builtIn);
     fuzionSysArray_u8_data   = fuzionSysArray_u8.lookup(Types.resolved.f_fuzion_sys_array_data  , SourcePosition.builtIn);
     fuzionSysArray_u8_length = fuzionSysArray_u8.lookup(Types.resolved.f_fuzion_sys_array_length, SourcePosition.builtIn);
     fuzionSysPtr = fuzionSysArray_u8_data.resultClazz();

--- a/src/dev/flang/ast/AbstractConstant.java
+++ b/src/dev/flang/ast/AbstractConstant.java
@@ -56,6 +56,25 @@ public abstract class AbstractConstant extends Expr
   public abstract byte[] data();
 
 
+  /**
+   * visit all the expressions within this feature.
+   *
+   * @param v the visitor instance that defines an action to be performed on
+   * visited objects.
+   *
+   * @param outer the feature surrounding this expression.
+   *
+   * @return this or an alternative Expr if the action performed during the
+   * visit replaces this by the alternative.
+   */
+  @Override
+  public Expr visit(FeatureVisitor v, AbstractFeature outer)
+  {
+    v.action(this);
+    return this;
+  }
+
+
 }
 
 /* end of file */

--- a/src/dev/flang/ast/BoolConst.java
+++ b/src/dev/flang/ast/BoolConst.java
@@ -104,23 +104,6 @@ public class BoolConst extends Constant
   }
 
 
-  /**
-   * visit all the expressions within this feature.
-   *
-   * @param v the visitor instance that defines an action to be performed on
-   * visited objects.
-   *
-   * @param outer the feature surrounding this expression.
-   *
-   * @return this.
-   */
-  public BoolConst visit(FeatureVisitor v, AbstractFeature outer)
-  {
-    // nothing to be done for a constant
-    return this;
-  }
-
-
   boolean isCompileTimeConst()
   {
     return true;

--- a/src/dev/flang/ast/NumLiteral.java
+++ b/src/dev/flang/ast/NumLiteral.java
@@ -727,23 +727,6 @@ public class NumLiteral extends Constant
 
 
   /**
-   * visit all the expressions within this feature.
-   *
-   * @param v the visitor instance that defines an action to be performed on
-   * visited objects.
-   *
-   * @param outer the feature surrounding this expression.
-   *
-   * @return this.
-   */
-  public NumLiteral visit(FeatureVisitor v, AbstractFeature outer)
-  {
-    // nothing to be done for a constant
-    return this;
-  }
-
-
-  /**
    * Get the little-endian representation of this constant.
    *
    * @return an array with length findConstantType(type_)._bytes containing the

--- a/src/dev/flang/ast/StrConst.java
+++ b/src/dev/flang/ast/StrConst.java
@@ -79,23 +79,6 @@ public class StrConst extends Constant
 
 
   /**
-   * visit all the expressions within this feature.
-   *
-   * @param v the visitor instance that defines an action to be performed on
-   * visited objects.
-   *
-   * @param outer the feature surrounding this expression.
-   *
-   * @return this.
-   */
-  public StrConst visit(FeatureVisitor v, AbstractFeature outer)
-  {
-    // nothing to be done for a constant
-    return this;
-  }
-
-
-  /**
    * Serialized form of the data of this constant.
    */
   public byte[] data()

--- a/src/dev/flang/me/MiddleEnd.java
+++ b/src/dev/flang/me/MiddleEnd.java
@@ -30,6 +30,7 @@ import java.util.LinkedList;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
+import java.util.stream.Stream;
 
 import dev.flang.air.AIR;
 
@@ -136,11 +137,7 @@ public class MiddleEnd extends ANY
   void markInternallyUsed() {
     var universe = _mir.universe();
     var m = Clazz._module;
-    markUsed(universe.get(m, "Const_String")                      , SourcePosition.builtIn);
-    markUsed(Types.resolved.f_fuzion_sys_array_data               , SourcePosition.builtIn);
-    markUsed(Types.resolved.f_fuzion_sys_array_length             , SourcePosition.builtIn);
-    markUsed(Types.resolved.f_fuzion_java_object                  , SourcePosition.builtIn);
-    markUsed(Types.resolved.f_fuzion_java_object_ref              , SourcePosition.builtIn);
+    markUsed(universe.get(m, "Const_String")                      , SourcePosition.builtIn); // NYI this should be unecessary?
     markUsed(universe.get(m, FuzionConstants.UNIT_NAME)           , SourcePosition.builtIn);
     markUsed(universe.get(m, "void")                              , SourcePosition.builtIn);
   }
@@ -273,6 +270,9 @@ public class MiddleEnd extends ANY
         //        public Expr action(Feature f, AbstractFeature outer) { markUsed(res, pos);      return f; } // NYI: this seems wrong ("f." missing) or unnecessary
         public void action(Tag     t, AbstractFeature outer) { findUsedFeatures(t._taggedType, t); }
       };
+    Stream
+      .concat(f.contract().req.stream(), f.contract().ens.stream())
+      .forEach(c -> c.visit(fv, f));
     f.visitCode(fv);
   }
 

--- a/src/dev/flang/me/MiddleEnd.java
+++ b/src/dev/flang/me/MiddleEnd.java
@@ -136,19 +136,7 @@ public class MiddleEnd extends ANY
   void markInternallyUsed() {
     var universe = _mir.universe();
     var m = Clazz._module;
-    markUsed(universe.get(m, "i8" ,1).get(m, "val")               , SourcePosition.builtIn);
-    markUsed(universe.get(m, "i16",1).get(m, "val")               , SourcePosition.builtIn);
-    markUsed(universe.get(m, "i32",1).get(m, "val")               , SourcePosition.builtIn);
-    markUsed(universe.get(m, "i64",1).get(m, "val")               , SourcePosition.builtIn);
-    markUsed(universe.get(m, "u8" ,1).get(m, "val")               , SourcePosition.builtIn);
-    markUsed(universe.get(m, "u16",1).get(m, "val")               , SourcePosition.builtIn);
-    markUsed(universe.get(m, "u32",1).get(m, "val")               , SourcePosition.builtIn);
-    markUsed(universe.get(m, "u64",1).get(m, "val")               , SourcePosition.builtIn);
-    markUsed(universe.get(m, "f32",1).get(m, "val")               , SourcePosition.builtIn);
-    markUsed(universe.get(m, "f64",1).get(m, "val")               , SourcePosition.builtIn);
     markUsed(universe.get(m, "Const_String")                      , SourcePosition.builtIn);
-    markUsed(universe.get(m, "Const_String").get(m, "is_empty" )  , SourcePosition.builtIn);  // NYI: check why this is not found automatically
-    markUsed(universe.get(m, "Const_String").get(m, "as_string")  , SourcePosition.builtIn);  // NYI: check why this is not found automatically
     markUsed(Types.resolved.f_fuzion_sys_array_data               , SourcePosition.builtIn);
     markUsed(Types.resolved.f_fuzion_sys_array_length             , SourcePosition.builtIn);
     markUsed(Types.resolved.f_fuzion_java_object                  , SourcePosition.builtIn);


### PR DESCRIPTION
- manually marking clazzes as called/instantiated
- marking i8 and other features as used
- move visit(s) to `AbstractConstant`