### PR TITLE
jvm: Fix code that writes count of arg slots for invokeInterface bytecode

### DIFF
--- a/src/dev/flang/be/jvm/Choices.java
+++ b/src/dev/flang/be/jvm/Choices.java
@@ -565,8 +565,7 @@ public class Choices extends ANY implements ClassFileConstants
             .andThen(Expr.invokeInterface(_types.interfaceFile(subjClazz)._name,
                                           _names.getTag(subjClazz),
                                           "()I",
-                                          PrimitiveType.type_int,
-                                          1 /* num arg slots: only one, Expr.value */));
+                                          PrimitiveType.type_int));
 
           var lEnd = new Label();
           for (var mc = 0; mc < _fuir.matchCaseCount(c, i); mc++)

--- a/src/dev/flang/be/jvm/CodeGen.java
+++ b/src/dev/flang/be/jvm/CodeGen.java
@@ -477,7 +477,6 @@ class CodeGen
     var dn = _names.dynamicFunction(cc0);
     var ds = isCall ? _types.dynDescriptor(cc0, false)          : "(" + _types.javaType(rc).descriptor() + ")V";
     var dr = isCall ? _types.javaType(rc)                       : PrimitiveType.type_void;
-    var da = isCall ? _types.dynDescriptorArgsCount(cc0, false) : 1;
     if (!intfc.hasMethod(dn))
       {
         intfc.method(ACC_PUBLIC | ACC_ABSTRACT, dn, ds, new List<>());
@@ -490,7 +489,7 @@ class CodeGen
         _types.classFile(tt).addImplements(intfc._name);
         addStub(tt, cc, dn, ds, isCall);
       }
-    return Expr.invokeInterface(intfc._name, dn, ds, dr, da);
+    return Expr.invokeInterface(intfc._name, dn, ds, dr);
   }
 
 

--- a/src/dev/flang/be/jvm/classfile/ClassFileConstants.java
+++ b/src/dev/flang/be/jvm/classfile/ClassFileConstants.java
@@ -726,6 +726,22 @@ public interface ClassFileConstants
   }
 
 
+  /**
+   * This counts the number of slots for a call with the given descriptor.  This
+   * is the sum of the slot count of all arguments in the descriptor, not
+   * including the target value.
+   *
+   * @param a call desrciptor, e.g., "(JDZLjava/lang/Object;II)F"
+   *
+   * @return the slot count, e.g., 8 for "(JDZLjava/lang/Object;II)F"
+   * (==2+2+1+1+1+1).
+   */
+  static int slotCountForArgs(String descriptor)
+  {
+    return argTypesFromDescriptor(descriptor).mapToInt(x -> x.stackSlots()).sum();
+  }
+
+
   public static int ACC_PUBLIC        = 0x0001;  // class,         field, method
   public static int ACC_PRIVATE       = 0x0002;  //                field, method
   public static int ACC_PROTECTED     = 0x0004;  //                field, method
@@ -990,6 +1006,15 @@ public interface ClassFileConstants
    */
   public static final int MIN_BRANCH_OFFSET = -0x8000;
   public static final int MAX_BRANCH_OFFSET =  0x7fff;
+
+
+
+  /**
+   * The invokeinterface bytecode requires the number of argument slots given in
+   * a byte:
+   */
+  public static final int MAX_INVOKE_INTERFACE_SLOTS = 0xff;
+
 
 }
 


### PR DESCRIPTION
This count can easily be determined from the signature, so this patch replaces the count argument in `Expr.invokeInterface()` by logic to determine the count.

This enables removing wrong hard-coded values in the JVM backend.