### PR TITLE
jvm: Add intrinsics concur.atomic.read0/write0/compare_and_(set|swap)0

### DIFF
--- a/src/dev/flang/be/jvm/CodeGen.java
+++ b/src/dev/flang/be/jvm/CodeGen.java
@@ -707,7 +707,7 @@ class CodeGen
             }
           else if (!(preCalled || Intrinsix.inRuntime(_jvm, cc)))
             {
-              return Intrinsix.inlineCode(_jvm, cc, tvalue, args);
+              return Intrinsix.inlineCode(_jvm, cl, pre, cc, tvalue, args);
             }
           // fall through!
         }

--- a/src/dev/flang/be/jvm/Names.java
+++ b/src/dev/flang/be/jvm/Names.java
@@ -118,6 +118,12 @@ public class Names extends ANY implements ClassFileConstants
 
 
   /**
+   * Name of Runtime.LOCK_FOR_ATOMIC
+   */
+  static final String RUNTIME_LOCK_FOR_ATOMIC   = "LOCK_FOR_ATOMIC";
+
+
+  /**
    * Prefix for Java class names created for Fuzion routines or intrinsics
    */
   private static final String CLASS_PREFIX = "fzC_";

--- a/src/dev/flang/be/jvm/classfile/ByteCode.java
+++ b/src/dev/flang/be/jvm/classfile/ByteCode.java
@@ -120,6 +120,8 @@ abstract class ByteCode extends ANY implements ClassFileConstants
   static byte[] BC_DUP_X1      = new byte[] { O_dup_x1              };
   static byte[] BC_DUP_X2      = new byte[] { O_dup_x2              };
   static byte[] BC_SWAP        = new byte[] { O_swap                };
+  static byte[] BC_DUP2_X1     = new byte[] { O_dup2_x1             };
+  static byte[] BC_DUP2_X2     = new byte[] { O_dup2_x2             };
   static byte[] BC_POP         = new byte[] { O_pop                 };
   static byte[] BC_POP2        = new byte[] { O_pop2                };
 
@@ -155,6 +157,8 @@ abstract class ByteCode extends ANY implements ClassFileConstants
   static byte[] BC_DNEWARRAY   = new byte[] { O_newarray, T_DOUBLE  };
 
   static byte[] BC_ACONST_NULL = new byte[] { O_aconst_null         };
+
+  static byte[] BC_LCMP        = new byte[] { O_lcmp                };
 
   static byte[] BC_MONITORENTER = new byte[] { O_monitorenter       };
   static byte[] BC_MONITOREXIT = new byte[] { O_monitorexit         };

--- a/src/dev/flang/be/jvm/classfile/ClassFileConstants.java
+++ b/src/dev/flang/be/jvm/classfile/ClassFileConstants.java
@@ -500,7 +500,7 @@ public interface ClassFileConstants
   }
 
   /* a class or array */
-  static abstract class AType implements JavaType
+  public static abstract class AType implements JavaType
   {
     final String _descriptor;
     AType(String descriptor)

--- a/src/dev/flang/be/jvm/classfile/Expr.java
+++ b/src/dev/flang/be/jvm/classfile/Expr.java
@@ -140,6 +140,8 @@ public abstract class Expr extends ByteCode
   public static final Expr DUP_X1      = new Simple("DUP_X1" , PrimitiveType.type_void, BC_DUP_X1 );
   public static final Expr DUP_X2      = new Simple("DUP_x2" , PrimitiveType.type_void, BC_DUP_X2 );
   public static final Expr SWAP        = new Simple("SWAP"   , PrimitiveType.type_void, BC_SWAP   );
+  public static final Expr DUP2_X1     = new Simple("DUP2_x1", PrimitiveType.type_void, BC_DUP2_X1);
+  public static final Expr DUP2_X2     = new Simple("DUP2_x2", PrimitiveType.type_void, BC_DUP2_X2);
 
   public static final Expr THROW       = new Simple("THROW"  , PrimitiveType.type_void, BC_ATHROW);
 
@@ -172,6 +174,8 @@ public abstract class Expr extends ByteCode
   public static final Expr DNEWARRAY   = new Simple("DNEWARRAY", PrimitiveType.type_double.array (), BC_DNEWARRAY);
 
   public static final Expr ACONST_NULL = new Simple("ACONST_NULL", JAVA_LANG_OBJECT, BC_ACONST_NULL);
+
+  public static final Expr LCMP        = new Simple("LCMP", PrimitiveType.type_int, BC_LCMP);
 
   public static final Expr MONITORENTER = new Simple("MONITORENTER", PrimitiveType.type_void, BC_MONITORENTER);
   public static final Expr MONITOREXIT = new Simple("MONITOREXIT", PrimitiveType.type_void, BC_MONITOREXIT);


### PR DESCRIPTION
For now, these just use a global lock, not java.util.concurrent.Atomic* classes.

Also, value types are not properly supported yet.

Since this patch needs to allocate local var slots for inline intrinsics, I had to add arguments cl and pre to the function that creates the code.

Also add new bytecode LCMP and DUP2_X1, DUP2_X2 (the latter are not used by this patch, but were needed in an intermediate version and may turn out useful anyway).