### PR TITLE
Support for constant arrays of numeric element types. 

### DIFF
--- a/src/dev/flang/air/Clazzes.java
+++ b/src/dev/flang/air/Clazzes.java
@@ -926,24 +926,24 @@ public class Clazzes extends ANY
     if (PRECONDITIONS) require
       (c != null, outerClazz != null);
 
-    clazz(c, outerClazz).instantiated(c.pos());
-
-    c.type()
-      .featureOfType()
-      // internal_array
-      .valueArguments()
-      .forEach(a -> {
-        var sa = c.type().actualType(a.resultType());
-        clazz(sa).called(c.pos());
-        clazz(sa).instantiated(c.pos());
-        sa
-          .featureOfType()
-          // data, length
-          .valueArguments()
-          .forEach(x -> {
-            clazz(sa.actualType(x.resultType())).instantiated(c.pos());
-          });
-      });
+    var p = c.pos();
+    var const_clazz = clazz(c, outerClazz);
+    if (const_clazz.feature() == Types.resolved.f_array)
+      { // add clazzes touched by constant creation:
+        //
+        //   array.internal_array
+        //   fuzion.sys.internal_array
+        //   fuzion.sys.internal_array.data
+        //   fuzion.sys.Pointer
+        //
+        var array          = const_clazz;
+        var internal_array = array.lookup(Types.resolved.f_array_internal_array);
+        var sys_array      = internal_array.resultClazz();
+        var data           = sys_array.lookup(Types.resolved.f_fuzion_sys_array_data);
+        array.instantiated(p);
+        sys_array.instantiated(p);
+        data.resultClazz().instantiated(p);
+      }
   }
 
 

--- a/src/dev/flang/air/Clazzes.java
+++ b/src/dev/flang/air/Clazzes.java
@@ -176,6 +176,16 @@ public class Clazzes extends ANY
   public static final OnDemandClazz string      = new OnDemandClazz(() -> Types.resolved.t_string           );
   public static final OnDemandClazz Const_String= new OnDemandClazz(() -> Types.resolved.t_Const_String     );
   public static final OnDemandClazz c_unit      = new OnDemandClazz(() -> Types.resolved.t_unit             );
+  public static final OnDemandClazz array_i8    = new OnDemandClazz(() -> Types.resolved.t_array_i8         );
+  public static final OnDemandClazz array_i16   = new OnDemandClazz(() -> Types.resolved.t_array_i16        );
+  public static final OnDemandClazz array_i32   = new OnDemandClazz(() -> Types.resolved.t_array_i32        );
+  public static final OnDemandClazz array_i64   = new OnDemandClazz(() -> Types.resolved.t_array_i64        );
+  public static final OnDemandClazz array_u8    = new OnDemandClazz(() -> Types.resolved.t_array_u8         );
+  public static final OnDemandClazz array_u16   = new OnDemandClazz(() -> Types.resolved.t_array_u16        );
+  public static final OnDemandClazz array_u32   = new OnDemandClazz(() -> Types.resolved.t_array_u32        );
+  public static final OnDemandClazz array_u64   = new OnDemandClazz(() -> Types.resolved.t_array_u64        );
+  public static final OnDemandClazz array_f32   = new OnDemandClazz(() -> Types.resolved.t_array_f32        );
+  public static final OnDemandClazz array_f64   = new OnDemandClazz(() -> Types.resolved.t_array_f64        );
   public static final OnDemandClazz error       = new OnDemandClazz(() -> Types.t_ERROR                     )
     {
       public Clazz get()
@@ -917,6 +927,23 @@ public class Clazzes extends ANY
       (c != null, outerClazz != null);
 
     clazz(c, outerClazz).instantiated(c.pos());
+
+    c.type()
+      .featureOfType()
+      // internal_array
+      .valueArguments()
+      .forEach(a -> {
+        var sa = c.type().actualType(a.resultType());
+        clazz(sa).called(c.pos());
+        clazz(sa).instantiated(c.pos());
+        sa
+          .featureOfType()
+          // data, length
+          .valueArguments()
+          .forEach(x -> {
+            clazz(sa.actualType(x.resultType())).instantiated(c.pos());
+          });
+      });
   }
 
 

--- a/src/dev/flang/air/Clazzes.java
+++ b/src/dev/flang/air/Clazzes.java
@@ -928,6 +928,7 @@ public class Clazzes extends ANY
 
     var p = c.pos();
     var const_clazz = clazz(c, outerClazz);
+    const_clazz.instantiated(p);
     if (const_clazz.feature() == Types.resolved.f_array)
       { // add clazzes touched by constant creation:
         //

--- a/src/dev/flang/ast/ArrayConstant.java
+++ b/src/dev/flang/ast/ArrayConstant.java
@@ -1,0 +1,94 @@
+/*
+
+This file is part of the Fuzion language implementation.
+
+The Fuzion language implementation is free software: you can redistribute it
+and/or modify it under the terms of the GNU General Public License as published
+by the Free Software Foundation, version 3 of the License.
+
+The Fuzion language implementation is distributed in the hope that it will be
+useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+License for more details.
+
+You should have received a copy of the GNU General Public License along with The
+Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+*/
+
+/*-----------------------------------------------------------------------
+ *
+ * Tokiwa Software GmbH, Germany
+ *
+ * Source of class ArrayConstant
+ *
+ *---------------------------------------------------------------------*/
+
+package dev.flang.ast;
+
+import java.nio.ByteBuffer;
+import java.util.stream.Collectors;
+
+import dev.flang.util.List;
+import dev.flang.util.SourcePosition;
+
+/**
+ * ArrayConstant
+ */
+public class ArrayConstant extends Constant
+{
+
+  private final AbstractType _type;
+  private final List<Expr> _elements;
+
+
+  /**
+   * @param pos
+   * @param elements
+   * @param et the elements type, e.g. u64, i32 etc.
+   */
+  public ArrayConstant(SourcePosition pos, List<Expr> elements, AbstractType et)
+  {
+    super(pos);
+    this._elements = elements;
+    this._type = new ResolvedNormalType(Types.resolved.f_array.selfType(), new List<>(et),
+      new List<>(), Types.resolved.universe.selfType());
+  }
+
+
+  /**
+   * typeIfKnown returns the type of this expression or null if the type is
+   * still unknown, i.e., before or during type resolution.  This is redefined
+   * by sub-classes of Expr to provide type information.
+   *
+   * @return this Expr's type or null if not known.
+   */
+  AbstractType typeIfKnown()
+  {
+    return _type;
+  }
+
+
+  @Override
+  public byte[] data()
+  {
+    var l = _elements
+      .stream()
+      .map(x -> ((AbstractConstant) x).data().length)
+      .collect(Collectors.summingInt(x -> x));
+    var b = ByteBuffer.wrap(new byte[l]);
+    _elements
+      .stream()
+      .forEach(x -> b.put(((AbstractConstant) x).data()));
+    return b.array();
+  }
+
+
+  @Override
+  public Expr visit(FeatureVisitor v, AbstractFeature outer)
+  {
+    v.action(this);
+    return this;
+  }
+
+}

--- a/src/dev/flang/ast/ArrayConstant.java
+++ b/src/dev/flang/ast/ArrayConstant.java
@@ -33,27 +33,54 @@ import dev.flang.util.List;
 import dev.flang.util.SourcePosition;
 
 /**
- * ArrayConstant
+ * ArrayConstant represents a constant array the source code such as '[3.14,
+ * 2.71]', '[1,2,3]'.
  */
 public class ArrayConstant extends Constant
 {
 
-  private final AbstractType _type;
-  private final List<Expr> _elements;
+
+  /*----------------------------  variables  ----------------------------*/
 
 
   /**
-   * @param pos
-   * @param elements
+   * The type of the array constant
+   */
+  private final AbstractType _type;
+
+
+  /**
+   * The elements of the array constant
+   */
+  private final List<Expr> _elements;
+
+
+  /*--------------------------  constructors  ---------------------------*/
+
+
+  /**
+   * Constructor for ArrayConstante at the given source code position, with the
+   * given elements and element type.
+   *
+   * @param pos the sourcecode position, used for error messages.
+   *
+   * @param elements the element values
+   *
    * @param et the elements type, e.g. u64, i32 etc.
    */
   public ArrayConstant(SourcePosition pos, List<Expr> elements, AbstractType et)
   {
     super(pos);
+
     this._elements = elements;
-    this._type = new ResolvedNormalType(Types.resolved.f_array.selfType(), new List<>(et),
-      new List<>(), Types.resolved.universe.selfType());
+    this._type = new ResolvedNormalType(Types.resolved.f_array.selfType(),
+                                        new List<>(et),
+                                        new List<>(),
+                                        Types.resolved.universe.selfType());
   }
+
+
+  /*-----------------------------  methods  -----------------------------*/
 
 
   /**
@@ -92,3 +119,5 @@ public class ArrayConstant extends Constant
   }
 
 }
+
+/* end of file */

--- a/src/dev/flang/ast/FeatureVisitor.java
+++ b/src/dev/flang/ast/FeatureVisitor.java
@@ -53,27 +53,27 @@ public abstract class FeatureVisitor extends ANY
   /*-----------------------------  methods  -----------------------------*/
 
 
-  public void         action      (AbstractAssign a, AbstractFeature outer) { }
-  public void         actionBefore(Block          b, AbstractFeature outer) { }
-  public void         actionAfter (Block          b, AbstractFeature outer) { }
-  public void         action      (AbstractCall   c                       ) { }
-  public void         action      (AbstractConstant c                     ) { }
-  public Expr         action      (Call           c, AbstractFeature outer) { return c; }
-  public Expr         action      (DotType        d, AbstractFeature outer) { return d; }
-  public void         actionBefore(AbstractCase   c                       ) { }
-  public void         actionAfter (AbstractCase   c                       ) { }
-  public void         action      (Cond           c, AbstractFeature outer) { }
-  public Expr         action      (Destructure    d, AbstractFeature outer) { return d; }
-  public Expr         action      (Feature        f, AbstractFeature outer) { return f; }
-  public Expr         action      (Function       f, AbstractFeature outer) { return f; }
-  public void         action      (If             i, AbstractFeature outer) { }
-  public void         action      (Impl           i, AbstractFeature outer) { }
-  public Expr         action      (InlineArray    i, AbstractFeature outer) { return i; }
-  public void         action      (AbstractMatch  m                      )  { }
-  public void         action      (Match          m, AbstractFeature outer) { }
-  public void         action      (Tag            b, AbstractFeature outer) { }
-  public Expr         action      (This           t, AbstractFeature outer) { return t; }
-  public AbstractType action      (AbstractType   t, AbstractFeature outer) { return t; }
+  public void         action      (AbstractAssign   a, AbstractFeature outer) { }
+  public void         actionBefore(Block            b, AbstractFeature outer) { }
+  public void         actionAfter (Block            b, AbstractFeature outer) { }
+  public void         action      (AbstractCall     c                       ) { }
+  public void         action      (AbstractConstant c                       ) { }
+  public Expr         action      (Call             c, AbstractFeature outer) { return c; }
+  public Expr         action      (DotType          d, AbstractFeature outer) { return d; }
+  public void         actionBefore(AbstractCase     c                       ) { }
+  public void         actionAfter (AbstractCase     c                       ) { }
+  public void         action      (Cond             c, AbstractFeature outer) { }
+  public Expr         action      (Destructure      d, AbstractFeature outer) { return d; }
+  public Expr         action      (Feature          f, AbstractFeature outer) { return f; }
+  public Expr         action      (Function         f, AbstractFeature outer) { return f; }
+  public void         action      (If               i, AbstractFeature outer) { }
+  public void         action      (Impl             i, AbstractFeature outer) { }
+  public Expr         action      (InlineArray      i, AbstractFeature outer) { return i; }
+  public void         action      (AbstractMatch    m                       ) { }
+  public void         action      (Match            m, AbstractFeature outer) { }
+  public void         action      (Tag              b, AbstractFeature outer) { }
+  public Expr         action      (This             t, AbstractFeature outer) { return t; }
+  public AbstractType action      (AbstractType     t, AbstractFeature outer) { return t; }
 
   /**
    * Visitors that want a different treatment for visiting actual arguments of a

--- a/src/dev/flang/ast/FeatureVisitor.java
+++ b/src/dev/flang/ast/FeatureVisitor.java
@@ -57,6 +57,7 @@ public abstract class FeatureVisitor extends ANY
   public void         actionBefore(Block          b, AbstractFeature outer) { }
   public void         actionAfter (Block          b, AbstractFeature outer) { }
   public void         action      (AbstractCall   c                       ) { }
+  public void         action      (AbstractConstant c                     ) { }
   public Expr         action      (Call           c, AbstractFeature outer) { return c; }
   public Expr         action      (DotType        d, AbstractFeature outer) { return d; }
   public void         actionBefore(AbstractCase   c                       ) { }

--- a/src/dev/flang/ast/InlineArray.java
+++ b/src/dev/flang/ast/InlineArray.java
@@ -286,6 +286,17 @@ public class InlineArray extends ExprWithPos
 
 
   /**
+   * Is this a compile-time constant?
+   */
+  @Override
+  boolean isCompileTimeConst()
+  {
+    return NumLiteral.findConstantType(elementType()) != null &&
+      this._elements.stream().allMatch(x -> !(x instanceof InlineArray) && x.isCompileTimeConst());
+  }
+
+
+  /**
    * Resolve syntactic sugar, e.g., by replacing anonymous inner functions by
    * declaration of corresponding inner features. Add (f,<>) to the list of
    * features to be searched for runtime types to be layouted.
@@ -297,9 +308,13 @@ public class InlineArray extends ExprWithPos
   public Expr resolveSyntacticSugar2(Resolution res, AbstractFeature outer)
   {
     Expr result = this;
-    if (true)  // NYI: This syntactic sugar should not be resolved if this array is a compile-time constant
+    var et = elementType();
+    if (isCompileTimeConst())
       {
-        var et           = elementType();
+        result = new ArrayConstant(pos(), this._elements, et);
+      }
+    else
+      {
         var eT           = new List<AbstractType>(et);
         var args         = new List<Actual>(new Actual(et),
                                             new Actual(new NumLiteral(_elements.size())));

--- a/src/dev/flang/ast/NumLiteral.java
+++ b/src/dev/flang/ast/NumLiteral.java
@@ -779,6 +779,16 @@ public class NumLiteral extends Constant
 
 
   /**
+   * Is this a compile-time constant?
+   */
+  @Override
+  boolean isCompileTimeConst()
+  {
+    return true;
+  }
+
+
+  /**
    * toString
    *
    * @return

--- a/src/dev/flang/ast/Types.java
+++ b/src/dev/flang/ast/Types.java
@@ -36,6 +36,7 @@ import java.util.TreeSet;
 import dev.flang.util.ANY;
 import dev.flang.util.Errors;
 import dev.flang.util.FuzionConstants;
+import dev.flang.util.List;
 
 /*---------------------------------------------------------------------*/
 
@@ -143,6 +144,16 @@ public class Types extends ANY
      * since the union of void  with any other type is the other type.
      */
     public final AbstractType t_void;
+    public final AbstractType t_array_i8;
+    public final AbstractType t_array_i16;
+    public final AbstractType t_array_i32;
+    public final AbstractType t_array_i64;
+    public final AbstractType t_array_u8;
+    public final AbstractType t_array_u16;
+    public final AbstractType t_array_u32;
+    public final AbstractType t_array_u64;
+    public final AbstractType t_array_f32;
+    public final AbstractType t_array_f64;
     public final AbstractFeature f_void;
     public final AbstractFeature f_choice;
     public final AbstractFeature f_TRUE;
@@ -231,6 +242,16 @@ public class Types extends ANY
       f_Types_get                  = f_Types.get(mod, "get");
       f_Lazy                       = universe.get(mod, LAZY_NAME);
       f_Unary                      = universe.get(mod, UNARY_NAME);
+      t_array_i8                   = new ResolvedNormalType(f_array.selfType(), new List<>(t_i8 ), new List<>(), universe.selfType());
+      t_array_i16                  = new ResolvedNormalType(f_array.selfType(), new List<>(t_i16), new List<>(), universe.selfType());
+      t_array_i32                  = new ResolvedNormalType(f_array.selfType(), new List<>(t_i32), new List<>(), universe.selfType());
+      t_array_i64                  = new ResolvedNormalType(f_array.selfType(), new List<>(t_i64), new List<>(), universe.selfType());
+      t_array_u8                   = new ResolvedNormalType(f_array.selfType(), new List<>(t_u8 ), new List<>(), universe.selfType());
+      t_array_u16                  = new ResolvedNormalType(f_array.selfType(), new List<>(t_u16), new List<>(), universe.selfType());
+      t_array_u32                  = new ResolvedNormalType(f_array.selfType(), new List<>(t_u32), new List<>(), universe.selfType());
+      t_array_u64                  = new ResolvedNormalType(f_array.selfType(), new List<>(t_u64), new List<>(), universe.selfType());
+      t_array_f32                  = new ResolvedNormalType(f_array.selfType(), new List<>(t_f32), new List<>(), universe.selfType());
+      t_array_f64                  = new ResolvedNormalType(f_array.selfType(), new List<>(t_f64), new List<>(), universe.selfType());
       resolved = this;
       ((ArtificialBuiltInType) t_ADDRESS  ).resolveArtificialType(universe.get(mod, FuzionConstants.ANY_NAME));
       ((ArtificialBuiltInType) t_UNDEFINED).resolveArtificialType(universe);
@@ -257,7 +278,18 @@ public class Types extends ANY
         t_Const_String,
         t_any        ,
         t_unit       ,
-        t_void       };
+        t_void       ,
+        t_array_i8   ,
+        t_array_i16  ,
+        t_array_i32  ,
+        t_array_i64  ,
+        t_array_u8   ,
+        t_array_u16  ,
+        t_array_u32  ,
+        t_array_u64  ,
+        t_array_f32  ,
+        t_array_f64
+      };
 
       for (var t : internalTypes)
         {

--- a/src/dev/flang/be/c/C.java
+++ b/src/dev/flang/be/c/C.java
@@ -224,34 +224,41 @@ public class C extends ANY
      */
     public Pair<CExpr, CStmnt> constData(int constCl, byte[] d)
     {
-      var o = CStmnt.EMPTY;
-      var r = switch (_fuir.getSpecialId(constCl))
+      return switch (_fuir.getSpecialId(constCl))
         {
-        case c_bool -> d[0] == 1 ? _names.FZ_TRUE : _names.FZ_FALSE;
-        case c_i8   -> CExpr. int8const( ByteBuffer.wrap(d).order(ByteOrder.LITTLE_ENDIAN).get     ());
-        case c_i16  -> CExpr. int16const(ByteBuffer.wrap(d).order(ByteOrder.LITTLE_ENDIAN).getShort());
-        case c_i32  -> CExpr. int32const(ByteBuffer.wrap(d).order(ByteOrder.LITTLE_ENDIAN).getInt  ());
-        case c_i64  -> CExpr. int64const(ByteBuffer.wrap(d).order(ByteOrder.LITTLE_ENDIAN).getLong ());
-        case c_u8   -> CExpr.uint8const (ByteBuffer.wrap(d).order(ByteOrder.LITTLE_ENDIAN).get     () & 0xff);
-        case c_u16  -> CExpr.uint16const(ByteBuffer.wrap(d).order(ByteOrder.LITTLE_ENDIAN).getChar ());
-        case c_u32  -> CExpr.uint32const(ByteBuffer.wrap(d).order(ByteOrder.LITTLE_ENDIAN).getInt  ());
-        case c_u64  -> CExpr.uint64const(ByteBuffer.wrap(d).order(ByteOrder.LITTLE_ENDIAN).getLong ());
-        case c_f32  -> CExpr.   f32const(ByteBuffer.wrap(d).order(ByteOrder.LITTLE_ENDIAN).getFloat());
-        case c_f64  -> CExpr.   f64const(ByteBuffer.wrap(d).order(ByteOrder.LITTLE_ENDIAN).getDouble());
-        case c_Const_String ->
-        {
-          var tmp = _names.newTemp();
-          o = constString(d, tmp);
-          yield tmp;
-        }
-        default ->
-        {
-          Errors.error("Unsupported constant in C backend.",
-                       "Backend cannot handle constant of clazz '" + _fuir.clazzAsString(constCl) + "' ");
-          yield CExpr.dummy(_fuir.clazzAsString(constCl));
-        }
+          case c_bool -> new Pair<>(d[0] == 1 ? _names.FZ_TRUE : _names.FZ_FALSE,CStmnt.EMPTY);
+          case c_i8   -> new Pair<>(CExpr. int8const( ByteBuffer.wrap(d).order(ByteOrder.LITTLE_ENDIAN).get     ()),CStmnt.EMPTY);
+          case c_i16  -> new Pair<>(CExpr. int16const(ByteBuffer.wrap(d).order(ByteOrder.LITTLE_ENDIAN).getShort()),CStmnt.EMPTY);
+          case c_i32  -> new Pair<>(CExpr. int32const(ByteBuffer.wrap(d).order(ByteOrder.LITTLE_ENDIAN).getInt  ()),CStmnt.EMPTY);
+          case c_i64  -> new Pair<>(CExpr. int64const(ByteBuffer.wrap(d).order(ByteOrder.LITTLE_ENDIAN).getLong ()),CStmnt.EMPTY);
+          case c_u8   -> new Pair<>(CExpr.uint8const (ByteBuffer.wrap(d).order(ByteOrder.LITTLE_ENDIAN).get     () & 0xff),CStmnt.EMPTY);
+          case c_u16  -> new Pair<>(CExpr.uint16const(ByteBuffer.wrap(d).order(ByteOrder.LITTLE_ENDIAN).getChar ()),CStmnt.EMPTY);
+          case c_u32  -> new Pair<>(CExpr.uint32const(ByteBuffer.wrap(d).order(ByteOrder.LITTLE_ENDIAN).getInt  ()),CStmnt.EMPTY);
+          case c_u64  -> new Pair<>(CExpr.uint64const(ByteBuffer.wrap(d).order(ByteOrder.LITTLE_ENDIAN).getLong ()),CStmnt.EMPTY);
+          case c_f32  -> new Pair<>(CExpr.   f32const(ByteBuffer.wrap(d).order(ByteOrder.LITTLE_ENDIAN).getFloat()),CStmnt.EMPTY);
+          case c_f64  -> new Pair<>(CExpr.   f64const(ByteBuffer.wrap(d).order(ByteOrder.LITTLE_ENDIAN).getDouble()),CStmnt.EMPTY);
+          case c_array_i8  -> constArray(constCl, ByteBuffer.wrap(d).order(ByteOrder.LITTLE_ENDIAN).array(), 1);
+          case c_array_i16 -> constArray(constCl, ByteBuffer.wrap(d).order(ByteOrder.LITTLE_ENDIAN).array(), 2);
+          case c_array_i32 -> constArray(constCl, ByteBuffer.wrap(d).order(ByteOrder.LITTLE_ENDIAN).array(), 4);
+          case c_array_i64 -> constArray(constCl, ByteBuffer.wrap(d).order(ByteOrder.LITTLE_ENDIAN).array(), 8);
+          case c_array_u8  -> constArray(constCl, ByteBuffer.wrap(d).order(ByteOrder.LITTLE_ENDIAN).array(), 1);
+          case c_array_u16 -> constArray(constCl, ByteBuffer.wrap(d).order(ByteOrder.LITTLE_ENDIAN).array(), 2);
+          case c_array_u32 -> constArray(constCl, ByteBuffer.wrap(d).order(ByteOrder.LITTLE_ENDIAN).array(), 4);
+          case c_array_u64 -> constArray(constCl, ByteBuffer.wrap(d).order(ByteOrder.LITTLE_ENDIAN).array(), 8);
+          case c_array_f32 -> constArray(constCl, ByteBuffer.wrap(d).order(ByteOrder.LITTLE_ENDIAN).array(), 4);
+          case c_array_f64 -> constArray(constCl, ByteBuffer.wrap(d).order(ByteOrder.LITTLE_ENDIAN).array(), 8);
+          case c_Const_String ->
+          {
+            var tmp = _names.newTemp();
+            yield new Pair<CExpr, CStmnt>(tmp, constString(d, tmp));
+          }
+          default ->
+          {
+            Errors.error("Unsupported constant in C backend.",
+            "Backend cannot handle constant of clazz '" + _fuir.clazzAsString(constCl) + "' ");
+            yield new Pair<>(CExpr.dummy(_fuir.clazzAsString(constCl)), CStmnt.EMPTY);
+          }
         };
-      return new Pair<>(r, o);
     }
 
 
@@ -966,6 +973,37 @@ public class C extends ANY
     return constString(CExpr.string(bytes),
                        CExpr.int32const(bytes.length),
                        tmp);
+  }
+
+
+  /**
+   * produce an expression to create an array
+   * on the heap from the given data
+   *
+   * @param constCl, e.g. array
+   * @param d
+   * @param bytesPerField
+   * @return
+   */
+  public Pair<CExpr, CStmnt> constArray(int constCl, byte[] d, int bytesPerField)
+  {
+    var tmp              = _names.newTemp();
+    var c_internal_array = _fuir.clazzField(constCl, 0);
+    if (CHECKS) check
+      (_fuir.clazzNumFields(constCl) == 4); // internal_array + 3x unit
+    var c_sys_array      = _fuir.clazzResultClazz(c_internal_array);
+    if (CHECKS) check
+      (_fuir.clazzNumFields(c_sys_array) == 2); // data, length
+    var c_data           = _fuir.clazzField(c_sys_array, 0);
+    var c_length         = _fuir.clazzField(c_sys_array, 1);
+    var internal_array   = _names.fieldName(c_internal_array);
+    var data             = _names.fieldName(c_data);
+    var length           = _names.fieldName(c_length);
+    var sysArray         = fields(tmp, constCl).field(internal_array);
+    return new Pair<>(tmp, CStmnt.seq(CStmnt.decl(_names.struct(constCl), tmp),
+      sysArray.field(data)
+        .assign(CExpr.call(CNames.HEAP_CLONE._name, new List<>(CExpr.arrayInit(d), CExpr.int32const(d.length)))),
+      sysArray.field(length).assign(CExpr.int32const(d.length / bytesPerField))));
   }
 
 

--- a/src/dev/flang/be/c/C.java
+++ b/src/dev/flang/be/c/C.java
@@ -34,7 +34,7 @@ import java.util.Arrays;
 import java.util.stream.Stream;
 
 import dev.flang.fuir.FUIR;
-
+import dev.flang.fuir.FUIR.SpecialClazzes;
 import dev.flang.fuir.analysis.AbstractInterpreter;
 import dev.flang.fuir.analysis.dfa.DFA;
 import dev.flang.fuir.analysis.TailCall;
@@ -226,27 +226,27 @@ public class C extends ANY
     {
       return switch (_fuir.getSpecialId(constCl))
         {
-          case c_bool -> new Pair<>(d[0] == 1 ? _names.FZ_TRUE : _names.FZ_FALSE,CStmnt.EMPTY);
-          case c_i8   -> new Pair<>(CExpr. int8const( ByteBuffer.wrap(d).order(ByteOrder.LITTLE_ENDIAN).get     ()),CStmnt.EMPTY);
-          case c_i16  -> new Pair<>(CExpr. int16const(ByteBuffer.wrap(d).order(ByteOrder.LITTLE_ENDIAN).getShort()),CStmnt.EMPTY);
-          case c_i32  -> new Pair<>(CExpr. int32const(ByteBuffer.wrap(d).order(ByteOrder.LITTLE_ENDIAN).getInt  ()),CStmnt.EMPTY);
-          case c_i64  -> new Pair<>(CExpr. int64const(ByteBuffer.wrap(d).order(ByteOrder.LITTLE_ENDIAN).getLong ()),CStmnt.EMPTY);
-          case c_u8   -> new Pair<>(CExpr.uint8const (ByteBuffer.wrap(d).order(ByteOrder.LITTLE_ENDIAN).get     () & 0xff),CStmnt.EMPTY);
-          case c_u16  -> new Pair<>(CExpr.uint16const(ByteBuffer.wrap(d).order(ByteOrder.LITTLE_ENDIAN).getChar ()),CStmnt.EMPTY);
-          case c_u32  -> new Pair<>(CExpr.uint32const(ByteBuffer.wrap(d).order(ByteOrder.LITTLE_ENDIAN).getInt  ()),CStmnt.EMPTY);
-          case c_u64  -> new Pair<>(CExpr.uint64const(ByteBuffer.wrap(d).order(ByteOrder.LITTLE_ENDIAN).getLong ()),CStmnt.EMPTY);
-          case c_f32  -> new Pair<>(CExpr.   f32const(ByteBuffer.wrap(d).order(ByteOrder.LITTLE_ENDIAN).getFloat()),CStmnt.EMPTY);
-          case c_f64  -> new Pair<>(CExpr.   f64const(ByteBuffer.wrap(d).order(ByteOrder.LITTLE_ENDIAN).getDouble()),CStmnt.EMPTY);
-          case c_array_i8  -> constArray(constCl, ByteBuffer.wrap(d).order(ByteOrder.LITTLE_ENDIAN).array(), 1);
-          case c_array_i16 -> constArray(constCl, ByteBuffer.wrap(d).order(ByteOrder.LITTLE_ENDIAN).array(), 2);
-          case c_array_i32 -> constArray(constCl, ByteBuffer.wrap(d).order(ByteOrder.LITTLE_ENDIAN).array(), 4);
-          case c_array_i64 -> constArray(constCl, ByteBuffer.wrap(d).order(ByteOrder.LITTLE_ENDIAN).array(), 8);
-          case c_array_u8  -> constArray(constCl, ByteBuffer.wrap(d).order(ByteOrder.LITTLE_ENDIAN).array(), 1);
-          case c_array_u16 -> constArray(constCl, ByteBuffer.wrap(d).order(ByteOrder.LITTLE_ENDIAN).array(), 2);
-          case c_array_u32 -> constArray(constCl, ByteBuffer.wrap(d).order(ByteOrder.LITTLE_ENDIAN).array(), 4);
-          case c_array_u64 -> constArray(constCl, ByteBuffer.wrap(d).order(ByteOrder.LITTLE_ENDIAN).array(), 8);
-          case c_array_f32 -> constArray(constCl, ByteBuffer.wrap(d).order(ByteOrder.LITTLE_ENDIAN).array(), 4);
-          case c_array_f64 -> constArray(constCl, ByteBuffer.wrap(d).order(ByteOrder.LITTLE_ENDIAN).array(), 8);
+          case c_bool -> new Pair<>(primitiveExpression(SpecialClazzes.c_bool, ByteBuffer.wrap(d).order(ByteOrder.LITTLE_ENDIAN)),CStmnt.EMPTY);
+          case c_i8   -> new Pair<>(primitiveExpression(SpecialClazzes.c_i8,   ByteBuffer.wrap(d).order(ByteOrder.LITTLE_ENDIAN)),CStmnt.EMPTY);
+          case c_i16  -> new Pair<>(primitiveExpression(SpecialClazzes.c_i16,  ByteBuffer.wrap(d).order(ByteOrder.LITTLE_ENDIAN)),CStmnt.EMPTY);
+          case c_i32  -> new Pair<>(primitiveExpression(SpecialClazzes.c_i32,  ByteBuffer.wrap(d).order(ByteOrder.LITTLE_ENDIAN)),CStmnt.EMPTY);
+          case c_i64  -> new Pair<>(primitiveExpression(SpecialClazzes.c_i64,  ByteBuffer.wrap(d).order(ByteOrder.LITTLE_ENDIAN)),CStmnt.EMPTY);
+          case c_u8   -> new Pair<>(primitiveExpression(SpecialClazzes.c_u8,   ByteBuffer.wrap(d).order(ByteOrder.LITTLE_ENDIAN)),CStmnt.EMPTY);
+          case c_u16  -> new Pair<>(primitiveExpression(SpecialClazzes.c_u16,  ByteBuffer.wrap(d).order(ByteOrder.LITTLE_ENDIAN)),CStmnt.EMPTY);
+          case c_u32  -> new Pair<>(primitiveExpression(SpecialClazzes.c_u32,  ByteBuffer.wrap(d).order(ByteOrder.LITTLE_ENDIAN)),CStmnt.EMPTY);
+          case c_u64  -> new Pair<>(primitiveExpression(SpecialClazzes.c_u64,  ByteBuffer.wrap(d).order(ByteOrder.LITTLE_ENDIAN)),CStmnt.EMPTY);
+          case c_f32  -> new Pair<>(primitiveExpression(SpecialClazzes.c_f32,  ByteBuffer.wrap(d).order(ByteOrder.LITTLE_ENDIAN)),CStmnt.EMPTY);
+          case c_f64  -> new Pair<>(primitiveExpression(SpecialClazzes.c_f64,  ByteBuffer.wrap(d).order(ByteOrder.LITTLE_ENDIAN)),CStmnt.EMPTY);
+          case c_array_i8  -> constArray(constCl, SpecialClazzes.c_i8 , d);
+          case c_array_i16 -> constArray(constCl, SpecialClazzes.c_i16, d);
+          case c_array_i32 -> constArray(constCl, SpecialClazzes.c_i32, d);
+          case c_array_i64 -> constArray(constCl, SpecialClazzes.c_i64, d);
+          case c_array_u8  -> constArray(constCl, SpecialClazzes.c_u8 , d);
+          case c_array_u16 -> constArray(constCl, SpecialClazzes.c_u16, d);
+          case c_array_u32 -> constArray(constCl, SpecialClazzes.c_u32, d);
+          case c_array_u64 -> constArray(constCl, SpecialClazzes.c_u64, d);
+          case c_array_f32 -> constArray(constCl, SpecialClazzes.c_f32, d);
+          case c_array_f64 -> constArray(constCl, SpecialClazzes.c_f64, d);
           case c_Const_String ->
           {
             var tmp = _names.newTemp();
@@ -977,6 +977,59 @@ public class C extends ANY
 
 
   /**
+   * produce CExpr for given special clazz sc and byte buffer bbLE.
+   *
+   * @param sc the spezial clazz we we are generating the CExpr for.
+   * @param bbLE byte buffer (little endian)
+   * @return
+   */
+  public CExpr primitiveExpression(SpecialClazzes sc, ByteBuffer bbLE)
+  {
+    return switch (sc)
+      {
+      case c_bool -> bbLE.get(0) == 1 ? _names.FZ_TRUE: _names.FZ_FALSE;
+      case c_u8 -> CExpr.uint8const(bbLE.get() & 0xff);
+      case c_u16 -> CExpr.uint16const(bbLE.getChar());
+      case c_u32 -> CExpr.uint32const(bbLE.getInt());
+      case c_u64 -> CExpr.uint64const(bbLE.getLong());
+      case c_i8 -> CExpr.int8const(bbLE.get());
+      case c_i16 -> CExpr.int16const(bbLE.getShort());
+      case c_i32 -> CExpr.int32const(bbLE.getInt());
+      case c_i64 -> CExpr.int64const(bbLE.getLong());
+      case c_f32 -> CExpr.f32const(bbLE.getFloat());
+      case c_f64 -> CExpr.f64const(bbLE.getDouble());
+      default -> throw new Error(sc.name() + " is not a supported primitive.");
+      };
+  }
+
+
+  /**
+   * How many bytes are needed to encode specialClazz sc?
+   *
+   * @param sc
+   * @return 1, 2, 4 or 8 => meaning 8bits, 16bits, 32bits, 64bits
+   */
+  public int bytesOfConst(SpecialClazzes sc)
+  {
+    return switch (sc)
+      {
+      case c_bool -> 1;
+      case c_u8 -> 1;
+      case c_u16 -> 2;
+      case c_u32 -> 4;
+      case c_u64 -> 8;
+      case c_i8 -> 1;
+      case c_i16 -> 2;
+      case c_i32 -> 4;
+      case c_i64 -> 8;
+      case c_f32 -> 4;
+      case c_f64 -> 8;
+      default -> throw new Error(sc.name() + " is not a supported primitive.");
+      };
+  }
+
+
+  /**
    * produce an expression to create an array
    * on the heap from the given data
    *
@@ -985,18 +1038,15 @@ public class C extends ANY
    * @param bytesPerField
    * @return
    */
-  public Pair<CExpr, CStmnt> constArray(int constCl, byte[] d, int bytesPerField)
+  public Pair<CExpr, CStmnt> constArray(int constCl, SpecialClazzes elementType, byte[] d)
   {
+    var bytesPerField = bytesOfConst(elementType);
     var tmp              = _names.newTemp();
     var tmpR             = _names.newTemp();
-    var c_internal_array = _fuir.clazzField(constCl, 0);
-    if (CHECKS) check
-      (_fuir.clazzNumFields(constCl) == 4); // internal_array + 3x unit
+    var c_internal_array = _fuir.lookup_array_internal_array(constCl);
     var c_sys_array      = _fuir.clazzResultClazz(c_internal_array);
-    if (CHECKS) check
-      (_fuir.clazzNumFields(c_sys_array) == 2); // data, length
-    var c_data           = _fuir.clazzField(c_sys_array, 0);
-    var c_length         = _fuir.clazzField(c_sys_array, 1);
+    var c_data           = _fuir.lookup_fuzion_sys_internal_array_data(c_sys_array);
+    var c_length         = _fuir.lookup_fuzion_sys_internal_array_length(c_sys_array);
     var internal_array   = _names.fieldName(c_internal_array);
     var data             = _names.fieldName(c_data);
     var length           = _names.fieldName(c_length);
@@ -1006,7 +1056,7 @@ public class C extends ANY
     var stmnts = CStmnt.seq(CStmnt.decl(type, tmp),
                            CStmnt.decl(typeR, tmpR),
                            sysArray.field(data).assign(CExpr.call(CNames.HEAP_CLONE._name,
-                                                                  new List<>(CExpr.arrayInit(d),
+                                                                  new List<>(arrayInit(d, elementType),
                                                                              CExpr.int32const(d.length)))),
                            sysArray.field(length).assign(CExpr.int32const(d.length / bytesPerField)),
                            tmpR.assign(CExpr.call(CNames.HEAP_CLONE._name,
@@ -1014,6 +1064,40 @@ public class C extends ANY
                                                              tmp.sizeOfExpr())).castTo(typeR)));
     return new Pair<>(tmpR.deref(),
                       stmnts);
+  }
+
+
+  /**
+   * create an array with the given bytes as input.
+   *
+   * @param d the data of the array
+   *
+   * @param elementType i8, f32, etc.
+   */
+  public CExpr arrayInit(byte[] d, SpecialClazzes elementType)
+  {
+    var bytesPerField = bytesOfConst(elementType);
+    return new CExpr() {
+      int precedence()
+      {
+        return 0;
+      }
+
+      void code(CString sb)
+      {
+        sb.append("(" + CTypes.scalar(elementType) + "[]){");
+        for(int i = 0; i < d.length; i = i + bytesPerField)
+          {
+            primitiveExpression(elementType, ByteBuffer.wrap(d, i, bytesPerField).order(ByteOrder.LITTLE_ENDIAN))
+              .code(sb);
+            if (i + bytesPerField != d.length)
+              {
+                sb.append(", ");
+              }
+          }
+        sb.append("}");
+      }
+    };
   }
 
 

--- a/src/dev/flang/be/c/C.java
+++ b/src/dev/flang/be/c/C.java
@@ -1055,7 +1055,8 @@ public class C extends ANY
     var typeR            = type + "*";
     var stmnts = CStmnt.seq(CStmnt.decl(type, tmp),
                            CStmnt.decl(typeR, tmpR),
-                           sysArray.field(data).assign(CExpr.call(CNames.HEAP_CLONE._name,
+                           sysArray.field(data).assign(CExpr.call(CNames.HEAP_CLONE._name, // NYI cast to void* should suffice but does
+                                                                                           // not work yet for e.g. floats: say [f32 -17.3, f32 1.2]
                                                                   new List<>(arrayInit(d, elementType),
                                                                              CExpr.int32const(d.length)))),
                            sysArray.field(length).assign(CExpr.int32const(d.length / bytesPerField)),

--- a/src/dev/flang/be/c/C.java
+++ b/src/dev/flang/be/c/C.java
@@ -980,24 +980,26 @@ public class C extends ANY
    * produce CExpr for given special clazz sc and byte buffer bbLE.
    *
    * @param sc the spezial clazz we we are generating the CExpr for.
+   *
    * @param bbLE byte buffer (little endian)
-   * @return
+   *
+   * @return C expression that creates corresponging constant value.
    */
   public CExpr primitiveExpression(SpecialClazzes sc, ByteBuffer bbLE)
   {
     return switch (sc)
       {
       case c_bool -> bbLE.get(0) == 1 ? _names.FZ_TRUE: _names.FZ_FALSE;
-      case c_u8 -> CExpr.uint8const(bbLE.get() & 0xff);
-      case c_u16 -> CExpr.uint16const(bbLE.getChar());
-      case c_u32 -> CExpr.uint32const(bbLE.getInt());
-      case c_u64 -> CExpr.uint64const(bbLE.getLong());
-      case c_i8 -> CExpr.int8const(bbLE.get());
-      case c_i16 -> CExpr.int16const(bbLE.getShort());
-      case c_i32 -> CExpr.int32const(bbLE.getInt());
-      case c_i64 -> CExpr.int64const(bbLE.getLong());
-      case c_f32 -> CExpr.f32const(bbLE.getFloat());
-      case c_f64 -> CExpr.f64const(bbLE.getDouble());
+      case c_u8   -> CExpr.uint8const (bbLE.get() & 0xff);
+      case c_u16  -> CExpr.uint16const(bbLE.getChar());
+      case c_u32  -> CExpr.uint32const(bbLE.getInt());
+      case c_u64  -> CExpr.uint64const(bbLE.getLong());
+      case c_i8   -> CExpr.int8const  (bbLE.get());
+      case c_i16  -> CExpr.int16const (bbLE.getShort());
+      case c_i32  -> CExpr.int32const (bbLE.getInt());
+      case c_i64  -> CExpr.int64const (bbLE.getLong());
+      case c_f32  -> CExpr.f32const   (bbLE.getFloat());
+      case c_f64  -> CExpr.f64const   (bbLE.getDouble());
       default -> throw new Error(sc.name() + " is not a supported primitive.");
       };
   }
@@ -1006,7 +1008,8 @@ public class C extends ANY
   /**
    * How many bytes are needed to encode specialClazz sc?
    *
-   * @param sc
+   * @param sc a special clazz id.
+   *
    * @return 1, 2, 4 or 8 => meaning 8bits, 16bits, 32bits, 64bits
    */
   public int bytesOfConst(SpecialClazzes sc)
@@ -1014,16 +1017,16 @@ public class C extends ANY
     return switch (sc)
       {
       case c_bool -> 1;
-      case c_u8 -> 1;
-      case c_u16 -> 2;
-      case c_u32 -> 4;
-      case c_u64 -> 8;
-      case c_i8 -> 1;
-      case c_i16 -> 2;
-      case c_i32 -> 4;
-      case c_i64 -> 8;
-      case c_f32 -> 4;
-      case c_f64 -> 8;
+      case c_u8   -> 1;
+      case c_u16  -> 2;
+      case c_u32  -> 4;
+      case c_u64  -> 8;
+      case c_i8   -> 1;
+      case c_i16  -> 2;
+      case c_i32  -> 4;
+      case c_i64  -> 8;
+      case c_f32  -> 4;
+      case c_f64  -> 8;
       default -> throw new Error(sc.name() + " is not a supported primitive.");
       };
   }
@@ -1040,7 +1043,7 @@ public class C extends ANY
    */
   public Pair<CExpr, CStmnt> constArray(int constCl, SpecialClazzes elementType, byte[] d)
   {
-    var bytesPerField = bytesOfConst(elementType);
+    var bytesPerField    = bytesOfConst(elementType);
     var tmp              = _names.newTemp();
     var tmpR             = _names.newTemp();
     var c_internal_array = _fuir.lookup_array_internal_array(constCl);

--- a/src/dev/flang/be/c/C.java
+++ b/src/dev/flang/be/c/C.java
@@ -988,6 +988,7 @@ public class C extends ANY
   public Pair<CExpr, CStmnt> constArray(int constCl, byte[] d, int bytesPerField)
   {
     var tmp              = _names.newTemp();
+    var tmpR             = _names.newTemp();
     var c_internal_array = _fuir.clazzField(constCl, 0);
     if (CHECKS) check
       (_fuir.clazzNumFields(constCl) == 4); // internal_array + 3x unit
@@ -1000,10 +1001,19 @@ public class C extends ANY
     var data             = _names.fieldName(c_data);
     var length           = _names.fieldName(c_length);
     var sysArray         = fields(tmp, constCl).field(internal_array);
-    return new Pair<>(tmp, CStmnt.seq(CStmnt.decl(_names.struct(constCl), tmp),
-      sysArray.field(data)
-        .assign(CExpr.call(CNames.HEAP_CLONE._name, new List<>(CExpr.arrayInit(d), CExpr.int32const(d.length)))),
-      sysArray.field(length).assign(CExpr.int32const(d.length / bytesPerField))));
+    var type             = _types.clazz(constCl);
+    var typeR            = type + "*";
+    var stmnts = CStmnt.seq(CStmnt.decl(type, tmp),
+                           CStmnt.decl(typeR, tmpR),
+                           sysArray.field(data).assign(CExpr.call(CNames.HEAP_CLONE._name,
+                                                                  new List<>(CExpr.arrayInit(d),
+                                                                             CExpr.int32const(d.length)))),
+                           sysArray.field(length).assign(CExpr.int32const(d.length / bytesPerField)),
+                           tmpR.assign(CExpr.call(CNames.HEAP_CLONE._name,
+                                                  new List<>(tmp.adrOf(),
+                                                             tmp.sizeOfExpr())).castTo(typeR)));
+    return new Pair<>(tmpR.deref(),
+                      stmnts);
   }
 
 

--- a/src/dev/flang/be/c/CExpr.java
+++ b/src/dev/flang/be/c/CExpr.java
@@ -917,6 +917,34 @@ abstract class CExpr extends CStmnt
     return "C-Expression '" + code() + "'";
   }
 
+
+  /**
+   * create an array with the given bytes as input.
+   *
+   * @param d the data of the array
+   */
+  public static CExpr arrayInit(byte[] d)
+  {
+    return new CExpr() {
+      int precedence()
+        {
+          return 0;
+        }
+      void code(CString sb)
+      {
+        sb.append("(uint8_t[]){");
+        for (int i = 0; i < d.length; i++) {
+          sb.append(d[i]);
+          if(i+1 != d.length)
+          {
+            sb.append(", ");
+          }
+        }
+        sb.append("}");
+      }
+    };
+  }
+
 }
 
 /* end of file */

--- a/src/dev/flang/be/c/CExpr.java
+++ b/src/dev/flang/be/c/CExpr.java
@@ -918,33 +918,6 @@ abstract class CExpr extends CStmnt
   }
 
 
-  /**
-   * create an array with the given bytes as input.
-   *
-   * @param d the data of the array
-   */
-  public static CExpr arrayInit(byte[] d)
-  {
-    return new CExpr() {
-      int precedence()
-        {
-          return 0;
-        }
-      void code(CString sb)
-      {
-        sb.append("(uint8_t[]){");
-        for (int i = 0; i < d.length; i++) {
-          sb.append(d[i]);
-          if(i+1 != d.length)
-          {
-            sb.append(", ");
-          }
-        }
-        sb.append("}");
-      }
-    };
-  }
-
 }
 
 /* end of file */

--- a/src/dev/flang/be/c/CTypes.java
+++ b/src/dev/flang/be/c/CTypes.java
@@ -170,7 +170,7 @@ public class CTypes extends ANY
    * @return the C scalar type corresponding to cl, null if cl is not scalar or
    * null.
    */
-  String scalar(FUIR.SpecialClazzes sc)
+  static String scalar(FUIR.SpecialClazzes sc)
   {
     return switch (sc)
       {

--- a/src/dev/flang/be/c/Intrinsics.java
+++ b/src/dev/flang/be/c/Intrinsics.java
@@ -833,7 +833,7 @@ public class Intrinsics extends ANY
         {
           var last_id = new CIdent("last_id");
           return CStmnt.seq(CStmnt.decl("static",
-                                        c._types.scalar(FUIR.SpecialClazzes.c_u64),
+                                        CTypes.scalar(FUIR.SpecialClazzes.c_u64),
                                         last_id,
                                         CExpr.uint64const(0)),
                             CExpr.call("__atomic_add_fetch", new List<>(last_id.adrOf(), CExpr.uint64const(1), new CIdent("__ATOMIC_SEQ_CST"))).ret());
@@ -1189,8 +1189,8 @@ public class Intrinsics extends ANY
   static CExpr castToUnsignedForArithmetic(C c, CExpr a, CExpr b, char op, FUIR.SpecialClazzes unsigned, FUIR.SpecialClazzes signed)
   {
     // C type
-    var ut = c._types.scalar(unsigned);
-    var st = c._types.scalar(signed  );
+    var ut = CTypes.scalar(unsigned);
+    var st = CTypes.scalar(signed  );
 
     // unsigned versions of a and b
     var au = a.castTo(ut);

--- a/src/dev/flang/be/interpreter/ArrayData.java
+++ b/src/dev/flang/be/interpreter/ArrayData.java
@@ -136,15 +136,17 @@ public class ArrayData extends Value
     AbstractType elementType)
   {
     checkIndex(x);
-    if      (elementType.compareTo(Types.resolved.t_i8  ) == 0) { ((byte   [])_array)[x] = (byte   ) v.i8Value();   }
-    else if (elementType.compareTo(Types.resolved.t_i16 ) == 0) { ((short  [])_array)[x] = (short  ) v.i16Value();  }
-    else if (elementType.compareTo(Types.resolved.t_i32 ) == 0) { ((int    [])_array)[x] =           v.i32Value();  }
-    else if (elementType.compareTo(Types.resolved.t_i64 ) == 0) { ((long   [])_array)[x] =           v.i64Value();  }
-    else if (elementType.compareTo(Types.resolved.t_u8  ) == 0) { ((byte   [])_array)[x] = (byte   ) v.u8Value();   }
-    else if (elementType.compareTo(Types.resolved.t_u16 ) == 0) { ((char   [])_array)[x] = (char   ) v.u16Value();  }
-    else if (elementType.compareTo(Types.resolved.t_u32 ) == 0) { ((int    [])_array)[x] =           v.u32Value();  }
-    else if (elementType.compareTo(Types.resolved.t_u64 ) == 0) { ((long   [])_array)[x] =           v.u64Value();  }
-    else if (elementType.compareTo(Types.resolved.t_bool) == 0) { ((boolean[])_array)[x] =           v.boolValue(); }
+    if      (elementType.compareTo(Types.resolved.t_i8  ) == 0 && _array instanceof byte   []) { ((byte   [])_array)[x] = (byte   ) v.i8Value();   }
+    else if (elementType.compareTo(Types.resolved.t_i16 ) == 0 && _array instanceof short  []) { ((short  [])_array)[x] = (short  ) v.i16Value();  }
+    else if (elementType.compareTo(Types.resolved.t_i32 ) == 0 && _array instanceof int    []) { ((int    [])_array)[x] =           v.i32Value();  }
+    else if (elementType.compareTo(Types.resolved.t_i64 ) == 0 && _array instanceof long   []) { ((long   [])_array)[x] =           v.i64Value();  }
+    else if (elementType.compareTo(Types.resolved.t_u8  ) == 0 && _array instanceof byte   []) { ((byte   [])_array)[x] = (byte   ) v.u8Value();   }
+    else if (elementType.compareTo(Types.resolved.t_u16 ) == 0 && _array instanceof char   []) { ((char   [])_array)[x] = (char   ) v.u16Value();  }
+    else if (elementType.compareTo(Types.resolved.t_u32 ) == 0 && _array instanceof int    []) { ((int    [])_array)[x] =           v.u32Value();  }
+    else if (elementType.compareTo(Types.resolved.t_u64 ) == 0 && _array instanceof long   []) { ((long   [])_array)[x] =           v.u64Value();  }
+    else if (elementType.compareTo(Types.resolved.t_f32 ) == 0 && _array instanceof float  []) { ((float  [])_array)[x] =           v.f32Value();  }
+    else if (elementType.compareTo(Types.resolved.t_f64 ) == 0 && _array instanceof double []) { ((double [])_array)[x] =           v.f64Value();  }
+    else if (elementType.compareTo(Types.resolved.t_bool) == 0 && _array instanceof boolean[]) { ((boolean[])_array)[x] =           v.boolValue(); }
     else                                                        { ((Value  [])_array)[x] =           v;             }
   }
 
@@ -161,15 +163,17 @@ public class ArrayData extends Value
     AbstractType elementType)
   {
     checkIndex(x);
-    if      (elementType.compareTo(Types.resolved.t_i8  ) == 0) { return new i8Value  (((byte   [])_array)[x]       ); }
-    else if (elementType.compareTo(Types.resolved.t_i16 ) == 0) { return new i16Value (((short  [])_array)[x]       ); }
-    else if (elementType.compareTo(Types.resolved.t_i32 ) == 0) { return new i32Value (((int    [])_array)[x]       ); }
-    else if (elementType.compareTo(Types.resolved.t_i64 ) == 0) { return new i64Value (((long   [])_array)[x]       ); }
-    else if (elementType.compareTo(Types.resolved.t_u8  ) == 0) { return new u8Value  (((byte   [])_array)[x] & 0xff); }
-    else if (elementType.compareTo(Types.resolved.t_u16 ) == 0) { return new u16Value (((char   [])_array)[x]       ); }
-    else if (elementType.compareTo(Types.resolved.t_u32 ) == 0) { return new u32Value (((int    [])_array)[x]       ); }
-    else if (elementType.compareTo(Types.resolved.t_u64 ) == 0) { return new u64Value (((long   [])_array)[x]       ); }
-    else if (elementType.compareTo(Types.resolved.t_bool) == 0) { return new boolValue(((boolean[])_array)[x]       ); }
+    if      (elementType.compareTo(Types.resolved.t_i8  ) == 0 && _array instanceof byte   []) { return new i8Value  (((byte   [])_array)[x]       ); }
+    else if (elementType.compareTo(Types.resolved.t_i16 ) == 0 && _array instanceof short  []) { return new i16Value (((short  [])_array)[x]       ); }
+    else if (elementType.compareTo(Types.resolved.t_i32 ) == 0 && _array instanceof int    []) { return new i32Value (((int    [])_array)[x]       ); }
+    else if (elementType.compareTo(Types.resolved.t_i64 ) == 0 && _array instanceof long   []) { return new i64Value (((long   [])_array)[x]       ); }
+    else if (elementType.compareTo(Types.resolved.t_u8  ) == 0 && _array instanceof byte   []) { return new u8Value  (((byte   [])_array)[x] & 0xff); }
+    else if (elementType.compareTo(Types.resolved.t_u16 ) == 0 && _array instanceof char   []) { return new u16Value (((char   [])_array)[x]       ); }
+    else if (elementType.compareTo(Types.resolved.t_u32 ) == 0 && _array instanceof int    []) { return new u32Value (((int    [])_array)[x]       ); }
+    else if (elementType.compareTo(Types.resolved.t_u64 ) == 0 && _array instanceof long   []) { return new u64Value (((long   [])_array)[x]       ); }
+    else if (elementType.compareTo(Types.resolved.t_f32 ) == 0 && _array instanceof float  []) { return new f32Value (((float  [])_array)[x]       ); }
+    else if (elementType.compareTo(Types.resolved.t_f64 ) == 0 && _array instanceof double []) { return new f64Value (((double [])_array)[x]       ); }
+    else if (elementType.compareTo(Types.resolved.t_bool) == 0 && _array instanceof boolean[]) { return new boolValue(((boolean[])_array)[x]       ); }
     else                                                        { return              ((Value   [])_array)[x]        ; }
   }
 

--- a/src/dev/flang/be/jvm/Choices.java
+++ b/src/dev/flang/be/jvm/Choices.java
@@ -330,12 +330,7 @@ public class Choices extends ANY implements ClassFileConstants
                                               bc_tag, new List<>(), new List<>());
               cf.method(ACC_PUBLIC, gtn, "()I", new List<>(code_tag));
 
-              bc_clinit = bc_clinit
-                .andThen(Expr.RETURN);
-              var code_clinit = cf.codeAttribute("<clinit> in class for " + _fuir.clazzAsString(cl),
-                                                 bc_clinit, new List<>(), new List<>());
-              cf.method(ACC_PUBLIC | ACC_STATIC, "<clinit>", "()V", new List<>(code_clinit));
-
+              cf.addToClInit(bc_clinit);
               break;
             }
           case general:

--- a/src/dev/flang/be/jvm/CodeGen.java
+++ b/src/dev/flang/be/jvm/CodeGen.java
@@ -954,16 +954,16 @@ class CodeGen
       case c_f32          -> new Pair<>(Expr.fconst(ByteBuffer.wrap(d).order(ByteOrder.LITTLE_ENDIAN).getInt  ()         ), Expr.UNIT);
       case c_f64          -> new Pair<>(Expr.dconst(ByteBuffer.wrap(d).order(ByteOrder.LITTLE_ENDIAN).getLong ()         ), Expr.UNIT);
       case c_Const_String -> _jvm.constString(d);
-      case c_array_i8     -> _jvm.const_array_8  (constCl, d);
-      case c_array_i16    -> _jvm.const_array_i16(constCl, d);
-      case c_array_i32    -> _jvm.const_array_32 (constCl, d);
-      case c_array_i64    -> _jvm.const_array_64 (constCl, d);
-      case c_array_u8     -> _jvm.const_array_8  (constCl, d);
-      case c_array_u16    -> _jvm.const_array_u16(constCl, d);
-      case c_array_u32    -> _jvm.const_array_32 (constCl, d);
-      case c_array_u64    -> _jvm.const_array_64 (constCl, d);
-      case c_array_f32    -> _jvm.const_array_f32(constCl, d);
-      case c_array_f64    -> _jvm.const_array_f64(constCl, d);
+      case c_array_i8     -> _jvm.constArray8  (constCl, d);
+      case c_array_i16    -> _jvm.constArrayI16(constCl, d);
+      case c_array_i32    -> _jvm.constArray32 (constCl, d);
+      case c_array_i64    -> _jvm.constArray64 (constCl, d);
+      case c_array_u8     -> _jvm.constArray8  (constCl, d);
+      case c_array_u16    -> _jvm.constArrayU16(constCl, d);
+      case c_array_u32    -> _jvm.constArray32 (constCl, d);
+      case c_array_u64    -> _jvm.constArray64 (constCl, d);
+      case c_array_f32    -> _jvm.constArrayF32(constCl, d);
+      case c_array_f64    -> _jvm.constArrayF64(constCl, d);
       default             ->
         {
           Errors.error("Unsupported constant in JVM backend.",

--- a/src/dev/flang/be/jvm/CodeGen.java
+++ b/src/dev/flang/be/jvm/CodeGen.java
@@ -885,10 +885,9 @@ class CodeGen
     var c = createConstant(constCl, d);
     return switch (constantCreationStrategy(constCl))
       {
-      case onEveryUse               -> c;
-      case onUniverseInitialization ->
+      case onEveryUse               -> c;  // create constant inline
+      case onUniverseInitialization ->     // or create constant in universe' static initializer:
         {
-          var ucln = _names.javaClass(_fuir.clazzUniverse());
           var ucl = _types.classFile(_fuir.clazzUniverse());
           var f = _names.preallocatedConstantField(constCl, d);
           var jt = _types.javaType(constCl);
@@ -899,9 +898,9 @@ class CodeGen
                         jt.descriptor(),
                         new List<>());
               ucl.addToClInit(c._v1);
-              ucl.addToClInit(c._v0.andThen(Expr.putstatic(ucln, f, jt)));
+              ucl.addToClInit(c._v0.andThen(Expr.putstatic(ucl._name, f, jt)));
             }
-          yield new Pair<Expr, Expr>(Expr.getstatic(ucln, f, jt), Expr.UNIT);
+          yield new Pair<Expr, Expr>(Expr.getstatic(ucl._name, f, jt), Expr.UNIT);
         }
       };
   }

--- a/src/dev/flang/be/jvm/JVM.java
+++ b/src/dev/flang/be/jvm/JVM.java
@@ -1358,18 +1358,35 @@ should be avoided as much as possible.
   }
 
 
+  /**
+   * Create bytecode for a getfield instruction. In case !fieldExists(field),
+   * do nothing and return Expr.UNIT.
+   *
+   * @param field the clazz id of a field in _fuir.
+   *
+   * @return bytecode to get the value of the given field.
+   */
   Expr getfield(int field)
   {
     if (PRECONDITIONS) require
-      (fieldExists(field));
+      (fieldExists(field) || _types.resultType(_fuir.clazzResultClazz(field)) == PrimitiveType.type_void);
 
     var cl = _fuir.clazzOuterClazz(field);
     var rt = _fuir.clazzResultClazz(field);
-    return
-      Expr.comment("Getting field `" + _fuir.clazzAsString(field) + "` in `" + _fuir.clazzAsString(cl) + "`")
-      .andThen(Expr.getfield(_names.javaClass(cl),
-                             _names.field(field),
-                             _types.resultType(rt)));
+    if (fieldExists(field))
+      {
+        return
+          Expr.comment("Getting field `" + _fuir.clazzAsString(field) + "` in `" + _fuir.clazzAsString(cl) + "`")
+          .andThen(Expr.getfield(_names.javaClass(cl),
+                                 _names.field(field),
+                                 _types.resultType(rt)));
+      }
+    else
+      {
+        return
+          Expr.comment("Eliminated getfield since field does not exist: `" + _fuir.clazzAsString(field) + "` in `" + _fuir.clazzAsString(cl) + "`")
+          .andThen(Expr.POP);
+      }
   }
 
 

--- a/src/dev/flang/be/jvm/JVM.java
+++ b/src/dev/flang/be/jvm/JVM.java
@@ -1165,8 +1165,10 @@ should be avoided as much as possible.
     StringBuilder sb = new StringBuilder();
     for (var i = 0; i < bytes.length; i+=2)
       {
-        sb.append((char) ((bytes[i  ] & 0xff)      |
-                          (bytes[i+1] & 0xff) << 8   ));
+        var b0 = bytes[i];
+        var b1 = i+1 < bytes.length ? bytes[i+1] : (byte) 0;
+        sb.append((char) ((b0 & 0xff)      |
+                          (b1 & 0xff) << 8   ));
       }
     return Expr.stringconst(sb.toString());
   }

--- a/src/dev/flang/be/jvm/JVM.java
+++ b/src/dev/flang/be/jvm/JVM.java
@@ -1185,7 +1185,7 @@ should be avoided as much as possible.
    * @param bytes the byte data of the array contents in Fuzions serialized from
    * (little endian).
    */
-  Pair<Expr, Expr> const_array_8(int arrayCl, byte[] bytes)
+  Pair<Expr, Expr> constArray8(int arrayCl, byte[] bytes)
   {
     return const_array(arrayCl,
                        bytesArrayAsString(bytes)
@@ -1203,7 +1203,7 @@ should be avoided as much as possible.
    * @param bytes the byte data of the array contents in Fuzions serialized from
    * (little endian).
    */
-  Pair<Expr, Expr> const_array_i16(int arrayCl, byte[] bytes)
+  Pair<Expr, Expr> constArrayI16(int arrayCl, byte[] bytes)
   {
     return const_array(arrayCl,
                        bytesArrayAsString(bytes)
@@ -1220,7 +1220,7 @@ should be avoided as much as possible.
    * @param bytes the byte data of the array contents in Fuzions serialized from
    * (little endian).
    */
-  Pair<Expr, Expr> const_array_u16(int arrayCl, byte[] bytes)
+  Pair<Expr, Expr> constArrayU16(int arrayCl, byte[] bytes)
   {
     return const_array(arrayCl,
                        bytesArrayAsString(bytes)
@@ -1237,7 +1237,7 @@ should be avoided as much as possible.
    * @param bytes the byte data of the array contents in Fuzions serialized from
    * (little endian).
    */
-  Pair<Expr, Expr> const_array_32(int arrayCl, byte[] bytes)
+  Pair<Expr, Expr> constArray32(int arrayCl, byte[] bytes)
   {
     return const_array(arrayCl,
                        bytesArrayAsString(bytes)
@@ -1254,7 +1254,7 @@ should be avoided as much as possible.
    * @param bytes the byte data of the array contents in Fuzions serialized from
    * (little endian).
    */
-  Pair<Expr, Expr> const_array_64(int arrayCl, byte[] bytes)
+  Pair<Expr, Expr> constArray64(int arrayCl, byte[] bytes)
   {
     return const_array(arrayCl,
                        bytesArrayAsString(bytes)
@@ -1271,7 +1271,7 @@ should be avoided as much as possible.
    * @param bytes the byte data of the array contents in Fuzions serialized from
    * (little endian).
    */
-  Pair<Expr, Expr> const_array_f32(int arrayCl, byte[] bytes)
+  Pair<Expr, Expr> constArrayF32(int arrayCl, byte[] bytes)
   {
     return const_array(arrayCl,
                        bytesArrayAsString(bytes)
@@ -1288,7 +1288,7 @@ should be avoided as much as possible.
    * @param bytes the byte data of the array contents in Fuzions serialized from
    * (little endian).
    */
-  Pair<Expr, Expr> const_array_f64(int arrayCl, byte[] bytes)
+  Pair<Expr, Expr> constArrayF64(int arrayCl, byte[] bytes)
   {
     return const_array(arrayCl,
                        bytesArrayAsString(bytes)
@@ -1300,7 +1300,7 @@ should be avoided as much as possible.
 
 
   /**
-   * Create code to create a constant array i64.
+   * Create code to create a constant array.
    *
    * @param arrayCl the clazz of the array to be created
    *

--- a/src/dev/flang/be/jvm/JVM.java
+++ b/src/dev/flang/be/jvm/JVM.java
@@ -1144,6 +1144,7 @@ should be avoided as much as possible.
     return new Pair<>(res, Expr.UNIT);
   }
 
+
   /**
    * Create code to create a constant string.
    *
@@ -1152,6 +1153,172 @@ should be avoided as much as possible.
   Pair<Expr, Expr> constString(String str)
   {
     return constString(str.getBytes(StandardCharsets.UTF_8));
+  }
+
+
+  /**
+   * Create a constant Java String that contains the given bytes.  This string
+   * will be used to create a constant array at runtime.
+   */
+  Expr bytesArrayAsString(byte[] bytes)
+  {
+    StringBuilder sb = new StringBuilder();
+    for (var i = 0; i < bytes.length; i+=2)
+      {
+        sb.append((char) ((bytes[i  ] & 0xff)      |
+                          (bytes[i+1] & 0xff) << 8   ));
+      }
+    return Expr.stringconst(sb.toString());
+  }
+
+
+  /**
+   * Create code to create a constant `array i8` and `array u8`.
+   *
+   * @param bytes the byte data of the array contents in Fuzions serialized from
+   * (little endian).
+   */
+  Pair<Expr, Expr> const_array_8(int arrayCl, byte[] bytes)
+  {
+    return const_array(arrayCl,
+                       bytesArrayAsString(bytes)
+                       .andThen(Expr.iconst(bytes.length))
+                       .andThen(Expr.invokeStatic(Names.RUNTIME_CLASS,
+                                                  Names.RUNTIME_INTERNAL_ARRAY_FOR_ARRAY_8,
+                                                  Names.RUNTIME_INTERNAL_ARRAY_FOR_ARRAY_8_SIG,
+                                                  PrimitiveType.type_byte.array())));
+  }
+
+
+  /**
+   * Create code to create a constant `array i16`.
+   *
+   * @param bytes the byte data of the array contents in Fuzions serialized from
+   * (little endian).
+   */
+  Pair<Expr, Expr> const_array_i16(int arrayCl, byte[] bytes)
+  {
+    return const_array(arrayCl,
+                       bytesArrayAsString(bytes)
+                       .andThen(Expr.invokeStatic(Names.RUNTIME_CLASS,
+                                                  Names.RUNTIME_INTERNAL_ARRAY_FOR_ARRAY_I16,
+                                                  Names.RUNTIME_INTERNAL_ARRAY_FOR_ARRAY_I16_SIG,
+                                                  PrimitiveType.type_byte.array())));
+  }
+
+
+  /**
+   * Create code to create a constant `array u16`.
+   *
+   * @param bytes the byte data of the array contents in Fuzions serialized from
+   * (little endian).
+   */
+  Pair<Expr, Expr> const_array_u16(int arrayCl, byte[] bytes)
+  {
+    return const_array(arrayCl,
+                       bytesArrayAsString(bytes)
+                       .andThen(Expr.invokeStatic(Names.RUNTIME_CLASS,
+                                                  Names.RUNTIME_INTERNAL_ARRAY_FOR_ARRAY_U16,
+                                                  Names.RUNTIME_INTERNAL_ARRAY_FOR_ARRAY_U16_SIG,
+                                                  PrimitiveType.type_byte.array())));
+  }
+
+
+  /**
+   * Create code to create a constants `array i32` and `array u32`.
+   *
+   * @param bytes the byte data of the array contents in Fuzions serialized from
+   * (little endian).
+   */
+  Pair<Expr, Expr> const_array_32(int arrayCl, byte[] bytes)
+  {
+    return const_array(arrayCl,
+                       bytesArrayAsString(bytes)
+                       .andThen(Expr.invokeStatic(Names.RUNTIME_CLASS,
+                                                  Names.RUNTIME_INTERNAL_ARRAY_FOR_ARRAY_32,
+                                                  Names.RUNTIME_INTERNAL_ARRAY_FOR_ARRAY_32_SIG,
+                                                  PrimitiveType.type_byte.array())));
+  }
+
+
+  /**
+   * Create code to create a constant `array i64` and `array u64`.
+   *
+   * @param bytes the byte data of the array contents in Fuzions serialized from
+   * (little endian).
+   */
+  Pair<Expr, Expr> const_array_64(int arrayCl, byte[] bytes)
+  {
+    return const_array(arrayCl,
+                       bytesArrayAsString(bytes)
+                       .andThen(Expr.invokeStatic(Names.RUNTIME_CLASS,
+                                                  Names.RUNTIME_INTERNAL_ARRAY_FOR_ARRAY_64,
+                                                  Names.RUNTIME_INTERNAL_ARRAY_FOR_ARRAY_64_SIG,
+                                                  PrimitiveType.type_byte.array())));
+  }
+
+
+  /**
+   * Create code to create a constants `array f32`.
+   *
+   * @param bytes the byte data of the array contents in Fuzions serialized from
+   * (little endian).
+   */
+  Pair<Expr, Expr> const_array_f32(int arrayCl, byte[] bytes)
+  {
+    return const_array(arrayCl,
+                       bytesArrayAsString(bytes)
+                       .andThen(Expr.invokeStatic(Names.RUNTIME_CLASS,
+                                                  Names.RUNTIME_INTERNAL_ARRAY_FOR_ARRAY_F32,
+                                                  Names.RUNTIME_INTERNAL_ARRAY_FOR_ARRAY_F32_SIG,
+                                                  PrimitiveType.type_byte.array())));
+  }
+
+
+  /**
+   * Create code to create a constant `array f64`.
+   *
+   * @param bytes the byte data of the array contents in Fuzions serialized from
+   * (little endian).
+   */
+  Pair<Expr, Expr> const_array_f64(int arrayCl, byte[] bytes)
+  {
+    return const_array(arrayCl,
+                       bytesArrayAsString(bytes)
+                       .andThen(Expr.invokeStatic(Names.RUNTIME_CLASS,
+                                                  Names.RUNTIME_INTERNAL_ARRAY_FOR_ARRAY_F64,
+                                                  Names.RUNTIME_INTERNAL_ARRAY_FOR_ARRAY_F64_SIG,
+                                                  PrimitiveType.type_byte.array())));
+  }
+
+
+  /**
+   * Create code to create a constant array i64.
+   *
+   * @param arrayCl the clazz of the array to be created
+   *
+   * @param bytes the bytes of the array as a Java string.
+   */
+  Pair<Expr, Expr> const_array(int arrayCl, Expr bytes)
+  {
+    var internalArray  = _fuir.lookup_array_internal_array(arrayCl);
+    var fuzionSysArray = _fuir.clazzResultClazz(internalArray);
+    var data           = _fuir.lookup_fuzion_sys_internal_array_data  (fuzionSysArray);
+    var length         = _fuir.lookup_fuzion_sys_internal_array_length(fuzionSysArray);
+    var res = new0(arrayCl)                           // stack: cs
+      .andThen(Expr.DUP)                              //        cs, cs
+      .andThen(new0(fuzionSysArray))                  //        cs, cs, fsa
+      .andThen(Expr.DUP)                              //        cs, cs, fsa, fsa
+      .andThen(bytes)                                 //        cs, cs, fsa, fsa, byt
+      .andThen(Expr.DUP_X2)                           //        cs, cs, byt, fsa, fsa, byt
+      .andThen(putfield(data))                        //        cs, cs, byt, fsa
+      .andThen(Expr.DUP_X1)                           //        cs, cs, fsa, byt, fsa
+      .andThen(Expr.SWAP)                             //        cs, cs, fsa, fsa, byt
+      .andThen(Expr.ARRAYLENGTH)                      //        cs, cs, fsa, fsa, len
+      .andThen(putfield(length))                      //        cs, cs, fsa
+      .andThen(putfield(internalArray))               //        cs
+      .is(_types.javaType(arrayCl));                  //        -
+    return new Pair<>(res, Expr.UNIT);
   }
 
 
@@ -1182,18 +1349,31 @@ should be avoided as much as possible.
   }
 
 
+  /**
+   * Create bytecode for a putfield instruction. In case !fieldExists(field),
+   * pop the value and the target instance ref from the stack.
+   */
   Expr putfield(int field)
   {
-    if (PRECONDITIONS) require
-      (fieldExists(field));
-
     var cl = _fuir.clazzOuterClazz(field);
     var rt = _fuir.clazzResultClazz(field);
-    return
-      Expr.comment("Setting field `" + _fuir.clazzAsString(field) + "` in `" + _fuir.clazzAsString(cl) + "`")
-      .andThen(Expr.putfield(_names.javaClass(cl),
-                             _names.field(field),
-                             _types.resultType(rt)));
+    if (fieldExists(field))
+      {
+        return
+          Expr.comment("Setting field `" + _fuir.clazzAsString(field) + "` in `" + _fuir.clazzAsString(cl) + "`")
+          .andThen(Expr.putfield(_names.javaClass(cl),
+                                 _names.field(field),
+                                 _types.resultType(rt)));
+      }
+    else
+      {
+        var popv = _types.javaType(rt).pop();
+        return
+          Expr.comment("Eliminated putfield since field does not exist: `" + _fuir.clazzAsString(field) + "` in `" + _fuir.clazzAsString(cl) + "`")
+          .andThen(popv)
+          .andThen(Expr.POP);
+
+      }
   }
 
 }

--- a/src/dev/flang/be/jvm/JVM.java
+++ b/src/dev/flang/be/jvm/JVM.java
@@ -1157,8 +1157,13 @@ should be avoided as much as possible.
 
 
   /**
-   * Create a constant Java String that contains the given bytes.  This string
+   * Create a constant Java String that contains the given bytes.  This String
    * will be used to create a constant array at runtime.
+   *
+   * @param bytes the bytes of a serialized constant.
+   *
+   * @return expression that results in a Java string with the bytes from bytes
+   * in its characters in little endian order.
    */
   Expr bytesArrayAsString(byte[] bytes)
   {
@@ -1324,6 +1329,23 @@ should be avoided as much as possible.
   }
 
 
+  /**
+   * Does given field exist as a Java field? This is the case for fields that
+   *
+   *  - contain data (are not unit types),
+   *
+   *  - whose outer type is not a primitive (scalar) type (i.e., i32.val does
+   *    not exist!),
+   *
+   *  - that needs code
+   *
+   *  - whose Java type is not 'void ' (which might happen for choice types that
+   *    are effectively unit types).
+   *
+   * @param field the clazz id of a field in _fuir.
+   *
+   * @return true if a Java field exists for the given field.
+   */
   boolean fieldExists(int field)
   {
     var occ   = _fuir.clazzOuterClazz(field);
@@ -1354,6 +1376,8 @@ should be avoided as much as possible.
   /**
    * Create bytecode for a putfield instruction. In case !fieldExists(field),
    * pop the value and the target instance ref from the stack.
+   *
+   * @param field the clazz id of a field in _fuir.
    */
   Expr putfield(int field)
   {

--- a/src/dev/flang/be/jvm/JVMOptions.java
+++ b/src/dev/flang/be/jvm/JVMOptions.java
@@ -20,7 +20,7 @@ Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
  *
  * Tokiwa Software GmbH, Germany
  *
- * Source of class COptions
+ * Source of class JVMOptions
  *
  *---------------------------------------------------------------------*/
 
@@ -38,6 +38,37 @@ import java.util.ArrayList;
  */
 public class JVMOptions extends FuzionOptions
 {
+
+
+  /*----------------------------  constnats  ----------------------------*/
+
+
+  /**
+   * Strategies for creation of instances for compile-time constants
+   */
+  public enum ConstantCreation
+  {
+    /**
+     * Create a new instance of a constant every time it is used.  This is ideal
+     * if the code using the constant is executed at most once, but fairly
+     * inefficient in case it is use repeatedly.
+     */
+    onEveryUse,
+
+    /**
+     * Create instances when the universe is initialized.  This is good if a
+     * constant is used repeatedly, but it adds startup overhead and wasted
+     * resources for constants used in code that is never exectued or executed
+     * only very infrequently (such as error handling code after a fatal error).
+     */
+    onUniverseInitialization;
+
+    /* There might be other alternatives, i.e., create constants on first use
+     * and cache them, or create constants on first use of the surrounding
+     * features, etc.
+     */
+  }
+
 
 
   /*----------------------------  variables  ----------------------------*/
@@ -71,6 +102,12 @@ public class JVMOptions extends FuzionOptions
    * List of arguments to pass to the program, if it is run immediately.
    */
   final ArrayList<String> _applicationArgs;
+
+
+  /**
+   * Constant creation strategy to be used for non-primitiv-type constants.
+   */
+  final ConstantCreation _constantCreationStrategy = ConstantCreation.onUniverseInitialization;
 
 
   /*--------------------------  constructors  ---------------------------*/

--- a/src/dev/flang/be/jvm/Names.java
+++ b/src/dev/flang/be/jvm/Names.java
@@ -20,7 +20,7 @@ Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
  *
  * Tokiwa Software GmbH, Germany
  *
- * Source of class CNames
+ * Source of class Names
  *
  *---------------------------------------------------------------------*/
 
@@ -88,7 +88,20 @@ public class Names extends ANY implements ClassFileConstants
    */
   static final String RUNTIME_INTERNAL_ARRAY_FOR_CONST_STRING     = "internalArrayForConstString";
   static final String RUNTIME_INTERNAL_ARRAY_FOR_CONST_STRING_SIG = "(Ljava/lang/String;)[B";
-
+  static final String RUNTIME_INTERNAL_ARRAY_FOR_ARRAY_8          = "constArray8FromString";
+  static final String RUNTIME_INTERNAL_ARRAY_FOR_ARRAY_8_SIG      = "(Ljava/lang/String;I)[B";
+  static final String RUNTIME_INTERNAL_ARRAY_FOR_ARRAY_I16        = "constArrayI16FromString";
+  static final String RUNTIME_INTERNAL_ARRAY_FOR_ARRAY_I16_SIG    = "(Ljava/lang/String;)[S";
+  static final String RUNTIME_INTERNAL_ARRAY_FOR_ARRAY_U16        = "constArrayU16FromString";
+  static final String RUNTIME_INTERNAL_ARRAY_FOR_ARRAY_U16_SIG    = "(Ljava/lang/String;)[C";
+  static final String RUNTIME_INTERNAL_ARRAY_FOR_ARRAY_32         = "constArray32FromString";
+  static final String RUNTIME_INTERNAL_ARRAY_FOR_ARRAY_32_SIG     = "(Ljava/lang/String;)[I";
+  static final String RUNTIME_INTERNAL_ARRAY_FOR_ARRAY_64         = "constArray64FromString";
+  static final String RUNTIME_INTERNAL_ARRAY_FOR_ARRAY_64_SIG     = "(Ljava/lang/String;)[J";
+  static final String RUNTIME_INTERNAL_ARRAY_FOR_ARRAY_F32        = "constArrayF32FromString";
+  static final String RUNTIME_INTERNAL_ARRAY_FOR_ARRAY_F32_SIG    = "(Ljava/lang/String;)[F";
+  static final String RUNTIME_INTERNAL_ARRAY_FOR_ARRAY_F64        = "constArrayF64FromString";
+  static final String RUNTIME_INTERNAL_ARRAY_FOR_ARRAY_F64_SIG    = "(Ljava/lang/String;)[D";
 
   /**
    * Name and signature of Runtime.effect_get()
@@ -165,6 +178,12 @@ public class Names extends ANY implements ClassFileConstants
    * each tag number for a unit type that contain preallocated references.
    */
   static final String CHOICE_UNIT_AS_REF_PREFIX = "fzU_";
+
+
+  /**
+   * Prefix for static fields in universe to hold pre-allocated constants
+   */
+  static final String PREALLOCATED_CONSTANT_PREFIX = "fzK_";
 
 
   /*----------------------------  variables  ----------------------------*/
@@ -353,6 +372,13 @@ public class Names extends ANY implements ClassFileConstants
    * Unique mapping from base names to mangled base names.
    */
   TreeMap<String,String> _simpleBaseNames = new TreeMap<>();
+
+
+  /**
+   * Map from PreallocatedConstants to field names if static field in
+   * fzC_univers that hold these constant values.
+   */
+  TreeMap<PreallocatedConstant, String> _preallocatedConstantFieldNames = new TreeMap<>();
 
 
   /*---------------------------  constructors  ---------------------------*/
@@ -577,6 +603,30 @@ public class Names extends ANY implements ClassFileConstants
     var tc = _fuir.clazzChoice(cc, tagNum);
     return _fuir.clazzIsRef(tc) ? CHOICE_REF_ENTRY_NAME
                                 : CHOICE_ENTRY_NAME + tagNum;
+  }
+
+
+  /**
+   * Get the field name for a static field in fzC_universo to hold a constant
+   * with given type and data.
+   *
+   * @param constCl the clazz of the type of the constant.
+   *
+   * @param data the constant value in serialized form
+   *
+   * @return the name of the (new or existing) static field to be declared to
+   * hold this constant.
+   */
+  String preallocatedConstantField(int constCl, byte[] data)
+  {
+    var c = new PreallocatedConstant(constCl, data);
+    var result = _preallocatedConstantFieldNames.get(c);
+    if (result == null)
+      {
+        result = PREALLOCATED_CONSTANT_PREFIX + _preallocatedConstantFieldNames.size() + "_" + _classNames.get(constCl);
+        _preallocatedConstantFieldNames.put(c, result);
+      }
+    return result;
   }
 
 }

--- a/src/dev/flang/be/jvm/PreallocatedConstant.java
+++ b/src/dev/flang/be/jvm/PreallocatedConstant.java
@@ -1,0 +1,105 @@
+/*
+
+This file is part of the Fuzion language implementation.
+
+The Fuzion language implementation is free software: you can redistribute it
+and/or modify it under the terms of the GNU General Public License as published
+by the Free Software Foundation, version 3 of the License.
+
+The Fuzion language implementation is distributed in the hope that it will be
+useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+License for more details.
+
+You should have received a copy of the GNU General Public License along with The
+Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+*/
+
+/*-----------------------------------------------------------------------
+ *
+ * Tokiwa Software GmbH, Germany
+ *
+ * Source of class PreallocatedConstant
+ *
+ *---------------------------------------------------------------------*/
+
+package dev.flang.be.jvm;
+
+import dev.flang.util.ANY;
+
+
+/**
+ * PreallocatedConstant is a pair of a clazz that defines a type of a constant
+ * and the serialized value of the constant.  It is used to find duplicates
+ * in constants.
+ *
+ * @author Fridtjof Siebert (siebert@tokiwa.software)
+ */
+class PreallocatedConstant extends ANY implements Comparable<PreallocatedConstant>
+{
+
+
+  /*----------------------------  variables  ----------------------------*/
+
+
+  /**
+   * The clazz of the constant
+   */
+  final int _constClazz;
+
+
+  /**
+   * The serialized byte data of the constnat
+   */
+  final byte[] _data;
+
+
+  /*---------------------------  constructors  --------------------------*/
+
+
+  /**
+   * Create instance of preallocated constant
+   *
+   * @param constCl the type of the constant
+   *
+   * @param data the serialized byte data
+   */
+  PreallocatedConstant(int constCl, byte[] data)
+  {
+    if (PRECONDITIONS) require
+      (data != null);
+
+    this._constClazz = constCl;
+    this._data = data;
+  }
+
+
+  /*-----------------------------  methods  -----------------------------*/
+
+
+  /**
+   * Compare operation.
+   */
+  public int compareTo(PreallocatedConstant other)
+  {
+    int result =
+      _constClazz  < other._constClazz  ? -1 :
+      _constClazz  > other._constClazz  ? +1 :
+      _data.length < other._data.length ? -1 :
+      _data.length > other._data.length ? -1 : 0;
+
+    for (int i = 0; result == 0 && i < _data.length; i++)
+      {
+        result =
+          _data[i] < other._data[i] ? -1 :
+          _data[i] > other._data[i] ? +1 : 0;
+      }
+
+    return result;
+  }
+
+
+}
+
+/* end of file */

--- a/src/dev/flang/be/jvm/classfile/ClassFile.java
+++ b/src/dev/flang/be/jvm/classfile/ClassFile.java
@@ -908,6 +908,15 @@ public class ClassFile extends ANY implements ClassFileConstants
   final List<Method> _methods = new List<>();
   final List<Attribute> _attributes = new List<>();
 
+  /**
+   * True if this class was finished by a call to finish().
+   */
+  boolean _finished = false;
+
+  /**
+   * static initializer code or null if none. Modified via calls to addToClInit.
+   */
+  Expr _clinitCode = null;
 
   /*---------------------------  constructors  ---------------------------*/
 
@@ -984,6 +993,7 @@ public class ClassFile extends ANY implements ClassFileConstants
    */
   public byte[] bytes()
   {
+    finish();
     var o = new Kaku();
     o.write(MAGIC);
     o.write(_version);
@@ -1131,6 +1141,46 @@ public class ClassFile extends ANY implements ClassFileConstants
   public ClassType classType()
   {
     return _type;
+  }
+
+
+  /**
+   * Add given code to the static initializer of this clazz.
+   *
+   * @param code the code to add.
+   */
+  public void addToClInit(Expr code)
+  {
+    if (PRECONDITIONS) require
+      (!_finished);
+
+    if (code != Expr.UNIT)
+      {
+        _clinitCode = _clinitCode == null ? code
+                                          : _clinitCode.andThen(code);
+      }
+  }
+
+
+  /**
+   * Finish this clazz and prepare it for writing. This will add a static
+   * initializer if code was added via addToClInit.
+   */
+  private void finish()
+  {
+    if (PRECONDITIONS) require
+      (!_finished);
+
+    _finished = true;
+    var bc_clinit = _clinitCode;
+    if (bc_clinit != null)
+      {
+        bc_clinit = bc_clinit
+          .andThen(Expr.RETURN);
+        var code_clinit = codeAttribute("<clinit> in class for " + _name,
+                                        bc_clinit, new List<>(), new List<>());
+        method(ACC_PUBLIC | ACC_STATIC, "<clinit>", "()V", new List<>(code_clinit));
+      }
   }
 
 

--- a/src/dev/flang/be/jvm/classfile/ClassFileConstants.java
+++ b/src/dev/flang/be/jvm/classfile/ClassFileConstants.java
@@ -626,9 +626,10 @@ public interface ClassFileConstants
     return switch (s)
       {
         case "V" -> PrimitiveType.type_void;
-        case "I" -> PrimitiveType.type_int;
         case "B" -> PrimitiveType.type_byte;
         case "S" -> PrimitiveType.type_short;
+        case "C" -> PrimitiveType.type_char;
+        case "I" -> PrimitiveType.type_int;
         case "J" -> PrimitiveType.type_long;
         case "F" -> PrimitiveType.type_float;
         case "D" -> PrimitiveType.type_double;

--- a/src/dev/flang/be/jvm/runtime/Runtime.java
+++ b/src/dev/flang/be/jvm/runtime/Runtime.java
@@ -212,9 +212,166 @@ public class Runtime extends ANY
   }
 
 
+  /**
+   * Create the internal (Java) array for a `Const_String` from data in the
+   * chars of a Java String.
+   *
+   * @param str the Java string as unicodes.
+   *
+   * @return the resulting array using utf_8 encoded bytes
+   */
   public static byte[] internalArrayForConstString(String str)
   {
     return str.getBytes(StandardCharsets.UTF_8);
+  }
+
+
+  /**
+   * Create the internal (Java) array for an `array i8` or `array u8` from data
+   * in the chars of a Java String.
+   *
+   * @param str the Java string, lower byte is the first, upper the second byte.
+   *
+   * @param len the length of the resulting byte[]
+   *
+   * @return the resulting array.
+   */
+  public static byte[] constArray8FromString(String str, int len)
+  {
+    var result = new byte[len];
+    for (var i = 0; i < result.length; i++)
+      {
+        var c = str.charAt(i/2);
+        result[i] = (byte) (i % 2 == 0 ? c : c >> 8);
+      }
+    return result;
+  }
+
+
+  /**
+   * Create the internal (Java) array for an `array i16` from data in the chars
+   * of a Java String.
+   *
+   * @param str the Java string, each char is one i16.
+   *
+   * @return the resulting array.
+   */
+  public static short[] constArrayI16FromString(String str)
+  {
+    var result = new short[str.length()];
+    for (var i = 0; i < result.length; i++)
+      {
+        result[i] = (short) str.charAt(i);
+      }
+    return result;
+  }
+
+
+  /**
+   * Create the internal (Java) array for an `array u16` from data in the chars
+   * of a Java String.
+   *
+   * @param str the Java string, each char is one u16.
+   *
+   * @return the resulting array.
+   */
+  public static char[] constArrayU16FromString(String str)
+  {
+    var result = new char[str.length()];
+    for (var i = 0; i < result.length; i++)
+      {
+        result[i] = str.charAt(i);
+      }
+    return result;
+  }
+
+
+  /**
+   * Create the internal (Java) array for an `array i32` or `array u32` from
+   * data in the chars of a Java String.
+   *
+   * @param str the Java string, two char form one i32 or u32 in little endian order.
+   *
+   * @return the resulting array.
+   */
+  public static int[] constArray32FromString(String str)
+  {
+    var result = new int[str.length() / 2];
+    for (var i = 0; i < result.length; i++)
+      {
+        result[i] =
+          ((str.charAt(2*i + 0) & 0xffff)      ) |
+          ((str.charAt(2*i + 1) & 0xffff) << 16) ;
+      }
+    return result;
+  }
+
+
+  /**
+   * Create the internal (Java) array for an `array i64` or `array u64` from
+   * data in the chars of a Java String.
+   *
+   * @param str the Java string, four char form one i64 or u64 in little endian
+   * order.
+   *
+   * @return the resulting array.
+   */
+  public static long[] constArray64FromString(String str)
+  {
+    var result = new long[str.length() / 4];
+    for (var i = 0; i < result.length; i++)
+      {
+        result[i] =
+          ((str.charAt(4*i + 0) & 0xffffL)      ) |
+          ((str.charAt(4*i + 1) & 0xffffL) << 16) |
+          ((str.charAt(4*i + 2) & 0xffffL) << 32) |
+          ((str.charAt(4*i + 3) & 0xffffL) << 48) ;
+      }
+    return result;
+  }
+
+
+  /**
+   * Create the internal (Java) array for an `array f32` from data in the chars
+   * of a Java String.
+   *
+   * @param str the Java string, two chars form the bits of one f32 in little
+   * endian order.
+   *
+   * @return the resulting array.
+   */
+  public static float[] constArrayF32FromString(String str)
+  {
+    var result = new float[str.length() / 2];
+    for (var i = 0; i < result.length; i++)
+      {
+        result[i] = Float.intBitsToFloat(((str.charAt(2*i + 0) & 0xffff)      ) |
+                                         ((str.charAt(2*i + 1) & 0xffff) << 16) );
+      }
+    return result;
+  }
+
+
+  /**
+   * Create the internal (Java) array for an `array f64` from data in the chars
+   * of a Java String.
+   *
+   * @param str the Java string, four chars form the bits of one f64 in little
+   * endian order.
+   *
+   * @return the resulting array.
+   */
+  public static double[] constArrayF64FromString(String str)
+  {
+    var result = new double[str.length() / 4];
+    for (var i = 0; i < result.length; i++)
+      {
+        result[i] = Double.longBitsToDouble(((str.charAt(4*i + 0) & 0xffffL)      ) |
+                                            ((str.charAt(4*i + 1) & 0xffffL) << 16) |
+                                            ((str.charAt(4*i + 2) & 0xffffL) << 32) |
+                                            ((str.charAt(4*i + 3) & 0xffffL) << 48) );
+      }
+    return result;
   }
 
 

--- a/src/dev/flang/fe/LibraryFeature.java
+++ b/src/dev/flang/fe/LibraryFeature.java
@@ -615,7 +615,7 @@ public class LibraryFeature extends AbstractFeature
                 {
                   public AbstractType type() { return t; }
                   public byte[] data() { return d; }
-                  public Expr visit(FeatureVisitor v, AbstractFeature af) { return this; };
+                  public Expr visit(FeatureVisitor v, AbstractFeature af) { v.action(this); return this; };
                   public String toString() { return "LibraryFeature.Constant of type "+type(); }
                   public SourcePosition pos() { return LibraryFeature.this.pos(fpos); }
                 };

--- a/src/dev/flang/fuir/FUIR.java
+++ b/src/dev/flang/fuir/FUIR.java
@@ -120,6 +120,16 @@ public class FUIR extends IR
     c_Const_String{ Clazz getIfCreated() { return Clazzes.Const_String.getIfCreated(); } },
     c_sys_ptr     { Clazz getIfCreated() { return Clazzes.fuzionSysPtr;               } },
     c_unit        { Clazz getIfCreated() { return Clazzes.c_unit     .getIfCreated(); } },
+    c_array_i8    { Clazz getIfCreated() { return Clazzes.array_i8   .getIfCreated(); } },
+    c_array_i16   { Clazz getIfCreated() { return Clazzes.array_i16  .getIfCreated(); } },
+    c_array_i32   { Clazz getIfCreated() { return Clazzes.array_i32  .getIfCreated(); } },
+    c_array_i64   { Clazz getIfCreated() { return Clazzes.array_i64  .getIfCreated(); } },
+    c_array_u8    { Clazz getIfCreated() { return Clazzes.array_u8   .getIfCreated(); } },
+    c_array_u16   { Clazz getIfCreated() { return Clazzes.array_u16  .getIfCreated(); } },
+    c_array_u32   { Clazz getIfCreated() { return Clazzes.array_u32  .getIfCreated(); } },
+    c_array_u64   { Clazz getIfCreated() { return Clazzes.array_u64  .getIfCreated(); } },
+    c_array_f32   { Clazz getIfCreated() { return Clazzes.array_f32  .getIfCreated(); } },
+    c_array_f64   { Clazz getIfCreated() { return Clazzes.array_f64  .getIfCreated(); } },
 
     // dummy entry to report failure of getSpecialId()
     c_NOT_FOUND   { Clazz getIfCreated() { return null;                               } };
@@ -1760,11 +1770,15 @@ hw25 is
     else if (t.compareTo(Types.resolved.t_f32   ) == 0) { clazz = Clazzes.f32        .getIfCreated(); }
     else if (t.compareTo(Types.resolved.t_f64   ) == 0) { clazz = Clazzes.f64        .getIfCreated(); }
     else if (t.compareTo(Types.resolved.t_string) == 0) { clazz = Clazzes.Const_String.getIfCreated(); } // NYI: a slight inconsistency here, need to change AST
+    else if (ic instanceof AbstractConstant)
+      {
+        clazz = Clazzes.clazz(t);
+      }
     else if (ic instanceof InlineArray)
       {
         throw new Error("NYI: FUIR support for InlineArray still missing");
       }
-    else { throw new Error("Unexpected type for ExprKind.Const: " + t); }
+    else { throw new Error("Unexpected type for ExprKind.Const: " + t + ", expr: " + ic); }
     return id(clazz);
   }
 

--- a/src/dev/flang/fuir/FUIR.java
+++ b/src/dev/flang/fuir/FUIR.java
@@ -1958,13 +1958,12 @@ hw25 is
    * 'abortable' that has to create code to call 'call'.
    *
    * @param cl index of a clazz that is an heir of 'Function'.
+   *
+   * @return the index of the requested `Functionl.call` method's clazz.
    */
   public int lookupCall(int cl)
   {
-    var cc = clazz(cl);
-    var call = Types.resolved.f_function_call;
-    var ic = cc.lookup(call);
-    return id(ic);
+    return lookup(cl, Types.resolved.f_function_call);
   }
 
 
@@ -1972,12 +1971,69 @@ hw25 is
    * For a clazz of concur.atomic, lookup the inner clazz of the value field.
    *
    * @param cl index of a clazz representing cl's value field
+   *
+   * @return the index of the requested `concur.atomic.value` field's clazz.
    */
   public int lookupAtomicValue(int cl)
   {
+    return lookup(cl, Types.resolved.f_concur_atomic_v);
+  }
+
+
+  /**
+   * For a clazz of array, lookup the inner clazz of the internal_array field.
+   *
+   * @param cl index of a clazz `array T` for some type parameter `T`
+   *
+   * @return the index of the requested `array.internal_array` field's clazz.
+   */
+  public int lookup_array_internal_array(int cl)
+  {
+    return lookup(cl, Types.resolved.f_array_internal_array);
+  }
+
+
+  /**
+   * For a clazz of fuzion.sys.internal_array, lookup the inner clazz of the
+   * data field.
+   *
+   * @param cl index of a clazz `fuzion.sys.internal_array T` for some type parameter `T`
+   *
+   * @return the index of the requested `fuzion.sys.internal_array.data` field's clazz.
+   */
+  public int lookup_fuzion_sys_internal_array_data(int cl)
+  {
+    return lookup(cl, Types.resolved.f_fuzion_sys_array_data);
+  }
+
+
+  /**
+   * For a clazz of fuzion.sys.internal_array, lookup the inner clazz of the
+   * length field.
+   *
+   * @param cl index of a clazz `fuzion.sys.internal_array T` for some type parameter `T`
+   *
+   * @return the index of the requested `fuzion.sys.internal_array.length` field's clazz.
+   */
+  public int lookup_fuzion_sys_internal_array_length(int cl)
+  {
+    return lookup(cl, Types.resolved.f_fuzion_sys_array_length);
+  }
+
+
+  /**
+   * Internal helper for lookup_* methods.
+   *
+   * @param cl index of the outer clazz for the lookup
+   *
+   * @param f the feature we look for
+   *
+   * @return the index of the requested inner clazz.
+   */
+  private int lookup(int cl, AbstractFeature f)
+  {
     var cc = clazz(cl);
-    var v = Types.resolved.f_concur_atomic_v;
-    var ic = cc.lookup(v);
+    var ic = cc.lookup(f);
     return id(ic);
   }
 

--- a/src/dev/flang/fuir/analysis/AbstractInterpreter.java
+++ b/src/dev/flang/fuir/analysis/AbstractInterpreter.java
@@ -502,7 +502,7 @@ public class AbstractInterpreter<VALUE, RESULT> extends ANY
     if (!containsVoid(stack) && stack.size() > 0)
       { // NYI: #1875: Manual stack cleanup.  This should not be needed since the
         // FUIR has the (so far undocumented) invariant that the stack must be
-        // empty at the end of a basic block. There ware some cases
+        // empty at the end of a basic block. There were some cases
         // (tests/reg_issue1294) where this is not the case that need to be
         // fixed, the FUIR code should contain a POP instructions to avoid this
         // special handling here!

--- a/src/dev/flang/fuir/analysis/dfa/Call.java
+++ b/src/dev/flang/fuir/analysis/dfa/Call.java
@@ -236,6 +236,16 @@ public class Call extends ANY implements Comparable<Call>, Context
                   case c_unit                    -> Value.UNIT;
                   case c_sys_ptr                 -> new Value(_cc); // NYI: we might add a specific value for system pointers
                   case c_NOT_FOUND               -> null;
+                  case c_array_i8  -> throw new Error("intrinsics do not return const arrays.");
+                  case c_array_i16 -> throw new Error("intrinsics do not return const arrays.");
+                  case c_array_i32 -> throw new Error("intrinsics do not return const arrays.");
+                  case c_array_i64 -> throw new Error("intrinsics do not return const arrays.");
+                  case c_array_u8  -> throw new Error("intrinsics do not return const arrays.");
+                  case c_array_u16 -> throw new Error("intrinsics do not return const arrays.");
+                  case c_array_u32 -> throw new Error("intrinsics do not return const arrays.");
+                  case c_array_u64 -> throw new Error("intrinsics do not return const arrays.");
+                  case c_array_f32 -> throw new Error("intrinsics do not return const arrays.");
+                  case c_array_f64 -> throw new Error("intrinsics do not return const arrays.");
                   };
               }
           }

--- a/src/dev/flang/fuir/analysis/dfa/Call.java
+++ b/src/dev/flang/fuir/analysis/dfa/Call.java
@@ -236,16 +236,11 @@ public class Call extends ANY implements Comparable<Call>, Context
                   case c_unit                    -> Value.UNIT;
                   case c_sys_ptr                 -> new Value(_cc); // NYI: we might add a specific value for system pointers
                   case c_NOT_FOUND               -> null;
-                  case c_array_i8  -> throw new Error("intrinsics do not return const arrays.");
-                  case c_array_i16 -> throw new Error("intrinsics do not return const arrays.");
-                  case c_array_i32 -> throw new Error("intrinsics do not return const arrays.");
-                  case c_array_i64 -> throw new Error("intrinsics do not return const arrays.");
-                  case c_array_u8  -> throw new Error("intrinsics do not return const arrays.");
-                  case c_array_u16 -> throw new Error("intrinsics do not return const arrays.");
-                  case c_array_u32 -> throw new Error("intrinsics do not return const arrays.");
-                  case c_array_u64 -> throw new Error("intrinsics do not return const arrays.");
-                  case c_array_f32 -> throw new Error("intrinsics do not return const arrays.");
-                  case c_array_f64 -> throw new Error("intrinsics do not return const arrays.");
+                  case c_array_i8 , c_array_i16,
+                       c_array_i32, c_array_i64,
+                       c_array_u8 , c_array_u16,
+                       c_array_u32, c_array_u64,
+                       c_array_f32, c_array_f64 -> throw new Error("intrinsics do not return const arrays.");
                   };
               }
           }

--- a/src/dev/flang/fuir/analysis/dfa/DFA.java
+++ b/src/dev/flang/fuir/analysis/dfa/DFA.java
@@ -1268,7 +1268,7 @@ public class DFA extends ANY
     put("fuzion.sys.fileio.lstats"       , cl -> cl._dfa._bool ); // NYI : manipulation of an array passed as argument needs to be tracked and recorded
     put("fuzion.sys.fileio.seek"         , cl -> Value.UNIT ); // NYI : manipulation of an array passed as argument needs to be tracked and recorded
     put("fuzion.sys.fileio.file_position", cl -> Value.UNIT ); // NYI : manipulation of an array passed as argument needs to be tracked and recorded
-    put("fuzion.sys.fileio.mmap"         , cl -> new SysArray(cl._dfa, new byte[0])); // NYI: length wrong, get from arg
+    put("fuzion.sys.fileio.mmap"         , cl -> new SysArray(cl._dfa, new NumericValue(cl._dfa, cl._dfa._fuir.clazz(FUIR.SpecialClazzes.c_u8)))); // NYI: length wrong, get from arg
     put("fuzion.sys.fileio.munmap"       , cl -> new NumericValue(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc)) );
     put("fuzion.sys.fileio.flush"        , cl -> new NumericValue(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc)) );
     put("fuzion.sys.stdin.stdin0"        , cl -> new NumericValue(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc)) );
@@ -1478,7 +1478,7 @@ public class DFA extends ANY
     put("f64.type.tanh"                  , cl -> new NumericValue(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc)) );
 
     put("Any.as_string"                  , cl -> cl._dfa.newConstString(null, cl) );
-    put("fuzion.sys.internal_array_init.alloc", cl -> { return new SysArray(cl._dfa, new byte[0]); } ); // NYI: get length from args
+    put("fuzion.sys.internal_array_init.alloc", cl -> new SysArray(cl._dfa, new byte[0], -1)); // NYI: get length from args
     put("fuzion.sys.internal_array.setel", cl ->
         {
           var array = cl._args.get(0).value();
@@ -1741,7 +1741,7 @@ public class DFA extends ANY
     var data          = _fuir.clazz_fuzionSysArray_u8_data();
     var length        = _fuir.clazz_fuzionSysArray_u8_length();
     var sysArray      = _fuir.clazzResultClazz(internalArray);
-    var adata = utf8Bytes != null ? new SysArray(this, utf8Bytes)
+    var adata = utf8Bytes != null ? new SysArray(this, utf8Bytes, _fuir.clazz(FUIR.SpecialClazzes.c_u8))
                                   : new SysArray(this, new NumericValue(this, _fuir.clazz(FUIR.SpecialClazzes.c_u8)));
     var r = newInstance(cs, context);
     var a = newInstance(sysArray, context);
@@ -1768,6 +1768,8 @@ public class DFA extends ANY
   Value constArray(int constCl, byte[] bytes, Context context)
   {
     var array         = _fuir.clazzAsValue(constCl);
+    check
+      (array == constCl);
     var elementType    = _fuir.clazzActualGeneric(array, 0);
     var internalArray = _fuir.clazzField(array, 0);
     var sysArray      = _fuir.clazzResultClazz(internalArray);
@@ -1775,8 +1777,8 @@ public class DFA extends ANY
     var length        = _fuir.clazzField(sysArray, 1);
     var r = newInstance(array, context);
     var a = newInstance(sysArray, context);
-    var dataArg = new SysArray(this, new NumericValue(this, elementType));
-    var lengthArg = new NumericValue(this, _fuir.clazzResultClazz(length));
+    var dataArg = new SysArray(this, bytes, elementType);
+    var lengthArg = new NumericValue(this, _fuir.clazzResultClazz(length)); // NYI: set actual length to bytes.length / sizeof(elementType)
     a.setField(this, data, dataArg);
     a.setField(this, length, lengthArg);
     r.setField(this, internalArray, a);

--- a/src/dev/flang/fuir/analysis/dfa/DFA.java
+++ b/src/dev/flang/fuir/analysis/dfa/DFA.java
@@ -1768,10 +1768,10 @@ public class DFA extends ANY
   Value constArray(int arrayCl, byte[] bytes, Context context)
   {
     var elementType   = _fuir.clazzActualGeneric(arrayCl, 0);
-    var internalArray = _fuir.clazzField(arrayCl, 0);
+    var internalArray = _fuir.lookup_array_internal_array(arrayCl);
     var sysArray      = _fuir.clazzResultClazz(internalArray);
-    var data          = _fuir.clazzField(sysArray, 0);
-    var length        = _fuir.clazzField(sysArray, 1);
+    var data          = _fuir.lookup_fuzion_sys_internal_array_data  (sysArray);
+    var length        = _fuir.lookup_fuzion_sys_internal_array_length(sysArray);
     var r = newInstance(arrayCl, context);
     var a = newInstance(sysArray, context);
     var dataArg = new SysArray(this, bytes, elementType);

--- a/src/dev/flang/fuir/analysis/dfa/DFA.java
+++ b/src/dev/flang/fuir/analysis/dfa/DFA.java
@@ -480,7 +480,7 @@ public class DFA extends ANY
              c_array_u32  ,
              c_array_u64  ,
              c_array_f32  ,
-             c_array_f64  -> constArray(constCl, d, _call);
+             c_array_f64  -> newConstArray(constCl, d, _call);
         case c_Const_String -> newConstString(d, _call);
         default ->
         {
@@ -1765,7 +1765,7 @@ public class DFA extends ANY
    * @param context for debugging: Reason that causes this array to be
    * part of the analysis.
    */
-  Value constArray(int arrayCl, byte[] bytes, Context context)
+  Value newConstArray(int arrayCl, byte[] bytes, Context context)
   {
     var elementType   = _fuir.clazzActualGeneric(arrayCl, 0);
     var internalArray = _fuir.lookup_array_internal_array(arrayCl);

--- a/src/dev/flang/fuir/analysis/dfa/DFA.java
+++ b/src/dev/flang/fuir/analysis/dfa/DFA.java
@@ -471,6 +471,16 @@ public class DFA extends ANY
              c_u64  ,
              c_f32  ,
              c_f64  -> new NumericValue(DFA.this, constCl, ByteBuffer.wrap(d).order(ByteOrder.LITTLE_ENDIAN));
+        case c_array_i8   ,
+             c_array_i16  ,
+             c_array_i32  ,
+             c_array_i64  ,
+             c_array_u8   ,
+             c_array_u16  ,
+             c_array_u32  ,
+             c_array_u64  ,
+             c_array_f32  ,
+             c_array_f64  -> constArray(constCl, d, _call);
         case c_Const_String -> newConstString(d, _call);
         default ->
         {
@@ -1740,6 +1750,35 @@ public class DFA extends ANY
                 utf8Bytes != null ? new NumericValue(this, _fuir.clazzResultClazz(length), utf8Bytes.length)
                                   : new NumericValue(this, _fuir.clazzResultClazz(length)));
     a.setField(this, data  , adata);
+    r.setField(this, internalArray, a);
+    return r;
+  }
+
+
+  /**
+   * Create constant array with given bytes.
+   *
+   * @param constCl, e.g. array f32, array u8, etc.
+   *
+   * @param bytes the array contents or null if contents unknown
+   *
+   * @param context for debugging: Reason that causes this array to be
+   * part of the analysis.
+   */
+  Value constArray(int constCl, byte[] bytes, Context context)
+  {
+    var array         = _fuir.clazzAsValue(constCl);
+    var elementType    = _fuir.clazzActualGeneric(array, 0);
+    var internalArray = _fuir.clazzField(array, 0);
+    var sysArray      = _fuir.clazzResultClazz(internalArray);
+    var data          = _fuir.clazzField(sysArray, 0);
+    var length        = _fuir.clazzField(sysArray, 1);
+    var r = newInstance(array, context);
+    var a = newInstance(sysArray, context);
+    var dataArg = new SysArray(this, new NumericValue(this, elementType));
+    var lengthArg = new NumericValue(this, _fuir.clazzResultClazz(length));
+    a.setField(this, data, dataArg);
+    a.setField(this, length, lengthArg);
     r.setField(this, internalArray, a);
     return r;
   }

--- a/src/dev/flang/fuir/analysis/dfa/DFA.java
+++ b/src/dev/flang/fuir/analysis/dfa/DFA.java
@@ -1758,24 +1758,21 @@ public class DFA extends ANY
   /**
    * Create constant array with given bytes.
    *
-   * @param constCl, e.g. array f32, array u8, etc.
+   * @param arrayCl, e.g. array f32, array u8, etc.
    *
    * @param bytes the array contents or null if contents unknown
    *
    * @param context for debugging: Reason that causes this array to be
    * part of the analysis.
    */
-  Value constArray(int constCl, byte[] bytes, Context context)
+  Value constArray(int arrayCl, byte[] bytes, Context context)
   {
-    var array         = _fuir.clazzAsValue(constCl);
-    check
-      (array == constCl);
-    var elementType    = _fuir.clazzActualGeneric(array, 0);
-    var internalArray = _fuir.clazzField(array, 0);
+    var elementType   = _fuir.clazzActualGeneric(arrayCl, 0);
+    var internalArray = _fuir.clazzField(arrayCl, 0);
     var sysArray      = _fuir.clazzResultClazz(internalArray);
     var data          = _fuir.clazzField(sysArray, 0);
     var length        = _fuir.clazzField(sysArray, 1);
-    var r = newInstance(array, context);
+    var r = newInstance(arrayCl, context);
     var a = newInstance(sysArray, context);
     var dataArg = new SysArray(this, bytes, elementType);
     var lengthArg = new NumericValue(this, _fuir.clazzResultClazz(length)); // NYI: set actual length to bytes.length / sizeof(elementType)

--- a/src/dev/flang/fuir/analysis/dfa/SysArray.java
+++ b/src/dev/flang/fuir/analysis/dfa/SysArray.java
@@ -187,22 +187,8 @@ public class SysArray extends Value implements Comparable<SysArray>
       }
     if (r == 0)
       {
-        if (_elements != null || other._elements != null)
-          {
-            if (_elements == null)
-              {
-                r = -1;
-              }
-            else if (other._elements == null)
-              {
-                r = +1;
-              }
-            else
-              {
-                return Value.compare(_elements, other._elements);
-              }
-          }
-        r = (_elements == null && other._elements != null) ? -1 :
+        r = (_elements == null && other._elements == null) ?  0 :
+            (_elements == null && other._elements != null) ? -1 :
             (_elements != null && other._elements == null) ? +1
                                                            : Value.compare(_elements, other._elements);
       }

--- a/src/dev/flang/fuir/analysis/dfa/SysArray.java
+++ b/src/dev/flang/fuir/analysis/dfa/SysArray.java
@@ -26,6 +26,8 @@ Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
 
 package dev.flang.fuir.analysis.dfa;
 
+import dev.flang.util.Errors;
+
 
 /**
  * Instance represents the result of fuzion.sys.array.alloc
@@ -72,8 +74,10 @@ public class SysArray extends Value implements Comparable<SysArray>
    * @param dfa the DFA analysis
    *
    * @param data the data stored in this array (in case this is a compile time constant).
+   *
+   * @param elementClazz clazz of the array elements, may be -1 if data[] is empty
    */
-  public SysArray(DFA dfa, byte[] data)
+  public SysArray(DFA dfa, byte[] data, int elementClazz)
   {
     super(dfa._fuir.clazzObject());
 
@@ -86,11 +90,25 @@ public class SysArray extends Value implements Comparable<SysArray>
       {
         if (data.length > 0)
           {
-            _elements = new NumericValue(dfa, dfa._fuir.clazz_u8());
+            _elements = switch (dfa._fuir.getSpecialId(elementClazz))
+              {
+              case
+                c_i8   , c_i16  ,
+                c_i32  , c_i64  ,
+                c_u8   , c_u16  ,
+                c_u32  , c_u64  ,
+                c_f32  , c_f64  -> new NumericValue(dfa, elementClazz); // NYI: any value, even if we could know the exact values from data
+              default           -> {
+                                     Errors.fatal("Constant array of element type "+dfa._fuir.clazzAsString(elementClazz)+" not supported yet");
+                                     yield null;
+                                   }
+              };
           }
       }
     else
-      { // NYI: accurate sys array element tracking does not work yet:
+      { // NYI: accurate sys array element tracking does not work yet.  This
+        // needs to be specialized for elementClazz, the following code is just
+        // for u8 and probably does not work:
         for (var i = 0; i < data.length; i++)
           {
             setel(null, new NumericValue(dfa, dfa._fuir.clazz_u8(), data[i] & 0xff));
@@ -166,6 +184,27 @@ public class SysArray extends Value implements Comparable<SysArray>
         r =
           _data[i] < other._data[i] ? -1 :
           _data[i] > other._data[i] ? +1 : 0;
+      }
+    if (r == 0)
+      {
+        if (_elements != null || other._elements != null)
+          {
+            if (_elements == null)
+              {
+                r = -1;
+              }
+            else if (other._elements == null)
+              {
+                r = +1;
+              }
+            else
+              {
+                return Value.compare(_elements, other._elements);
+              }
+          }
+        r = (_elements == null && other._elements != null) ? -1 :
+            (_elements != null && other._elements == null) ? +1
+                                                           : Value.compare(_elements, other._elements);
       }
     return r;
   }

--- a/src/dev/flang/me/MiddleEnd.java
+++ b/src/dev/flang/me/MiddleEnd.java
@@ -293,23 +293,6 @@ public class MiddleEnd extends ANY
   void findUsedFeatures(AbstractConstant c)
   {
     findUsedFeatures(c.type(), c);
-
-    // NYI this is probably unnecessary?
-    c.type()
-    .featureOfType()
-    // internal_array
-    .valueArguments()
-    .forEach(a -> {
-      var sa = c.type().actualType(a.resultType());
-      findUsedFeatures(sa, c);
-      sa
-        .featureOfType()
-        // data, length
-        .valueArguments()
-        .forEach(x -> {
-          findUsedFeatures(sa.actualType(x.resultType()), c);
-        });
-    });
   }
 
 

--- a/src/dev/flang/me/MiddleEnd.java
+++ b/src/dev/flang/me/MiddleEnd.java
@@ -151,6 +151,8 @@ public class MiddleEnd extends ANY
     markUsed(universe.get(m, "Const_String").get(m, "as_string")  , SourcePosition.builtIn);  // NYI: check why this is not found automatically
     markUsed(Types.resolved.f_fuzion_sys_array_data               , SourcePosition.builtIn);
     markUsed(Types.resolved.f_fuzion_sys_array_length             , SourcePosition.builtIn);
+    markUsed(Types.resolved.f_fuzion_java_object                  , SourcePosition.builtIn);
+    markUsed(Types.resolved.f_fuzion_java_object_ref              , SourcePosition.builtIn);
     markUsed(universe.get(m, FuzionConstants.UNIT_NAME)           , SourcePosition.builtIn);
     markUsed(universe.get(m, "void")                              , SourcePosition.builtIn);
   }

--- a/src/dev/flang/me/MiddleEnd.java
+++ b/src/dev/flang/me/MiddleEnd.java
@@ -34,6 +34,7 @@ import java.util.TreeSet;
 import dev.flang.air.AIR;
 
 import dev.flang.ast.AbstractCall; // NYI: remove dependency!
+import dev.flang.ast.AbstractConstant; // NYI: remove dependency!
 import dev.flang.ast.AbstractFeature; // NYI: remove dependency!
 import dev.flang.ast.AbstractType; // NYI: remove dependency!
 import dev.flang.ast.Feature; // NYI: remove dependency!
@@ -278,12 +279,38 @@ public class MiddleEnd extends ANY
         // it does not seem to be necessary to mark all features in types as used:
         // public Type  action(Type    t, AbstractFeature outer) { t.findUsedFeatures(res, pos); return t; }
         public void action(AbstractCall c               ) { findUsedFeatures(c); }
+        public void action(AbstractConstant c           ) { findUsedFeatures(c); }
         //        public Expr action(Feature f, AbstractFeature outer) { markUsed(res, pos);      return f; } // NYI: this seems wrong ("f." missing) or unnecessary
         public void action(Tag     t, AbstractFeature outer) { findUsedFeatures(t._taggedType, t); }
       };
     f.visitCode(fv);
   }
 
+
+  /**
+   * Mark all features used for this abstract constant as used.
+   */
+  void findUsedFeatures(AbstractConstant c)
+  {
+    findUsedFeatures(c.type(), c);
+
+    // NYI this is probably unnecessary?
+    c.type()
+    .featureOfType()
+    // internal_array
+    .valueArguments()
+    .forEach(a -> {
+      var sa = c.type().actualType(a.resultType());
+      findUsedFeatures(sa, c);
+      sa
+        .featureOfType()
+        // data, length
+        .valueArguments()
+        .forEach(x -> {
+          findUsedFeatures(sa.actualType(x.resultType()), c);
+        });
+    });
+  }
 
 
   /**

--- a/tests/contracts_negative/SquareRoot.fz.expected_err_jvm
+++ b/tests/contracts_negative/SquareRoot.fz.expected_err_jvm
@@ -1,7 +1,7 @@
 
 error 1: CONTRACT FAILED: pre-condition on call to 'SquareRoot.sqrt'
 java.lang.Throwable
-	at dev.flang.be.jvm.runtime.Runtime.contract_fail(Runtime.java:404)
+	at dev.flang.be.jvm.runtime.Runtime.contract_fail(Runtime.java:561)
 	at fzC_SquareRoot__1sqrt.fzPrecondition(Unknown Source)
 	at fzC_SquareRoot.fzRoutine(Unknown Source)
 	at fzC_universe.main(Unknown Source)

--- a/tests/contracts_negative/SquareRoot.fz.expected_err_jvm
+++ b/tests/contracts_negative/SquareRoot.fz.expected_err_jvm
@@ -1,7 +1,7 @@
 
 error 1: CONTRACT FAILED: pre-condition on call to 'SquareRoot.sqrt'
 java.lang.Throwable
-	at dev.flang.be.jvm.runtime.Runtime.contract_fail(Runtime.java:561)
+	at dev.flang.be.jvm.runtime.Runtime.contract_fail(Runtime.java:617)
 	at fzC_SquareRoot__1sqrt.fzPrecondition(Unknown Source)
 	at fzC_SquareRoot.fzRoutine(Unknown Source)
 	at fzC_universe.main(Unknown Source)
@@ -10,18 +10,18 @@ java.lang.Throwable
 	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
 	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
 	at dev.flang.be.jvm.Runner.runMain(Runner.java:120)
-	at dev.flang.be.jvm.JVM$CompilePhase$4.finish(JVM.java:483)
-	at dev.flang.be.jvm.JVM.lambda$createCode$0(JVM.java:674)
+	at dev.flang.be.jvm.JVM$CompilePhase$4.finish(JVM.java:488)
+	at dev.flang.be.jvm.JVM.lambda$createCode$0(JVM.java:785)
 	at java.base/java.util.Spliterators$ArraySpliterator.forEachRemaining(Spliterators.java:992)
 	at java.base/java.util.stream.ReferencePipeline$Head.forEachOrdered(ReferencePipeline.java:772)
-	at dev.flang.be.jvm.JVM.createCode(JVM.java:665)
-	at dev.flang.be.jvm.JVM.compile(JVM.java:650)
+	at dev.flang.be.jvm.JVM.createCode(JVM.java:776)
+	at dev.flang.be.jvm.JVM.compile(JVM.java:761)
 	at dev.flang.tools.Fuzion$Backend$3.process(Fuzion.java:163)
-	at dev.flang.tools.Fuzion$Backend.processFrontEnd(Fuzion.java:422)
-	at dev.flang.tools.Fuzion.lambda$parseArgsForBackend$3(Fuzion.java:886)
+	at dev.flang.tools.Fuzion$Backend.processFrontEnd(Fuzion.java:444)
+	at dev.flang.tools.Fuzion.lambda$parseArgsForBackend$3(Fuzion.java:908)
 	at dev.flang.tools.Tool.lambda$run$0(Tool.java:145)
 	at dev.flang.util.Errors.runAndExit(Errors.java:762)
 	at dev.flang.tools.Tool.run(Tool.java:145)
-	at dev.flang.tools.Fuzion.main(Fuzion.java:535)
+	at dev.flang.tools.Fuzion.main(Fuzion.java:557)
 
 *** fatal errors encountered, stopping.

--- a/tests/reg_issue270/issue270.fz.expected_err_jvm
+++ b/tests/reg_issue270/issue270.fz.expected_err_jvm
@@ -1,7 +1,7 @@
 
 error 1: CONTRACT FAILED: pre-condition on call to 'issue270'
 java.lang.Throwable
-	at dev.flang.be.jvm.runtime.Runtime.contract_fail(Runtime.java:404)
+	at dev.flang.be.jvm.runtime.Runtime.contract_fail(Runtime.java:561)
 	at fzC_issue270.fzPrecondition(Unknown Source)
 	at fzC_universe.main(Unknown Source)
 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)

--- a/tests/reg_issue270/issue270.fz.expected_err_jvm
+++ b/tests/reg_issue270/issue270.fz.expected_err_jvm
@@ -1,7 +1,7 @@
 
 error 1: CONTRACT FAILED: pre-condition on call to 'issue270'
 java.lang.Throwable
-	at dev.flang.be.jvm.runtime.Runtime.contract_fail(Runtime.java:561)
+	at dev.flang.be.jvm.runtime.Runtime.contract_fail(Runtime.java:617)
 	at fzC_issue270.fzPrecondition(Unknown Source)
 	at fzC_universe.main(Unknown Source)
 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
@@ -9,18 +9,18 @@ java.lang.Throwable
 	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
 	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
 	at dev.flang.be.jvm.Runner.runMain(Runner.java:120)
-	at dev.flang.be.jvm.JVM$CompilePhase$4.finish(JVM.java:483)
-	at dev.flang.be.jvm.JVM.lambda$createCode$0(JVM.java:674)
+	at dev.flang.be.jvm.JVM$CompilePhase$4.finish(JVM.java:488)
+	at dev.flang.be.jvm.JVM.lambda$createCode$0(JVM.java:785)
 	at java.base/java.util.Spliterators$ArraySpliterator.forEachRemaining(Spliterators.java:992)
 	at java.base/java.util.stream.ReferencePipeline$Head.forEachOrdered(ReferencePipeline.java:772)
-	at dev.flang.be.jvm.JVM.createCode(JVM.java:665)
-	at dev.flang.be.jvm.JVM.compile(JVM.java:650)
+	at dev.flang.be.jvm.JVM.createCode(JVM.java:776)
+	at dev.flang.be.jvm.JVM.compile(JVM.java:761)
 	at dev.flang.tools.Fuzion$Backend$3.process(Fuzion.java:163)
-	at dev.flang.tools.Fuzion$Backend.processFrontEnd(Fuzion.java:422)
-	at dev.flang.tools.Fuzion.lambda$parseArgsForBackend$3(Fuzion.java:886)
+	at dev.flang.tools.Fuzion$Backend.processFrontEnd(Fuzion.java:444)
+	at dev.flang.tools.Fuzion.lambda$parseArgsForBackend$3(Fuzion.java:908)
 	at dev.flang.tools.Tool.lambda$run$0(Tool.java:145)
 	at dev.flang.util.Errors.runAndExit(Errors.java:762)
 	at dev.flang.tools.Tool.run(Tool.java:145)
-	at dev.flang.tools.Fuzion.main(Fuzion.java:535)
+	at dev.flang.tools.Fuzion.main(Fuzion.java:557)
 
 *** fatal errors encountered, stopping.


### PR DESCRIPTION
This reduces the size of the generated code, in particular for the JVM backend that previously was not able to create bytecode for the tables used for ryu float to string conversion code. 

Now, constant arrays are serialized into an array of bytes that is then processed by the backend to produce code that creates the array. 