### PR TITLE
be/jvm: revert move of `fuzion.sys.env_vars.get0` in caf4b895

### DIFF
--- a/src/dev/flang/be/jvm/Intrinsix.java
+++ b/src/dev/flang/be/jvm/Intrinsix.java
@@ -554,6 +554,15 @@ public class Intrinsix extends ANY implements ClassFileConstants
             PrimitiveType.type_long));
       return new Pair<>(res, Expr.UNIT);
     });
+    put("fuzion.sys.env_vars.get0", (jvm, cl, pre, cc, tvalue, args) -> {
+      return jvm.constString(
+        tvalue.drop()
+          .andThen(args.get(0))
+          .andThen(Expr.invokeStatic(Names.RUNTIME_CLASS,
+            "fuzion_sys_env_vars_get0",
+            methodDescriptor(Runtime.class, "fuzion_sys_env_vars_get0"),
+            JAVA_LANG_STRING)));
+    });
     put("fuzion.sys.env_vars.set0", (jvm, cl, pre, cc, tvalue, args) -> {
       var res =
         tvalue.drop()

--- a/src/dev/flang/be/jvm/runtime/Intrinsics.java
+++ b/src/dev/flang/be/jvm/runtime/Intrinsics.java
@@ -791,11 +791,6 @@ public class Intrinsics extends ANY
     return System.getenv(Runtime.utf8ByteArrayDataToString((byte[])s)) != null;
   }
 
-  public static String fuzion_sys_env_vars_get0(Object s)
-  {
-    return System.getenv(Runtime.utf8ByteArrayDataToString((byte[])s));
-  }
-
 }
 
 /* end of file */

--- a/src/dev/flang/be/jvm/runtime/Runtime.java
+++ b/src/dev/flang/be/jvm/runtime/Runtime.java
@@ -651,6 +651,12 @@ public class Runtime extends ANY
   }
 
 
+  public static String fuzion_sys_env_vars_get0(byte[] d)
+  {
+    return System.getenv(utf8ByteArrayDataToString(d));
+  }
+
+
   /**
    * @param instance the effect instance that is installed
    *


### PR DESCRIPTION
`fuzion_sys_env_vars_get0` does not return an `fzI_String` instance, which is expected by the intrinsic as a result.