### PR TITLE
fix #2114: add all type features for type pars, fix JVM error msg, use intrinsic_constructor for `bool` result

### DIFF
--- a/lib/concur/atomic.fz
+++ b/lib/concur/atomic.fz
@@ -41,7 +41,7 @@ is
   # such as `i32`, `f64`, etc. while this is typically not the case for
   # more complex types such as `point(x,y i64)`.
   #
-  public racy_accesses_supported bool is intrinsic
+  public racy_accesses_supported bool is intrinsic_constructor
 
 
   # read the value stored in this atomic and do not care about synchronization.
@@ -137,4 +137,4 @@ is
   #
   # returns true, if successful
   #
-  compare_and_set0(expected, new_value T) bool is intrinsic
+  compare_and_set0(expected, new_value T) bool is intrinsic_constructor

--- a/lib/effect.fz
+++ b/lib/effect.fz
@@ -103,7 +103,7 @@ is
 
 
   # has an effect of the given type been installed?
-  public type.is_installed(E type) bool is intrinsic
+  public type.is_installed(E type) bool is intrinsic_constructor
 
 
 

--- a/lib/f32.fz
+++ b/lib/f32.fz
@@ -44,11 +44,11 @@ public f32(public val f32) : float is
 
   # comparision
   #
-  fixed infix = (other f32) bool is intrinsic
-  fixed infix <= (other f32) bool is intrinsic
-  fixed infix >= (other f32) bool is intrinsic
-  fixed infix < (other f32) bool is intrinsic
-  fixed infix > (other f32) bool is intrinsic
+  fixed infix = (other f32) bool is intrinsic_constructor
+  fixed infix <= (other f32) bool is intrinsic_constructor
+  fixed infix >= (other f32) bool is intrinsic_constructor
+  fixed infix < (other f32) bool is intrinsic_constructor
+  fixed infix > (other f32) bool is intrinsic_constructor
 
 
   # conversion
@@ -192,7 +192,7 @@ public f32(public val f32) : float is
     val.as_f32
 
 
-  public fixed type.is_NaN(val f32) bool is intrinsic
+  public fixed type.is_NaN(val f32) bool is intrinsic_constructor
 
 
   public fixed type.min_exp i32 is intrinsic

--- a/lib/f64.fz
+++ b/lib/f64.fz
@@ -46,11 +46,11 @@ public f64(public val f64) : float is
 
   # comparision
   #
-  fixed infix = (other f64) bool is intrinsic
-  fixed infix <= (other f64) bool is intrinsic
-  fixed infix >= (other f64) bool is intrinsic
-  fixed infix < (other f64) bool is intrinsic
-  fixed infix > (other f64) bool is intrinsic
+  fixed infix = (other f64) bool is intrinsic_constructor
+  fixed infix <= (other f64) bool is intrinsic_constructor
+  fixed infix >= (other f64) bool is intrinsic_constructor
+  fixed infix < (other f64) bool is intrinsic_constructor
+  fixed infix > (other f64) bool is intrinsic_constructor
 
 
   # conversion
@@ -205,7 +205,7 @@ public f64(public val f64) : float is
     val.as_f64
 
 
-  public fixed type.is_NaN(val f64) bool is intrinsic
+  public fixed type.is_NaN(val f64) bool is intrinsic_constructor
 
 
   public fixed type.min_exp i32 is intrinsic

--- a/lib/fuzion/java.fz
+++ b/lib/fuzion/java.fz
@@ -59,7 +59,7 @@ public fuzion.java is
   #
   public Java_Object(private Java_Ref Any) ref
   is
-    public is_null bool is intrinsic
+    public is_null bool is intrinsic_constructor
 
     # dummy feature to make sure Java_Object.type exists. This is required since
     # Java-related intrinsics may return an array of Java_Object and require Java_Object.type.

--- a/lib/fuzion/sys/env_vars.fz
+++ b/lib/fuzion/sys/env_vars.fz
@@ -32,7 +32,7 @@ module env_vars is
   #
   # NOTE: parameter s must be 0-terminated char *
   #
-  private has0(s fuzion.sys.Pointer) bool is intrinsic
+  private has0(s fuzion.sys.Pointer) bool is intrinsic_constructor
 
 
   # intrinsic to get env var with given name
@@ -43,10 +43,10 @@ module env_vars is
   is intrinsic
 
   # intrinsic to set env var
-  private set0(s fuzion.sys.Pointer, t fuzion.sys.Pointer) bool is intrinsic
+  private set0(s fuzion.sys.Pointer, t fuzion.sys.Pointer) bool is intrinsic_constructor
 
   # intrinsic to unset env var
-  private unset0(s fuzion.sys.Pointer) bool is intrinsic
+  private unset0(s fuzion.sys.Pointer) bool is intrinsic_constructor
 
 
   # check if env var with given name exists

--- a/lib/fuzion/sys/fileio.fz
+++ b/lib/fuzion/sys/fileio.fz
@@ -118,7 +118,7 @@ module fileio is
                  # the internal array data representing the file/dir path in bytes
                  path fuzion.sys.Pointer,
                  # dummy parameter to avoid duplicate feature name
-                 _ unit) bool is intrinsic
+                 _ unit) bool is intrinsic_constructor
 
 
   #  moves file/dir from an old path to a the new path
@@ -145,7 +145,7 @@ module fileio is
                # the internal array data representing the new file/dir path in bytes
                new_path fuzion.sys.Pointer,
                # dummy parameter for overloading
-               _ unit) bool is intrinsic
+               _ unit) bool is intrinsic_constructor
 
 
   # creates a directory using the specified path
@@ -166,7 +166,7 @@ module fileio is
                      # the internal array data representing the dir path in bytes
                      path fuzion.sys.Pointer,
                      # dummy parameter to enable overloading
-                     _ unit) bool is intrinsic
+                     _ unit) bool is intrinsic_constructor
 
 
   # intrinsic that fills an array with some metadata of the file/dir provided by the path
@@ -180,7 +180,7 @@ module fileio is
         # the internal array data representing the file/dir path in bytes
         path fuzion.sys.Pointer,
         # the internal array data representing the metadata fields [size in bytes, creation_time in seconds, regular file? 1 : 0, dir? 1 : 0]
-        meta_data fuzion.sys.Pointer) bool is intrinsic
+        meta_data fuzion.sys.Pointer) bool is intrinsic_constructor
 
   # intrinsic that fills an array with some metadata of the file/dir provided by the path
   # returns TRUE in case the operation was successful and FALSE in case of failure

--- a/lib/fuzion/sys/net.fz
+++ b/lib/fuzion/sys/net.fz
@@ -80,7 +80,7 @@ module net is
   # true  => arr_result[0] is the socket descriptor
   # false => arr_result[0] is an error number
   #
-  accept (sd i64, arr_result fuzion.sys.Pointer) bool is intrinsic
+  accept (sd i64, arr_result fuzion.sys.Pointer) bool is intrinsic_constructor
 
 
   # accept a new connection for given socket descriptor, wrapper for accept intrinsic.
@@ -116,7 +116,7 @@ module net is
   # true  => arr_result[0] is the number of bytes read
   # false => arr_result[0] is an error number
   #
-  read(sd i64, arr_data fuzion.sys.Pointer, length i32, arr_result fuzion.sys.Pointer) bool is intrinsic
+  read(sd i64, arr_data fuzion.sys.Pointer, length i32, arr_result fuzion.sys.Pointer) bool is intrinsic_constructor
 
 
   # read a maximum of max_bytes from descriptor, wrapper for read intrinsic

--- a/lib/i16.fz
+++ b/lib/i16.fz
@@ -168,12 +168,12 @@ public i16(public val i16) : num.wrap_around, has_interval is
 
   # equality
   #
-  fixed type.equality(a, b i16) bool is intrinsic
+  fixed type.equality(a, b i16) bool is intrinsic_constructor
 
 
   # total order
   #
-  fixed type.lteq(a, b i16) bool is intrinsic
+  fixed type.lteq(a, b i16) bool is intrinsic_constructor
 
 
   # returns the number in whose bit representation all bits are ones

--- a/lib/i32.fz
+++ b/lib/i32.fz
@@ -179,12 +179,12 @@ public i32(public val i32) : num.wrap_around, has_interval is
 
   # equality
   #
-  fixed type.equality(a, b i32) bool is intrinsic
+  fixed type.equality(a, b i32) bool is intrinsic_constructor
 
 
   # total order
   #
-  fixed type.lteq(a, b i32) bool is intrinsic
+  fixed type.lteq(a, b i32) bool is intrinsic_constructor
 
 
   # returns the number in whose bit representation all bits are ones

--- a/lib/i64.fz
+++ b/lib/i64.fz
@@ -224,12 +224,12 @@ public i64(public val i64) : num.wrap_around, has_interval is
 
   # equality
   #
-  fixed type.equality(a, b i64) bool is intrinsic
+  fixed type.equality(a, b i64) bool is intrinsic_constructor
 
 
   # total order
   #
-  fixed type.lteq(a, b i64) bool is intrinsic
+  fixed type.lteq(a, b i64) bool is intrinsic_constructor
 
 
   # returns the number in whose bit representation all bits are ones

--- a/lib/i8.fz
+++ b/lib/i8.fz
@@ -163,12 +163,12 @@ public i8(public val i8) : num.wrap_around, has_interval is
 
   # equality
   #
-  fixed type.equality(a, b i8) bool is intrinsic
+  fixed type.equality(a, b i8) bool is intrinsic_constructor
 
 
   # total order
   #
-  fixed type.lteq(a, b i8) bool is intrinsic
+  fixed type.lteq(a, b i8) bool is intrinsic_constructor
 
 
   # returns the number in whose bit representation all bits are ones

--- a/lib/quantor.fz
+++ b/lib/quantor.fz
@@ -38,7 +38,7 @@ public quantor is
   #
   # NYI: If open generics could be passed as actual generic arguments, we no
   # longer need this code duplication here:
-  #   for_all(A..., f A -> bool) bool is intrinsic
+  #   for_all(A..., f A -> bool) bool is intrinsic_constructor
   #
   for_all  (A0                                     type, f (A0                                    ) -> bool) bool is fuzion.std.panic "quantors are for analysis only"
   for_all2 (A0, A1                                 type, f (A0, A1                                ) -> bool) bool is fuzion.std.panic "quantors are for analysis only"
@@ -61,7 +61,7 @@ public quantor is
   #
   # NYI: If open generics could be passed as actual generic arguments, we no
   # longer need this code duplication here:
-  #   exists(A..., f A -> bool) bool is intrinsic
+  #   exists(A..., f A -> bool) bool is intrinsic_constructor
   #
   exists  (A0                                     type, f (A0                                    ) -> bool) bool is fuzion.std.panic "quantors are for analysis only"
   exists2 (A0, A1                                 type, f (A0, A1                                ) -> bool) bool is fuzion.std.panic "quantors are for analysis only"

--- a/lib/safety.fz
+++ b/lib/safety.fz
@@ -40,4 +40,4 @@
 # If the program is compiled, not interpreted, then the value of this option
 # at compile time will be used.
 #
-public safety bool is intrinsic
+public safety bool is intrinsic_constructor

--- a/lib/u16.fz
+++ b/lib/u16.fz
@@ -165,12 +165,12 @@ public u16(public val u16) : num.wrap_around, has_interval is
 
   # equality
   #
-  fixed type.equality(a, b u16) bool is intrinsic
+  fixed type.equality(a, b u16) bool is intrinsic_constructor
 
 
   # total order
   #
-  fixed type.lteq(a, b u16) bool is intrinsic
+  fixed type.lteq(a, b u16) bool is intrinsic_constructor
 
 
   # returns the number in whose bit representation all bits are ones

--- a/lib/u32.fz
+++ b/lib/u32.fz
@@ -236,12 +236,12 @@ public u32(public val u32) : num.wrap_around, has_interval is
 
   # equality
   #
-  fixed type.equality(a, b u32) bool is intrinsic
+  fixed type.equality(a, b u32) bool is intrinsic_constructor
 
 
   # total order
   #
-  fixed type.lteq(a, b u32) bool is intrinsic
+  fixed type.lteq(a, b u32) bool is intrinsic_constructor
 
 
   # returns the number in whose bit representation all bits are ones

--- a/lib/u64.fz
+++ b/lib/u64.fz
@@ -236,12 +236,12 @@ public u64(public val u64) : num.wrap_around, has_interval is
 
   # equality
   #
-  fixed type.equality(a, b u64) bool is intrinsic
+  fixed type.equality(a, b u64) bool is intrinsic_constructor
 
 
   # total order
   #
-  fixed type.lteq(a, b u64) bool is intrinsic
+  fixed type.lteq(a, b u64) bool is intrinsic_constructor
 
 
   # returns the number in whose bit representation all bits are ones

--- a/lib/u8.fz
+++ b/lib/u8.fz
@@ -173,12 +173,12 @@ public u8(public val u8) : num.wrap_around, has_interval is
 
   # equality
   #
-  fixed type.equality(a, b u8) bool is intrinsic
+  fixed type.equality(a, b u8) bool is intrinsic_constructor
 
 
   # total order
   #
-  fixed type.lteq(a, b u8) bool is intrinsic
+  fixed type.lteq(a, b u8) bool is intrinsic_constructor
 
 
   # returns the number in whose bit representation all bits are ones

--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -2240,6 +2240,31 @@ public class Call extends AbstractCall
         _type = _type.replace_type_parameters_of_type_feature_origin(outer);
       }
 
+    // make sure type features exist for all features used as actual type
+    // parameters. This is required since the type parameter can be used to get
+    // an instance of the type feature, which requires the presence of all type
+    // features of all actual type parameters and outer types. See #2114 for an
+    // example: There `array a` is used, which requires the presence of `a`'s
+    // type feature.
+    for (var t : actualTypeParameters())
+      {
+        if (!t.isGenericArgument())
+          {
+            t.applyToGenericsAndOuter(t2 ->
+                                      {
+                                        if (!t2.isGenericArgument())
+                                          {
+                                            var f2 = t2.featureOfType();
+                                            if (!f2.isUniverse())
+                                              {
+                                                var t2f = f2.typeFeature(res);
+                                              }
+                                          }
+                                        return t2;
+                                      });
+          }
+      }
+
     if (POSTCONDITIONS) ensure
       (Errors.any() || result.typeIfKnown() != Types.t_ERROR);
 

--- a/src/dev/flang/be/jvm/Choices.java
+++ b/src/dev/flang/be/jvm/Choices.java
@@ -35,6 +35,7 @@ import dev.flang.be.jvm.classfile.Label;
 import dev.flang.fuir.analysis.AbstractInterpreter;
 
 import dev.flang.util.ANY;
+import dev.flang.util.Errors;
 import dev.flang.util.List;
 
 
@@ -438,7 +439,8 @@ public class Choices extends ANY implements ClassFileConstants
       {
       case voidlike:
         {
-          throw new Error("JVM backend match called for voidlike choice type" + _fuir.clazzAsString(subjClazz) + " when compiling " + _fuir.clazzAsString(cl));
+          Errors.fatal("JVM backend match called for void-like choice type " + _fuir.clazzAsString(subjClazz) + " when compiling " + _fuir.clazzAsString(cl));
+          throw new Error(); // never executed, just to keep javac from complaining.
         }
       case unitlike:
         {


### PR DESCRIPTION
This fix actually required three changes, see the individual commits for details: 

1. ast: For actual type parameters, create all required type features
    
    The problem was that for a type passed as an actual type parameter, the type
    parameter of that type itself did not get its type feature created, resulting in
    an error when finding all used features in the middle end.
    
    This patch forces the creation of all type features for all features appearing
    as outer features or as type parameters of an actual type parameter in a call.

2. jvm: Fix error message in case match is performed for void-like choice
    
    The error message was hard to read, it lacked spaces and a hyphen.
    
    Additionally, this now uses `Errors.fatal` instead of just throwing an `Error`.

3. lib: use intrinsic_constructor for instrinsics resulting in bool
    
    The example of #2114 was so minimalistic that during findClazzes, no instances
    of `TRUE` or `FALSE` where found to be created, resulting in broken C code and
    an error in the JVM backend (since type `bool` is effectively `void` when no
    instances of `TRUE` nor `FALSE` exist).
    
    Now, using `instrinc_constructor`, a call to one of these intrinsics ensures
    that `TRUE` and `FALSE` exist.