### PR TITLE
Fix jvm outer normalization test failure

### DIFF
--- a/src/dev/flang/be/jvm/Choices.java
+++ b/src/dev/flang/be/jvm/Choices.java
@@ -565,8 +565,7 @@ public class Choices extends ANY implements ClassFileConstants
             .andThen(Expr.invokeInterface(_types.interfaceFile(subjClazz)._name,
                                           _names.getTag(subjClazz),
                                           "()I",
-                                          PrimitiveType.type_int,
-                                          1 /* num arg slots: only one, Expr.value */));
+                                          PrimitiveType.type_int));
 
           var lEnd = new Label();
           for (var mc = 0; mc < _fuir.matchCaseCount(c, i); mc++)

--- a/src/dev/flang/be/jvm/CodeGen.java
+++ b/src/dev/flang/be/jvm/CodeGen.java
@@ -477,7 +477,6 @@ class CodeGen
     var dn = _names.dynamicFunction(cc0);
     var ds = isCall ? _types.dynDescriptor(cc0, false)          : "(" + _types.javaType(rc).descriptor() + ")V";
     var dr = isCall ? _types.javaType(rc)                       : PrimitiveType.type_void;
-    var da = isCall ? _types.dynDescriptorArgsCount(cc0, false) : 1;
     if (!intfc.hasMethod(dn))
       {
         intfc.method(ACC_PUBLIC | ACC_ABSTRACT, dn, ds, new List<>());
@@ -490,7 +489,7 @@ class CodeGen
         _types.classFile(tt).addImplements(intfc._name);
         addStub(tt, cc, dn, ds, isCall);
       }
-    return Expr.invokeInterface(intfc._name, dn, ds, dr, da);
+    return Expr.invokeInterface(intfc._name, dn, ds, dr);
   }
 
 

--- a/src/dev/flang/be/jvm/CodeGen.java
+++ b/src/dev/flang/be/jvm/CodeGen.java
@@ -397,12 +397,12 @@ class CodeGen
   {
     var res = Expr.UNIT;
     var s   = Expr.UNIT;
-    var isCall = _fuir.codeAt(c, i) == FUIR.ExprKind.Call;
+    var isCall = _fuir.codeAt(c, i) == FUIR.ExprKind.Call;  // call or assignment?
     var cc0 = _fuir.accessedClazz  (cl, c, i);
     var ccs = _fuir.accessedClazzes(cl, c, i);
+    var rt = isCall ? _fuir.clazzResultClazz(cc0) : _fuir.clazz(FUIR.SpecialClazzes.c_unit);
     if (ccs.length == 0)
       {
-        var rt = isCall ? _fuir.clazzResultClazz(cc0) : _fuir.clazz(FUIR.SpecialClazzes.c_unit);
         s = s.andThen(tvalue.drop());
         for (var a : args)
           {
@@ -424,10 +424,10 @@ class CodeGen
           (_fuir.hasData(_fuir.accessTargetClazz(cl, c, i)),  // would be strange if target is unit type
            _fuir.accessIsDynamic(cl, c, i));                  // or call is not dynamic
 
-        var dynCall = args(true, tvalue, args, cc0, _fuir.clazzArgCount(cc0))
+        var dynCall = args(true, tvalue, args, cc0, isCall ? _fuir.clazzArgCount(cc0) : 1)
           .andThen(Expr.comment("Dynamic access of " + _fuir.clazzAsString(cc0)))
           .andThen(addDynamicFunctionAndStubs(cc0, ccs, isCall));
-        if (AbstractInterpreter.clazzHasUniqueValue(_fuir, _fuir.clazzResultClazz(cc0)))
+        if (AbstractInterpreter.clazzHasUniqueValue(_fuir, rt))
           {
             s = dynCall;  // make sure we do not throw away the code even if it is of unit type
           }

--- a/src/dev/flang/be/jvm/classfile/ClassFileConstants.java
+++ b/src/dev/flang/be/jvm/classfile/ClassFileConstants.java
@@ -726,6 +726,22 @@ public interface ClassFileConstants
   }
 
 
+  /**
+   * This counts the number of slots for a call with the given descriptor.  This
+   * is the sum of the slot count of all arguments in the descriptor, not
+   * including the target value.
+   *
+   * @param a call desrciptor, e.g., "(JDZLjava/lang/Object;II)F"
+   *
+   * @return the slot count, e.g., 8 for "(JDZLjava/lang/Object;II)F"
+   * (==2+2+1+1+1+1).
+   */
+  static int slotCountForArgs(String descriptor)
+  {
+    return argTypesFromDescriptor(descriptor).mapToInt(x -> x.stackSlots()).sum();
+  }
+
+
   public static int ACC_PUBLIC        = 0x0001;  // class,         field, method
   public static int ACC_PRIVATE       = 0x0002;  //                field, method
   public static int ACC_PROTECTED     = 0x0004;  //                field, method
@@ -990,6 +1006,15 @@ public interface ClassFileConstants
    */
   public static final int MIN_BRANCH_OFFSET = -0x8000;
   public static final int MAX_BRANCH_OFFSET =  0x7fff;
+
+
+
+  /**
+   * The invokeinterface bytecode requires the number of argument slots given in
+   * a byte:
+   */
+  public static final int MAX_INVOKE_INTERFACE_SLOTS = 0xff;
+
 
 }
 


### PR DESCRIPTION
This is based on #2068 and should hence be be reviewed / pulled after #2068.

No code was generated for a dynamically bound assignment since the wrong result clazz was used.

This patch moves the local var `rt` outside an `if` such that the result type is determined only once.

Also, the argument count for an assignment, which should always be 1, was wrong for a dynamically bound assignment.