### PR TITLE
tests: On failure of a positive test, show stderr output.

### DIFF
--- a/tests/positive.mk
+++ b/tests/positive.mk
@@ -32,10 +32,10 @@ FUZION_OPTIONS ?=
 FUZION = ../../bin/fz $(FUZION_OPTIONS)
 
 int:
-	$(FUZION) $(NAME) 2>err.txt
+	$(FUZION) $(NAME) 2>err.txt || cat err.txt
 
 jvm:
-	$(FUZION) -jvm $(NAME) 2>err.txt
+	$(FUZION) -jvm $(NAME) 2>err.txt || cat err.txt
 
 c:
-	($(FUZION) -c -o=testbin $(NAME) && ./testbin) 2>err.txt
+	($(FUZION) -c -o=testbin $(NAME) && ./testbin) 2>err.txt || cat err.txt


### PR DESCRIPTION
This helps understanding the issue when looking at the test run output, in particular for tests `inheritance` and `unicode` when run with the current JVM backend.