### PR TITLE
jvm: Fix compilation of routines that produce a void result

### DIFF
--- a/src/dev/flang/be/jvm/CodeGen.java
+++ b/src/dev/flang/be/jvm/CodeGen.java
@@ -538,10 +538,9 @@ class CodeGen
             na.add(t.load(1));
           }
         var p = staticAccess(-1, false, tt, cc, tv, na, isCall);
-        var code = p._v0 == null
-          ? p._v1
-          : (p._v1.andThen(p._v0)
-                  .andThen(retoern));
+        var code = p._v1
+          .andThen(p._v0 == null ? Expr.UNIT : p._v0)
+          .andThen(retoern);
         var ca = cf.codeAttribute(dn + "in class for " + _fuir.clazzAsString(tt),
                                   code, new List<>(), new List<>());
         cf.method(ACC_PUBLIC, dn, ds, new List<>(ca));

--- a/src/dev/flang/be/jvm/JVM.java
+++ b/src/dev/flang/be/jvm/JVM.java
@@ -954,11 +954,9 @@ should be avoided as much as possible.
         var jt = _types.javaType(t);
         var ft = _types.resultType(t);
         var getf =
-          ft != PrimitiveType.type_void ? (Expr.aload(current_index(cl), jt)
-                                           .andThen(Expr.getfield(_names.javaClass(cl),
-                                                                  _names.field(r),
-                                                                  ft)))
-                                        : Expr.UNIT;
+          fieldExists(r) ? (Expr.aload(current_index(cl), jt)
+                            .andThen(getfield(r)))
+                         : Expr.UNIT;
         return
           traceReturn(cl, pre)
           .andThen(getf)


### PR DESCRIPTION
This fixes the code for stubs for calls to features that do never return (Fuzion result type `void`), these need a `return` bytecode anyway to keep the JVM classfile verifier happy.

Additionally, a feature's result field may not exist if the code produces a void value as in

  f i32 => panic "bah"

so we must not attempt to read the result field in the epilog.

This fixes the failure of tests/local_mutate when using the JVM backend.