### PR TITLE
be/jvm: fix `thread.join0`

### DIFF
--- a/src/dev/flang/be/interpreter/Intrinsics.java
+++ b/src/dev/flang/be/interpreter/Intrinsics.java
@@ -827,17 +827,29 @@ public class Intrinsics extends ANY
         });
     put("fuzion.sys.thread.join0", (interpreter, innerClazz) -> args ->
         {
-          try
+          var thread = _startedThreads_.get(args.get(1).i64Value());
+          var result = false;
+          do
             {
-              _startedThreads_.get(args.get(1).i64Value()).join();
-              _startedThreads_.remove(args.get(1).i64Value());
+              try
+                {
+                  thread.join();
+                  result = true;
+                }
+              catch (InterruptedException e)
+                {
+
+                }
             }
-          catch (InterruptedException e)
-            {
-              // NYI handle this exception
-              System.err.println("Joining of threads was interrupted: " + e);
-              System.exit(1);
-            }
+          while (!result);
+
+          // NYI: comment, fridi:
+          // Furthermore, remove should probably not be called by join, but either by
+          // the Thread itself or by some cleanup mechanism that removes terminated
+          // threads, either when new threads are started or by a system thread that
+          // joins and removes threads that are about to terminate.
+          _startedThreads_.remove(args.get(1).i64Value());
+
           return Value.EMPTY_VALUE;
         });
 

--- a/src/dev/flang/be/jvm/Intrinsix.java
+++ b/src/dev/flang/be/jvm/Intrinsix.java
@@ -575,16 +575,6 @@ public class Intrinsix extends ANY implements ClassFileConstants
           .andThen(Expr.iconst(0)); // false
       return new Pair<>(res, Expr.UNIT);
     });
-    put("fuzion.sys.thread.join0", (jvm, cl, pre, cc, tvalue, args) -> {
-      var res =
-        tvalue.drop()
-          .andThen(args.get(0))
-          .andThen(Expr.invokeStatic(Names.RUNTIME_CLASS,
-            "fuzion_sys_thread_join0",
-            methodDescriptor(Runtime.class, "fuzion_sys_thread_join0"),
-            PrimitiveType.type_void));
-      return new Pair<>(Expr.UNIT, res);
-    });
 
     put("fuzion.sys.thread.spawn0",
         (jvm, cl, pre, cc, tvalue, args) ->

--- a/src/dev/flang/be/jvm/runtime/Intrinsics.java
+++ b/src/dev/flang/be/jvm/runtime/Intrinsics.java
@@ -811,6 +811,21 @@ public class Intrinsics extends ANY
     return System.getenv(Runtime.utf8ByteArrayDataToString((byte[])s)) != null;
   }
 
+  public static void fuzion_sys_thread_join0(long threadId)
+  {
+    try
+      {
+        Runtime._startedThreads_.get(threadId).join();
+        Runtime._startedThreads_.remove(threadId);
+      }
+    catch (InterruptedException e)
+      {
+        // NYI handle this exception
+        System.err.println("Joining of threads was interrupted: " + e);
+        System.exit(1);
+      }
+  };
+
 }
 
 /* end of file */

--- a/src/dev/flang/be/jvm/runtime/Intrinsics.java
+++ b/src/dev/flang/be/jvm/runtime/Intrinsics.java
@@ -813,18 +813,30 @@ public class Intrinsics extends ANY
 
   public static void fuzion_sys_thread_join0(long threadId)
   {
-    try
+    var thread = Runtime._startedThreads_.get(threadId);
+    var result = false;
+    do
       {
-        Runtime._startedThreads_.get(threadId).join();
-        Runtime._startedThreads_.remove(threadId);
+        try
+          {
+            thread.join();
+            result = true;
+          }
+        catch (InterruptedException e)
+          {
+
+          }
       }
-    catch (InterruptedException e)
-      {
-        // NYI handle this exception
-        System.err.println("Joining of threads was interrupted: " + e);
-        System.exit(1);
-      }
-  };
+    while (!result);
+
+    // NYI: comment, fridi:
+    // Furthermore, remove should probably not be called by join, but either by
+    // the Thread itself or by some cleanup mechanism that removes terminated
+    // threads, either when new threads are started or by a system thread that
+    // joins and removes threads that are about to terminate.
+    Runtime._startedThreads_.remove(threadId);
+  }
+
 
 }
 

--- a/src/dev/flang/be/jvm/runtime/Runtime.java
+++ b/src/dev/flang/be/jvm/runtime/Runtime.java
@@ -149,7 +149,7 @@ public class Runtime extends ANY
   /**
    * This contains all started threads.
    */
-  private static OpenResources<Thread> _startedThreads_ = new OpenResources<Thread>() {
+  static OpenResources<Thread> _startedThreads_ = new OpenResources<Thread>() {
     @Override
     protected boolean close(Thread f)
     {
@@ -703,27 +703,12 @@ public class Runtime extends ANY
     else
       {
         var t = new FuzionThread(r, code);
-        result = t.getId();
+        result = _startedThreads_.add(t);
+        // result = t.getId();
         // result = t.threadId(); // NYI: use for Java >=19
       }
     return result;
   }
-
-
-  public static void fuzion_sys_thread_join0(long threadId)
-  {
-    try
-      {
-        _startedThreads_.get(threadId).join();
-        _startedThreads_.remove(threadId);
-      }
-    catch (InterruptedException e)
-      {
-        // NYI handle this exception
-        System.err.println("Joining of threads was interrupted: " + e);
-        System.exit(1);
-      }
-  };
 
 
   static long unique_id()


### PR DESCRIPTION
previous to this change skipped test concur_simple did not work: 
```
RUN concur_simple.fz 0a1,26
> 
> error 1: java.lang.NullPointerException: Cannot invoke "java.lang.Thread.join()" because the return value of "dev.flang.be.interpreter.OpenResources.get(java.lang.Long)" is null
>       at dev.flang.be.jvm.runtime.Runtime.fuzion_sys_thread_join0(Runtime.java:717)
>       at fzC_concur__1thread__1spawned__join.fzRoutine(Unknown Source)
>       at fzC_concur_simple.fzRoutine(Unknown Source)
>       at fzC_universe.main(Unknown Source)
>       at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
>       at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
>       at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
>       at java.base/java.lang.reflect.Method.invoke(Method.java:568)
>       at dev.flang.be.jvm.Runner.runMain(Runner.java:120)
>       at dev.flang.be.jvm.JVM$CompilePhase$4.finish(JVM.java:493)
>       at dev.flang.be.jvm.JVM.lambda$createCode$0(JVM.java:799)
>       at java.base/java.util.Spliterators$ArraySpliterator.forEachRemaining(Spliterators.java:992)
>       at java.base/java.util.stream.ReferencePipeline$Head.forEachOrdered(ReferencePipeline.java:772)
>       at dev.flang.be.jvm.JVM.createCode(JVM.java:790)
>       at dev.flang.be.jvm.JVM.compile(JVM.java:775)
>       at dev.flang.tools.Fuzion$Backend$3.process(Fuzion.java:163)
>       at dev.flang.tools.Fuzion$Backend.processFrontEnd(Fuzion.java:444)
>       at dev.flang.tools.Fuzion.lambda$parseArgsForBackend$3(Fuzion.java:908)
>       at dev.flang.tools.Tool.lambda$run$0(Tool.java:145)
>       at dev.flang.util.Errors.runAndExit(Errors.java:790)
>       at dev.flang.tools.Tool.run(Tool.java:145)
>       at dev.flang.tools.Fuzion.main(Fuzion.java:557)
> 
> *** fatal errors encountered, stopping.

```