### PR TITLE
be/jvm: Choices: when tagging nullable choices, supply type information

### DIFF
--- a/src/dev/flang/be/jvm/Choices.java
+++ b/src/dev/flang/be/jvm/Choices.java
@@ -729,7 +729,8 @@ public class Choices extends ANY implements ClassFileConstants
           if (_fuir.clazzIsUnitType(tc))
             {
               res = value.drop()
-                .andThen(Expr.ACONST_NULL);
+                .andThen(Expr.ACONST_NULL)
+                .andThen(Expr.checkcast(_types.javaType(newcl)));
             }
           else
             {


### PR DESCRIPTION
Previously, this would just put an `ACONST_NULL` on the stack, which by default supplies `java.lang.Object` as its type. This caused a check-condition failure in `CodeGen.drop`. Supply the type of the choice to fix the problem.