### PR TITLE
jvm: Add support for labels as branch targets when generating bytecode

### DIFF
--- a/src/dev/flang/be/jvm/Choices.java
+++ b/src/dev/flang/be/jvm/Choices.java
@@ -444,7 +444,6 @@ public class Choices extends ANY implements ClassFileConstants
           code = null;
           for (var mc = 0; mc < _fuir.matchCaseCount(c, i); mc++)
             {
-              var caze = Expr.UNIT.andThen(ai.process(cl, pre, _fuir.matchCaseCode(c, i, mc)));
               var tags = _fuir.matchCaseTags(cl, c, i, mc);
               for (var tagNum : tags)
                 {
@@ -453,7 +452,7 @@ public class Choices extends ANY implements ClassFileConstants
                     {
                       if (CHECKS) check
                         (code == null);  // if there are several non-voids, we would have at least boollike kind
-                      code = caze;
+                      code = Expr.UNIT.andThen(ai.process(cl, pre, _fuir.matchCaseCode(c, i, mc)));
                     }
                 }
             }
@@ -468,15 +467,14 @@ public class Choices extends ANY implements ClassFileConstants
 
           for (var mc = 0; mc < _fuir.matchCaseCount(c, i); mc++)
             {
-              var caze = Expr.UNIT.andThen(ai.process(cl, pre, _fuir.matchCaseCode(c, i, mc)));
               var tags = _fuir.matchCaseTags(cl, c, i, mc);
               for (var tagNum : tags)
                 {
                   var t = intValueForTagNum(subjClazz, tagNum);
                   switch (t)
                     {
-                    case 0: neg = caze; break;
-                    case 1: pos = caze; break;
+                    case 0: neg = Expr.UNIT.andThen(ai.process(cl, pre, _fuir.matchCaseCode(c, i, mc))); break;
+                    case 1: pos = Expr.UNIT.andThen(ai.process(cl, pre, _fuir.matchCaseCode(c, i, mc))); break;
                     case -1: break; //  void type
                     default: throw new Error("JVM backend match found unexpected tag number " + t + " when compiling " + _fuir.clazzAsString(cl));
                   }
@@ -493,7 +491,6 @@ public class Choices extends ANY implements ClassFileConstants
           for (var mc = 0; mc < _fuir.matchCaseCount(c, i); mc++)
             {
               // NYI: This currently uses a cascade of if..else if.., should better uses tableswitch.
-              var caze = ai.process(cl, pre, _fuir.matchCaseCode(c, i, mc));
               var field = _fuir.matchCaseField(cl, c, i, mc);
               var tags = _fuir.matchCaseTags(cl, c, i, mc);
               for (var tagNum : tags)
@@ -506,7 +503,7 @@ public class Choices extends ANY implements ClassFileConstants
                       code = code.andThen(Expr.DUP)                                 //          tag, tag
                         .andThen(Expr.iconst(tagNum))                               //          tag, tag, tagNum
                         .andThen(Expr.branch(ClassFileConstants.O_if_icmpeq,        //          tag
-                                             Expr.UNIT.andThen(caze),
+                                             Expr.UNIT.andThen(ai.process(cl, pre, _fuir.matchCaseCode(c, i, mc))),
                                              Expr.UNIT));
                     }
                 }
@@ -522,7 +519,6 @@ public class Choices extends ANY implements ClassFileConstants
 
           for (var mc = 0; mc < _fuir.matchCaseCount(c, i); mc++)
             {
-              var caze = ai.process(cl, pre, _fuir.matchCaseCode(c, i, mc));
               var field = _fuir.matchCaseField(cl, c, i, mc);
               var tags = _fuir.matchCaseTags(cl, c, i, mc);
               for (var tagNum : tags)
@@ -540,12 +536,12 @@ public class Choices extends ANY implements ClassFileConstants
                         {                                                       //          sub
                           pos = Expr.POP;                                       //          -
                         }
-                      pos = pos.andThen(caze);
+                      pos = pos.andThen(ai.process(cl, pre, _fuir.matchCaseCode(c, i, mc)));
                     }
                   else if (_fuir.clazzIsUnitType(tc))
                     {
                       neg = Expr.POP                                            //          -
-                        .andThen(caze);
+                        .andThen(ai.process(cl, pre, _fuir.matchCaseCode(c, i, mc)));
                     }
                 }
             }
@@ -570,7 +566,6 @@ public class Choices extends ANY implements ClassFileConstants
           for (var mc = 0; mc < _fuir.matchCaseCount(c, i); mc++)
             {
               // NYI: This currently uses a cascade of if..else if.., should better uses tableswitch.
-              var caze = ai.process(cl, pre, _fuir.matchCaseCode(c, i, mc));
               var field = _fuir.matchCaseField(cl, c, i, mc);
               var tags = _fuir.matchCaseTags(cl, c, i, mc);
               for (var tagNum : tags)
@@ -596,7 +591,7 @@ public class Choices extends ANY implements ClassFileConstants
                         {
                           pos = Expr.UNIT;                                      //          sub, tag
                         }
-                      pos = pos.andThen(caze);
+                      pos = pos.andThen(ai.process(cl, pre, _fuir.matchCaseCode(c, i, mc)));
                       code = code.andThen(Expr.DUP)                             //          sub, tag, tag
                         .andThen(Expr.iconst(tagNum))                           //          sub, tag, tag, tagNum
                         .andThen(Expr.branch(ClassFileConstants.O_if_icmpeq,    //          sub, tag
@@ -619,7 +614,6 @@ public class Choices extends ANY implements ClassFileConstants
           for (var mc = 0; mc < _fuir.matchCaseCount(c, i); mc++)
             {
               // NYI: This currently uses a cascade of if..else if.., should better uses tableswitch.
-              var caze = ai.process(cl, pre, _fuir.matchCaseCode(c, i, mc));
               var field = _fuir.matchCaseField(cl, c, i, mc);
               var tags = _fuir.matchCaseTags(cl, c, i, mc);
               for (var tagNum : tags)
@@ -650,7 +644,7 @@ public class Choices extends ANY implements ClassFileConstants
                         {
                           pos = Expr.UNIT;                                          //          sub, tag
                         }
-                      pos = pos.andThen(caze);
+                      pos = pos.andThen(ai.process(cl, pre, _fuir.matchCaseCode(c, i, mc)));
                       code = code.andThen(Expr.DUP)                                 //          sub, tag, tag
                         .andThen(Expr.iconst(tagNum))                               //          sub, tag, tag, tagNum
                         .andThen(Expr.branch(ClassFileConstants.O_if_icmpeq,        //          sub, tag

--- a/src/dev/flang/be/jvm/JVM.java
+++ b/src/dev/flang/be/jvm/JVM.java
@@ -1082,7 +1082,6 @@ should be avoided as much as possible.
           .andThen(code)
           .andThen(epilog);
         var code_cl = cf.codeAttribute((pre ? "precondition of " : "") + _fuir.clazzAsString(cl),
-                                       bc_cl.max_stack(),
                                        numLocals(cl, pre),
                                        bc_cl,
                                        new List<>(), new List<>());

--- a/src/dev/flang/be/jvm/classfile/ByteCode.java
+++ b/src/dev/flang/be/jvm/classfile/ByteCode.java
@@ -175,8 +175,10 @@ abstract class ByteCode extends ANY implements ClassFileConstants
 
 
   /**
-   * Create byte[] for bytecode instruction followed by 2 unsigned bytes giving
-   * the index of the given CPool entry.
+   * Write bytecode instruction bc followed by 2 unsigned bytes giving the index
+   * of the given CPool entry.
+   *
+   * @param bw target to write bytecodes to.
    *
    * @param bc a bytecode operation that expects an unsigned index
    *
@@ -184,7 +186,7 @@ abstract class ByteCode extends ANY implements ClassFileConstants
    *
    * @return new byte[] { bx, hi-index, ho-index }
    */
-  byte[] bc(byte bc, ClassFile.CPEntry e)
+  void code(ClassFile.ByteCodeWriter ba, byte bc, ClassFile.CPEntry e)
   {
     if (PRECONDITIONS) require
       (e != null,
@@ -214,25 +216,28 @@ abstract class ByteCode extends ANY implements ClassFileConstants
         bc = O_ldc2_w;
       }
 
-    return bc(bc, e.index());
+    code(ba, bc, e.index());
   }
 
 
   /**
-   * Create byte[] for bytecode instruction followed by a 1 or 2 bytes long
+   * Write bytecode instruction bc followed by a 1 or 2 bytes long
    * unsigned integer index.
+   *
+   * Depending on bc and the value of index, the data written is
+   *
+   *           new byte[] { bc, index }                          -- or --
+   *           new byte[] { O_wide, bc, hi-index, ho-index }     -- or --
+   *           new byte[] { bc, hi-index, ho-index }
+   *
+   * @param bw target to write bytecodes to.
    *
    * @param bc a bytecode operation that expects an unsigned integer index
    *
    * @param index the unsigned integer
    *
-   * @return depending on bc and the value of index, either
-   *
-   *           new byte[] { bc, index }                          -- or --
-   *           new byte[] { O_wide, bc, hi-index, ho-index }
-   *           new byte[] { bc, hi-index, ho-index }
    */
-  byte[] bc(byte bc, int index)
+  void code(ClassFile.ByteCodeWriter ba, byte bc, int index)
   {
     if (PRECONDITIONS) require
       (index >= 0 && index < 0x10000,
@@ -260,25 +265,40 @@ abstract class ByteCode extends ANY implements ClassFileConstants
          default           -> false;
          });
 
-    return switch (bc)
+    switch (bc)
       {
       case
         O_iload, O_istore,
         O_lload, O_lstore,
         O_fload, O_fstore,
         O_dload, O_dstore,
-        O_aload, O_astore -> index <= 0xff ? new byte[] { bc, (byte) index }
-                                           : new byte[] { O_wide,
-                                                          bc,
-                                                          (byte) (index >> 8),
-                                                          (byte) index
-                                                        };
+        O_aload, O_astore -> {
+                               if (index <= 0xff)
+                                 {
+                                   ba.write(bc);
+                                   ba.writeU1(index);
+                                 }
+                               else
+                                 {
+                                   ba.write(O_wide);
+                                   ba.write(bc);
+                                   ba.writeU2(index);
+                                 }
+                              }
+
       case
-        O_ldc             -> index <= 0xff ? new byte[] { O_ldc, (byte) index }
-                                           : new byte[] { O_ldc_w,
-                                                          (byte) (index >> 8),
-                                                          (byte) index
-                                                        };
+        O_ldc             -> {
+                               if (index <= 0xff)
+                                 {
+                                   ba.write(O_ldc);
+                                   ba.writeU1(index);
+                                 }
+                               else
+                                 {
+                                   ba.write(O_ldc_w);
+                                   ba.writeU2(index);
+                                 }
+                              }
       case
         O_invokespecial,
         O_invokestatic,
@@ -291,18 +311,20 @@ abstract class ByteCode extends ANY implements ClassFileConstants
         O_anewarray,
         O_checkcast,
         O_instanceof,
-        O_ldc2_w          -> new byte[] { bc,
-                                          (byte) (index >> 8),
-                                          (byte)  index
-                                        };
-      default             -> throw new Error("bc(bc,index) unexpected bytecode "+Integer.toHexString(bc));
+        O_ldc2_w           -> {
+                                ba.write(bc);
+                                ba.writeU2(index);
+                              }
+      default              -> throw new Error("bc(bc,index) unexpected bytecode "+Integer.toHexString(bc));
       };
   }
 
 
   /**
-   * Create byte[] for bytecode instruction followed by a 2 bytes long
+   * Write bytecode instruction bc followed by a 2 bytes long
    * signed integer offset.
+   *
+   * @param bw target to write bytecodes to.
    *
    * @param bc a bytecode operation that expects an unsigned integer index
    *
@@ -310,11 +332,10 @@ abstract class ByteCode extends ANY implements ClassFileConstants
    *
    * @return new byte[] { bc, hi-offset, ho-offset }
    */
-  byte[] bcsigned(byte bc, int offset)
+  void code(ClassFile.ByteCodeWriter bw, byte bc, Label from, Label to)
   {
     if (PRECONDITIONS) require
-      (offset >= -0x8000 && offset < 0x8000,
-       switch (bc)
+      (switch (bc)
          { case
              O_ifeq        ,
              O_ifne        ,
@@ -336,16 +357,18 @@ abstract class ByteCode extends ANY implements ClassFileConstants
          default           -> false;
          });
 
-    return new byte[]
-      { bc,
-        (byte) (offset >> 8),
-        (byte)  offset
-      };
+    // NYI: Support for goto_w
+    int offset = bw.offset(from, to);
+    bw.write(bc);
+    bw.write((byte) (offset >> 8));
+    bw.write((byte)  offset      );
   }
 
 
   /**
    * Create byte[] of O_invokeinterface
+   *
+   * @param bw target to write bytecodes to.
    *
    * @param bc O_invokeinterface.
    *
@@ -355,18 +378,20 @@ abstract class ByteCode extends ANY implements ClassFileConstants
    *
    * @param b2 0
    */
-  byte[] bc(byte bc, ClassFile.CPEntry e, byte b1, byte b2)
+  void code(ClassFile.ByteCodeWriter bw, byte bc, ClassFile.CPEntry e, byte b1, byte b2)
   {
     if (PRECONDITIONS) require
       (bc == O_invokeinterface,
        (0xff & b1) > 0,
        b2 == 0);
 
-    return bc(bc, e.index(), b1, b2);
+    code(bw, bc, e.index(), b1, b2);
   }
 
   /**
    * Create byte[] of O_invokeinterface
+   *
+   * @param bw target to write bytecodes to.
    *
    * @param bc O_invokeinterface.
    *
@@ -376,166 +401,29 @@ abstract class ByteCode extends ANY implements ClassFileConstants
    *
    * @param b2 0
    */
-  byte[] bc(byte bc, int index, byte b1, byte b2)
+  void code(ClassFile.ByteCodeWriter bw, byte bc, int index, byte b1, byte b2)
   {
-    if (PRECONDITIONS) require
-      (bc == O_invokeinterface,
-       index >= 0 && index < 0x10000,
-       (0xff & b1) > 0,
-       b2 == 0);
-
-    return new byte[]
-      { bc,
-        (byte) (index >> 8),
-        (byte)  index,
-                b1,
-                b2
-      };
+    bw.write(bc);
+    bw.writeU2(index);
+    bw.write(b1);
+    bw.write(b2);
   }
 
 
   /**
-   * Create a new bc array by appending b to a.
+   * Create the byte code for this ByteCode.
    *
-   * @param a a bytecode array
+   * This will run several passes with different instances of ByteCodeWrite
+   * where first an ByteCodeSizeEstimate is used to get an upper bound for the
+   * bytecode size, then ByteCodeFixlabals is used to find all branch targets
+   * and fix the layout, and finally ByteCodeWrite is used to write the
+   * bytecodes to a file.
    *
-   * @param b another bytecode array
+   * @param bw the writer to write the bytecode to.
    *
-   * @return a new bytecode array
+   * @param cf the class file we are generating, used for cpool indices.
    */
-  byte[] bc(byte[] a, byte[] b)
-  {
-    var res = new byte[a.length + b.length];
-    System.arraycopy(a, 0, res, 0,        a.length);
-    System.arraycopy(b, 0, res, a.length, b.length);
-
-    return res;
-  }
-
-
-  /**
-   * Create bytecode array for code `if (cc) pos else neg`.
-   *
-   * @param bc a conditional branch bytecode.
-   *
-   * @param pos bytecode to execute in case bc's condition is true
-   *
-   * @param neg bytecode to execute in case bc's condition is false
-   */
-  byte[] bc(byte bc, byte[] pos, byte[] neg)
-  {
-    if (PRECONDITIONS) require
-      (switch (bc)
-         { case
-             O_ifeq        ,
-             O_ifne        ,
-             O_iflt        ,
-             O_ifge        ,
-             O_ifgt        ,
-             O_ifle        ,
-             O_if_icmpeq   ,
-             O_if_icmpne   ,
-             O_if_icmplt   ,
-             O_if_icmpge   ,
-             O_if_icmpgt   ,
-             O_if_icmple   ,
-             O_if_acmpeq   ,
-             O_if_acmpne   ,
-             O_ifnull      ,
-             O_ifnonnull   -> true;
-         default           -> false;
-         });
-
-    byte[] res;
-    if (pos.length == 0)
-      {
-        res = bc(bc, neg);
-      }
-    else if (neg.length == 0)
-      {
-        var nbc = switch (bc)
-          {
-          case O_ifeq        -> O_ifne     ;
-          case O_ifne        -> O_ifeq     ;
-          case O_iflt        -> O_ifge     ;
-          case O_ifge        -> O_iflt     ;
-          case O_ifgt        -> O_ifle     ;
-          case O_ifle        -> O_ifgt     ;
-          case O_if_icmpeq   -> O_if_icmpne;
-          case O_if_icmpne   -> O_if_icmpeq;
-          case O_if_icmplt   -> O_if_icmpge;
-          case O_if_icmpge   -> O_if_icmplt;
-          case O_if_icmpgt   -> O_if_icmple;
-          case O_if_icmple   -> O_if_icmpgt;
-          case O_if_acmpeq   -> O_if_acmpne;
-          case O_if_acmpne   -> O_if_acmpeq;
-          case O_ifnull      -> O_ifnonnull;
-          case O_ifnonnull   -> O_ifnull   ;
-          default -> throw new Error("unexpected bc "+bc);
-          };
-        res = bc(nbc, pos);
-      }
-    else
-      {
-        res = new byte[6 + neg.length + pos.length];
-        var cc = bcsigned(bc    , 6 + neg.length);
-        var gt = bcsigned(O_goto, 3 + pos.length);
-        System.arraycopy(cc  , 0, res, 0             , 3);
-        System.arraycopy(neg , 0, res, 3             , neg.length);
-        System.arraycopy(gt  , 0, res, 3 + neg.length, 3);
-        System.arraycopy(pos , 0, res, 6 + neg.length, pos.length);
-      }
-    return res;
-  }
-
-
-  /**
-   * Create bytecode array for code `if (!cc) neg`.
-   *
-   * @param bc a conditional branch bytecode.
-   *
-   * @param neg bytecode to execute in case bc's condition is false
-   */
-  byte[] bc(byte bc, byte[] neg)
-  {
-    if (PRECONDITIONS) require
-      (switch (bc)
-         { case
-             O_ifeq        ,
-             O_ifne        ,
-             O_iflt        ,
-             O_ifge        ,
-             O_ifgt        ,
-             O_ifle        ,
-             O_if_icmpeq   ,
-             O_if_icmpne   ,
-             O_if_icmplt   ,
-             O_if_icmpge   ,
-             O_if_icmpgt   ,
-             O_if_icmple   ,
-             O_if_acmpeq   ,
-             O_if_acmpne   ,
-             O_ifnull      ,
-             O_ifnonnull   -> true;
-         default           -> false;
-         });
-
-    var res = new byte[3 + neg.length];
-    var cc = bcsigned(bc    , 3 + neg.length);
-    System.arraycopy(cc  , 0, res, 0             , 3);
-    System.arraycopy(neg , 0, res, 3             , neg.length);
-
-    return res;
-  }
-
-
-  /**
-   * The byte code for this ByteCode.
-   *
-   * NYI: This should better be a byteCodeCollector with an argument of type
-   * Kaku to avoid exponential runtime when copying nested conditionals
-   */
-  public abstract byte[] byteCode(ClassFile cf);
+  public abstract void code(ClassFile.ByteCodeWriter bw, ClassFile cf);
 
 
   /**

--- a/src/dev/flang/be/jvm/classfile/ClassFileConstants.java
+++ b/src/dev/flang/be/jvm/classfile/ClassFileConstants.java
@@ -984,6 +984,13 @@ public interface ClassFileConstants
    */
   public static final int MAX_BYTECODE_LENGTH = 0xffff;
 
+
+  /**
+   * min / max offset in a branching bytecode instrution such as `ifeq`.
+   */
+  public static final int MIN_BRANCH_OFFSET = -0x8000;
+  public static final int MAX_BRANCH_OFFSET =  0x7fff;
+
 }
 
 /* end of file */

--- a/src/dev/flang/be/jvm/classfile/Expr.java
+++ b/src/dev/flang/be/jvm/classfile/Expr.java
@@ -53,7 +53,7 @@ public abstract class Expr extends ByteCode
   {
     public String toString() { return "UNIT"; }
     public JavaType type() { return PrimitiveType.type_void; }
-    public byte[] byteCode(ClassFile cf) { return BC_EMPTY; }
+    public void code(ClassFile.ByteCodeWriter ba, ClassFile cf) { ba.write(BC_EMPTY); }
   }
 
 
@@ -64,9 +64,9 @@ public abstract class Expr extends ByteCode
   static abstract class LoadConst extends Expr
   {
     abstract ClassFile.CPEntry cpEntry(ClassFile cf);
-    public byte[] byteCode(ClassFile cf)
+    public void code(ClassFile.ByteCodeWriter ba, ClassFile cf)
     {
-      return bc(O_ldc, cpEntry(cf));
+      code(ba, O_ldc, cpEntry(cf));
     }
   }
 
@@ -87,7 +87,10 @@ public abstract class Expr extends ByteCode
     }
     public String   toString()             { return _str;  }
     public JavaType type()                 { return _type; }
-    public byte[]   byteCode(ClassFile cf) { return _bc;   }
+    public void code(ClassFile.ByteCodeWriter ba, ClassFile cf)
+    {
+      ba.write(_bc);
+    }
   }
 
 
@@ -220,7 +223,7 @@ public abstract class Expr extends ByteCode
       {
         public String toString() { return "invokeStatic " + cls + "." + name; }
         public JavaType type() { return rt;  }
-        public byte[] byteCode(ClassFile cf)
+        public void code(ClassFile.ByteCodeWriter ba, ClassFile cf)
         {
           var c   = cf.cpUtf8(cls);
           var n   = cf.cpUtf8(name);
@@ -228,8 +231,8 @@ public abstract class Expr extends ByteCode
           var cl  = cf.cpClass(c);
           var nat = cf.cpNameAndType(n, d);
           var m   = cf.cpMethod(cl, nat);
-          return bc(O_invokestatic, m);
-        };
+          code(ba, O_invokestatic, m);
+        }
     };
   }
 
@@ -244,7 +247,7 @@ public abstract class Expr extends ByteCode
       {
         public String toString() { return "invokeSpecial " + cls + "." + name; }
         public JavaType type() { return PrimitiveType.type_void; }
-        public byte[] byteCode(ClassFile cf)
+        public void code(ClassFile.ByteCodeWriter ba, ClassFile cf)
         {
           var c   = cf.cpUtf8(cls);
           var n   = cf.cpUtf8(name);
@@ -252,8 +255,8 @@ public abstract class Expr extends ByteCode
           var cl  = cf.cpClass(c);
           var nat = cf.cpNameAndType(n, d);
           var m   = cf.cpMethod(cl, nat);
-          return bc(O_invokespecial, m);
-        };
+          code(ba, O_invokespecial, m);
+        }
     };
   }
 
@@ -268,14 +271,14 @@ public abstract class Expr extends ByteCode
       {
         public String toString() { return "invokeSpecial " + cl + "." + name; }
         public JavaType type() { return PrimitiveType.type_void;  }
-        public byte[] byteCode(ClassFile cf)
+        public void code(ClassFile.ByteCodeWriter ba, ClassFile cf)
         {
           var n   = cf.cpUtf8(name);
           var d   = cf.cpUtf8(descr);
           var nat = cf.cpNameAndType(n, d);
           var m   = cf.cpMethod(cl, nat);
-          return bc(O_invokespecial, m);
-        };
+          code(ba, O_invokespecial, m);
+        }
     };
   }
 
@@ -290,7 +293,7 @@ public abstract class Expr extends ByteCode
       {
         public String toString() { return "invokeVirtual " + cls + "." + name; }
         public JavaType type() { return rt;  }
-        public byte[] byteCode(ClassFile cf)
+        public void code(ClassFile.ByteCodeWriter ba, ClassFile cf)
         {
           var c   = cf.cpUtf8(cls);
           var n   = cf.cpUtf8(name);
@@ -298,8 +301,8 @@ public abstract class Expr extends ByteCode
           var cl  = cf.cpClass(c);
           var nat = cf.cpNameAndType(n, d);
           var m   = cf.cpMethod(cl, nat);
-          return bc(O_invokevirtual, m);
-        };
+          code(ba, O_invokevirtual, m);
+        }
     };
   }
 
@@ -316,7 +319,7 @@ public abstract class Expr extends ByteCode
       {
         public String toString() { return "invokeInterface " + cls + "." + name; }
         public JavaType type() { return rt;  }
-        public byte[] byteCode(ClassFile cf)
+        public void code(ClassFile.ByteCodeWriter ba, ClassFile cf)
         {
           var c   = cf.cpUtf8(cls);
           var n   = cf.cpUtf8(name);
@@ -324,8 +327,8 @@ public abstract class Expr extends ByteCode
           var cl  = cf.cpClass(c);
           var nat = cf.cpNameAndType(n, d);
           var m   = cf.cpInterfaceMethod(cl, nat);
-          return bc(O_invokeinterface, m, (byte) count, (byte) 0);
-        };
+          code(ba, O_invokeinterface, m, (byte) count, (byte) 0);
+        }
     };
   }
 
@@ -345,9 +348,9 @@ public abstract class Expr extends ByteCode
         {
           return type;
         }
-        public byte[] byteCode(ClassFile cf)
+        public void code(ClassFile.ByteCodeWriter ba, ClassFile cf)
         {
-          return bc(O_getfield, cf.cpField(cf.cpClass(cls), cf.cpNameAndType(name, type.descriptor())));
+          code(ba, O_getfield, cf.cpField(cf.cpClass(cls), cf.cpNameAndType(name, type.descriptor())));
         }
     };
   }
@@ -368,9 +371,9 @@ public abstract class Expr extends ByteCode
       {
         public String toString() { return "putfield " + cls + "." + name; }
         public JavaType type() { return PrimitiveType.type_void;  }
-        public byte[] byteCode(ClassFile cf)
+        public void code(ClassFile.ByteCodeWriter ba, ClassFile cf)
         {
-          return bc(O_putfield, cf.cpField(cf.cpClass(cls), cf.cpNameAndType(name, type.descriptor())));
+          code(ba, O_putfield, cf.cpField(cf.cpClass(cls), cf.cpNameAndType(name, type.descriptor())));
         }
     };
   }
@@ -394,9 +397,9 @@ public abstract class Expr extends ByteCode
         {
           return type;
         }
-        public byte[] byteCode(ClassFile cf)
+        public void code(ClassFile.ByteCodeWriter ba, ClassFile cf)
         {
-          return bc(O_getstatic, cf.cpField(cf.cpClass(cls), cf.cpNameAndType(name, type.descriptor())));
+          code(ba, O_getstatic, cf.cpField(cf.cpClass(cls), cf.cpNameAndType(name, type.descriptor())));
         }
     };
   }
@@ -417,9 +420,9 @@ public abstract class Expr extends ByteCode
       {
         public String toString() { return "putstatic " + cls + "." + name; }
         public JavaType type() { return PrimitiveType.type_void;  }
-        public byte[] byteCode(ClassFile cf)
+        public void code(ClassFile.ByteCodeWriter ba, ClassFile cf)
         {
-          return bc(O_putstatic, cf.cpField(cf.cpClass(cls), cf.cpNameAndType(name, type.descriptor())));
+          code(ba, O_putstatic, cf.cpField(cf.cpClass(cls), cf.cpNameAndType(name, type.descriptor())));
         }
     };
   }
@@ -438,18 +441,18 @@ public abstract class Expr extends ByteCode
           return PrimitiveType.type_int;
         }
         ClassFile.CPEntry cpEntry(ClassFile cf) { return cf.cpInteger(c); }
-        public byte[] byteCode(ClassFile cf)
+        public void code(ClassFile.ByteCodeWriter ba, ClassFile cf)
         {
-          return switch (c)
+          switch (c)
             {
-            case -1 -> BC_ICONST_M1;
-            case 0 -> BC_ICONST_0;
-            case 1 -> BC_ICONST_1;
-            case 2 -> BC_ICONST_2;
-            case 3 -> BC_ICONST_3;
-            case 4 -> BC_ICONST_4;
-            case 5 -> BC_ICONST_5;
-            default -> super.byteCode(cf);
+            case -1 -> ba.write(BC_ICONST_M1);
+            case  0 -> ba.write(BC_ICONST_0);
+            case  1 -> ba.write(BC_ICONST_1);
+            case  2 -> ba.write(BC_ICONST_2);
+            case  3 -> ba.write(BC_ICONST_3);
+            case  4 -> ba.write(BC_ICONST_4);
+            case  5 -> ba.write(BC_ICONST_5);
+            default -> super.code(ba, cf);
             };
         }
     };
@@ -469,11 +472,11 @@ public abstract class Expr extends ByteCode
           return PrimitiveType.type_long;
         }
         ClassFile.CPEntry cpEntry(ClassFile cf) { return cf.cpLong(c); }
-        public byte[] byteCode(ClassFile cf)
+        public void code(ClassFile.ByteCodeWriter ba, ClassFile cf)
         {
-          return
-            c == 0L ? BC_LCONST_0 :
-            c == 1L ? BC_LCONST_1 : super.byteCode(cf);
+          if      (c == 0L) { ba.write(BC_LCONST_0); }
+          else if (c == 1L) { ba.write(BC_LCONST_1); }
+          else              { super.code(ba, cf);    }
         }
     };
   }
@@ -492,12 +495,12 @@ public abstract class Expr extends ByteCode
           return PrimitiveType.type_float;
         }
         ClassFile.CPEntry cpEntry(ClassFile cf) { return cf.cpFloat(c); }
-        public byte[] byteCode(ClassFile cf)
+        public void code(ClassFile.ByteCodeWriter ba, ClassFile cf)
         {
-          return
-            Float.intBitsToFloat(c) == 0F ? BC_FCONST_0 :
-            Float.intBitsToFloat(c) == 1F ? BC_FCONST_1 :
-            Float.intBitsToFloat(c) == 2F ? BC_FCONST_2 : super.byteCode(cf);
+          if      (Float.intBitsToFloat(c) == 0F) { ba.write(BC_FCONST_0); }
+          else if (Float.intBitsToFloat(c) == 1F) { ba.write(BC_FCONST_1); }
+          else if (Float.intBitsToFloat(c) == 2F) { ba.write(BC_FCONST_2); }
+          else                                    { super.code(ba, cf);    }
         }
     };
   }
@@ -516,11 +519,11 @@ public abstract class Expr extends ByteCode
           return PrimitiveType.type_double;
         }
         ClassFile.CPEntry cpEntry(ClassFile cf) { return cf.cpDouble(c); }
-        public byte[] byteCode(ClassFile cf)
+        public void code(ClassFile.ByteCodeWriter ba, ClassFile cf)
         {
-          return
-            Double.longBitsToDouble(c) == 0F ? BC_DCONST_0 :
-            Double.longBitsToDouble(c) == 1F ? BC_DCONST_1 : super.byteCode(cf);
+          if      (Double.longBitsToDouble(c) == 0F) { ba.write(BC_DCONST_0); }
+          else if (Double.longBitsToDouble(c) == 1F) { ba.write(BC_DCONST_1); }
+          else                                       { super.code(ba, cf);    }
         }
     };
   }
@@ -578,15 +581,15 @@ public abstract class Expr extends ByteCode
         {
           return PrimitiveType.type_int;
         }
-        public byte[] byteCode(ClassFile cf)
+        public void code(ClassFile.ByteCodeWriter ba, ClassFile cf)
         {
-          return switch (index)
+          switch (index)
             {
-            case 0 -> BC_ILOAD_0;
-            case 1 -> BC_ILOAD_1;
-            case 2 -> BC_ILOAD_2;
-            case 3 -> BC_ILOAD_3;
-            default -> bc(O_iload, index);
+            case 0 -> ba.write(BC_ILOAD_0);
+            case 1 -> ba.write(BC_ILOAD_1);
+            case 2 -> ba.write(BC_ILOAD_2);
+            case 3 -> ba.write(BC_ILOAD_3);
+            default -> code(ba, O_iload, index);
             };
         }
     };
@@ -600,15 +603,15 @@ public abstract class Expr extends ByteCode
     return new Store()
       {
         public String toString() { return "istore"; }
-        public byte[] byteCode(ClassFile cf)
+        public void code(ClassFile.ByteCodeWriter ba, ClassFile cf)
         {
-          return switch (index)
+          switch (index)
             {
-            case 0 -> BC_ISTORE_0;
-            case 1 -> BC_ISTORE_1;
-            case 2 -> BC_ISTORE_2;
-            case 3 -> BC_ISTORE_3;
-            default -> bc(O_istore, index);
+            case 0 -> ba.write(BC_ISTORE_0);
+            case 1 -> ba.write(BC_ISTORE_1);
+            case 2 -> ba.write(BC_ISTORE_2);
+            case 3 -> ba.write(BC_ISTORE_3);
+            default -> code(ba, O_istore, index);
             };
         }
     };
@@ -627,15 +630,15 @@ public abstract class Expr extends ByteCode
         {
           return PrimitiveType.type_long;
         }
-        public byte[] byteCode(ClassFile cf)
+        public void code(ClassFile.ByteCodeWriter ba, ClassFile cf)
         {
-          return switch (index)
+          switch (index)
             {
-            case 0 -> BC_LLOAD_0;
-            case 1 -> BC_LLOAD_1;
-            case 2 -> BC_LLOAD_2;
-            case 3 -> BC_LLOAD_3;
-            default -> bc(O_lload, index);
+            case 0 -> ba.write(BC_LLOAD_0);
+            case 1 -> ba.write(BC_LLOAD_1);
+            case 2 -> ba.write(BC_LLOAD_2);
+            case 3 -> ba.write(BC_LLOAD_3);
+            default -> code(ba, O_lload, index);
             };
         }
     };
@@ -650,15 +653,15 @@ public abstract class Expr extends ByteCode
     return new Store()
       {
         public String toString() { return "lstore"; }
-        public byte[] byteCode(ClassFile cf)
+        public void code(ClassFile.ByteCodeWriter ba, ClassFile cf)
         {
-          return switch (index)
+          switch (index)
             {
-            case 0 -> BC_LSTORE_0;
-            case 1 -> BC_LSTORE_1;
-            case 2 -> BC_LSTORE_2;
-            case 3 -> BC_LSTORE_3;
-            default -> bc(O_lstore, index);
+            case 0 -> ba.write(BC_LSTORE_0);
+            case 1 -> ba.write(BC_LSTORE_1);
+            case 2 -> ba.write(BC_LSTORE_2);
+            case 3 -> ba.write(BC_LSTORE_3);
+            default -> code(ba, O_lstore, index);
             };
         }
     };
@@ -677,15 +680,15 @@ public abstract class Expr extends ByteCode
         {
           return PrimitiveType.type_float;
         }
-        public byte[] byteCode(ClassFile cf)
+        public void code(ClassFile.ByteCodeWriter ba, ClassFile cf)
         {
-          return switch (index)
+          switch (index)
             {
-            case 0 -> BC_FLOAD_0;
-            case 1 -> BC_FLOAD_1;
-            case 2 -> BC_FLOAD_2;
-            case 3 -> BC_FLOAD_3;
-            default -> bc(O_fload, index);
+            case 0 -> ba.write(BC_FLOAD_0);
+            case 1 -> ba.write(BC_FLOAD_1);
+            case 2 -> ba.write(BC_FLOAD_2);
+            case 3 -> ba.write(BC_FLOAD_3);
+            default -> code(ba, O_fload, index);
             };
         }
     };
@@ -700,15 +703,15 @@ public abstract class Expr extends ByteCode
     return new Store()
       {
         public String toString() { return "fstore"; }
-        public byte[] byteCode(ClassFile cf)
+        public void code(ClassFile.ByteCodeWriter ba, ClassFile cf)
         {
-          return switch (index)
+          switch (index)
             {
-            case 0 -> BC_FSTORE_0;
-            case 1 -> BC_FSTORE_1;
-            case 2 -> BC_FSTORE_2;
-            case 3 -> BC_FSTORE_3;
-            default -> bc(O_fstore, index);
+            case 0 -> ba.write(BC_FSTORE_0);
+            case 1 -> ba.write(BC_FSTORE_1);
+            case 2 -> ba.write(BC_FSTORE_2);
+            case 3 -> ba.write(BC_FSTORE_3);
+            default -> code(ba, O_fstore, index);
             };
         }
     };
@@ -727,15 +730,15 @@ public abstract class Expr extends ByteCode
         {
           return PrimitiveType.type_double;
         }
-        public byte[] byteCode(ClassFile cf)
+        public void code(ClassFile.ByteCodeWriter ba, ClassFile cf)
         {
-          return switch (index)
+          switch (index)
             {
-            case 0 -> BC_DLOAD_0;
-            case 1 -> BC_DLOAD_1;
-            case 2 -> BC_DLOAD_2;
-            case 3 -> BC_DLOAD_3;
-            default -> bc(O_dload, index);
+            case 0 -> ba.write(BC_DLOAD_0);
+            case 1 -> ba.write(BC_DLOAD_1);
+            case 2 -> ba.write(BC_DLOAD_2);
+            case 3 -> ba.write(BC_DLOAD_3);
+            default -> code(ba, O_dload, index);
             };
         }
     };
@@ -750,15 +753,15 @@ public abstract class Expr extends ByteCode
     return new Store()
       {
         public String toString() { return "dstore"; }
-        public byte[] byteCode(ClassFile cf)
+        public void code(ClassFile.ByteCodeWriter ba, ClassFile cf)
         {
-          return switch (index)
+          switch (index)
             {
-            case 0 -> BC_DSTORE_0;
-            case 1 -> BC_DSTORE_1;
-            case 2 -> BC_DSTORE_2;
-            case 3 -> BC_DSTORE_3;
-            default -> bc(O_dstore, index);
+            case 0 -> ba.write(BC_DSTORE_0);
+            case 1 -> ba.write(BC_DSTORE_1);
+            case 2 -> ba.write(BC_DSTORE_2);
+            case 3 -> ba.write(BC_DSTORE_3);
+            default -> code(ba, O_dstore, index);
             };
         }
     };
@@ -777,15 +780,15 @@ public abstract class Expr extends ByteCode
         {
           return type;
         }
-        public byte[] byteCode(ClassFile cf)
+        public void code(ClassFile.ByteCodeWriter ba, ClassFile cf)
         {
-          return switch (n)
+          switch (n)
             {
-            case 0 -> BC_ALOAD_0;
-            case 1 -> BC_ALOAD_1;
-            case 2 -> BC_ALOAD_2;
-            case 3 -> BC_ALOAD_3;
-            default -> bc(O_aload, n);
+            case 0 -> ba.write(BC_ALOAD_0);
+            case 1 -> ba.write(BC_ALOAD_1);
+            case 2 -> ba.write(BC_ALOAD_2);
+            case 3 -> ba.write(BC_ALOAD_3);
+            default -> code(ba, O_aload, n);
             };
         }
     };
@@ -800,15 +803,15 @@ public abstract class Expr extends ByteCode
     return new Store()
       {
         public String toString() { return "astore"; }
-        public byte[] byteCode(ClassFile cf)
+        public void code(ClassFile.ByteCodeWriter ba, ClassFile cf)
         {
-          return switch (n)
+          switch (n)
             {
-            case 0 -> BC_ASTORE_0;
-            case 1 -> BC_ASTORE_1;
-            case 2 -> BC_ASTORE_2;
-            case 3 -> BC_ASTORE_3;
-            default -> bc(O_astore, n);
+            case 0 -> ba.write(BC_ASTORE_0);
+            case 1 -> ba.write(BC_ASTORE_1);
+            case 2 -> ba.write(BC_ASTORE_2);
+            case 3 -> ba.write(BC_ASTORE_3);
+            default -> code(ba, O_astore, n);
             };
         }
     };
@@ -827,9 +830,9 @@ public abstract class Expr extends ByteCode
         {
           return type;
         }
-        public byte[] byteCode(ClassFile cf)
+        public void code(ClassFile.ByteCodeWriter ba, ClassFile cf)
         {
-          return BC_AALOAD;
+          ba.write(BC_AALOAD);
         }
     };
   }
@@ -849,9 +852,9 @@ public abstract class Expr extends ByteCode
         {
           return type;
         }
-        public byte[] byteCode(ClassFile cf)
+        public void code(ClassFile.ByteCodeWriter ba, ClassFile cf)
         {
-          return bc(O_new, cf.cpClass(className));
+          code(ba, O_new, cf.cpClass(className));
         }
     };
   }
@@ -873,9 +876,9 @@ public abstract class Expr extends ByteCode
         {
           return type.array();
         }
-        public byte[] byteCode(ClassFile cf)
+        public void code(ClassFile.ByteCodeWriter ba, ClassFile cf)
         {
-          return bc(O_anewarray, cf.cpClass(type.descriptor2()));
+          code(ba, O_anewarray, cf.cpClass(type.descriptor2()));
         }
     };
   }
@@ -901,20 +904,69 @@ public abstract class Expr extends ByteCode
        bc == ClassFileConstants.O_ifnull    ||
        bc == ClassFileConstants.O_ifnonnull   );
 
-    return new Expr()
+    Label lStart = new Label();
+    Label lEnd   = new Label();
+    Label lPos   = new Label();
+
+    if (pos != UNIT && neg != UNIT)
       {
-        public String toString() { return "branch"; }
-        public JavaType type()
+        neg = neg.andThen(gotoLabel(lEnd));
+        pos = lPos.andThen(pos);
+      }
+
+    // effectively final vars for use in inner class:
+    var fpos = pos;
+    var fneg = neg;
+
+    return lStart.andThen
+      (new Expr()
         {
-          return PrimitiveType.type_void;
-        }
-        public byte[] byteCode(ClassFile cf)
-        {
-          var pb = pos.byteCode(cf);
-          var nb = neg.byteCode(cf);
-          return bc(bc, pb, nb);
-        }
-    };
+          public String toString() { return "branch"; }
+          public JavaType type()
+          {
+            return PrimitiveType.type_void;
+          }
+          public void code(ClassFile.ByteCodeWriter ba, ClassFile cf)
+          {
+            if (fpos == UNIT)
+              {
+                code(ba, bc, lStart, lEnd);
+                fneg.code(ba, cf);
+              }
+            else if (fneg == UNIT)
+              {
+                var nbc = switch (bc)
+                  {
+                  case O_ifeq        -> O_ifne     ;
+                  case O_ifne        -> O_ifeq     ;
+                  case O_iflt        -> O_ifge     ;
+                  case O_ifge        -> O_iflt     ;
+                  case O_ifgt        -> O_ifle     ;
+                  case O_ifle        -> O_ifgt     ;
+                  case O_if_icmpeq   -> O_if_icmpne;
+                  case O_if_icmpne   -> O_if_icmpeq;
+                  case O_if_icmplt   -> O_if_icmpge;
+                  case O_if_icmpge   -> O_if_icmplt;
+                  case O_if_icmpgt   -> O_if_icmple;
+                  case O_if_icmple   -> O_if_icmpgt;
+                  case O_if_acmpeq   -> O_if_acmpne;
+                  case O_if_acmpne   -> O_if_acmpeq;
+                  case O_ifnull      -> O_ifnonnull;
+                  case O_ifnonnull   -> O_ifnull   ;
+                  default -> throw new Error("unexpected bc "+bc);
+                  };
+                code(ba, nbc, lStart, lEnd);
+                fpos.code(ba, cf);
+              }
+            else
+              {
+                code(ba, bc, lStart, lPos);
+                fneg.code(ba, cf);
+                fpos.code(ba, cf);
+              }
+          }
+        })
+      .andThen(lEnd);
   }
 
 
@@ -927,9 +979,9 @@ public abstract class Expr extends ByteCode
         {
           return type;
         }
-        public byte[] byteCode(ClassFile cf)
+        public void code(ClassFile.ByteCodeWriter ba, ClassFile cf)
         {
-          return bc(O_checkcast, cf.cpClass(type.descriptor2()));
+          code(ba, O_checkcast, cf.cpClass(type.descriptor2()));
         }
     };
   }
@@ -942,20 +994,30 @@ public abstract class Expr extends ByteCode
    */
   public static Expr endless_loop()
   {
-    return new Expr()
-      {
-        public String toString() { return "endless_loop"; }
-        public JavaType type()
-        {
-          return ClassFileConstants.PrimitiveType.type_void;
-        }
-        public byte[] byteCode(ClassFile cf)
-        {
-          return bcsigned(O_goto, 0);
-        }
-    };
+    Label l = new Label();
+    return l.andThen(gotoLabel(l));
   }
 
+
+  /**
+   */
+  public static Expr gotoLabel(Label to)
+  {
+    Label from = new Label();
+    return from.andThen
+      (new Expr()
+        {
+          public String toString() { return "goto " + to; }
+          public JavaType type()
+          {
+            return ClassFileConstants.PrimitiveType.type_void;
+          }
+          public void code(ClassFile.ByteCodeWriter ba, ClassFile cf)
+          {
+            code(ba, O_goto, from, to);
+          }
+        });
+  }
 
 
   /*-----------------------------  methods  -----------------------------*/
@@ -988,10 +1050,11 @@ public abstract class Expr extends ByteCode
           {
             public String toString() { return "...andThen" + s; }
             public JavaType type() { return s.type();  }
-            public byte[] byteCode(ClassFile cf)
+            public void code(ClassFile.ByteCodeWriter ba, ClassFile cf)
             {
-              return bc(Expr.this.byteCode(cf), s.byteCode(cf));
-            };
+              Expr.this.code(ba, cf);
+              s.code(ba, cf);
+            }
           };
       }
   }
@@ -1035,10 +1098,10 @@ public abstract class Expr extends ByteCode
       {
         public String toString() { return Expr.this.toString() + "[" + t + "]"; }
         public JavaType type() { return t;  }
-        public byte[] byteCode(ClassFile cf)
+        public void code(ClassFile.ByteCodeWriter ba, ClassFile cf)
         {
-          return Expr.this.byteCode(cf);
-        };
+          Expr.this.code(ba, cf);
+        }
       };
   }
 

--- a/src/dev/flang/be/jvm/classfile/Label.java
+++ b/src/dev/flang/be/jvm/classfile/Label.java
@@ -1,0 +1,113 @@
+/*
+
+This file is part of the Fuzion language implementation.
+
+The Fuzion language implementation is free software: you can redistribute it
+and/or modify it under the terms of the GNU General Public License as published
+by the Free Software Foundation, version 3 of the License.
+
+The Fuzion language implementation is distributed in the hope that it will be
+useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+License for more details.
+
+You should have received a copy of the GNU General Public License along with The
+Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+*/
+
+/*-----------------------------------------------------------------------
+ *
+ * Tokiwa Software GmbH, Germany
+ *
+ * Source of class Label
+ *
+ *---------------------------------------------------------------------*/
+
+package dev.flang.be.jvm.classfile;
+
+import dev.flang.util.Pair;
+
+
+/**
+ * Label is a symbolic label in byte code. A Label is an Expr that produces
+ * no code.  Its only function is to carry around the bytecode location of the
+ * subsequent bytecode.
+ *
+ * @author Fridtjof Siebert (siebert@tokiwa.software)
+ */
+
+public class Label extends Expr
+{
+
+  /*----------------------------  variables  ----------------------------*/
+
+
+  /**
+   * Absolute position of this label: estimate and final value.
+   *
+   * The position has the following values:
+   *
+   * initially: -1
+   *
+   * after ByteCodeSizeEstimate: pe: A position estimate that may shrink
+   * during ByteCodeFixLabals phase.
+   *
+   * after ByteCodeFixLabels: pf: The final position.
+   *
+   * after Kaku: pf, unchanged.
+   *
+   * Final positions may not be larger than estimates:
+   *
+   *   ∀ l: l.pe >= l.pf
+   *
+   * And distances between final labels will not exceed the estimates:
+   *
+   *   ∀ l1, l2: |l1.pe - l2.pe| >= |l1.pf - l2.pf|
+   *
+   */
+  int _posEstimate = -1;
+  int _posFinal = -1;
+
+
+  /*---------------------------  constructors  ---------------------------*/
+
+
+  public Label()
+  {
+  }
+
+
+  /*-----------------------------  methods  -----------------------------*/
+
+
+  /**
+   * Create the byte code for this ByteCode.
+   *
+   * For a Label, this will set this label.
+   *
+   * @param bw the writer to write the bytecode to.
+   *
+   * @param cf the class file we are generating, used for cpool indices.
+   */
+  public void code(ClassFile.ByteCodeWriter ba, ClassFile cf)
+  {
+    ba.setLabel(this);
+  }
+
+
+  public JavaType type()
+  {
+    return ClassFileConstants.PrimitiveType.type_void;
+  }
+
+
+  /**
+   * String representation of this label:
+   */
+  public String toString() { return "label:"; }
+
+
+}
+
+/* end of file */


### PR DESCRIPTION
This is required for more complex control flow, in particular for tail recursion where we need a `goto` to the beginning of a method.

The main change is that ByteCode no longer provides a methods `bypeCode` and `bc*` that produce a `byte[]`, but instead there are methods `code(bw, ...)` that write bytecode to a `ByteCodeWriter`.

These `ByteCodeWriters` is an abstract class that will be run three times: first, to get an upper bound estimate for the bytecode size and offsets of labels, next to then freeze this upper bound and fix all labels, and finally to produce the code now that the labels adresses are known.

This infrastructure will also be needed to support bytecode `lookupswitch` and `tableswitch` that have some alignment requirements.

Unfortunately, this patch requires changes in `Choices.java` since labels can only be used once, so an `Expr` using a label cannot be used for code generation repeatedly.  The code for the cases in a choice were, however, reused, which had to be changed such that every case has its own copy of the code with its own labels.