### PR TITLE
jvm: Add casts when reading field from class that has interface, fix #2064

### DIFF
--- a/src/dev/flang/be/jvm/CodeGen.java
+++ b/src/dev/flang/be/jvm/CodeGen.java
@@ -441,7 +441,7 @@ class CodeGen
         var tc = _fuir.accessTargetClazz(cl, c, i);
         var tt = ccs[0];                   // target clazz we match against
         var cc = ccs[1];                   // called clazz in case of match
-        if (tc != tt)
+        if (tc != tt || _types.hasInterfaceFile(tc))
           {
             tvalue = tvalue.andThen(Expr.checkcast(_types.javaType(tt)));
           }


### PR DESCRIPTION
The problem is the following: If a ref clazz A may have multiple actual heirs H1, H2,..., an interface Ai is created and used for type A, while Ai is implemented by all the heirs and A itself.

The code generated for a call to a feature of A via a ref to A is then done via an interface call if DFA found that there may be different targets at runtime.

However, if there is only one target T at runtime at a given call site, the target value is first cast to T before a direct call is made, in case of a field, a direct access to the field is made an.

The problem was, that in case T is A, the cast was omitted, so the code generated accessed a field in an interface class, which is not possible.

This patch fixed this by adding the cast if the target has an interface file, i..e, if that interface type is used for refs to the target.