### PR TITLE
tests: for simple tests, output diff in stdout if diff in stderr is empty

### DIFF
--- a/tests/check_simple_example.sh
+++ b/tests/check_simple_example.sh
@@ -68,9 +68,7 @@ else
         experr=$2.expected_err_int
     fi
     # show diff in stdout unless an unexpected output occured to stderr:
-    if [ ! -s tmp_err.txt  ] && [ -s "$experr" ]; then
-        diff "$expout" tmp_out.txt || (echo -e "\033[31;1m*** FAILED\033[0m out on $2")
-    fi
+    diff "$experr" tmp_err.txt && (diff "$expout" tmp_out.txt || (echo -e "\033[31;1m*** FAILED\033[0m out on $2"))
     diff "$experr" tmp_err.txt || (echo -e "\033[31;1m*** FAILED\033[0m err on $2")
     diff "$expout" tmp_out.txt >/dev/null && diff "$experr" tmp_err.txt >/dev/null && echo -e "\033[32;1mPASSED\033[0m."
     RC=$?

--- a/tests/check_simple_example_c.sh
+++ b/tests/check_simple_example_c.sh
@@ -79,9 +79,7 @@ else
     expout=tmp_exp_out.txt
 
     # show diff in stdout unless an unexpected output occured to stderr
-    if [ ! -s tmp_err.txt  ] && [ -s "$experr" ]; then
-        diff "$expout" tmp_out.txt || (echo -e "\033[31;1m*** FAILED\033[0m out on $2")
-    fi
+    diff "$experr" tmp_err.txt && (diff "$expout" tmp_out.txt || (echo -e "\033[31;1m*** FAILED\033[0m out on $2"))
     diff "$experr" tmp_err.txt || (echo -e "\033[31;1m*** FAILED\033[0m err on $2")
     diff "$expout" tmp_out.txt >/dev/null && diff "$experr" tmp_err.txt >/dev/null && echo -e "\033[32;1mPASSED\033[0m."
     RC=$?

--- a/tests/check_simple_example_jvm.sh
+++ b/tests/check_simple_example_jvm.sh
@@ -68,9 +68,7 @@ else
         experr=$2.expected_err_jvm
     fi
     # show diff in stdout unless an unexpected output occured to stderr:
-    if [ ! -s tmp_err.txt  ] && [ -s "$experr" ]; then
-        diff "$expout" tmp_out.txt || (echo -e "\033[31;1m*** FAILED\033[0m out on $2")
-    fi
+    diff "$experr" tmp_err.txt && (diff "$expout" tmp_out.txt || (echo -e "\033[31;1m*** FAILED\033[0m out on $2"))
     diff "$experr" tmp_err.txt || (echo -e "\033[31;1m*** FAILED\033[0m err on $2")
     diff "$expout" tmp_out.txt >/dev/null && diff "$experr" tmp_err.txt >/dev/null && echo -e "\033[32;1mPASSED\033[0m."
     RC=$?


### PR DESCRIPTION
The original condition suppresses the stdout diff if actual and expected error output are both empty, which is often the case.