### PR TITLE
lib/jvm: Add support for mmap to JVM backend, cleanup of mmap implementation

### DIFF
--- a/lib/container/Buffer.fz
+++ b/lib/container/Buffer.fz
@@ -17,15 +17,15 @@
 #
 #  Tokiwa Software GmbH, Germany
 #
-#  Source code of Fuzion standard library feature buffer
+#  Source code of Fuzion standard library feature Buffer
 #
 #  Author: Fridtjof Siebert (siebert@tokiwa.software)
 #
 # -----------------------------------------------------------------------
 
-# buffer -- one-dimensional mutable buffer with effect
+# Buffer -- one-dimensional mutable buffer with effect
 #
-# buffer can be used to implement ranges of mutable memory that may be
+# Buffer can be used to implement ranges of mutable memory that may be
 # visible to the outside or even may be modified by the outside.  Examples
 # are memory mapped files, memory shared between processes, bitmaps on a
 # display, memory mapped I/O, etc.
@@ -37,12 +37,12 @@
 # memory used in a native backend, or via an API such as `java.nio.ByteBuffer`
 # for a JVM backend.
 #
-module:public buffer
+module:public Buffer
   (# type of elements stored in this buffer
    T type,
 
    # effect used to modify this buffer
-   E type : effect)
+   E type : effect) ref
 
 is
 
@@ -82,7 +82,7 @@ is
   # create immutable array from this buffer
   #
   public as_array ! E =>
-    array T length.as_i32 (i -> buffer.this[i.as_i64])
+    array T length.as_i32 (i -> Buffer.this[i.as_i64])
 
 
   # create a list from this buffer

--- a/lib/container/buffer.fz
+++ b/lib/container/buffer.fz
@@ -1,0 +1,94 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion standard library feature buffer
+#
+#  Author: Fridtjof Siebert (siebert@tokiwa.software)
+#
+# -----------------------------------------------------------------------
+
+# buffer -- one-dimensional mutable buffer with effect
+#
+# buffer can be used to implement ranges of mutable memory that may be
+# visible to the outside or even may be modified by the outside.  Examples
+# are memory mapped files, memory shared between processes, bitmaps on a
+# display, memory mapped I/O, etc.
+#
+# To model the effects of reading or writing a buffer, an effect is given
+# as an argument to a buffer.  This effect should implement the operations
+# required to implement the `index []` and `set []` features as needed by
+# the backend.  This could be done via direct memory accesses, as for `mmap`
+# memory used in a native backend, or via an API such as `java.nio.ByteBuffer`
+# for a JVM backend.
+#
+module:public buffer
+  (# type of elements stored in this buffer
+   T type,
+
+   # effect used to modify this buffer
+   E type : effect)
+
+is
+
+
+  # length of this buffer.
+  #
+  public length i64 is abstract
+
+
+  # a sequence of all valid indices to access this array. Useful e.g., for
+  # `for`-loops:
+  #
+  #   for i in arr.indices do
+  #     say arr[i]
+  #
+  public indices => (i64 0)..length-1
+
+
+  # get element at given index i
+  #
+  public index [ ] (i i64) T ! E
+    pre
+      safety: 0 ≤ i < length
+  is
+    abstract
+
+
+  # set element at given index i to given value o
+  #
+  public set [ ] (i i64, o T) unit ! E
+    pre
+      safety: 0 ≤ i < length
+  is
+    abstract
+
+
+  # create immutable array from this buffer
+  #
+  public as_array ! E =>
+    array T length.as_i32 (i -> buffer.this[i.as_i64])
+
+
+  # create a list from this buffer
+  #
+  public as_list =>
+    # since buffer is mutable,
+    # we first copy the elements
+    # to an immutable array.
+    as_array.as_list

--- a/lib/fuzion/sys/fileio.fz
+++ b/lib/fuzion/sys/fileio.fz
@@ -309,7 +309,7 @@ module fileio is
   # note: offset+size must not exceed file size.
   # note: returning allocated memory - instead of error code - simplifies handling in DFA.
   #
-  module mmap(fd i64, offset, size i64, res fuzion.sys.Pointer) Pointer is intrinsic
+  module mmap(fd i64, offset, size i64, res fuzion.sys.Pointer) Pointer is intrinsic_constructor
 
 
   # close a memory mapped file
@@ -317,6 +317,31 @@ module fileio is
   # return: 0 on success, -1 on error
   #
   module munmap(address fuzion.sys.Pointer, size i64) i32 is intrinsic
+
+
+  # get a byte from a given mapped buffer
+  #
+  module mapped_buffer_get
+    (# memory address obtained by `mmap`
+     m fuzion.sys.Pointer,
+
+     # index of the byte
+     i i64
+    ) u8 is intrinsic_constructor
+
+
+  # set a byte of a given mapped buffer to a new value
+  #
+  module mapped_buffer_set
+    (# memory address obtained by `mmap`
+     m fuzion.sys.Pointer,
+
+     # index of the byte
+     i i64,
+
+     # new value to be written at m[i]
+     o u8
+    ) unit is intrinsic
 
 
   # flush user-space buffers of file descriptor

--- a/lib/io/file/open.fz
+++ b/lib/io/file/open.fz
@@ -43,17 +43,6 @@ module:public open(T type, private fd i64, public file_name String) : simple_eff
     io.file.read.read_file fd
 
 
-  # mmap effect
-  private mmap(data marray u8) : simple_effect is
-
-
-  # shorthand to get the memory mapped file as an array
-  public mmap marray u8
-  pre effect.type.is_installed (io.file.open T).mmap
-  is
-    (io.file.open T).mmap.env.data
-
-
   # install mmap effect an run code
   #
   # note: the offset must be a multiple of the pagesize which usually is 4096, windows 65536?
@@ -64,26 +53,64 @@ module:public open(T type, private fd i64, public file_name String) : simple_eff
   #   io.file.open.mmap (i64 0) (i64 100) ()->
   #     io.file.open.mmap[99] := 42
   #
-  public mmap(R type, offset i64, size i64, code ()->R) outcome R
+  public mmap(R type, offset i64, size i64, code mapped_buffer->R) outcome R
   pre offset % 4096 = 0 # NYI get real page size instead of 4096.
   is
 
     arr := fuzion.sys.internal_array_init i32 1
-    allocated_memory := fuzion.sys.fileio.mmap fd offset size arr.data
+    mapped_memory := fuzion.sys.fileio.mmap fd offset size arr.data
     res := arr.as_array
 
     if res[0] = -1
       error "mmap failed"
     else
-      marr := marray u8 size.as_i32 (fuzion.sys.internal_array u8 allocated_memory size.as_i32) unit
+      r := code (mapped_buffer mapped_memory size)
 
-      r := mmap marr
-        .go code
-
-      if fuzion.sys.fileio.munmap marr.data.data size = 0
+      if fuzion.sys.fileio.munmap mapped_memory size = 0
         r
       else
         error "error closing the memory mapped file"
+
+  # get a byte from a given mapped buffer
+  #
+  module mapped_buffer_get(memory fuzion.sys.Pointer, i i64) =>
+    open.this.env.replace
+    fuzion.sys.fileio.mapped_buffer_get memory i
+
+  # set a byte of a given mapped buffer
+  #
+  module mapped_buffer_set(memory fuzion.sys.Pointer, i i64, o u8) =>
+    open.this.env.replace
+    fuzion.sys.fileio.mapped_buffer_set memory i o
+
+  # mapped buffer passed to the code by `mmap`
+  #
+  module:public mapped_buffer
+    (# internal pointer to the mapped memory
+     private memory fuzion.sys.Pointer,
+
+     # the length of this buffer
+     public length i64
+    )
+    : container.buffer u8 (io.file.open T) is
+
+
+    # get element at given index i
+    #
+    public index [ ] (i i64) u8 ! open T
+      pre
+        safety: i64 0 ≤ i < length
+    =>
+      mapped_buffer_get memory i
+
+
+    # set element at given index i to given value o
+    #
+    public set [ ] (i i64, o u8) unit ! io.file.open T
+      pre
+        safety: i64 0 ≤ i < length
+    is
+      mapped_buffer_set memory i o
 
 
 
@@ -94,7 +121,6 @@ module:public open(T type, private fd i64, public file_name String) : simple_eff
 #
 public open(T type) =>
   (open T).env
-
 
 
 # unit type used internally by open- and use-

--- a/lib/io/file/open.fz
+++ b/lib/io/file/open.fz
@@ -95,7 +95,7 @@ module:public open(T type, private fd i64, public file_name String) : simple_eff
      # the length of this buffer
      public length i64
     )
-    : container.buffer u8 (io.file.open T) is
+    : container.Buffer u8 (io.file.open T) is
 
 
     # get byte at given index i

--- a/lib/io/file/open.fz
+++ b/lib/io/file/open.fz
@@ -71,6 +71,7 @@ module:public open(T type, private fd i64, public file_name String) : simple_eff
       else
         error "error closing the memory mapped file"
 
+
   # get a byte from a given mapped buffer
   #
   module mapped_buffer_get(memory fuzion.sys.Pointer, i i64) =>
@@ -83,7 +84,9 @@ module:public open(T type, private fd i64, public file_name String) : simple_eff
     open.this.env.replace
     fuzion.sys.fileio.mapped_buffer_set memory i o
 
-  # mapped buffer passed to the code by `mmap`
+
+  # mapped buffer gives access to the memory region a file is mapped
+  # to via `mmap`.
   #
   module:public mapped_buffer
     (# internal pointer to the mapped memory
@@ -95,7 +98,7 @@ module:public open(T type, private fd i64, public file_name String) : simple_eff
     : container.buffer u8 (io.file.open T) is
 
 
-    # get element at given index i
+    # get byte at given index i
     #
     public index [ ] (i i64) u8 ! open T
       pre
@@ -104,7 +107,7 @@ module:public open(T type, private fd i64, public file_name String) : simple_eff
       mapped_buffer_get memory i
 
 
-    # set element at given index i to given value o
+    # set byte at given index i to given value o
     #
     public set [ ] (i i64, o u8) unit ! io.file.open T
       pre

--- a/src/dev/flang/be/c/Intrinsics.java
+++ b/src/dev/flang/be/c/Intrinsics.java
@@ -523,7 +523,7 @@ public class Intrinsics extends ANY
         }
         );
 
-    put("fuzion.sys.fileio.mmap", (c,cl,outer,in) -> CExpr.call("fzE_mmap", new List<CExpr>(
+    put("fuzion.sys.fileio.mmap"  , (c,cl,outer,in) -> CExpr.call("fzE_mmap", new List<CExpr>(
       A0.castTo("FILE * "),   // file
       A1.castTo("off_t"),     // offset
       A2.castTo("size_t"),    // size

--- a/src/dev/flang/be/c/Intrinsics.java
+++ b/src/dev/flang/be/c/Intrinsics.java
@@ -523,7 +523,7 @@ public class Intrinsics extends ANY
         }
         );
 
-    put("fuzion.sys.fileio.mmap"  , (c,cl,outer,in) -> CExpr.call("fzE_mmap", new List<CExpr>(
+    put("fuzion.sys.fileio.mmap", (c,cl,outer,in) -> CExpr.call("fzE_mmap", new List<CExpr>(
       A0.castTo("FILE * "),   // file
       A1.castTo("off_t"),     // offset
       A2.castTo("size_t"),    // size
@@ -533,6 +533,8 @@ public class Intrinsics extends ANY
       A0.castTo("void *"),    // address
       A1.castTo("size_t")     // size
     )).ret());
+    put("fuzion.sys.fileio.mapped_buffer_get", (c,cl,outer,in) -> A0.castTo("int8_t*").index(A1).ret());
+    put("fuzion.sys.fileio.mapped_buffer_set", (c,cl,outer,in) -> A0.castTo("int8_t*").index(A1).assign(A2.castTo("int8_t")));
 
     put("fuzion.sys.fileio.flush"      , (c,cl,outer,in) ->
       CExpr.call("fflush", new List<>(A0.castTo("FILE *"))).ret());

--- a/src/dev/flang/be/interpreter/Intrinsics.java
+++ b/src/dev/flang/be/interpreter/Intrinsics.java
@@ -616,6 +616,19 @@ public class Intrinsics extends ANY
         {
           return new i32Value(0);
         });
+    put("fuzion.sys.fileio.mapped_buffer_get", (interpreter, innerClazz) -> args ->
+        {
+          return ((ArrayData)args.get(1)).get(/* index */ (int) args.get(2).i64Value(),
+                                              /* type  */ Types.resolved.t_u8);
+        });
+    put("fuzion.sys.fileio.mapped_buffer_set", (interpreter, innerClazz) -> args ->
+        {
+          ((ArrayData)args.get(1)).set(/* index */ (int) args.get(2).i64Value(),
+                                       /* value */ args.get(3),
+                                       /* type  */ Types.resolved.t_u8);
+          return Value.EMPTY_VALUE;
+        });
+
     put("fuzion.std.exit", (interpreter, innerClazz) -> args ->
         {
           int rc = args.get(1).i32Value();

--- a/src/dev/flang/be/jvm/runtime/Intrinsics.java
+++ b/src/dev/flang/be/jvm/runtime/Intrinsics.java
@@ -749,7 +749,7 @@ public class Intrinsics extends ANY
       }
   }
 
-  public static byte[] fuzion_sys_fileio_mmap(long fd, long offset, long size, Object res)
+  public static Object fuzion_sys_fileio_mmap(long fd, long offset, long size, Object res)
   {
     if (CHECKS)
       Runtime.ensure_not_frozen(res);
@@ -771,32 +771,7 @@ public class Intrinsics extends ANY
 
         // success
         result[0] = 0;
-        return new byte[0];
-        /* NYI
-                  @Override
-                  void set(
-                    int x,
-                    Value v,
-                    AbstractType elementType)
-                  {
-                    checkIndex(x);
-                    mmap.put(x, (byte)v.u8Value());
-                  }
-
-                  @Override
-                  Value get(
-                    int x,
-                    AbstractType elementType)
-                  {
-                    checkIndex(x);
-                    return new u8Value(mmap.get(x));
-                  }
-
-                  @Override
-                  int length(){
-                    return (int)size;
-                  }
-        */
+        return mmap;
       }
     catch (IOException e)
       {
@@ -805,9 +780,18 @@ public class Intrinsics extends ANY
       }
   }
 
-  public static int fuzion_sys_fileio_munmap()
+  public static int fuzion_sys_fileio_munmap(Object adr, long size)
   {
     return 0;
+  }
+
+  public static byte fuzion_sys_fileio_mapped_buffer_get(Object buf, long i)
+  {
+    return ((ByteBuffer)buf).get((int) i);
+  }
+  public static void fuzion_sys_fileio_mapped_buffer_set(Object buf, long i, byte b)
+  {
+    ((ByteBuffer)buf).put((int) i, b);
   }
 
   public static void fuzion_std_nano_sleep(long d)

--- a/src/dev/flang/fuir/analysis/dfa/DFA.java
+++ b/src/dev/flang/fuir/analysis/dfa/DFA.java
@@ -1362,7 +1362,7 @@ public class DFA extends ANY
               throw new Error("intrinsic fuzion.sys.fileio.file_position: Expected class SysArray, found "+array.getClass()+" "+array);
             }
         });
-    put("fuzion.sys.fileio.mmap"         , cl ->
+    put("fuzion.sys.fileio.mmap"        , cl ->
         {
           var array = cl._args.get(3);
           if (array instanceof SysArray sa)
@@ -1376,7 +1376,36 @@ public class DFA extends ANY
               throw new Error("intrinsic fuzion.sys.fileio.mmap: Expected class SysArray, found "+array.getClass()+" "+array);
             }
         });
-    put("fuzion.sys.fileio.munmap"       , cl -> new NumericValue(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc)) );
+    put("fuzion.sys.fileio.munmap"      , cl -> new NumericValue(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc)) );
+    put("fuzion.sys.fileio.mapped_buffer_get", cl ->
+        {
+          var array = cl._args.get(0).value();
+          var index = cl._args.get(1).value();
+          if (array instanceof SysArray sa)
+            {
+              return sa.get(index);
+            }
+          else
+            {
+              throw new Error("intrinsic fuzion.sys.internal_array.gel: Expected class SysArray, found "+array.getClass()+" "+array);
+            }
+        });
+    put("fuzion.sys.fileio.mapped_buffer_set", cl ->
+        {
+          var array = cl._args.get(0).value();
+          var index = cl._args.get(1).value();
+          var value = cl._args.get(2).value();
+          if (array instanceof SysArray sa)
+            {
+              sa.setel(index, value);
+              return Value.UNIT;
+            }
+          else
+            {
+              throw new Error("intrinsic fuzion.sys.internal_array.setel: Expected class SysArray, found "+array.getClass()+" "+array);
+            }
+        });
+
     put("fuzion.sys.fileio.flush"        , cl -> new NumericValue(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc)) );
     put("fuzion.sys.stdin.stdin0"        , cl -> new NumericValue(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc)) );
     put("fuzion.sys.out.stdout"          , cl -> new NumericValue(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc)) );

--- a/src/dev/flang/fuir/analysis/dfa/DFA.java
+++ b/src/dev/flang/fuir/analysis/dfa/DFA.java
@@ -1362,7 +1362,7 @@ public class DFA extends ANY
               throw new Error("intrinsic fuzion.sys.fileio.file_position: Expected class SysArray, found "+array.getClass()+" "+array);
             }
         });
-    put("fuzion.sys.fileio.mmap"        , cl ->
+    put("fuzion.sys.fileio.mmap"         , cl ->
         {
           var array = cl._args.get(3);
           if (array instanceof SysArray sa)
@@ -1376,7 +1376,7 @@ public class DFA extends ANY
               throw new Error("intrinsic fuzion.sys.fileio.mmap: Expected class SysArray, found "+array.getClass()+" "+array);
             }
         });
-    put("fuzion.sys.fileio.munmap"      , cl -> new NumericValue(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc)) );
+    put("fuzion.sys.fileio.munmap"       , cl -> new NumericValue(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc)) );
     put("fuzion.sys.fileio.mapped_buffer_get", cl ->
         {
           var array = cl._args.get(0).value();

--- a/src/dev/flang/fuir/cfg/CFG.java
+++ b/src/dev/flang/fuir/cfg/CFG.java
@@ -244,6 +244,8 @@ public class CFG extends ANY
     put("fuzion.sys.fileio.file_position", (cfg, cl) -> { } );
     put("fuzion.sys.fileio.mmap"         , (cfg, cl) -> { } );
     put("fuzion.sys.fileio.munmap"       , (cfg, cl) -> { } );
+    put("fuzion.sys.fileio.mapped_buffer_get", (cfg, cl) -> { } );
+    put("fuzion.sys.fileio.mapped_buffer_set", (cfg, cl) -> { } );
     put("fuzion.sys.fileio.flush"        , (cfg, cl) -> { } );
     put("fuzion.sys.stdin.stdin0"        , (cfg, cl) -> { } );
     put("fuzion.sys.out.stdout"          , (cfg, cl) -> { } );

--- a/tests/lib_fileio_mmap/Makefile
+++ b/tests/lib_fileio_mmap/Makefile
@@ -24,4 +24,9 @@
 # -----------------------------------------------------------------------
 
 override NAME = mmap_test
+
+# NYI: JVM backend requires a deep recursion for `list.drop 65536`, need
+# to check why tail recursion optimization is not used here
+FUZION_JAVA_STACK_SIZE=25m
+
 include ../simple.mk

--- a/tests/lib_fileio_mmap/mmap_test.fz
+++ b/tests/lib_fileio_mmap/mmap_test.fz
@@ -40,12 +40,12 @@ mmap_test is
     offset := page_size.as_i64
 
     # map 6 bytes of file starting from the end of the '+'s.
-    say (f.mmap offset (i64 6) ()->
+    say (f.mmap offset (i64 6) buf->
           # change the 'e' in hello to an 'a'.
-          f.mmap[1] := f.mmap[1] - 4)
+          buf[1] := buf[1] - 4)
 
     # mmap should fail, since offset+size exceeds file size.
-    say (f.mmap offset (i64 7) ()->)
+    say (f.mmap offset (i64 7) _->)
   )
 
 


### PR DESCRIPTION

This patch first introduced a new abstract feature `container.buffer` that is the basis of `io.file.open.mapped_buffer` that is no used for `mmap`.

The use of `mapped_buffer` instead of `marray` permits the JVM backand to chose a different impementation for mmapped memory: These are represented as `java.nio.ByteBuffer`, while `marray u8` internally use Java's `byte[]`.

All the other backends need to impement new intrinsics for `mapped_buffer`, but can use the original representation.

This patch removes te effect `io.file.open.mmap` and uses `io.file.open` instead.  Consequently, the code passed to `io.file.open.mmap` no longer needs to use `io.file.open.mmap` (no arguments) to access the mapped memory. Instead, I have added an argument `buf` to the lambda that gives access to the memory.

One remaining issue that affects all code using effects: It is ensured that the mapped buffer is accessed only while `io.file.open T` is installed, but it is currently not enforced that a buffer is stored in a mutable variable and accessed later, when a different instance of `io.file.open T` was installed. This is curently solved only for `mutate` that uses a unique id for this that is checked at runtime.