### PR TITLE
fix inconsistency of type of StrConst

### DIFF
--- a/bin/aspell.dict
+++ b/bin/aspell.dict
@@ -1308,7 +1308,7 @@ typedef
 typeFeature
 typeFeatureOrigin
 typefrom
-typeIfKnown
+typeForInferencing
 typeInference
 typeInParens
 typeList

--- a/src/dev/flang/air/Clazz.java
+++ b/src/dev/flang/air/Clazz.java
@@ -1934,7 +1934,6 @@ public class Clazz extends ANY implements Comparable<Clazz>
       // to be considered instantiated if there is any clazz D that
       // normalize() would replace by C if it occurs as an outer clazz.
       _outer == Clazzes.any.getIfCreated()    ||
-      _outer == Clazzes.string.getIfCreated() ||
 
       _outer._isNormalized ||
 
@@ -1977,9 +1976,8 @@ public class Clazz extends ANY implements Comparable<Clazz>
    */
   public boolean isInstantiated()
   {
-    return this == Clazzes.fuzionSysArray_u8 ||
-      this == Clazzes.Const_String.get() ||
-      _checkingInstantiatedHeirs>0 || (isOuterInstantiated() || isChoice() || _outer.isRef() && _outer.hasInstantiatedHeirs() || _outer.feature().isTypeFeature()) && _isInstantiated;
+    return _checkingInstantiatedHeirs > 0 || (isOuterInstantiated() || isChoice()
+      || _outer.isRef() && _outer.hasInstantiatedHeirs() || _outer.feature().isTypeFeature()) && _isInstantiated;
   }
 
 

--- a/src/dev/flang/air/Clazzes.java
+++ b/src/dev/flang/air/Clazzes.java
@@ -164,7 +164,6 @@ public class Clazzes extends ANY
   public static final OnDemandClazz ref_f32     = new OnDemandClazz(() -> Types.resolved.t_f32.asRef()      );
   public static final OnDemandClazz ref_f64     = new OnDemandClazz(() -> Types.resolved.t_f64.asRef()      );
   public static final OnDemandClazz any         = new OnDemandClazz(() -> Types.resolved.t_any              );
-  public static final OnDemandClazz string      = new OnDemandClazz(() -> Types.resolved.t_string           );
   public static final OnDemandClazz Const_String= new OnDemandClazz(() -> Types.resolved.t_Const_String     );
   public static final OnDemandClazz c_unit      = new OnDemandClazz(() -> Types.resolved.t_unit             );
   public static final OnDemandClazz array_i8    = new OnDemandClazz(() -> Types.resolved.t_array_i8         );
@@ -1073,15 +1072,6 @@ public class Clazzes extends ANY
     else if (e instanceof AbstractConstant c)
       {
         result = outerClazz.actualClazz(c.type());
-        if (result == string.get())
-          { /* this is a bit tricky: in the front end, the type of a string
-             * constant is 'string'.  However, for the back end, the type is
-             * 'Const_String' such that the backend can create an instance of
-             * 'constString' and see the correct type (and create proper type
-             * conversion code to 'string' if this is needed).
-             */
-            result = Const_String.get();
-          }
       }
 
     else if (e instanceof Tag t)
@@ -1323,7 +1313,6 @@ public class Clazzes extends ANY
     ref_f32.clear();
     ref_f64.clear();
     any.clear();
-    string.clear();
     Const_String.clear();
     c_unit.clear();
     error.clear();

--- a/src/dev/flang/ast/AbstractBlock.java
+++ b/src/dev/flang/ast/AbstractBlock.java
@@ -103,18 +103,19 @@ public abstract class AbstractBlock extends Expr
 
 
   /**
-   * typeIfKnown returns the type of this expression or null if the type is
+   * typeForInferencing returns the type of this expression or null if the type is
    * still unknown, i.e., before or during type resolution.  This is redefined
    * by sub-classes of Expr to provide type information.
    *
    * @return this Expr's type or null if not known.
    */
-  AbstractType typeIfKnown()
+  @Override
+  AbstractType typeForInferencing()
   {
     Expr resExpr = resultExpression();
     return resExpr == null
       ? Types.resolved.t_unit
-      : resExpr.typeIfKnown();
+      : resExpr.typeForInferencing();
   }
 
 

--- a/src/dev/flang/ast/AbstractCurrent.java
+++ b/src/dev/flang/ast/AbstractCurrent.java
@@ -66,13 +66,13 @@ public abstract class AbstractCurrent extends Expr
 
 
   /**
-   * typeIfKnown returns the type of this expression or null if the type is
+   * typeForInferencing returns the type of this expression or null if the type is
    * still unknown, i.e., before or during type resolution.  This is redefined
    * by sub-classes of Expr to provide type information.
    *
    * @return this Expr's type or null if not known.
    */
-  AbstractType typeIfKnown()
+  AbstractType typeForInferencing()
   {
     return _type;
   }

--- a/src/dev/flang/ast/AbstractMatch.java
+++ b/src/dev/flang/ast/AbstractMatch.java
@@ -130,7 +130,7 @@ public abstract class AbstractMatch extends Expr
 
 
   /**
-   * Helper routine for typeIfKnown to determine the type of this match
+   * Helper routine for typeForInferencing to determine the type of this match
    * expression on demand, i.e., as late as possible.
    */
   private AbstractType typeFromCases()
@@ -138,7 +138,7 @@ public abstract class AbstractMatch extends Expr
     AbstractType result = Types.resolved.t_void;
     for (var c: cases())
       {
-        var t = c.code().typeIfKnown();
+        var t = c.code().typeForInferencing();
         result = result == null || t == null ? null : result.union(t);
       }
     if (result == Types.t_UNDEFINED)
@@ -158,13 +158,13 @@ public abstract class AbstractMatch extends Expr
 
 
   /**
-   * typeIfKnown returns the type of this expression or null if the type is
+   * typeForInferencing returns the type of this expression or null if the type is
    * still unknown, i.e., before or during type resolution.  This is redefined
    * by sub-classes of Expr to provide type information.
    *
    * @return this Expr's type or null if not known.
    */
-  AbstractType typeIfKnown()
+  AbstractType typeForInferencing()
   {
     if (_type == null)
       {

--- a/src/dev/flang/ast/AbstractType.java
+++ b/src/dev/flang/ast/AbstractType.java
@@ -1771,6 +1771,17 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
   }
 
 
+  /**
+   * @return the type to use for inferencing instead of `t`.
+   */
+  public static AbstractType forInferencing(AbstractType t)
+  {
+    return t == Types.resolved.t_Const_String
+      ? Types.resolved.t_string
+      : t;
+  }
+
+
 }
 
 /* end of file */

--- a/src/dev/flang/ast/ArrayConstant.java
+++ b/src/dev/flang/ast/ArrayConstant.java
@@ -84,13 +84,13 @@ public class ArrayConstant extends Constant
 
 
   /**
-   * typeIfKnown returns the type of this expression or null if the type is
+   * typeForInferencing returns the type of this expression or null if the type is
    * still unknown, i.e., before or during type resolution.  This is redefined
    * by sub-classes of Expr to provide type information.
    *
    * @return this Expr's type or null if not known.
    */
-  AbstractType typeIfKnown()
+  AbstractType typeForInferencing()
   {
     return _type;
   }

--- a/src/dev/flang/ast/BoolConst.java
+++ b/src/dev/flang/ast/BoolConst.java
@@ -92,13 +92,13 @@ public class BoolConst extends Constant
 
 
   /**
-   * typeIfKnown returns the type of this expression or null if the type is
+   * typeForInferencing returns the type of this expression or null if the type is
    * still unknown, i.e., before or during type resolution.  This is redefined
    * by sub-classes of Expr to provide type information.
    *
    * @return this Expr's type or null if not known.
    */
-  AbstractType typeIfKnown()
+  AbstractType typeForInferencing()
   {
     return Types.resolved.t_bool;
   }

--- a/src/dev/flang/ast/Box.java
+++ b/src/dev/flang/ast/Box.java
@@ -117,13 +117,13 @@ public class Box extends Expr
 
 
   /**
-   * typeIfKnown returns the type of this expression or null if the type is
+   * typeForInferencing returns the type of this expression or null if the type is
    * still unknown, i.e., before or during type resolution.  This is redefined
    * by sub-classes of Expr to provide type information.
    *
    * @return this Expr's type or null if not known.
    */
-  AbstractType typeIfKnown()
+  AbstractType typeForInferencing()
   {
     return _type;
   }

--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -475,7 +475,7 @@ public class Call extends AbstractCall
     if (POSTCONDITIONS) ensure
       (result != null);
 
-    return result;
+    return AbstractType.forInferencing(result);
   }
 
 
@@ -1882,7 +1882,7 @@ public class Call extends AbstractCall
             actualType = Types.resolved.f_Type.selfType();
           }
       }
-    return actualType;
+    return AbstractType.forInferencing(actualType);
   }
 
 

--- a/src/dev/flang/ast/Env.java
+++ b/src/dev/flang/ast/Env.java
@@ -78,13 +78,13 @@ public class Env extends ExprWithPos
 
 
   /**
-   * typeIfKnown returns the type of this expression or null if the type is
+   * typeForInferencing returns the type of this expression or null if the type is
    * still unknown, i.e., before or during type resolution.  This is redefined
    * by sub-classes of Expr to provide type information.
    *
    * @return this Expr's type or null if not known.
    */
-  AbstractType typeIfKnown()
+  AbstractType typeForInferencing()
   {
     return _type;
   }

--- a/src/dev/flang/ast/Expr.java
+++ b/src/dev/flang/ast/Expr.java
@@ -73,7 +73,7 @@ public abstract class Expr extends ANY implements HasSourcePosition
       {
         return this;
       }
-      AbstractType typeIfKnown()
+      AbstractType typeForInferencing()
       {
         return Types.t_ERROR;
       }
@@ -117,7 +117,7 @@ public abstract class Expr extends ANY implements HasSourcePosition
    */
   public AbstractType type()
   {
-    var result = typeIfKnown();
+    var result = typeForInferencing();
     if (result == null)
       {
         result = Types.t_ERROR;
@@ -143,13 +143,13 @@ public abstract class Expr extends ANY implements HasSourcePosition
 
 
   /**
-   * typeIfKnown returns the type of this expression or null if the type is
+   * typeForInferencing returns the type of this expression or null if the type is
    * still unknown, i.e., before or during type resolution.  This is redefined
    * by sub-classes of Expr to provide type information.
    *
    * @return this Expr's type or null if not known.
    */
-  AbstractType typeIfKnown()
+  AbstractType typeForInferencing()
   {
     return type();
   }

--- a/src/dev/flang/ast/Feature.java
+++ b/src/dev/flang/ast/Feature.java
@@ -2298,6 +2298,9 @@ public class Feature extends AbstractFeature
         result = result.asThis();
       }
 
+    if (POSTCONDITIONS) ensure
+      (isTypeFeaturesThisType() || selfType() == Types.resolved.t_Const_String || result != Types.resolved.t_Const_String);
+
     return result;
   }
 

--- a/src/dev/flang/ast/Function.java
+++ b/src/dev/flang/ast/Function.java
@@ -338,7 +338,7 @@ public class Function extends ExprWithPos
 
     if (f != null)
       {
-        var t = typeIfKnown();
+        var t = typeForInferencing();
         AbstractFeature tf = null;
 
         if (t != null)
@@ -441,13 +441,13 @@ public class Function extends ExprWithPos
 
 
   /**
-   * typeIfKnown returns the type of this expression or null if the type is
+   * typeForInferencing returns the type of this expression or null if the type is
    * still unknown, i.e., before or during type resolution.  This is redefined
    * by sub-classes of Expr to provide type information.
    *
    * @return this Expr's type or null if not known.
    */
-  AbstractType typeIfKnown()
+  AbstractType typeForInferencing()
   {
     // unlike type(), we do not produce an error but just return null here since
     // everything might eventually turn out fine in this case.

--- a/src/dev/flang/ast/If.java
+++ b/src/dev/flang/ast/If.java
@@ -169,7 +169,7 @@ public class If extends ExprWithPos
 
 
   /**
-   * Helper routine for typeIfKnown to determine the
+   * Helper routine for typeForInferencing to determine the
    * type of this if expression on demand, i.e., as late as possible.
    */
   private AbstractType typeFromIfOrElse()
@@ -179,7 +179,7 @@ public class If extends ExprWithPos
     Iterator<Expr> it = branches();
     while (it.hasNext())
       {
-        var t = it.next().typeIfKnown();
+        var t = it.next().typeForInferencing();
         t = t == null
           ? Types.resolved.t_void
           : t;
@@ -197,13 +197,13 @@ public class If extends ExprWithPos
 
 
   /**
-   * typeIfKnown returns the type of this expression or null if the type is
+   * typeForInferencing returns the type of this expression or null if the type is
    * still unknown, i.e., before or during type resolution.  This is redefined
    * by sub-classes of Expr to provide type information.
    *
    * @return this Expr's type or null if not known.
    */
-  AbstractType typeIfKnown()
+  AbstractType typeForInferencing()
   {
     if (PRECONDITIONS) require
       (elseBlock != null || elseIf != null);

--- a/src/dev/flang/ast/Impl.java
+++ b/src/dev/flang/ast/Impl.java
@@ -481,7 +481,7 @@ public class Impl extends ANY
               {
                 var iv = _initialValues.get(i);
                 var io = _outerOfInitialValues.get(i);
-                var t = iv.typeIfKnown();
+                var t = AbstractType.forInferencing(iv.typeIfKnown());
                 if (t != null)
                   {
                     var l = positions.get(t);
@@ -521,13 +521,13 @@ public class Impl extends ANY
        _kind == Kind.FieldActual ||
        _kind == Kind.RoutineDef     );
 
-    return switch (_kind)
+    return AbstractType.forInferencing(switch (_kind)
       {
       case FieldDef    -> _initialValue.typeIfKnown();
       case RoutineDef  -> _code.typeIfKnown();
       case FieldActual -> typeFromInitialValues(res, f, false);
       default -> throw new Error("missing case "+_kind);
-      };
+      });
   }
 
 

--- a/src/dev/flang/ast/Impl.java
+++ b/src/dev/flang/ast/Impl.java
@@ -461,7 +461,7 @@ public class Impl extends ANY
           {
             iv.visit(new Feature.ResolveTypes(res),io);
           }
-        var t = iv.typeIfKnown();
+        var t = iv.typeForInferencing();
         if (t != null)
           {
             result = result.union(t);
@@ -481,7 +481,7 @@ public class Impl extends ANY
               {
                 var iv = _initialValues.get(i);
                 var io = _outerOfInitialValues.get(i);
-                var t = AbstractType.forInferencing(iv.typeIfKnown());
+                var t = iv.typeForInferencing();
                 if (t != null)
                   {
                     var l = positions.get(t);
@@ -521,13 +521,13 @@ public class Impl extends ANY
        _kind == Kind.FieldActual ||
        _kind == Kind.RoutineDef     );
 
-    return AbstractType.forInferencing(switch (_kind)
+    return switch (_kind)
       {
-      case FieldDef    -> _initialValue.typeIfKnown();
-      case RoutineDef  -> _code.typeIfKnown();
+      case FieldDef    -> _initialValue.typeForInferencing();
+      case RoutineDef  -> _code.typeForInferencing();
       case FieldActual -> typeFromInitialValues(res, f, false);
       default -> throw new Error("missing case "+_kind);
-      });
+      };
   }
 
 

--- a/src/dev/flang/ast/InlineArray.java
+++ b/src/dev/flang/ast/InlineArray.java
@@ -107,7 +107,7 @@ public class InlineArray extends ExprWithPos
         AbstractType t = Types.resolved.t_void;
         for (var e : _elements)
           {
-            var et = e.typeIfKnown();
+            var et = AbstractType.forInferencing(e.typeIfKnown());
             t =
               t  == null ? null :
               et == null ? null : t.union(et);

--- a/src/dev/flang/ast/InlineArray.java
+++ b/src/dev/flang/ast/InlineArray.java
@@ -94,20 +94,20 @@ public class InlineArray extends ExprWithPos
 
 
   /**
-   * typeIfKnown returns the type of this expression or null if the type is
+   * typeForInferencing returns the type of this expression or null if the type is
    * still unknown, i.e., before or during type resolution.  This is redefined
    * by sub-classes of Expr to provide type information.
    *
    * @return this Expr's type or null if not known.
    */
-  AbstractType typeIfKnown()
+  AbstractType typeForInferencing()
   {
     if (_type == null && !_elements.isEmpty())
       {
         AbstractType t = Types.resolved.t_void;
         for (var e : _elements)
           {
-            var et = AbstractType.forInferencing(e.typeIfKnown());
+            var et = e.typeForInferencing();
             t =
               t  == null ? null :
               et == null ? null : t.union(et);

--- a/src/dev/flang/ast/NumLiteral.java
+++ b/src/dev/flang/ast/NumLiteral.java
@@ -351,13 +351,13 @@ public class NumLiteral extends Constant
   }
 
   /**
-   * typeIfKnown returns the type of this expression or null if the type is
+   * typeForInferencing returns the type of this expression or null if the type is
    * still unknown, i.e., before or during type resolution.  This is redefined
    * by sub-classes of Expr to provide type information.
    *
    * @return this Expr's type or null if not known.
    */
-  AbstractType typeIfKnown()
+  AbstractType typeForInferencing()
   {
     if (_type == null)
       {

--- a/src/dev/flang/ast/StrConst.java
+++ b/src/dev/flang/ast/StrConst.java
@@ -74,7 +74,7 @@ public class StrConst extends Constant
    */
   AbstractType typeIfKnown()
   {
-    return Types.resolved.t_string;
+    return Types.resolved.t_Const_String;
   }
 
 

--- a/src/dev/flang/ast/StrConst.java
+++ b/src/dev/flang/ast/StrConst.java
@@ -66,13 +66,27 @@ public class StrConst extends Constant
 
 
   /**
-   * typeIfKnown returns the type of this expression or null if the type is
+   * typeForInferencing returns the type of this expression or null if the type is
    * still unknown, i.e., before or during type resolution.  This is redefined
    * by sub-classes of Expr to provide type information.
    *
    * @return this Expr's type or null if not known.
    */
-  AbstractType typeIfKnown()
+  @Override
+  AbstractType typeForInferencing()
+  {
+    return Types.resolved.t_string;
+  }
+
+
+  /**
+   * type returns the type of this expression or Types.t_ERROR if the type is
+   * still unknown, i.e., before or during type resolution.
+   *
+   * @return this Expr's type or t_ERROR in case it is not known yet.
+   */
+  @Override
+  public AbstractType type()
   {
     return Types.resolved.t_Const_String;
   }

--- a/src/dev/flang/ast/Tag.java
+++ b/src/dev/flang/ast/Tag.java
@@ -110,13 +110,13 @@ public class Tag extends Expr
 
 
   /**
-   * typeIfKnown returns the type of this expression or null if the type is
+   * typeForInferencing returns the type of this expression or null if the type is
    * still unknown, i.e., before or during type resolution.  This is redefined
    * by sub-classes of Expr to provide type information.
    *
    * @return this Expr's type or null if not known.
    */
-  AbstractType typeIfKnown()
+  AbstractType typeForInferencing()
   {
     return _taggedType;
   }

--- a/src/dev/flang/ast/This.java
+++ b/src/dev/flang/ast/This.java
@@ -155,13 +155,13 @@ public class This extends ExprWithPos
 
 
   /**
-   * typeIfKnown returns the type of this expression or null if the type is
+   * typeForInferencing returns the type of this expression or null if the type is
    * still unknown, i.e., before or during type resolution.  This is redefined
    * by sub-classes of Expr to provide type information.
    *
    * @return this Expr's type or null if not known.
    */
-  AbstractType typeIfKnown()
+  AbstractType typeForInferencing()
   {
     return null;  // After type resolution, This is no longer part of the code.
   }
@@ -239,7 +239,7 @@ public class This extends ExprWithPos
                 Expr c = new Call(pos(), getOuter, or, -1)
                   {
                     @Override
-                    AbstractType typeIfKnown()
+                    AbstractType typeForInferencing()
                     {
                       return isAdr ? t : _type;
                     }

--- a/src/dev/flang/ast/Universe.java
+++ b/src/dev/flang/ast/Universe.java
@@ -82,13 +82,13 @@ public class Universe extends Expr
 
 
   /**
-   * typeIfKnown returns the type of this expression or null if the type is
+   * typeForInferencing returns the type of this expression or null if the type is
    * still unknown, i.e., before or during type resolution.  This is redefined
    * by sub-classes of Expr to provide type information.
    *
    * @return this Expr's type or null if not known.
    */
-  AbstractType typeIfKnown()
+  AbstractType typeForInferencing()
   {
     return Types.resolved.universe.selfType();
   }

--- a/src/dev/flang/be/interpreter/Interpreter.java
+++ b/src/dev/flang/be/interpreter/Interpreter.java
@@ -372,7 +372,7 @@ public class Interpreter extends ANY
             else if (t.compareTo(Types.resolved.t_u64   ) == 0) { result = new u64Value (ByteBuffer.wrap(d).order(ByteOrder.LITTLE_ENDIAN).getLong  ()       ); }
             else if (t.compareTo(Types.resolved.t_f32   ) == 0) { result = new f32Value (ByteBuffer.wrap(d).order(ByteOrder.LITTLE_ENDIAN).getFloat ()       ); }
             else if (t.compareTo(Types.resolved.t_f64   ) == 0) { result = new f64Value (ByteBuffer.wrap(d).order(ByteOrder.LITTLE_ENDIAN).getDouble()       ); }
-            else if (t.compareTo(Types.resolved.t_string) == 0) { result = value(new String(d, StandardCharsets.UTF_8));                                        }
+            else if (t.compareTo(Types.resolved.t_Const_String) == 0) { result = value(new String(d, StandardCharsets.UTF_8));                                  }
             else if (t.compareTo(Types.resolved.t_array_i8 ) == 0) { result = constArray(d,t); }
             else if (t.compareTo(Types.resolved.t_array_i16) == 0) { result = constArray(d,t); }
             else if (t.compareTo(Types.resolved.t_array_i32) == 0) { result = constArray(d,t); }

--- a/src/dev/flang/fuir/FUIR.java
+++ b/src/dev/flang/fuir/FUIR.java
@@ -1758,18 +1758,18 @@ hw25 is
     Clazz clazz;
     var ic = _codeIds.get(c).get(ix);
     var t = ((Expr) ic).type();
-    if      (t.compareTo(Types.resolved.t_bool  ) == 0) { clazz = Clazzes.bool       .getIfCreated(); }
-    else if (t.compareTo(Types.resolved.t_i8    ) == 0) { clazz = Clazzes.i8         .getIfCreated(); }
-    else if (t.compareTo(Types.resolved.t_i16   ) == 0) { clazz = Clazzes.i16        .getIfCreated(); }
-    else if (t.compareTo(Types.resolved.t_i32   ) == 0) { clazz = Clazzes.i32        .getIfCreated(); }
-    else if (t.compareTo(Types.resolved.t_i64   ) == 0) { clazz = Clazzes.i64        .getIfCreated(); }
-    else if (t.compareTo(Types.resolved.t_u8    ) == 0) { clazz = Clazzes.u8         .getIfCreated(); }
-    else if (t.compareTo(Types.resolved.t_u16   ) == 0) { clazz = Clazzes.u16        .getIfCreated(); }
-    else if (t.compareTo(Types.resolved.t_u32   ) == 0) { clazz = Clazzes.u32        .getIfCreated(); }
-    else if (t.compareTo(Types.resolved.t_u64   ) == 0) { clazz = Clazzes.u64        .getIfCreated(); }
-    else if (t.compareTo(Types.resolved.t_f32   ) == 0) { clazz = Clazzes.f32        .getIfCreated(); }
-    else if (t.compareTo(Types.resolved.t_f64   ) == 0) { clazz = Clazzes.f64        .getIfCreated(); }
-    else if (t.compareTo(Types.resolved.t_string) == 0) { clazz = Clazzes.Const_String.getIfCreated(); } // NYI: a slight inconsistency here, need to change AST
+    if      (t.compareTo(Types.resolved.t_bool        ) == 0) { clazz = Clazzes.bool        .getIfCreated(); }
+    else if (t.compareTo(Types.resolved.t_i8          ) == 0) { clazz = Clazzes.i8          .getIfCreated(); }
+    else if (t.compareTo(Types.resolved.t_i16         ) == 0) { clazz = Clazzes.i16         .getIfCreated(); }
+    else if (t.compareTo(Types.resolved.t_i32         ) == 0) { clazz = Clazzes.i32         .getIfCreated(); }
+    else if (t.compareTo(Types.resolved.t_i64         ) == 0) { clazz = Clazzes.i64         .getIfCreated(); }
+    else if (t.compareTo(Types.resolved.t_u8          ) == 0) { clazz = Clazzes.u8          .getIfCreated(); }
+    else if (t.compareTo(Types.resolved.t_u16         ) == 0) { clazz = Clazzes.u16         .getIfCreated(); }
+    else if (t.compareTo(Types.resolved.t_u32         ) == 0) { clazz = Clazzes.u32         .getIfCreated(); }
+    else if (t.compareTo(Types.resolved.t_u64         ) == 0) { clazz = Clazzes.u64         .getIfCreated(); }
+    else if (t.compareTo(Types.resolved.t_f32         ) == 0) { clazz = Clazzes.f32         .getIfCreated(); }
+    else if (t.compareTo(Types.resolved.t_f64         ) == 0) { clazz = Clazzes.f64         .getIfCreated(); }
+    else if (t.compareTo(Types.resolved.t_Const_String) == 0) { clazz = Clazzes.Const_String.getIfCreated(); }
     else if (ic instanceof AbstractConstant)
       {
         clazz = Clazzes.clazz(t);


### PR DESCRIPTION
Idea is that StrConst has type `Const_String`, but when a type is used for inferencing `String` is used instead of `Const_String`