### PR TITLE
air: Restrict replacing outer clazz to fix #2058

### DIFF
--- a/src/dev/flang/air/Clazz.java
+++ b/src/dev/flang/air/Clazz.java
@@ -354,22 +354,11 @@ public class Clazz extends ANY implements Comparable<Clazz>
       ? Types.intern(ResolvedNormalType.newType(actualType, this._outer._type))
       : actualType;
     this._dynamicBinding = null;
-
-    if (POSTCONDITIONS) ensure
-      (Errors.any() || !hasCycles());
   }
 
 
   /*-----------------------------  methods  -----------------------------*/
 
-
-  /**
-   * Is there any outers that share the same feature?
-   */
-  private boolean hasCycles()
-  {
-    return selfAndOuters().count() != selfAndOuters().map(x -> x.feature()).collect(Collectors.toSet()).size();
-  }
 
   /**
    * Returns itself and all outer clazzes
@@ -2150,10 +2139,12 @@ public class Clazz extends ANY implements Comparable<Clazz>
   {
     if (_typeClazz == null)
       {
+        var tt = _type.typeType();
+        var ty = Types.resolved.f_Type.selfType();
         _typeClazz = _type.containsError()  ? Clazzes.error.get() :
-                     feature().isUniverse() ? this
-                                            : Clazzes.create(_type.typeType(),
-                                                             _outer.typeClazz());
+                     feature().isUniverse() ? this                :
+                     tt.compareTo(ty) == 0  ? Clazzes.create(ty, Clazzes.universe.get())
+                                            : Clazzes.create(tt, _outer.typeClazz()    );
       }
     return _typeClazz;
   }

--- a/src/dev/flang/air/Clazzes.java
+++ b/src/dev/flang/air/Clazzes.java
@@ -317,12 +317,11 @@ public class Clazzes extends ANY
     var ao = actualType.featureOfType().outer();
     while (o != null)
       {
-        if (actualType.isRef() && ao != null && ao.inheritsFrom(o.feature()))
+        if (actualType.isRef() && ao != null && ao.inheritsFrom(o.feature()) && !outer.isRef())
           {
             outer = o;  // short-circuit outer relation if suitable outer was found
           }
 
-        // NYI: Check if the following code is still needed:
         if (o._type == actualType && actualType != Types.t_ERROR &&
             // a recursive outer-relation
 
@@ -368,8 +367,7 @@ public class Clazzes extends ANY
     // e.g. treat clazzes of inherited features with a reference outer clazz
     // the same.
 
-    var newcl = wouldCreateCycleInOuters(actualType, outer) ? clazz(actualType)
-                                                            : new Clazz(actualType, select, outer);
+    var newcl = new Clazz(actualType, select, outer);
     var result = intern(newcl);
     if (result == newcl)
       {
@@ -396,17 +394,6 @@ public class Clazzes extends ANY
        outer == result._outer || true /* NYI: Check why this sometimes does not hold */);
 
     return result;
-  }
-
-
-  /**
-   * Would creating new clazz for actualType and outer result in a cycle?
-   */
-  private static boolean wouldCreateCycleInOuters(AbstractType actualType, Clazz outer)
-  {
-    if (PRECONDITIONS) require
-      (Errors.any() || !actualType.dependsOnGenerics());
-    return outer != null && outer.selfAndOuters().anyMatch(ou -> actualType.featureOfType().equals(ou.feature()));
   }
 
 


### PR DESCRIPTION
The original code could replace an outer value type resulting in wrong memory
accesses.

This patch essentially does

 - prevent short-circuiting an outer relation in a clazz if outer is a ref

 - remove unneded code aroung `wouldCreateCycleInOuters`

 - removed too strict postCondition for Clazzz using `hasCycles`, this was too
   strict since it ony checks cycles of features, which may happen

 - adds special handling in Clazz.typeClazz to for the outer clazz of a type
   clazz' type clazz: Since the type clazz of a type clazz is just the clazz of
   feature Type.fz, the outer of this must alsway be universe and not Type.fz.