### PR TITLE
jvm: fix assignments of value types

### DIFF
--- a/src/dev/flang/be/c/C.java
+++ b/src/dev/flang/be/c/C.java
@@ -125,6 +125,10 @@ public class C extends ANY
     /**
      * Create code to assign value to a given field w/o dynamic binding.
      *
+     * @param cl the clazz we are compiling
+     *
+     * @param pre true iff we are compiling the precondition
+     *
      * @param tc clazz id of the target instance
      *
      * @param f clazz id of the assigned field
@@ -137,7 +141,7 @@ public class C extends ANY
      *
      * @return statement to perform the given access
      */
-    public CStmnt assignStatic(int tc, int f, int rt, CExpr tvalue, CExpr val)
+    public CStmnt assignStatic(int cl, boolean pre, int tc, int f, int rt, CExpr tvalue, CExpr val)
     {
       return assignField(tvalue, tc, tc, f, val, rt);
     }
@@ -146,6 +150,18 @@ public class C extends ANY
     /**
      * Perform an assignment of a value to a field in tvalue. The type of tvalue
      * might be dynamic (a reference). See FUIR.access*().
+     *
+     * @param cl id of clazz we are interpreting
+     *
+     * @param pre true iff interpreting cl's precondition, false for cl itself.
+     *
+     * @param c current code block
+     *
+     * @param i index of call in current code block
+     *
+     * @param tvalue the target instance
+     *
+     * @param avalue the new value to be assigned to the field.
      */
     public CStmnt assign(int cl, boolean pre, int c, int i, CExpr tvalue, CExpr avalue)
     {

--- a/src/dev/flang/be/jvm/CodeGen.java
+++ b/src/dev/flang/be/jvm/CodeGen.java
@@ -634,8 +634,9 @@ class CodeGen
             tvalue = tvalue
               .andThen(_jvm.LOAD_UNIVERSE);
           }
-        res = tvalue
-          .andThen(value)
+        var v = cloneValue(cl, pre, value, rt, f);
+        return tvalue
+          .andThen(v)
           .andThen(_jvm.putfield(f));
       }
     else
@@ -649,6 +650,125 @@ class CodeGen
           .andThen(value.drop());
       }
     return res;
+  }
+
+
+  /**
+   * Clone a value if it is of value type. This is required since value types in
+   * the JVM backend are currently imlemented as reference values to instances
+   * of a Java class, so they have reference semantics.  To get value semantics,
+   * this creates a new instance and copies all the fields from value into the
+   * new instance.
+   *
+   * NYI: OPTIMIZATION: Once value features like `point(x,y i32)` are
+   * represented as tuples of primitive values (`int, int`) instead of instances
+   * of Java classes (`class Point { int x, y; }`, this cloning will no longer
+   * be needed.
+   *
+   * @param cl the class whose code requires this cloning
+   *
+   * @param pre true iff this happens in cl's pre-condition.
+   *
+   * @param value the value that might need to be cloned.
+   *
+   * @param rt the Fuzion type of the value
+   *
+   * @return value iff cloning was not required, or an expression that creates a
+   * clone of value.
+   */
+  Expr cloneValue(int cl, boolean pre, Expr value, int rt, int f)
+  {
+    if (!_fuir.clazzIsRef(rt) &&
+        (f == -1 || !_fuir.clazzFieldIsAdrOfValue(f)) && // an outer ref field must not be cloned
+        !_types.isScalar(rt) &&
+        (!_fuir.clazzIsChoice(rt) || _choices.kind(rt) == Choices.ImplKind.general))
+      {
+        var vl = _jvm.allocLocal(cl, pre, 1);
+        var nl = _jvm.allocLocal(cl, pre, 1);
+        var e = value
+          .andThen(Expr.astore(vl))
+          .andThen(_jvm.new0(rt))
+          .andThen(Expr.astore(nl));
+        var jt = _types.javaType(rt);
+        if (_fuir.clazzIsChoice(rt))
+          {
+            var cf = _types.classFile(rt);
+            var cc = _names.javaClass(rt);
+            e = e
+              .andThen(Expr.aload(nl, jt))
+              .andThen(Expr.aload(vl, jt))
+              .andThen(Expr.getfield(cc, Names.TAG_NAME, PrimitiveType.type_int))
+              .andThen(Expr.putfield(cc, Names.TAG_NAME, PrimitiveType.type_int));
+            var hasref = false;
+            for (int i = 0; i < _fuir.clazzNumChoices(rt); i++)
+              {
+                var tc = _fuir.clazzChoice(rt, i);
+                if (_fuir.clazzIsRef(tc))
+                  {
+                    hasref = true;
+                  }
+                else
+                  {
+                    var ft = _choices.generalValueFieldType(rt, i);
+                    if (ft != PrimitiveType.type_void)
+                      {
+                        var fn = _choices.generalValueFieldName(rt, i);
+                        var v = Expr.aload(vl, jt)
+                          .andThen(Expr.getfield(cc, fn, ft));
+                        if (!_fuir.clazzIsRef(tc) && _types.javaType(tc) instanceof AType)
+                          { // the value type may be a null reference if it is unused.
+                            v = v
+                              .andThen(Expr.DUP)
+                              .andThen(Expr.branch(O_ifnonnull,
+                                                   cloneValue(cl, pre, Expr.UNIT /* target is DUPped on stack */, tc, -1),
+                                                   Expr.UNIT));
+                          }
+                        else
+                          {
+                            v = cloneValue(cl, pre, v, tc, -1);
+                          }
+                        e = e
+                          .andThen(Expr.aload(nl, jt))
+                          .andThen(v)
+                          .andThen(Expr.putfield(cc, fn, ft));
+                      }
+                  }
+              }
+            if (hasref)
+              {
+                e = e
+                  .andThen(Expr.aload(nl, jt))
+                  .andThen(Expr.aload(vl, jt))
+                  .andThen(Expr.getfield(cc, Names.CHOICE_REF_ENTRY_NAME, Names.ANYI_TYPE))
+                  .andThen(Expr.putfield(cc, Names.CHOICE_REF_ENTRY_NAME, Names.ANYI_TYPE));
+              }
+          }
+        else
+          {
+            for (var i = 0; i < _fuir.clazzNumFields(rt); i++)
+              {
+                var fi = _fuir.clazzField(rt, i);
+                if (_jvm.fieldExists(fi))
+                  {
+                    var rti = _fuir.clazzResultClazz(fi);
+                    var v = readField(Expr.aload(vl, jt),
+                                         rt,
+                                         fi,
+                                         rti);
+                    v = cloneValue(cl, pre, v, rti, fi);
+                    e = e
+                      .andThen(assignField(cl, pre,
+                                           Expr.aload(nl, jt),
+                                           fi,
+                                           v,
+                                           rti));
+                  }
+              }
+          }
+        value = e
+          .andThen(Expr.aload(nl, jt));
+      }
+    return value;
   }
 
 

--- a/src/dev/flang/be/jvm/CodeGen.java
+++ b/src/dev/flang/be/jvm/CodeGen.java
@@ -210,6 +210,10 @@ class CodeGen
   /**
    * Create code to assign value to a given field w/o dynamic binding.
    *
+   * @param cl id of clazz we are interpreting
+   *
+   * @param pre true iff interpreting cl's precondition, false for cl itself.
+   *
    * @param tc clazz id of the target instance
    *
    * @param f clazz id of the assigned field
@@ -222,7 +226,7 @@ class CodeGen
    *
    * @return statement to perform the given assignment
    */
-  public Expr assignStatic(int tc, int f, int rt, Expr tvalue, Expr val)
+  public Expr assignStatic(int cl, boolean pre, int tc, int f, int rt, Expr tvalue, Expr val)
   {
     if (_fuir.clazzIsOuterRef(f) && _fuir.clazzIsUnitType(rt))
       {
@@ -230,7 +234,7 @@ class CodeGen
       }
     else
       {
-        return assignField(tvalue, f, val, rt);
+        return assignField(cl, pre, tvalue, f, val, rt);
       }
   }
 
@@ -248,6 +252,9 @@ class CodeGen
    *
    * @param i index of the access statement, must be ExprKind.Assign or ExprKind.Call
    *
+   * @param tvalue the target instance
+   *
+   * @param avalue the new value to be assigned to the field.
    */
   public Expr assign(int cl, boolean pre, int c, int i, Expr tvalue, Expr avalue)
   {
@@ -589,12 +596,16 @@ class CodeGen
 
     return isCall ? staticCall(cl, pre, tv, args, cc, false, c, i)
                   : new Pair<>(Expr.UNIT,
-                               assignField(tv, cc, args.get(0), _fuir.clazzResultClazz(cc)));
+                               assignField(cl, pre, tv, cc, args.get(0), _fuir.clazzResultClazz(cc)));
   }
 
 
   /**
    * Create code to assign value to a field
+   *
+   * @param cl the clazz we are compiling
+   *
+   * @param pre true iff we are compiling the precondition
    *
    * @param tc the static target clazz
    *
@@ -602,7 +613,7 @@ class CodeGen
    *
    * @param f the field
    */
-  Expr assignField(Expr tvalue, int f, Expr value, int rt)
+  Expr assignField(int cl, boolean pre, Expr tvalue, int f, Expr value, int rt)
   {
     if (CHECKS) check
       (tvalue != null || !_fuir.hasData(rt) || _fuir.clazzOuterClazz(f) == _fuir.clazzUniverse());

--- a/src/dev/flang/be/jvm/Intrinsix.java
+++ b/src/dev/flang/be/jvm/Intrinsix.java
@@ -219,12 +219,19 @@ public class Intrinsix extends ANY implements ClassFileConstants
               ifcc = O_ifeq;
               jt2 = ClassFileConstants.PrimitiveType.type_long;
             }
-          else if (jt instanceof ClassFileConstants.AType)
+          else if (jvm._fuir.clazzIsRef(rc) || jvm._fuir.clazzIsChoice(rc) && jt instanceof ClassFileConstants.AType)
+            {
+              if (CHECKS) check
+                (jt instanceof ClassFileConstants.AType);
+              ifcc = O_if_acmpeq;
+            }
+          else if (jvm._fuir.clazzIsChoice(rc) && jt instanceof ClassFileConstants.AType)
             {
               ifcc = O_if_acmpeq;
             }
           else
             {
+              // NYI: need support to compare arbitrary value and choice types
               throw new Error("NYI: compare_and_set0 does not support type " + jvm._fuir.clazzAsString(rc));
             }
           var val =  locked

--- a/src/dev/flang/fuir/analysis/AbstractInterpreter.java
+++ b/src/dev/flang/fuir/analysis/AbstractInterpreter.java
@@ -123,6 +123,10 @@ public class AbstractInterpreter<VALUE, RESULT> extends ANY
     /**
      * Perform an assignment val to field f in instance rt
      *
+     * @param cl id of clazz we are interpreting
+     *
+     * @param pre true iff interpreting cl's precondition, false for cl itself.
+     *
      * @param tc clazz id of the target instance
      *
      * @param f clazz id of the assigned field
@@ -135,11 +139,23 @@ public class AbstractInterpreter<VALUE, RESULT> extends ANY
      *
      * @return resulting code of this assignment.
      */
-    public abstract RESULT assignStatic(int tc, int f, int rt, VALUE tvalue, VALUE val);
+    public abstract RESULT assignStatic(int cl, boolean pre, int tc, int f, int rt, VALUE tvalue, VALUE val);
 
     /**
      * Perform an assignment of a value to a field in tvalue. The type of tvalue
      * might be dynamic (a reference). See FUIR.access*().
+     *
+     * @param cl id of clazz we are interpreting
+     *
+     * @param pre true iff interpreting cl's precondition, false for cl itself.
+     *
+     * @param c current code block
+     *
+     * @param i index of call in current code block
+     *
+     * @param tvalue the target instance
+     *
+     * @param avalue the new value to be assigned to the field.
      */
     public abstract RESULT              assign(int cl, boolean pre, int c, int i, VALUE tvalue, VALUE avalue);
 
@@ -409,6 +425,8 @@ public class AbstractInterpreter<VALUE, RESULT> extends ANY
    * @param l list that will receive the result
    *
    * @param cl the clazz we are interpreting.
+   *
+   * @param pre true iff interpreting cl's precondition, false for cl itself.
    */
   void assignOuterAndArgFields(List<RESULT> l, int cl, boolean pre)
   {
@@ -420,7 +438,7 @@ public class AbstractInterpreter<VALUE, RESULT> extends ANY
         l.add(cur._v1);
         var out = _processor.outer(cl);
         l.add(out._v1);
-        l.add(_processor.assignStatic(cl, or, rt, cur._v0, out._v0));
+        l.add(_processor.assignStatic(cl, pre, cl, or, rt, cur._v0, out._v0));
       }
 
     var ac = _fuir.clazzArgCount(cl);
@@ -433,7 +451,7 @@ public class AbstractInterpreter<VALUE, RESULT> extends ANY
         var ai = _processor.arg(cl, i);
         if (ai != null)
           {
-            l.add(_processor.assignStatic(cl, af, at, cur._v0, ai));
+            l.add(_processor.assignStatic(cl, pre, cl, af, at, cur._v0, ai));
           }
       }
   }
@@ -477,6 +495,8 @@ public class AbstractInterpreter<VALUE, RESULT> extends ANY
    * Perform abstract interpretation on given code
    *
    * @param cl clazz id
+   *
+   * @param pre true to process cl's precondition, false to process cl's code.
    *
    * @param c the code block to interpret
    *
@@ -561,6 +581,9 @@ public class AbstractInterpreter<VALUE, RESULT> extends ANY
    * Perform abstract interpretation on given statement
    *
    * @param cl clazz id
+   *
+   * @param pre true to process cl's precondition, false to process cl's code
+   * followed by its postcondition.
    *
    * @param stack the stack containing the current arguments waiting to be used
    *

--- a/src/dev/flang/fuir/analysis/dfa/DFA.java
+++ b/src/dev/flang/fuir/analysis/dfa/DFA.java
@@ -167,6 +167,10 @@ public class DFA extends ANY
     /**
      * Perform an assignment val to field f in instance rt
      *
+     * @param cl id of clazz we are interpreting
+     *
+     * @param pre true iff interpreting cl's precondition, false for cl itself.
+     *
      * @param tc clazz id of the target instance
      *
      * @param f clazz id of the assigned field
@@ -179,7 +183,7 @@ public class DFA extends ANY
      *
      * @return resulting code of this assignment.
      */
-    public Unit assignStatic(int tc, int f, int rt, Val tvalue, Val val)
+    public Unit assignStatic(int cl, boolean pre, int tc, int f, int rt, Val tvalue, Val val)
     {
       tvalue.value().setField(DFA.this, f, val.value());
       return _unit_;
@@ -189,6 +193,18 @@ public class DFA extends ANY
     /**
      * Perform an assignment of avalue to a field in tvalue. The type of tvalue
      * might be dynamic (a reference). See FUIR.access*().
+     *
+     * @param cl id of clazz we are interpreting
+     *
+     * @param pre true iff interpreting cl's precondition, false for cl itself.
+     *
+     * @param c current code block
+     *
+     * @param i index of call in current code block
+     *
+     * @param tvalue the target instance
+     *
+     * @param avalue the new value to be assigned to the field.
      */
     public Unit assign(int cl, boolean pre, int c, int i, Val tvalue, Val avalue)
     {


### PR DESCRIPTION
This consists of three commits: 

1. add `cl` and `pre` parameters to some methods in `AbstractIntperpreter`
2. add error handling for unsupported value types in intrinsic for `compare_and_set`/`swap`
3. Support assignments of value types, fix `tests/assignments` failure

The last commit is the important one: 

Value types are allocated as instances of a Java class. So far, assignments of value types was done by assigning references to these instances. This is ok only if the value is immutable, which is not always the case.

This patch creates new instances on assigments of value types. Performance-wise, this is catastrophic since really many temporary instances are allocated on the heap.

To improve the performance, the goal is to avoid class instances for value types altogether and expand value types into a sequence of fields, i.e., to implement

```
  point(x, y i32) is
  line(a, b point) is
  l := line (point 3 4) point (5 12)

```
as follows (in pseudo-Java code):

```
  int temp1_x = 3
  int temp1_y = 4
  int temp2_x = 5
  int temp2_y = 12
  int temp3_a_x = temp1_x
  int temp3_a_y = temp1_y
  int temp3_b_x = temp2_x
  int temp3_b_y = temp2_y
  int l_a_x = temp3_a_x
  int l_a_y = temp3_a_y
  int l_b_x = temp3_b_x
  int l_b_y = temp3_b_y

```
i.e., the local var `l` will get expanded into four local variables in Java code.

