### PR TITLE
lib: `slice` now returns `Sequence T` instead of `list T`

### DIFF
--- a/lib/Sequence.fz
+++ b/lib/Sequence.fz
@@ -198,9 +198,8 @@ public Sequence(T type) ref is
   # create a slice from this Sequence that consists of the elements starting at index
   # from (including) up to index to (excluding).
   #
-  public slice(from, to i32) => drop(from).take to-from
-    # NYI: OPTIMIZATION: We could redefine this, e.g. to avoid copying array data
-    # on array.slice(from,to).as_array.
+  public slice(from, to i32) Sequence T is
+    drop(from).take to-from
 
 
   # create a tuple of two Sequences by splitting this at the given index, i.e.,

--- a/lib/String.fz
+++ b/lib/String.fz
@@ -384,7 +384,7 @@ public String ref : property.equatable, property.hashable, property.orderable is
   is
     codepoint_array
       .slice from to
-      .map String c->c  # NYI: this should maybe not be needed since codepoint is a string
+      .map_sequence String c->c  # NYI: this should maybe not be needed since codepoint is a string
       .fold String.type.concat
 
 

--- a/lib/array.fz
+++ b/lib/array.fz
@@ -116,34 +116,58 @@ public array(redef T type,
     pre
       debug: i ≥ 0
   is
-    slice i length
+    (slice i length).as_list
 
 
   # create a slice from this array's elements at index 'from' (included)
   # up to 'to' (excluded).
   #
-  # NYI: array.slice should better return an array containing a slice of
-  # internal_array.
+  # Complexity:
+  # index access : O(1)
+  # count        : O(1)
   #
-  public redef slice(from, to i32) list T
+  public redef slice(from, to i32) Sequence T
     pre
       debug: from ≥ 0
   is
-    if to ≤ from
-      nil
-    else
-      array_cons from to
+
+    ref : Sequence T
+
+      # this array slice as a list
+      #
+      public redef as_list list T is
+        if to ≤ from
+          nil
+        else
+          array_cons from to
+
+      # get the contents of this slice at the given index
+      #
+      public redef index [ ] (i i32) T
+      is
+        array.this[from+i]
+
+      # is this sequence known to be finite?  For infinite sequences, features like
+      # count diverge.
+      #
+      public redef finite => true
+
+      # redefines Sequence.count for array.slice,
+      # reducing complexity from O(n) to O(1).
+      #
+      public redef count => to-from
+
 
 
   # create a cons cell for a list of this array starting at the given
-  # index and up to to
+  # index `i` and up to `to`
   #
   array_cons (i, to i32) : Cons T (list T)
     pre
       debug: 0 ≤ i < to ≤ length
   is
     head => array.this[i]
-    tail => slice i+1 to
+    tail => (slice i+1 to).as_list
 
 
   # map the array to a new array applying function f to all elements

--- a/lib/list.fz
+++ b/lib/list.fz
@@ -341,12 +341,6 @@ public list(A type) : choice nil (Cons A (list A)), Sequence A is
                 | c Cons => c.tail.drop n-1
 
 
-  # create a slice from this list that consists of the elements starting at index
-  # 'from' (including) up to index 'to' (excluding).
-  #
-  public redef slice(from, to i32) => (drop from).take to-from
-
-
   # Lazily take the first elements of a list for which predicate 'p' holds.
   #
   public redef take_while (p A -> bool) list A


### PR DESCRIPTION
for arrays this allows avoiding copying of `internal_array` as well as reducing complexity of slice index access and count.