### PR TITLE
lib: Add collection of features for function composition, #2046

### DIFF
--- a/lib/composition.fz
+++ b/lib/composition.fz
@@ -1,0 +1,142 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion standard library feature composition
+#
+#  Author: Fridtjof Siebert (siebert@tokiwa.software)
+#
+# -----------------------------------------------------------------------
+
+# composition -- a collection of features for function composition
+#
+# see https://mlochbaum.github.io/BQN/tutorial/combinator.html
+#     https://combinatorylogic.com/table.html
+#
+# Talk at Strange Loop 2016 by Amar Shah: Point-Free or Die: Tacit Programming in Haskell and Beyond
+# https://www.youtube.com/watch?v=seVSlKazsNk
+#
+# Talk at CppNorth 2023 by Conor Hoekstra: Function Composition in Programming Languages - Conor Hoekstra - CppNorth 2023
+# https://www.youtube.com/watch?v=JELcdZLre3s
+#
+# Paper by Conor Hoekstra: Combinatory Logic and Combinators in Array Languages
+# https://web.archive.org/web/20220617020347id_/https://dl.acm.org/doi/pdf/10.1145/3520306.3534504
+#
+# BQN tutorial: https://mlochbaum.github.io/BQN/tutorial/index.html
+#
+# Bird names from Raymond M Smullyan. 2000. To Mock a Mockingbird: and other
+# logic puzzles including an amazing adventure in combinatory logic. Oxford
+# University Press, USA.
+#
+composition is
+
+  # I
+  # identity
+  # BQN: ⊣⊢
+  # Haskell id
+  id(T type) T -> T is x->x
+
+  # K
+  # Elementary Cancellator
+  # Kestrel
+  # BQN: ⊣
+  # Haskell ?
+  left(T, U type) (T,U) -> T is (x,y) -> x
+
+  # S
+  # hook, monadic after
+  # Bird: Starling
+  # BQN: ⟜
+  # Haskell: <*>
+  after1(f (T, U) -> V, g T -> U) T -> V is x -> f x (g x)
+
+  # B
+  # Elementare Compositor
+  # Bird: Bluebird
+  # BQN: ∘
+  # Haskell: .
+  compose( f U -> V, g T -> U) T -> V => f ∘ g
+
+  # B1
+  # Elementare Compositor
+  # Bird: Blackbird
+  # BQN: ∘
+  # Haskell: .: or ...
+  atop(f V -> W, g (T,U) -> V) (T,U) -> W is (x,y) -> f (g x y)
+
+  # C
+  # Elementary Permutator
+  # Bird: Cardinal
+  # BQN: ˜
+  # Haskell: flip
+  flip(f (T,U) -> V) (U,T) -> V is (x,y) -> f y x
+
+  # W
+  # Elementary Duplicator
+  # Bird: Warbler
+  # BQN: ~
+  # Haskell: join
+  join(f (T,T) -> U) T->U is x -> f x x
+
+  # Ψ - psi
+  # composition of binary and unary function
+  # Bird: ?
+  # BQN: ○
+  # Haskell: on
+  over(f (U,U) -> V, g T -> U) (T,T) -> V is (x,y) -> f (g x) (g y)
+
+  # Φ (S′)
+  # composition of two unary functions and one binary function
+  # BQN: 3-train?
+  # Haskell: liftA2
+  fork(f (U1,U2) -> V, g T1 -> U1, h T2 -> U2) (T1,T2) -> V is (x,y) -> f (g x) (h y)
+
+  # Φ1
+  # composition of two unary functions and one binary function
+  # Bird: Pheasant (Hoekstra)
+  # BQN: 3-train?
+  # Haskell: ?
+  fork2(f (U1,U2) -> V, g (T1,T2) -> U1, h (T1,T2) -> U2) (T1,T2) -> V is (x,y) -> f (g x y) (h x y)
+
+  # D
+  # composition of one binary function f and one unaray function g...
+  # Bird: Dove
+  # BQN: ⟜
+  # Haskell:
+  after2(f (V, U) -> W, g T -> U) (V,T) -> W is (x,y) -> f x (g y)
+
+  # D2
+  # composition of one binary function g and tow unaray functions f, h
+  # Bird: Dovekie
+  # BQN: a⊸b⟜c
+  # Haskell:
+  d2(f T -> V, g (V,W) -> X, h U -> W) (T,U) -> X is (x,y) -> g (f x) (h y)
+
+  # left ∘ flip
+  # BQN: ⊢
+  right(T, U type) (T,U) -> U is (x,y) -> y
+
+  #
+  # BQN: ⊸
+  before1(f V -> U, g (U, V) -> W) V     -> W is x     -> g (f x) x
+  before2(f T -> U, g (U, V) -> W) (T,V) -> W is (x,y) -> g (f x) y
+
+  #
+  # BQN: ˙
+  const1(T, U    type, v T) U     -> T is x     -> v
+  const2(T, U, V type, v T) (U,V) -> T is (x,y) -> v

--- a/lib/composition.fz
+++ b/lib/composition.fz
@@ -47,13 +47,14 @@ composition is
 
   # I
   # identity
+  # Bird: ?
   # BQN: ⊣⊢
   # Haskell id
   id(T type) T -> T is x->x
 
   # K
   # Elementary Cancellator
-  # Kestrel
+  # Bird: Kestrel
   # BQN: ⊣
   # Haskell ?
   left(T, U type) (T,U) -> T is (x,y) -> x
@@ -102,6 +103,7 @@ composition is
 
   # Φ (S′)
   # composition of two unary functions and one binary function
+  # Bird: ?
   # BQN: 3-train?
   # Haskell: liftA2
   fork(f (U1,U2) -> V, g T1 -> U1, h T2 -> U2) (T1,T2) -> V is (x,y) -> f (g x) (h y)
@@ -114,29 +116,34 @@ composition is
   fork2(f (U1,U2) -> V, g (T1,T2) -> U1, h (T1,T2) -> U2) (T1,T2) -> V is (x,y) -> f (g x y) (h x y)
 
   # D
-  # composition of one binary function f and one unaray function g...
+  # composition of one binary function f and one unary function g...
   # Bird: Dove
   # BQN: ⟜
   # Haskell:
   after2(f (V, U) -> W, g T -> U) (V,T) -> W is (x,y) -> f x (g y)
 
   # D2
-  # composition of one binary function g and tow unaray functions f, h
+  # composition of one binary function g and tow unary functions f, h
   # Bird: Dovekie
   # BQN: a⊸b⟜c
   # Haskell:
   d2(f T -> V, g (V,W) -> X, h U -> W) (T,U) -> X is (x,y) -> g (f x) (h y)
 
   # left ∘ flip
+  # Bird: ?
   # BQN: ⊢
   right(T, U type) (T,U) -> U is (x,y) -> y
 
-  #
+  # ?
+  # composition of one unary function f and one binary function g...
+  # Bird: ?
   # BQN: ⊸
   before1(f V -> U, g (U, V) -> W) V     -> W is x     -> g (f x) x
   before2(f T -> U, g (U, V) -> W) (T,V) -> W is (x,y) -> g (f x) y
 
-  #
+  # ?
+  # Constant cancellator?
+  # Bird: ?
   # BQN: ˙
   const1(T, U    type, v T) U     -> T is x     -> v
   const2(T, U, V type, v T) (U,V) -> T is (x,y) -> v


### PR DESCRIPTION
This is not intended to be useful at this point, it is just a first try to collect basic composition features that appear in literature and other languages.

To make this useful, we need to write example code using these and play around with it. Maybe we need to move these into Unary.fz, maybe add Binary.fz, maybe make some operators or add operator aliases, maybe add features or operators to the universe, etc. Maybe we want these in a separate module?