### PR TITLE
JVM: Add support for call target type being unit (Java's void), fix #1902

### DIFF
--- a/src/dev/flang/be/jvm/Types.java
+++ b/src/dev/flang/be/jvm/Types.java
@@ -533,7 +533,11 @@ public class Types extends ANY implements ClassFileConstants
       {
         var or = _fuir.clazzOuterRef(cl);
         var ot = _fuir.clazzResultClazz(or);
-        as.append(resultType(ot).descriptor());
+        var at = resultType(ot);
+        if (at != PrimitiveType.type_void)
+          {
+            as.append(at.descriptor());
+          }
       }
     for (var ai = 0; ai < _fuir.clazzArgCount(cl); ai++)
       {


### PR DESCRIPTION
The code to filter out unit type values was present for the arguments already, we need this as well for the target that is passed as a first argument and that may be unit type as well.