### PR TITLE
fe: improve error messages that list a number of candidate features

### DIFF
--- a/src/dev/flang/ast/AstErrors.java
+++ b/src/dev/flang/ast/AstErrors.java
@@ -178,6 +178,20 @@ public class AstErrors extends ANY
   {
     return s(f.visibility()) + " " + s(f);
   }
+
+
+  /**
+   * Produce a String from a list of candidates of the form "one of the features
+   * x at x.fz:23, or y at y.fz:42
+   */
+  static String sc(List<FeatureAndOuter> candidates)
+  {
+    return candidates.stream().map(c -> sbn(c._feature.featureName()) + " at " + c._feature.pos().show() + "\n")
+      .collect(List.collector())
+      .toString(candidates.size() > 1 ? "one of the features " : "the feature ", ", or\n", "");
+  }
+
+
   static String code(String s) { return ticksOrNewLine(Terminal.PURPLE + s + Terminal.REGULAR_COLOR); }
   static String type(String s) { return ticksOrNewLine(Terminal.YELLOW + s + Terminal.REGULAR_COLOR); }
   static String expr(String s) { return ticksOrNewLine(Terminal.CYAN   + s + Terminal.REGULAR_COLOR); }
@@ -1088,13 +1102,12 @@ public class AstErrors extends ANY
 
     if (!candidates.isEmpty())
       {
-        solution = "To solve this, you might change the actual number of arguments to match " +
-                   (candidates.size() > 1 ? "one of these features" : "this feature") + ": " +
-                   slbn(candidates.stream().map(c -> c._feature.featureName()).collect(List.collector()));
+        solution = "To solve this, you might change the actual number of arguments to match " + sc(candidates);
       }
 
     return solution;
   }
+
 
   /**
    * Suggest to a user that they are trying to call a hidden feature.
@@ -1107,9 +1120,7 @@ public class AstErrors extends ANY
 
     if (!candidates.isEmpty())
       {
-        solution = "To solve this, you might change the visibility of " +
-                   (candidates.size() > 1 ? "one of these features" : "this feature") + ": " +
-                   slbn(candidates.stream().map(c -> c._feature.featureName()).collect(List.collector()));
+        solution = "To solve this, you might change the visibility of " + sc(candidates);
       }
 
     return solution;

--- a/tests/visibility_modules_negative/main.fz.expected_err
+++ b/tests/visibility_modules_negative/main.fz.expected_err
@@ -5,7 +5,9 @@
 Feature not found: 'mod_pub' (no arguments)
 Target feature: 'b'
 In call: 'mod_pub'
-To solve this, you might change the visibility of this feature: 'mod_pub' (no arguments)
+To solve this, you might change the visibility of the feature 'mod_pub' (no arguments) at $FUZION/lib/b.fz:26:17:
+  module:public mod_pub is
+----------------^
 
 
 --CURDIR--/main.fz:54:22: error 2: Type not found


### PR DESCRIPTION
Errors such as wrong visibility modifiers gives a list of features that are invisible, but this was only a list of feature names.  This patch adds the source code position where these features are declared.