### PR TITLE
jvm: Fix classfile VerifyError in intrinsic `fuzion.sys.env.vars.get0`

### DIFF
--- a/src/dev/flang/be/jvm/Intrinsix.java
+++ b/src/dev/flang/be/jvm/Intrinsix.java
@@ -561,7 +561,7 @@ public class Intrinsix extends ANY implements ClassFileConstants
           .andThen(Expr.invokeStatic(Names.RUNTIME_CLASS,
             "fuzion_sys_env_vars_get0",
             methodDescriptor(Runtime.class, "fuzion_sys_env_vars_get0"),
-            JAVA_LANG_STRING)));
+            PrimitiveType.type_byte.array())));
     });
     put("fuzion.sys.env_vars.set0", (jvm, cl, pre, cc, tvalue, args) -> {
       var res =

--- a/src/dev/flang/be/jvm/runtime/Runtime.java
+++ b/src/dev/flang/be/jvm/runtime/Runtime.java
@@ -176,7 +176,7 @@ public class Runtime extends ANY
 
 
   /**
-   * Create a Java string from 0-terminated given byte array.
+   * Create a Java string from given byte array.
    */
   public static String utf8ByteArrayDataToString(byte[] ba)
   {
@@ -186,6 +186,19 @@ public class Runtime extends ANY
         l++;
       }
     return new String(ba, 0, l, StandardCharsets.UTF_8);
+  }
+
+
+  /**
+   * Create the internal (Java) byte array for given Java String.
+   *
+   * @param str the Java string
+   *
+   * @return the resulting array using utf_8 encoded bytes
+   */
+  public static byte[] stringToUtf8ByteArray(String str)
+  {
+    return str.getBytes(StandardCharsets.UTF_8);
   }
 
 
@@ -238,7 +251,7 @@ public class Runtime extends ANY
    */
   public static byte[] internalArrayForConstString(String str)
   {
-    return str.getBytes(StandardCharsets.UTF_8);
+    return stringToUtf8ByteArray(str);
   }
 
 
@@ -672,9 +685,9 @@ public class Runtime extends ANY
   }
 
 
-  public static String fuzion_sys_env_vars_get0(byte[] d)
+  public static byte[] fuzion_sys_env_vars_get0(Object d)
   {
-    return System.getenv(utf8ByteArrayDataToString(d));
+    return stringToUtf8ByteArray(System.getenv(utf8ByteArrayDataToString((byte[]) d)));
   }
 
 
@@ -740,7 +753,7 @@ public class Runtime extends ANY
 
   public static byte[] args_get(int i)
   {
-    return args[i].getBytes(StandardCharsets.UTF_8);
+    return stringToUtf8ByteArray(args[i]);
   }
 
 


### PR DESCRIPTION
The argument type and result type of `RUntime.fuzion_sys_env_varfs.get0` where wrong.  Result is now explicitly converted to `byte[]`.

Also added a new helper method `Runtime.stringToUtf8ByteArray` since this conversion is done at three different places now.

This fixes the JVM for `idiom10ex.fz`.