### PR TITLE
jvm: add checks to trap accidental modifications of immutable array data

### DIFF
--- a/lib/array.fz
+++ b/lib/array.fz
@@ -37,6 +37,7 @@ public array(redef T type,
       _ unit,
       _ unit) : Sequence T is
 
+  internal_array.freeze
 
   public length => internal_array.length
 

--- a/lib/fuzion/sys/internal_array.fz
+++ b/lib/fuzion/sys/internal_array.fz
@@ -39,6 +39,17 @@ module:public internal_array(T type, module data Pointer, public length i32) is
   private get  (X type, d Pointer, i i32) X is intrinsic
   private setel(X type, d Pointer, i i32, o X) unit is intrinsic
 
+  # make sure that this internal array will no longer be modified.  This is just for
+  # debugging and will be a NOP in case internal checks are disabled or in case the
+  # backend does not support this.
+  #
+  module freeze unit is intrinsic
+
+  # check that this internal array was not frozen, i.e., `freeze` was not called.
+  # Cause a runtime error if this `freeze` was called.  Note that this is a NOP if
+  # the backend does not support these checks or intenal checks are disabled.
+  #
+  module ensure_not_frozen unit is intrinsic
 
   module indices => 0..length-1
 

--- a/src/dev/flang/be/c/Intrinsics.java
+++ b/src/dev/flang/be/c/Intrinsics.java
@@ -797,6 +797,14 @@ public class Intrinsics extends ANY
             ? A0.castTo(c._types.clazz(gc) + "*").index(A1).ret()
             : CStmnt.EMPTY;
         });
+    put("fuzion.sys.internal_array.freeze", (c,cl,outer,in) ->
+        {
+          return CStmnt.EMPTY;
+        });
+    put("fuzion.sys.internal_array.ensure_not_frozen", (c,cl,outer,in) ->
+        {
+          return CStmnt.EMPTY;
+        });
     put("fuzion.sys.env_vars.has0", (c,cl,outer,in) ->
         {
           return CStmnt.seq(CStmnt.iff(CExpr.call("getenv",new List<>(A0.castTo("char*"))).ne(CNames.NULL),

--- a/src/dev/flang/be/interpreter/Intrinsics.java
+++ b/src/dev/flang/be/interpreter/Intrinsics.java
@@ -785,6 +785,14 @@ public class Intrinsics extends ANY
                               /* type  */ elementType(innerClazz._outer));
           return Value.EMPTY_VALUE;
         });
+    put("fuzion.sys.internal_array.freeze", (interpreter, innerClazz) -> args ->
+        {
+          return Value.EMPTY_VALUE;
+        });
+    put("fuzion.sys.internal_array.ensure_not_frozen", (interpreter, innerClazz) -> args ->
+        {
+          return Value.EMPTY_VALUE;
+        });
     put("fuzion.sys.env_vars.has0", (interpreter, innerClazz) -> args -> new boolValue(System.getenv(utf8ByteArrayDataToString(args.get(1))) != null));
     put("fuzion.sys.env_vars.get0", (interpreter, innerClazz) -> args -> Interpreter.value(System.getenv(utf8ByteArrayDataToString(args.get(1)))));
     // setting env variable not supported in java

--- a/src/dev/flang/be/jvm/runtime/Intrinsics.java
+++ b/src/dev/flang/be/jvm/runtime/Intrinsics.java
@@ -286,6 +286,9 @@ public class Intrinsics extends ANY
 
   public static int fuzion_sys_net_bind0(int family, int socketType, int protocol, Object host0, Object port0, Object res)
   {
+    if (CHECKS)
+      Runtime.ensure_not_frozen(res);
+
     long[] result = (long[]) res;
     var host = Runtime.utf8ByteArrayDataToString((byte[]) host0);
     var port = Runtime.utf8ByteArrayDataToString((byte[]) port0);
@@ -334,6 +337,9 @@ public class Intrinsics extends ANY
 
   public static boolean fuzion_sys_net_accept(long sockfd, Object res)
   {
+    if (CHECKS)
+      Runtime.ensure_not_frozen(res);
+
     long[] result = (long[]) res;
     try
       {
@@ -359,6 +365,9 @@ public class Intrinsics extends ANY
 
   public static int fuzion_sys_net_connect0(int family, int socketType, int protocol, Object host0, Object port0, Object res)
   {
+    if (CHECKS)
+      Runtime.ensure_not_frozen(res);
+
     long[] result = (long[]) res;
     var host = Runtime.utf8ByteArrayDataToString((byte[]) host0);
     var port = Runtime.utf8ByteArrayDataToString((byte[]) port0);
@@ -396,6 +405,9 @@ public class Intrinsics extends ANY
 
   public static int fuzion_sys_net_get_peer_address(long sockfd, Object res)
   {
+    if (CHECKS)
+      Runtime.ensure_not_frozen(res);
+
     byte[] data = (byte[])res;
     try
       {
@@ -431,6 +443,12 @@ public class Intrinsics extends ANY
 
   public static boolean fuzion_sys_net_read(long sockfd, Object b, int length, Object res)
   {
+    if (CHECKS)
+      {
+        Runtime.ensure_not_frozen(b);
+        Runtime.ensure_not_frozen(res);
+      }
+
     byte[] buff = (byte[])b;
     long[] result = (long[])res;
 
@@ -512,6 +530,10 @@ public class Intrinsics extends ANY
 
   public static int fuzion_sys_fileio_read(long fd, Object d, int l)
   {
+    System.err.println("fuzion_sys_fileio_read");
+    if (CHECKS)
+      Runtime.ensure_not_frozen(d);
+
     byte[] byteArr = (byte[])d;
     try
       {
@@ -606,6 +628,9 @@ public class Intrinsics extends ANY
 
   public static void fuzion_sys_fileio_open(Object s, Object res, byte mode)
   {
+    if (CHECKS)
+      Runtime.ensure_not_frozen(res);
+
     var path = Runtime.utf8ByteArrayDataToString((byte[])s);
     long[] open_results = (long[])res;
     try
@@ -652,6 +677,9 @@ public class Intrinsics extends ANY
 
   public static boolean fuzion_sys_fileio_stats(Object s, Object res)
   {
+    if (CHECKS)
+      Runtime.ensure_not_frozen(res);
+
     Path path = Path.of(Runtime.utf8ByteArrayDataToString((byte[])s));
     long[] stats = (long[]) res;
     var err = SystemErrNo.UNSPECIFIED;
@@ -686,6 +714,9 @@ public class Intrinsics extends ANY
 
   public static void fuzion_sys_fileio_seek(long fd, short s, Object res)
   {
+    if (CHECKS)
+      Runtime.ensure_not_frozen(res);
+
     long[] seekResults = (long[]) res;
     try
       {
@@ -703,6 +734,9 @@ public class Intrinsics extends ANY
 
   public static void fuzion_sys_fileio_file_position(long fd, Object res)
   {
+    if (CHECKS)
+      Runtime.ensure_not_frozen(res);
+
     long[] arr = (long[])res;
     try
       {
@@ -718,6 +752,9 @@ public class Intrinsics extends ANY
 
   public static byte[] fuzion_sys_fileio_mmap(long fd, long offset, long size, Object res)
   {
+    if (CHECKS)
+      Runtime.ensure_not_frozen(res);
+
     int[] result = (int[])res;
     try
       {

--- a/src/dev/flang/be/jvm/runtime/Intrinsics.java
+++ b/src/dev/flang/be/jvm/runtime/Intrinsics.java
@@ -530,7 +530,6 @@ public class Intrinsics extends ANY
 
   public static int fuzion_sys_fileio_read(long fd, Object d, int l)
   {
-    System.err.println("fuzion_sys_fileio_read");
     if (CHECKS)
       Runtime.ensure_not_frozen(d);
 

--- a/src/dev/flang/fuir/analysis/dfa/DFA.java
+++ b/src/dev/flang/fuir/analysis/dfa/DFA.java
@@ -1523,6 +1523,10 @@ public class DFA extends ANY
               throw new Error("intrinsic fuzion.sys.internal_array.gel: Expected class SysArray, found "+array.getClass()+" "+array);
             }
         });
+    put("fuzion.sys.internal_array.freeze"
+                                         , cl -> Value.UNIT);
+    put("fuzion.sys.internal_array.ensure_not_frozen"
+                                         , cl -> Value.UNIT);
     put("fuzion.sys.env_vars.has0"       , cl -> cl._dfa._bool );
     put("fuzion.sys.env_vars.get0"       , cl -> cl._dfa.newConstString(null, cl) );
     put("fuzion.sys.env_vars.set0"       , cl -> cl._dfa._bool );

--- a/src/dev/flang/fuir/cfg/CFG.java
+++ b/src/dev/flang/fuir/cfg/CFG.java
@@ -455,6 +455,10 @@ public class CFG extends ANY
     put("fuzion.sys.internal_array_init.alloc", (cfg, cl) -> { } );
     put("fuzion.sys.internal_array.setel", (cfg, cl) -> { } );
     put("fuzion.sys.internal_array.get"  , (cfg, cl) -> { } );
+    put("fuzion.sys.internal_array.freeze"
+                                         , (cfg, cl) -> { } );
+    put("fuzion.sys.internal_array.ensure_not_frozen"
+                                         , (cfg, cl) -> { } );
     put("fuzion.sys.env_vars.has0"       , (cfg, cl) -> { } );
     put("fuzion.sys.env_vars.get0"       , (cfg, cl) -> { } );
     put("fuzion.sys.env_vars.set0"       , (cfg, cl) -> { } );


### PR DESCRIPTION
This turns the precondition failure in `test/stdin` into a nicer error saying `error 1: Attempt to modify immutable array`.

The way this works is that all internal array data that are put into an instance of an (immutable) array will be marked as frozen using a weak map of all frozen array data pointers. On modification, it will then be checked that the modified array is not in that map.

These checks are currently enabled only if CHECKS is set. In case debugging is disabled, eventually no code should be generated for this.