### PR TITLE
tests: for simple tests, the last PR caused the error diff to be shown twice

### DIFF
--- a/tests/check_simple_example.sh
+++ b/tests/check_simple_example.sh
@@ -68,8 +68,7 @@ else
         experr=$2.expected_err_int
     fi
     # show diff in stdout unless an unexpected output occured to stderr:
-    diff "$experr" tmp_err.txt && (diff "$expout" tmp_out.txt || (echo -e "\033[31;1m*** FAILED\033[0m out on $2"))
-    diff "$experr" tmp_err.txt || (echo -e "\033[31;1m*** FAILED\033[0m err on $2")
+    (diff "$experr" tmp_err.txt && diff "$expout" tmp_out.txt) || echo -e "\033[31;1m*** FAILED\033[0m out on $2"
     diff "$expout" tmp_out.txt >/dev/null && diff "$experr" tmp_err.txt >/dev/null && echo -e "\033[32;1mPASSED\033[0m."
     RC=$?
     rm tmp_out.txt tmp_err.txt

--- a/tests/check_simple_example_c.sh
+++ b/tests/check_simple_example_c.sh
@@ -79,8 +79,7 @@ else
     expout=tmp_exp_out.txt
 
     # show diff in stdout unless an unexpected output occured to stderr
-    diff "$experr" tmp_err.txt && (diff "$expout" tmp_out.txt || (echo -e "\033[31;1m*** FAILED\033[0m out on $2"))
-    diff "$experr" tmp_err.txt || (echo -e "\033[31;1m*** FAILED\033[0m err on $2")
+    (diff "$experr" tmp_err.txt && diff "$expout" tmp_out.txt) || echo -e "\033[31;1m*** FAILED\033[0m out on $2"
     diff "$expout" tmp_out.txt >/dev/null && diff "$experr" tmp_err.txt >/dev/null && echo -e "\033[32;1mPASSED\033[0m."
     RC=$?
     if [ -f testbin ]; then

--- a/tests/check_simple_example_jvm.sh
+++ b/tests/check_simple_example_jvm.sh
@@ -68,8 +68,7 @@ else
         experr=$2.expected_err_jvm
     fi
     # show diff in stdout unless an unexpected output occured to stderr:
-    diff "$experr" tmp_err.txt && (diff "$expout" tmp_out.txt || (echo -e "\033[31;1m*** FAILED\033[0m out on $2"))
-    diff "$experr" tmp_err.txt || (echo -e "\033[31;1m*** FAILED\033[0m err on $2")
+    (diff "$experr" tmp_err.txt && diff "$expout" tmp_out.txt) || echo -e "\033[31;1m*** FAILED\033[0m out on $2"
     diff "$expout" tmp_out.txt >/dev/null && diff "$experr" tmp_err.txt >/dev/null && echo -e "\033[32;1mPASSED\033[0m."
     RC=$?
     rm tmp_out.txt tmp_err.txt


### PR DESCRIPTION
Simplified the scripts since the line for the error output is no longer needed.