### PR TITLE
jvm: fix checks to not modify immutable array for `array unit`

### DIFF
--- a/src/dev/flang/be/jvm/runtime/Runtime.java
+++ b/src/dev/flang/be/jvm/runtime/Runtime.java
@@ -763,7 +763,13 @@ public class Runtime extends ANY
   {
     if (CHECKS)
       {
-        _frozenPointers_.put(p, "");
+        // note that the internal array for `array unit` is null, we never
+        // freeze this since modifcations of unit-type arrays are pretty
+        // harmless.
+        if (p != null)
+          {
+            _frozenPointers_.put(p, "");
+          }
       }
   }
 
@@ -778,6 +784,8 @@ public class Runtime extends ANY
   {
     if (CHECKS)
       {
+        // note that p may be null for `array unit`, and `null` is supported by
+        // Java's WeakHashMap and will not be added by `freeze`, so we are fine.
         if (_frozenPointers_.containsKey(p))
           {
             Errors.fatal("Attempt to modify immutable array", stackTrace());


### PR DESCRIPTION
The internal array data in the JVM backend for `array unit` is just `null` since there is no data to be stored.  However, this causes problems when one such array is frozen and a second one is initialized, since the internal array pointer is the same (`null`), the runtime check that the second one is not frozen when it is initialized fired.

This patch makes sure that the internal arrays for `array unit` will never be frozen such that the checks do not apply.