### PR TITLE
be/jvm: Fix broken error message for missing intrinsic.

### DIFF
--- a/src/dev/flang/be/jvm/Intrinsix.java
+++ b/src/dev/flang/be/jvm/Intrinsix.java
@@ -836,8 +836,8 @@ public class Intrinsix extends ANY implements ClassFileConstants
           var name = jvm._names.function(cc, false);
           var in = jvm._fuir.clazzIntrinsicName(cc);
           var msg = "NYI: missing implementation of JVM backend intrinsic '" +
-            in + "', need '" + Intrinsics.class + "." + name + "' or inline code in " +
-            Intrinsics.class + ".";
+            in + "', need '" + Intrinsics.class.getName() + "." + name + "' or inline code in " +
+            Intrinsix.class.getName() + ".";
           return new Pair<>(null,
                             jvm.reportErrorInCode(msg));
         });


### PR DESCRIPTION
The error was, e.g.,

  error 1: NYI: missing implementation of JVM backend intrinsic 'fuzion.sys.net.bind0', need 'class dev.flang.be.jvm.runtime.Intrinsics.fuzion_sys_net_bind0' or inline code in class dev.flang.be.jvm.runtime.Intrinsics.

but should be

  error 1: NYI: missing implementation of JVM backend intrinsic 'fuzion.sys.net.bind0', need 'dev.flang.be.jvm.runtime.Intrinsics.fuzion_sys_net_bind0' or inline code in dev.flang.be.jvm.runtime.Intrinsix.