### PR TITLE
 lib/dfa: For intrinsics that write arrays, do this before creating immutable array

### DIFF
--- a/lib/fuzion/sys/fileio.fz
+++ b/lib/fuzion/sys/fileio.fz
@@ -34,8 +34,9 @@ module fileio is
   # has been reached.
   #
   module read(fd i64, n u64) outcome (array u8) is
-    buf := array n.as_i32 i->(u8 0)
-    res := read fd buf.internal_array.data buf.length
+    len := n.as_i32
+    arr := fuzion.sys.internal_array_init u8 len
+    res := read fd arr.data len
 
     if res < -1
       error "unspecified read error: {res}"
@@ -43,6 +44,7 @@ module fileio is
       r array u8 := [] # NYI type inference assigning array to choice
       r
     else
+      buf := arr.as_array
       (buf.slice 0 res).as_array
 
 
@@ -67,9 +69,9 @@ module fileio is
   private get_file_size(
                         # the (relative or absolute) file name, using platform specific path separators
                         path String) outcome i64 is
-    md array i64 := [0, 0, 0, 0]
-    match stats (fuzion.sys.c_string path) md.internal_array.data
-      TRUE => md[0]
+    md := fuzion.sys.internal_array_init i64 4
+    match stats (fuzion.sys.c_string path) md.data
+      TRUE  => md.as_array[0]
       FALSE => error "error getting file size"
 
 
@@ -200,8 +202,9 @@ module fileio is
               path String,
               # a flag to speicify the open method (Read: 0, Write: 1, Append: 2)
               flag i8) outcome i64 is
-    open_results array i64 := [0, 0] # open_results[file descriptor, error number]
-    open (fuzion.sys.c_string path) open_results.internal_array.data flag
+    or := fuzion.sys.internal_array_init i64 2  # [file descriptor, error number]
+    open (fuzion.sys.c_string path) or.data flag
+    open_results := or.as_array
     if open_results[1] = i64 0
       open_results[0]
     else
@@ -251,8 +254,9 @@ module fileio is
               fd i64,
               # the offset to seek from the beginning of this file
               offset i64) outcome i64 is
-    arr array i64 := [0, 0]
-    seek fd offset arr.internal_array.data
+    iarr := fuzion.sys.internal_array_init i64 2
+    seek fd offset iarr.data
+    arr := iarr.as_array
     if arr[1] = i64 0
       arr[0]
     else
@@ -279,8 +283,9 @@ module fileio is
   module file_position(
                        # file descriptor
                        fd i64) outcome i64 is
-    arr array i64 := [0, 0]
-    file_position fd arr.internal_array.data
+    iarr := fuzion.sys.internal_array_init i64 2
+    file_position fd iarr.data
+    arr := iarr.as_array
     if arr[1] = i64 0
       arr[0]
     else

--- a/lib/fuzion/sys/internal_array.fz
+++ b/lib/fuzion/sys/internal_array.fz
@@ -28,16 +28,16 @@
 #
 public internal_array_init(T type, private length i32) =>
 
-  private alloc(X type, l i32) Pointer is intrinsic
+  private alloc(X type, l i32) fuzion.sys.Pointer is intrinsic
 
   internal_array T (alloc T length) length
 
 
 # fuzion.sys.internal_array_init -- one-dimensional low-level array
-module:public internal_array(T type, module data Pointer, public length i32) is
+module:public internal_array(T type, module data fuzion.sys.Pointer, public length i32) is
 
-  private get  (X type, d Pointer, i i32) X is intrinsic
-  private setel(X type, d Pointer, i i32, o X) unit is intrinsic
+  private get  (X type, d fuzion.sys.Pointer, i i32) X is intrinsic
+  private setel(X type, d fuzion.sys.Pointer, i i32, o X) unit is intrinsic
 
   # make sure that this internal array will no longer be modified.  This is just for
   # debugging and will be a NOP in case internal checks are disabled or in case the
@@ -50,6 +50,13 @@ module:public internal_array(T type, module data Pointer, public length i32) is
   # the backend does not support these checks or intenal checks are disabled.
   #
   module ensure_not_frozen unit is intrinsic
+
+
+  # wrap this into an immutable array.
+  #
+  module fixed as_array =>
+    array T (fuzion.sys.internal_array T data length) unit unit unit
+
 
   module indices => 0..length-1
 

--- a/lib/fuzion/sys/net.fz
+++ b/lib/fuzion/sys/net.fz
@@ -124,7 +124,7 @@ module net is
   #
   module read(descriptor i64, max_bytes i32) outcome (array u8) is
     buff := fuzion.sys.internal_array_init u8 max_bytes
-    iarr := fuzion.sys.internal_array_init i64 0
+    iarr := fuzion.sys.internal_array_init i64 1
     res := read descriptor buff.data max_bytes iarr.data
     arr := iarr.as_array
     if res
@@ -204,9 +204,9 @@ module net is
   # not useful for UDP sockets (information not necessarily available)
   #
   module get_peer_address(sockfd i64) outcome (list u8) is
-    addr array u8 := [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
-    l := get_peer_address sockfd addr.internal_array.data
-    addr.take l
+    iarr := fuzion.sys.internal_array_init u8 16
+    l := get_peer_address sockfd iarr.data
+    iarr.as_array.take l
 
 
   # get a socket's peer's port

--- a/lib/fuzion/sys/net.fz
+++ b/lib/fuzion/sys/net.fz
@@ -53,8 +53,10 @@ module net is
   # bind a name to a newly created socket, wrapper for bind0 intrinsic
   #
   module bind    (family, socket_type, protocol i32, host String, port u16) outcome i64 is
-    arr array i64 := [0]
-    if (bind0 family socket_type protocol (fuzion.sys.c_string host) (fuzion.sys.c_string port.as_string) arr.internal_array.data) = 0
+    iarr := fuzion.sys.internal_array_init i64 1
+    r := bind0 family socket_type protocol (fuzion.sys.c_string host) (fuzion.sys.c_string port.as_string) iarr.data = 0
+    arr := iarr.as_array
+    if r
       arr[0]
     else
       error "error: {arr[0]}"
@@ -99,8 +101,10 @@ module net is
   # open and connect a client socket
   #
   module connect(family, socket_type, protocol i32, host String, port u16) outcome i64 is
-    arr array i64 := [0]
-    if (connect0 family socket_type protocol (fuzion.sys.c_string host) (fuzion.sys.c_string port.as_string) arr.internal_array.data) = 0
+    iarr := fuzion.sys.internal_array_init i64 1
+    res := connect0 family socket_type protocol (fuzion.sys.c_string host) (fuzion.sys.c_string port.as_string) iarr.data = 0
+    arr := iarr.as_array
+    if res
       arr[0]
     else
       error "error: {arr[0]}"
@@ -120,10 +124,12 @@ module net is
   #
   module read(descriptor i64, max_bytes i32) outcome (array u8) is
     buff := fuzion.sys.internal_array_init u8 max_bytes
-    arr array i64 := [0]
-    if read descriptor buff.data max_bytes arr.internal_array.data
+    iarr := fuzion.sys.internal_array_init i64 0
+    res := read descriptor buff.data max_bytes iarr.data
+    arr := iarr.as_array
+    if res
       if arr[0].as_i32 = max_bytes
-        array u8 buff unit unit unit
+        buff.as_array
       else
         # NYI there should be a way to use a slice of internal_array to init array
         array u8 arr[0].as_i32 (idx -> buff[idx])

--- a/lib/io/file/open.fz
+++ b/lib/io/file/open.fz
@@ -68,9 +68,9 @@ module:public open(T type, private fd i64, public file_name String) : simple_eff
   pre offset % 4096 = 0 # NYI get real page size instead of 4096.
   is
 
-    res := array i32 1 (i->0)
-
-    allocated_memory := fuzion.sys.fileio.mmap fd offset size res.internal_array.data
+    arr := fuzion.sys.internal_array_init i32 1
+    allocated_memory := fuzion.sys.fileio.mmap fd offset size arr.data
+    res := arr.as_array
 
     if res[0] = -1
       error "mmap failed"
@@ -111,4 +111,3 @@ private:public open_unique_type is
 #
 public open =>
   (open open_unique_type).env
-

--- a/lib/io/file/stat.fz
+++ b/lib/io/file/stat.fz
@@ -47,8 +47,10 @@ public stat(ps Stat_Handler) : simple_effect is
   public stats(
         # the (relative or absolute) file name, using platform specific path separators
         path String) outcome meta_data is
-    data := array 4 i->(i64 0) # data will contain: [size, time of last modification in seconds, regular file? 1 : 0, dir? 1 : 0]
-    if (ps.stats (fuzion.sys.c_string path) data.internal_array.data)
+    arr := fuzion.sys.internal_array_init i64 4  # will contain: [size, time of last modification in seconds, regular file? 1 : 0, dir? 1 : 0]
+    res := ps.stats (fuzion.sys.c_string path) arr.data
+    data := arr.as_array
+    if res
       replace
       meta_data data[0] data[1] (data[2] = i64 1) (data[3] = i64 1)
     else
@@ -63,8 +65,10 @@ public stat(ps Stat_Handler) : simple_effect is
   public lstats(
          # the (relative or absolute) file name, using platform specific path separators
          path String) outcome meta_data is # NYI : not sure whether to use meta_data or introduce a new feature for lstats metadata
-    data := array 4 i->(i64 0) # data will contain: [size, time of last modification in seconds, regular file? 1 : 0, dir? 1 : 0]
-    if (ps.stats (fuzion.sys.c_string path) data.internal_array.data)
+    arr := fuzion.sys.internal_array_init i64 4  # will contain: [size, time of last modification in seconds, regular file? 1 : 0, dir? 1 : 0]
+    res := ps.stats (fuzion.sys.c_string path) arr.data
+    data := arr.as_array
+    if res
       replace
       meta_data data[0] data[1] (data[2] = i64 1) (data[3] = i64 1)
     else

--- a/lib/io/stdin.fz
+++ b/lib/io/stdin.fz
@@ -38,19 +38,14 @@ public stdin io.buffered.reader is
 
   read_provider : io.Read_Provider is
     read(count i32) choice (array u8) io.end_of_file error is
-      # NYI next line should be
-      # res := [u8 0]
-      # but a bug in array constants implementation
-      # leads to failure of tests/stdin currently
-      # this is just a quick hack to work around this
-      res := (array u8 1 i->0)
-      v := fuzion.sys.fileio.read fuzion.sys.stdin.stdin0 res.internal_array.data 1
+      arr := fuzion.sys.internal_array_init u8 1
+      v := fuzion.sys.fileio.read fuzion.sys.stdin.stdin0 arr.data 1
       if v < -1
         error "an error occurred while reading stdin"
       else if v <= 0
         io.end_of_file
       else
-        res
+        arr.as_array
 
 
   # NYI #169 backward type propagation for []

--- a/lib/time/now.fz
+++ b/lib/time/now.fz
@@ -39,8 +39,9 @@ public now (p () -> time.date_time) : simple_effect is
   # the system is giving us.
   #
   private type.default_now ()->time.date_time is () ->
-    a := array i32 6 i->0
-    fuzion.std.date_time a.internal_array.data
+    arr := fuzion.sys.internal_array_init i32 6
+    fuzion.std.date_time arr.data
+    a := arr.as_array
     time.date_time a[0] a[1] a[2] a[3] a[4] a[5]
 
 

--- a/src/dev/flang/fuir/analysis/dfa/DFA.java
+++ b/src/dev/flang/fuir/analysis/dfa/DFA.java
@@ -1688,7 +1688,7 @@ public class DFA extends ANY
           if (array instanceof SysArray sa)
             {
               sa.setel(new NumericValue(cl._dfa, cl._dfa._fuir.clazz(FUIR.SpecialClazzes.c_i32)),
-                       new NumericValue(cl._dfa, cl._dfa._fuir.clazz(FUIR.SpecialClazzes.c_i64)));
+                       new NumericValue(cl._dfa, cl._dfa._fuir.clazz(FUIR.SpecialClazzes.c_u8  )));
               return new NumericValue(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc));
             }
           else

--- a/src/dev/flang/fuir/analysis/dfa/DFA.java
+++ b/src/dev/flang/fuir/analysis/dfa/DFA.java
@@ -1273,18 +1273,109 @@ public class DFA extends ANY
     put("fuzion.sys.args.count"          , cl -> new NumericValue(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc)) );
     put("fuzion.sys.args.get"            , cl -> cl._dfa.newConstString(null, cl) );
     put("fuzion.std.exit"                , cl -> null );
-    put("fuzion.sys.fileio.read"         , cl -> new NumericValue(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc)) ); // NYI : manipulation of an array passed as argument needs to be tracked and recorded
+    put("fuzion.sys.fileio.read"         , cl ->
+        {
+          var array = cl._args.get(1);
+          if (array instanceof SysArray sa)
+            {
+              sa.setel(new NumericValue(cl._dfa, cl._dfa._fuir.clazz(FUIR.SpecialClazzes.c_i32)),
+                       new NumericValue(cl._dfa, cl._dfa._fuir.clazz(FUIR.SpecialClazzes.c_u8 )));
+              return new NumericValue(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc));
+            }
+          else
+            {
+              throw new Error("intrinsic fuzion.sys.fileio.read: Expected class SysArray, found "+array.getClass()+" "+array);
+            }
+        });
     put("fuzion.sys.fileio.write"        , cl -> new NumericValue(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc)) );
     put("fuzion.sys.fileio.delete"       , cl -> cl._dfa._bool );
     put("fuzion.sys.fileio.move"         , cl -> cl._dfa._bool );
     put("fuzion.sys.fileio.create_dir"   , cl -> cl._dfa._bool );
-    put("fuzion.sys.fileio.open"         , cl -> Value.UNIT ); // NYI : manipulation of an array passed as argument needs to be tracked and recorded
+    put("fuzion.sys.fileio.open"         , cl ->
+        {
+          var array = cl._args.get(1);
+          if (array instanceof SysArray sa)
+            {
+              sa.setel(new NumericValue(cl._dfa, cl._dfa._fuir.clazz(FUIR.SpecialClazzes.c_i32)),
+                       new NumericValue(cl._dfa, cl._dfa._fuir.clazz(FUIR.SpecialClazzes.c_i64)));
+              return Value.UNIT;
+            }
+          else
+            {
+              throw new Error("intrinsic fuzion.sys.fileio.open: Expected class SysArray, found "+array.getClass()+" "+array);
+            }
+        });
     put("fuzion.sys.fileio.close"        , cl -> new NumericValue(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc)) );
-    put("fuzion.sys.fileio.stats"        , cl -> cl._dfa._bool ); // NYI : manipulation of an array passed as argument needs to be tracked and recorded
-    put("fuzion.sys.fileio.lstats"       , cl -> cl._dfa._bool ); // NYI : manipulation of an array passed as argument needs to be tracked and recorded
-    put("fuzion.sys.fileio.seek"         , cl -> Value.UNIT ); // NYI : manipulation of an array passed as argument needs to be tracked and recorded
-    put("fuzion.sys.fileio.file_position", cl -> Value.UNIT ); // NYI : manipulation of an array passed as argument needs to be tracked and recorded
-    put("fuzion.sys.fileio.mmap"         , cl -> new SysArray(cl._dfa, new NumericValue(cl._dfa, cl._dfa._fuir.clazz(FUIR.SpecialClazzes.c_u8)))); // NYI: length wrong, get from arg
+    put("fuzion.sys.fileio.stats"        , cl ->
+        {
+          var array = cl._args.get(1);
+          if (array instanceof SysArray sa)
+            {
+              sa.setel(new NumericValue(cl._dfa, cl._dfa._fuir.clazz(FUIR.SpecialClazzes.c_i32)),
+                       new NumericValue(cl._dfa, cl._dfa._fuir.clazz(FUIR.SpecialClazzes.c_i64)));
+              return cl._dfa._bool;
+            }
+          else
+            {
+              throw new Error("intrinsic fuzion.sys.fileio.stats: Expected class SysArray, found "+array.getClass()+" "+array);
+            }
+        });
+    put("fuzion.sys.fileio.lstats"       , cl ->
+        {
+          var array = cl._args.get(1);
+          if (array instanceof SysArray sa)
+            {
+              sa.setel(new NumericValue(cl._dfa, cl._dfa._fuir.clazz(FUIR.SpecialClazzes.c_i32)),
+                       new NumericValue(cl._dfa, cl._dfa._fuir.clazz(FUIR.SpecialClazzes.c_i64)));
+              return cl._dfa._bool;
+            }
+          else
+            {
+              throw new Error("intrinsic fuzion.sys.fileio.lstats: Expected class SysArray, found "+array.getClass()+" "+array);
+            }
+        });
+    put("fuzion.sys.fileio.seek"         , cl ->
+        {
+          var array = cl._args.get(2);
+          if (array instanceof SysArray sa)
+            {
+              sa.setel(new NumericValue(cl._dfa, cl._dfa._fuir.clazz(FUIR.SpecialClazzes.c_i32)),
+                       new NumericValue(cl._dfa, cl._dfa._fuir.clazz(FUIR.SpecialClazzes.c_i64)));
+              return Value.UNIT;
+            }
+          else
+            {
+              throw new Error("intrinsic fuzion.sys.fileio.seek: Expected class SysArray, found "+array.getClass()+" "+array);
+            }
+        });
+    put("fuzion.sys.fileio.file_position", cl ->
+        {
+          var array = cl._args.get(1);
+          if (array instanceof SysArray sa)
+            {
+              sa.setel(new NumericValue(cl._dfa, cl._dfa._fuir.clazz(FUIR.SpecialClazzes.c_i32)),
+                       new NumericValue(cl._dfa, cl._dfa._fuir.clazz(FUIR.SpecialClazzes.c_i64)));
+              return Value.UNIT;
+            }
+          else
+            {
+              throw new Error("intrinsic fuzion.sys.fileio.file_position: Expected class SysArray, found "+array.getClass()+" "+array);
+            }
+        });
+    put("fuzion.sys.fileio.mmap"         , cl ->
+        {
+          var array = cl._args.get(3);
+          if (array instanceof SysArray sa)
+            {
+              sa.setel(new NumericValue(cl._dfa, cl._dfa._fuir.clazz(FUIR.SpecialClazzes.c_i32)),
+                       new NumericValue(cl._dfa, cl._dfa._fuir.clazz(FUIR.SpecialClazzes.c_i32)));
+              return new SysArray(cl._dfa, new NumericValue(cl._dfa, cl._dfa._fuir.clazz(FUIR.SpecialClazzes.c_u8))); // NYI: length wrong, get from arg
+            }
+          else
+            {
+              throw new Error("intrinsic fuzion.sys.fileio.mmap: Expected class SysArray, found "+array.getClass()+" "+array);
+            }
+        });
     put("fuzion.sys.fileio.munmap"       , cl -> new NumericValue(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc)) );
     put("fuzion.sys.fileio.flush"        , cl -> new NumericValue(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc)) );
     put("fuzion.sys.stdin.stdin0"        , cl -> new NumericValue(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc)) );
@@ -1548,13 +1639,84 @@ public class DFA extends ANY
     put("fuzion.sys.thread.join0"        , cl -> Value.UNIT);
 
     // NYI these intrinsics manipulate an array passed as an arg.
-    put("fuzion.sys.net.bind0"           , cl -> new NumericValue(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc)) );
+    put("fuzion.sys.net.bind0"           , cl ->
+        {
+          var array = cl._args.get(5);
+          if (array instanceof SysArray sa)
+            {
+              sa.setel(new NumericValue(cl._dfa, cl._dfa._fuir.clazz(FUIR.SpecialClazzes.c_i32)),
+                       new NumericValue(cl._dfa, cl._dfa._fuir.clazz(FUIR.SpecialClazzes.c_i64)));
+              return new NumericValue(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc));
+            }
+          else
+            {
+              throw new Error("intrinsic fuzion.sys.net.bind0: Expected class SysArray, found "+array.getClass()+" "+array);
+            }
+        });
     put("fuzion.sys.net.listen"          , cl -> new NumericValue(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc)) );
-    put("fuzion.sys.net.accept"          , cl -> cl._dfa._bool );
-    put("fuzion.sys.net.connect0"        , cl -> new NumericValue(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc)) );
-    put("fuzion.sys.net.get_peer_address", cl -> new NumericValue(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc)) );
+    put("fuzion.sys.net.accept"          , cl ->
+        {
+          var array = cl._args.get(1);
+          if (array instanceof SysArray sa)
+            {
+              sa.setel(new NumericValue(cl._dfa, cl._dfa._fuir.clazz(FUIR.SpecialClazzes.c_i32)),
+                       new NumericValue(cl._dfa, cl._dfa._fuir.clazz(FUIR.SpecialClazzes.c_i64)));
+              return cl._dfa._bool;
+            }
+          else
+            {
+              throw new Error("intrinsic fuzion.sys.net.accept: Expected class SysArray, found "+array.getClass()+" "+array);
+            }
+        } );
+    put("fuzion.sys.net.connect0"        , cl ->
+        {
+          var array = cl._args.get(5);
+          if (array instanceof SysArray sa)
+            {
+              sa.setel(new NumericValue(cl._dfa, cl._dfa._fuir.clazz(FUIR.SpecialClazzes.c_i32)),
+                       new NumericValue(cl._dfa, cl._dfa._fuir.clazz(FUIR.SpecialClazzes.c_i64)));
+              return new NumericValue(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc));
+            }
+          else
+            {
+              throw new Error("intrinsic fuzion.sys.net.connect0: Expected class SysArray, found "+array.getClass()+" "+array);
+            }
+        });
+    put("fuzion.sys.net.get_peer_address", cl ->
+        {
+          var array = cl._args.get(1);
+          if (array instanceof SysArray sa)
+            {
+              sa.setel(new NumericValue(cl._dfa, cl._dfa._fuir.clazz(FUIR.SpecialClazzes.c_i32)),
+                       new NumericValue(cl._dfa, cl._dfa._fuir.clazz(FUIR.SpecialClazzes.c_i64)));
+              return new NumericValue(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc));
+            }
+          else
+            {
+              throw new Error("intrinsic fuzion.sys.net.get_peer_address: Expected class SysArray, found "+array.getClass()+" "+array);
+            }
+        });
     put("fuzion.sys.net.get_peer_port"   , cl -> new NumericValue(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc)) );
-    put("fuzion.sys.net.read"            , cl -> cl._dfa._bool );
+    put("fuzion.sys.net.read"            , cl ->
+        {
+          var buf_array = cl._args.get(1);
+          var res_array = cl._args.get(3);
+          if (buf_array instanceof SysArray bsa &&
+              res_array instanceof SysArray rsa    )
+            {
+              bsa.setel(new NumericValue(cl._dfa, cl._dfa._fuir.clazz(FUIR.SpecialClazzes.c_i32)),
+                        new NumericValue(cl._dfa, cl._dfa._fuir.clazz(FUIR.SpecialClazzes.c_u8 )));
+              rsa.setel(new NumericValue(cl._dfa, cl._dfa._fuir.clazz(FUIR.SpecialClazzes.c_i32)),
+                        new NumericValue(cl._dfa, cl._dfa._fuir.clazz(FUIR.SpecialClazzes.c_i64)));
+              return cl._dfa._bool;
+            }
+          else
+            {
+              throw new Error("intrinsic fuzion.sys.net.readt: Expected class SysArray, found " +
+                              buf_array.getClass() + " " + buf_array + " and " +
+                              res_array.getClass() + " " + res_array);
+            }
+        });
     put("fuzion.sys.net.write"           , cl -> new NumericValue(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc)) );
     put("fuzion.sys.net.close0"          , cl -> new NumericValue(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc)) );
     put("fuzion.sys.net.set_blocking0"   , cl -> new NumericValue(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc)) );


### PR DESCRIPTION
In general, the code pattern
```
  arr := [0,0]
  intrinsic_function arr.internal_array.data
  result := arr
```
is changed into
```
  iarr := fuzion.sys.internal_array_init T length
  intrinsic_function iarr.add
  result := iarr.as_array
```
This is a little clumsy, but in many cases the code should be change anyway once
we can return tuples from intrinsics.

Since this removes the code to initialize the array, the DFA no longer sees any
values assigned to these arrays. So this patch adds explicit handling in the DFA
to initialize these arrays.

