### PR TITLE
jvm: On contract failure, show only fuzion features in stack trace

### DIFF
--- a/src/dev/flang/be/jvm/Names.java
+++ b/src/dev/flang/be/jvm/Names.java
@@ -131,11 +131,13 @@ public class Names extends ANY implements ClassFileConstants
   private static final String DYNAMIC_FUNCTION_PREFIX = "fzD_";
 
   static final String PRECONDITION_NAME = "fzPrecondition";
-  static final String ROUTINE_NAME = "fzRoutine";
+  static final String ROUTINE_NAME      = "fzRoutine";
   static
   {
     if (CHECKS) check
-      (ROUTINE_NAME.equals(Runtime.ROUTINE_NAME));
+      (PRECONDITION_NAME.equals(Runtime.PRECONDITION_NAME),
+       ROUTINE_NAME.equals(Runtime.ROUTINE_NAME),
+       CLASS_PREFIX.equals(Runtime.CLASS_PREFIX));
   }
 
   /**

--- a/src/dev/flang/be/jvm/runtime/Runtime.java
+++ b/src/dev/flang/be/jvm/runtime/Runtime.java
@@ -114,11 +114,13 @@ public class Runtime extends ANY
 
 
   /**
-   * Copy of dev.flang.be.jvm.Names.ROUTINE_NAME without adding a dependency on
+   * Copy of dev.flang.be.jvm.Names.* without adding a dependency on
    * that package.  We do not want to bundle the backend classes with a
    * stand-alone application that needs the runtime classes, so this is copied.
    */
-  public static final String ROUTINE_NAME = "fzRoutine";
+  public static final String PRECONDITION_NAME = "fzPrecondition";
+  public static final String ROUTINE_NAME      = "fzRoutine";
+  public static final String CLASS_PREFIX      = "fzC_";
 
 
   /*--------------------------  static fields  --------------------------*/
@@ -597,7 +599,38 @@ public class Runtime extends ANY
   public static void contract_fail(String msg)
   {
     var stacktrace = new StringWriter();
-    new Throwable().printStackTrace(new PrintWriter(stacktrace));
+    stacktrace.write("Call stack:\n");
+    String last = "";
+    int count = 0;
+    for (var s : new Throwable().getStackTrace())
+      {
+        var m = s.getMethodName();
+        var r = switch (m)
+          {
+          case ROUTINE_NAME      -> "";
+          case PRECONDITION_NAME -> "precondition of ";
+          default -> null;
+          };
+        var cl = s.getClassName();
+        if (r != null && cl.startsWith(CLASS_PREFIX))
+          {
+            cl = cl.substring(CLASS_PREFIX.length());
+            var str = r + cl + "\n";
+            if (str == last)
+              {
+                count++;
+              }
+            else
+              {
+                if (count > 1)
+                  {
+                    stacktrace.write("\n  ... repeated " + count + " times ...");
+                  }
+                stacktrace.write(str);
+                count = 1;
+              }
+          }
+      }
     Errors.fatal("CONTRACT FAILED: " + msg, stacktrace.toString());
   }
 

--- a/tests/contracts_negative/SquareRoot.fz.expected_err_jvm
+++ b/tests/contracts_negative/SquareRoot.fz.expected_err_jvm
@@ -1,27 +1,7 @@
 
 error 1: CONTRACT FAILED: pre-condition on call to 'SquareRoot.sqrt'
-java.lang.Throwable
-	at dev.flang.be.jvm.runtime.Runtime.contract_fail(Runtime.java:600)
-	at fzC_SquareRoot__1sqrt.fzPrecondition(Unknown Source)
-	at fzC_SquareRoot.fzRoutine(Unknown Source)
-	at fzC_universe.main(Unknown Source)
-	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
-	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
-	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
-	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
-	at dev.flang.be.jvm.Runner.runMain(Runner.java:120)
-	at dev.flang.be.jvm.JVM$CompilePhase$4.finish(JVM.java:488)
-	at dev.flang.be.jvm.JVM.lambda$createCode$0(JVM.java:785)
-	at java.base/java.util.Spliterators$ArraySpliterator.forEachRemaining(Spliterators.java:992)
-	at java.base/java.util.stream.ReferencePipeline$Head.forEachOrdered(ReferencePipeline.java:772)
-	at dev.flang.be.jvm.JVM.createCode(JVM.java:776)
-	at dev.flang.be.jvm.JVM.compile(JVM.java:761)
-	at dev.flang.tools.Fuzion$Backend$3.process(Fuzion.java:163)
-	at dev.flang.tools.Fuzion$Backend.processFrontEnd(Fuzion.java:444)
-	at dev.flang.tools.Fuzion.lambda$parseArgsForBackend$3(Fuzion.java:908)
-	at dev.flang.tools.Tool.lambda$run$0(Tool.java:145)
-	at dev.flang.util.Errors.runAndExit(Errors.java:762)
-	at dev.flang.tools.Tool.run(Tool.java:145)
-	at dev.flang.tools.Fuzion.main(Fuzion.java:557)
+Call stack:
+precondition of SquareRoot__1sqrt
+SquareRoot
 
 *** fatal errors encountered, stopping.

--- a/tests/reg_issue270/issue270.fz.expected_err_jvm
+++ b/tests/reg_issue270/issue270.fz.expected_err_jvm
@@ -1,26 +1,6 @@
 
 error 1: CONTRACT FAILED: pre-condition on call to 'issue270'
-java.lang.Throwable
-	at dev.flang.be.jvm.runtime.Runtime.contract_fail(Runtime.java:600)
-	at fzC_issue270.fzPrecondition(Unknown Source)
-	at fzC_universe.main(Unknown Source)
-	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
-	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
-	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
-	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
-	at dev.flang.be.jvm.Runner.runMain(Runner.java:120)
-	at dev.flang.be.jvm.JVM$CompilePhase$4.finish(JVM.java:488)
-	at dev.flang.be.jvm.JVM.lambda$createCode$0(JVM.java:785)
-	at java.base/java.util.Spliterators$ArraySpliterator.forEachRemaining(Spliterators.java:992)
-	at java.base/java.util.stream.ReferencePipeline$Head.forEachOrdered(ReferencePipeline.java:772)
-	at dev.flang.be.jvm.JVM.createCode(JVM.java:776)
-	at dev.flang.be.jvm.JVM.compile(JVM.java:761)
-	at dev.flang.tools.Fuzion$Backend$3.process(Fuzion.java:163)
-	at dev.flang.tools.Fuzion$Backend.processFrontEnd(Fuzion.java:444)
-	at dev.flang.tools.Fuzion.lambda$parseArgsForBackend$3(Fuzion.java:908)
-	at dev.flang.tools.Tool.lambda$run$0(Tool.java:145)
-	at dev.flang.util.Errors.runAndExit(Errors.java:762)
-	at dev.flang.tools.Tool.run(Tool.java:145)
-	at dev.flang.tools.Fuzion.main(Fuzion.java:557)
+Call stack:
+precondition of issue270
 
 *** fatal errors encountered, stopping.


### PR DESCRIPTION
This removes confusing information and avoid frequent changes do to line number changes in our sources.