### PR TITLE
dfa/JVM: Add array initialization effect to intrinsic fuzion.std.date_time

### DIFF
--- a/src/dev/flang/be/jvm/runtime/Intrinsics.java
+++ b/src/dev/flang/be/jvm/runtime/Intrinsics.java
@@ -272,7 +272,7 @@ public class Intrinsics extends ANY
 
   public static void fuzion_std_date_time(Object data)
   {
-    int[] arg0 = (int[])data;
+    int[] arg0 = (int[]) data;
     var date = new Date();
     var calendar = new GregorianCalendar(TimeZone.getTimeZone("UTC"));
     calendar.setTime(date);
@@ -449,8 +449,8 @@ public class Intrinsics extends ANY
         Runtime.ensure_not_frozen(res);
       }
 
-    byte[] buff = (byte[])b;
-    long[] result = (long[])res;
+    byte[] buff   = (byte[]) b;
+    long[] result = (long[]) res;
 
     try
       {
@@ -488,7 +488,7 @@ public class Intrinsics extends ANY
     try
       {
         var sc = (ByteChannel)Runtime._openStreams_.get(sockfd);
-        sc.write(ByteBuffer.wrap((byte[])fileContent));
+        sc.write(ByteBuffer.wrap((byte[]) fileContent));
         return 0;
       }
     catch(IOException e)
@@ -585,7 +585,7 @@ public class Intrinsics extends ANY
 
   public static boolean fuzion_sys_fileio_delete(Object s)
   {
-    Path path = Path.of(Runtime.utf8ByteArrayDataToString((byte[])s));
+    Path path = Path.of(Runtime.utf8ByteArrayDataToString((byte[]) s));
     try
       {
         return Files.deleteIfExists(path);
@@ -598,8 +598,8 @@ public class Intrinsics extends ANY
 
   public static boolean fuzion_sys_fileio_move(Object o, Object n)
   {
-    Path oldPath = Path.of(Runtime.utf8ByteArrayDataToString((byte[])o));
-    Path newPath = Path.of(Runtime.utf8ByteArrayDataToString((byte[])n));
+    Path oldPath = Path.of(Runtime.utf8ByteArrayDataToString((byte[]) o));
+    Path newPath = Path.of(Runtime.utf8ByteArrayDataToString((byte[]) n));
     try
       {
         Files.move(oldPath, newPath);
@@ -613,7 +613,7 @@ public class Intrinsics extends ANY
 
   public static boolean fuzion_sys_fileio_create_dir(Object s)
   {
-    Path path = Path.of(Runtime.utf8ByteArrayDataToString((byte[])s));
+    Path path = Path.of(Runtime.utf8ByteArrayDataToString((byte[]) s));
     try
       {
         Files.createDirectory(path);
@@ -630,8 +630,8 @@ public class Intrinsics extends ANY
     if (CHECKS)
       Runtime.ensure_not_frozen(res);
 
-    var path = Runtime.utf8ByteArrayDataToString((byte[])s);
-    long[] open_results = (long[])res;
+    var path = Runtime.utf8ByteArrayDataToString((byte[]) s);
+    long[] open_results = (long[]) res;
     try
       {
         switch (mode)
@@ -679,7 +679,7 @@ public class Intrinsics extends ANY
     if (CHECKS)
       Runtime.ensure_not_frozen(res);
 
-    Path path = Path.of(Runtime.utf8ByteArrayDataToString((byte[])s));
+    Path path = Path.of(Runtime.utf8ByteArrayDataToString((byte[]) s));
     long[] stats = (long[]) res;
     var err = SystemErrNo.UNSPECIFIED;
     try
@@ -736,7 +736,7 @@ public class Intrinsics extends ANY
     if (CHECKS)
       Runtime.ensure_not_frozen(res);
 
-    long[] arr = (long[])res;
+    long[] arr = (long[]) res;
     try
       {
         arr[0] = ((RandomAccessFile) Runtime._openStreams_.get(fd)).getFilePointer();
@@ -754,7 +754,7 @@ public class Intrinsics extends ANY
     if (CHECKS)
       Runtime.ensure_not_frozen(res);
 
-    int[] result = (int[])res;
+    int[] result = (int[]) res;
     try
       {
         var raf = (RandomAccessFile) Runtime._openStreams_.get(fd);
@@ -808,7 +808,7 @@ public class Intrinsics extends ANY
 
   public static boolean fuzion_sys_env_vars_has0(Object s)
   {
-    return System.getenv(Runtime.utf8ByteArrayDataToString((byte[])s)) != null;
+    return System.getenv(Runtime.utf8ByteArrayDataToString((byte[]) s)) != null;
   }
 
 }

--- a/src/dev/flang/fuir/analysis/dfa/DFA.java
+++ b/src/dev/flang/fuir/analysis/dfa/DFA.java
@@ -1330,8 +1330,8 @@ public class DFA extends ANY
     put("fuzion.sys.fileio.close"        , cl -> new NumericValue(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc)) );
     put("fuzion.sys.fileio.stats"        , cl -> { setArrayI64ElementsToAnything(cl, 1, "fuzion.sys.fileio.stats"   ); return cl._dfa._bool; });
     put("fuzion.sys.fileio.lstats"       , cl -> { setArrayI64ElementsToAnything(cl, 1, "fuzion.sys.fileio.lstats"  ); return cl._dfa._bool; });
-    put("fuzion.sys.fileio.seek"         , cl -> { setArrayI64ElementsToAnything(cl, 2, "fuzion.sys.fileio.seek"    ); return cl._dfa._bool; });
-    put("fuzion.sys.fileio.file_position", cl -> { setArrayI64ElementsToAnything(cl, 1, "fuzion.sys.fileio.position"); return cl._dfa._bool; });
+    put("fuzion.sys.fileio.seek"         , cl -> { setArrayI64ElementsToAnything(cl, 2, "fuzion.sys.fileio.seek"    ); return Value.UNIT; });
+    put("fuzion.sys.fileio.file_position", cl -> { setArrayI64ElementsToAnything(cl, 1, "fuzion.sys.fileio.position"); return Value.UNIT; });
     put("fuzion.sys.fileio.mmap"         , cl ->
         {
           setArrayI32ElementsToAnything(cl, 3, "fuzion.sys.fileio.mmap");

--- a/src/dev/flang/fuir/analysis/dfa/DFA.java
+++ b/src/dev/flang/fuir/analysis/dfa/DFA.java
@@ -1188,6 +1188,46 @@ public class DFA extends ANY
   }
 
 
+  /**
+   * Helper routine for intrinsics that set the elements of an array given as an argument
+   *
+   * @param cl the intrinsic call
+   *
+   * @param argnum the argument that is an internal array
+   *
+   * @param intrinsicName name of the intrinsic, just of error handling
+   *
+   * @param elementClazz the element type of the array.
+   */
+  static void setArrayElementsToAnything(Call cl, int argnum, String intrinsicName, FUIR.SpecialClazzes elementClazz)
+  {
+    var array = cl._args.get(argnum);
+    if (array instanceof SysArray sa)
+      {
+        sa.setel(new NumericValue(cl._dfa, cl._dfa._fuir.clazz(FUIR.SpecialClazzes.c_i32)),
+                 new NumericValue(cl._dfa, cl._dfa._fuir.clazz(elementClazz)));
+      }
+    else
+      {
+        Errors.fatal("DFA internal error: intrinsic '" + intrinsicName+ ": Expected class SysArray, found " + array.getClass() + " " + array);
+      }
+  }
+
+
+  /**
+   * Helper routine to call setArrayElementsToAnything with specific clazz.
+   *
+   * @param cl the intrinsic call
+   *
+   * @param argnum the argument that is an internal array
+   *
+   * @param intrinsicName name of the intrinsic, just of error handling
+   */
+  static void setArrayU8ElementsToAnything (Call cl, int argnum, String intrinsicName) { setArrayElementsToAnything(cl, argnum, intrinsicName, FUIR.SpecialClazzes.c_u8 ); }
+  static void setArrayI32ElementsToAnything(Call cl, int argnum, String intrinsicName) { setArrayElementsToAnything(cl, argnum, intrinsicName, FUIR.SpecialClazzes.c_i32); }
+  static void setArrayI64ElementsToAnything(Call cl, int argnum, String intrinsicName) { setArrayElementsToAnything(cl, argnum, intrinsicName, FUIR.SpecialClazzes.c_i64); }
+
+
   static
   {
     put("Type.name"                      , cl -> cl._dfa.newConstString(cl._dfa._fuir.clazzTypeName(cl._dfa._fuir.clazzOuterClazz(cl._cc)), cl) );
@@ -1275,17 +1315,8 @@ public class DFA extends ANY
     put("fuzion.std.exit"                , cl -> null );
     put("fuzion.sys.fileio.read"         , cl ->
         {
-          var array = cl._args.get(1);
-          if (array instanceof SysArray sa)
-            {
-              sa.setel(new NumericValue(cl._dfa, cl._dfa._fuir.clazz(FUIR.SpecialClazzes.c_i32)),
-                       new NumericValue(cl._dfa, cl._dfa._fuir.clazz(FUIR.SpecialClazzes.c_u8 )));
-              return new NumericValue(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc));
-            }
-          else
-            {
-              throw new Error("intrinsic fuzion.sys.fileio.read: Expected class SysArray, found "+array.getClass()+" "+array);
-            }
+          setArrayU8ElementsToAnything(cl, 1, "fuzion.sys.fileio.read");
+          return new NumericValue(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc));
         });
     put("fuzion.sys.fileio.write"        , cl -> new NumericValue(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc)) );
     put("fuzion.sys.fileio.delete"       , cl -> cl._dfa._bool );
@@ -1293,88 +1324,18 @@ public class DFA extends ANY
     put("fuzion.sys.fileio.create_dir"   , cl -> cl._dfa._bool );
     put("fuzion.sys.fileio.open"         , cl ->
         {
-          var array = cl._args.get(1);
-          if (array instanceof SysArray sa)
-            {
-              sa.setel(new NumericValue(cl._dfa, cl._dfa._fuir.clazz(FUIR.SpecialClazzes.c_i32)),
-                       new NumericValue(cl._dfa, cl._dfa._fuir.clazz(FUIR.SpecialClazzes.c_i64)));
-              return Value.UNIT;
-            }
-          else
-            {
-              throw new Error("intrinsic fuzion.sys.fileio.open: Expected class SysArray, found "+array.getClass()+" "+array);
-            }
+          setArrayI64ElementsToAnything(cl, 1, "fuzion.sys.fileio.open");
+          return Value.UNIT;
         });
     put("fuzion.sys.fileio.close"        , cl -> new NumericValue(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc)) );
-    put("fuzion.sys.fileio.stats"        , cl ->
-        {
-          var array = cl._args.get(1);
-          if (array instanceof SysArray sa)
-            {
-              sa.setel(new NumericValue(cl._dfa, cl._dfa._fuir.clazz(FUIR.SpecialClazzes.c_i32)),
-                       new NumericValue(cl._dfa, cl._dfa._fuir.clazz(FUIR.SpecialClazzes.c_i64)));
-              return cl._dfa._bool;
-            }
-          else
-            {
-              throw new Error("intrinsic fuzion.sys.fileio.stats: Expected class SysArray, found "+array.getClass()+" "+array);
-            }
-        });
-    put("fuzion.sys.fileio.lstats"       , cl ->
-        {
-          var array = cl._args.get(1);
-          if (array instanceof SysArray sa)
-            {
-              sa.setel(new NumericValue(cl._dfa, cl._dfa._fuir.clazz(FUIR.SpecialClazzes.c_i32)),
-                       new NumericValue(cl._dfa, cl._dfa._fuir.clazz(FUIR.SpecialClazzes.c_i64)));
-              return cl._dfa._bool;
-            }
-          else
-            {
-              throw new Error("intrinsic fuzion.sys.fileio.lstats: Expected class SysArray, found "+array.getClass()+" "+array);
-            }
-        });
-    put("fuzion.sys.fileio.seek"         , cl ->
-        {
-          var array = cl._args.get(2);
-          if (array instanceof SysArray sa)
-            {
-              sa.setel(new NumericValue(cl._dfa, cl._dfa._fuir.clazz(FUIR.SpecialClazzes.c_i32)),
-                       new NumericValue(cl._dfa, cl._dfa._fuir.clazz(FUIR.SpecialClazzes.c_i64)));
-              return Value.UNIT;
-            }
-          else
-            {
-              throw new Error("intrinsic fuzion.sys.fileio.seek: Expected class SysArray, found "+array.getClass()+" "+array);
-            }
-        });
-    put("fuzion.sys.fileio.file_position", cl ->
-        {
-          var array = cl._args.get(1);
-          if (array instanceof SysArray sa)
-            {
-              sa.setel(new NumericValue(cl._dfa, cl._dfa._fuir.clazz(FUIR.SpecialClazzes.c_i32)),
-                       new NumericValue(cl._dfa, cl._dfa._fuir.clazz(FUIR.SpecialClazzes.c_i64)));
-              return Value.UNIT;
-            }
-          else
-            {
-              throw new Error("intrinsic fuzion.sys.fileio.file_position: Expected class SysArray, found "+array.getClass()+" "+array);
-            }
-        });
+    put("fuzion.sys.fileio.stats"        , cl -> { setArrayI64ElementsToAnything(cl, 1, "fuzion.sys.fileio.stats"   ); return cl._dfa._bool; });
+    put("fuzion.sys.fileio.lstats"       , cl -> { setArrayI64ElementsToAnything(cl, 1, "fuzion.sys.fileio.lstats"  ); return cl._dfa._bool; });
+    put("fuzion.sys.fileio.seek"         , cl -> { setArrayI64ElementsToAnything(cl, 2, "fuzion.sys.fileio.seek"    ); return cl._dfa._bool; });
+    put("fuzion.sys.fileio.file_position", cl -> { setArrayI64ElementsToAnything(cl, 1, "fuzion.sys.fileio.position"); return cl._dfa._bool; });
     put("fuzion.sys.fileio.mmap"         , cl ->
         {
-          var array = cl._args.get(3);
-          if (array instanceof SysArray sa)
-            {
-              sa.setel(new NumericValue(cl._dfa, cl._dfa._fuir.clazz(FUIR.SpecialClazzes.c_i32)),
-                       new NumericValue(cl._dfa, cl._dfa._fuir.clazz(FUIR.SpecialClazzes.c_i32)));
-              return new SysArray(cl._dfa, new NumericValue(cl._dfa, cl._dfa._fuir.clazz(FUIR.SpecialClazzes.c_u8))); // NYI: length wrong, get from arg
-            }
-          else
-            {
-              throw new Error("intrinsic fuzion.sys.fileio.mmap: Expected class SysArray, found "+array.getClass()+" "+array);
-            }
+          setArrayI32ElementsToAnything(cl, 3, "fuzion.sys.fileio.mmap");
+          return new SysArray(cl._dfa, new NumericValue(cl._dfa, cl._dfa._fuir.clazz(FUIR.SpecialClazzes.c_u8))); // NYI: length wrong, get from arg
         });
     put("fuzion.sys.fileio.munmap"       , cl -> new NumericValue(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc)) );
     put("fuzion.sys.fileio.mapped_buffer_get", cl ->
@@ -1670,81 +1631,31 @@ public class DFA extends ANY
     // NYI these intrinsics manipulate an array passed as an arg.
     put("fuzion.sys.net.bind0"           , cl ->
         {
-          var array = cl._args.get(5);
-          if (array instanceof SysArray sa)
-            {
-              sa.setel(new NumericValue(cl._dfa, cl._dfa._fuir.clazz(FUIR.SpecialClazzes.c_i32)),
-                       new NumericValue(cl._dfa, cl._dfa._fuir.clazz(FUIR.SpecialClazzes.c_i64)));
-              return new NumericValue(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc));
-            }
-          else
-            {
-              throw new Error("intrinsic fuzion.sys.net.bind0: Expected class SysArray, found "+array.getClass()+" "+array);
-            }
+          setArrayI64ElementsToAnything(cl, 5, "fuzion.sys.net.bind0");
+          return new NumericValue(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc));
         });
     put("fuzion.sys.net.listen"          , cl -> new NumericValue(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc)) );
     put("fuzion.sys.net.accept"          , cl ->
         {
-          var array = cl._args.get(1);
-          if (array instanceof SysArray sa)
-            {
-              sa.setel(new NumericValue(cl._dfa, cl._dfa._fuir.clazz(FUIR.SpecialClazzes.c_i32)),
-                       new NumericValue(cl._dfa, cl._dfa._fuir.clazz(FUIR.SpecialClazzes.c_i64)));
-              return cl._dfa._bool;
-            }
-          else
-            {
-              throw new Error("intrinsic fuzion.sys.net.accept: Expected class SysArray, found "+array.getClass()+" "+array);
-            }
-        } );
+          setArrayI64ElementsToAnything(cl, 1, "fuzion.sys.net.accept");
+          return cl._dfa._bool;
+        });
     put("fuzion.sys.net.connect0"        , cl ->
         {
-          var array = cl._args.get(5);
-          if (array instanceof SysArray sa)
-            {
-              sa.setel(new NumericValue(cl._dfa, cl._dfa._fuir.clazz(FUIR.SpecialClazzes.c_i32)),
-                       new NumericValue(cl._dfa, cl._dfa._fuir.clazz(FUIR.SpecialClazzes.c_i64)));
-              return new NumericValue(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc));
-            }
-          else
-            {
-              throw new Error("intrinsic fuzion.sys.net.connect0: Expected class SysArray, found "+array.getClass()+" "+array);
-            }
+          setArrayI64ElementsToAnything(cl, 5, "fuzion.sys.net.connect0");
+          return new NumericValue(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc));
         });
     put("fuzion.sys.net.get_peer_address", cl ->
         {
-          var array = cl._args.get(1);
-          if (array instanceof SysArray sa)
-            {
-              sa.setel(new NumericValue(cl._dfa, cl._dfa._fuir.clazz(FUIR.SpecialClazzes.c_i32)),
-                       new NumericValue(cl._dfa, cl._dfa._fuir.clazz(FUIR.SpecialClazzes.c_u8  )));
-              return new NumericValue(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc));
-            }
-          else
-            {
-              throw new Error("intrinsic fuzion.sys.net.get_peer_address: Expected class SysArray, found "+array.getClass()+" "+array);
-            }
+          setArrayU8ElementsToAnything(cl, 1, "fuzion.sys.net.get_peer_address");
+          return new NumericValue(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc));
         });
     put("fuzion.sys.net.get_peer_port"   , cl -> new NumericValue(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc)) );
     put("fuzion.sys.net.read"            , cl ->
         {
-          var buf_array = cl._args.get(1);
-          var res_array = cl._args.get(3);
-          if (buf_array instanceof SysArray bsa &&
-              res_array instanceof SysArray rsa    )
-            {
-              bsa.setel(new NumericValue(cl._dfa, cl._dfa._fuir.clazz(FUIR.SpecialClazzes.c_i32)),
-                        new NumericValue(cl._dfa, cl._dfa._fuir.clazz(FUIR.SpecialClazzes.c_u8 )));
-              rsa.setel(new NumericValue(cl._dfa, cl._dfa._fuir.clazz(FUIR.SpecialClazzes.c_i32)),
-                        new NumericValue(cl._dfa, cl._dfa._fuir.clazz(FUIR.SpecialClazzes.c_i64)));
-              return cl._dfa._bool;
-            }
-          else
-            {
-              throw new Error("intrinsic fuzion.sys.net.readt: Expected class SysArray, found " +
-                              buf_array.getClass() + " " + buf_array + " and " +
-                              res_array.getClass() + " " + res_array);
-            }
+          setArrayU8ElementsToAnything(cl, 1, "fuzion.sys.net.read");
+          setArrayI64ElementsToAnything(cl, 3, "fuzion.sys.net.read");
+          return new NumericValue(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc));
         });
     put("fuzion.sys.net.write"           , cl -> new NumericValue(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc)) );
     put("fuzion.sys.net.close0"          , cl -> new NumericValue(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc)) );
@@ -1753,7 +1664,11 @@ public class DFA extends ANY
     put("fuzion.std.nano_sleep"          , cl -> Value.UNIT );
     put("fuzion.std.nano_time"           , cl -> new NumericValue(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc)) );
 
-    put("fuzion.std.date_time"           , cl -> Value.UNIT );
+    put("fuzion.std.date_time"           , cl ->
+        {
+          setArrayI32ElementsToAnything(cl, 0, "fuzion.sys.net.date_time");
+          return Value.UNIT;
+        });
 
     put("effect.replace"                 , cl ->
         {

--- a/src/dev/flang/fuir/analysis/dfa/DFA.java
+++ b/src/dev/flang/fuir/analysis/dfa/DFA.java
@@ -1655,7 +1655,7 @@ public class DFA extends ANY
         {
           setArrayU8ElementsToAnything(cl, 1, "fuzion.sys.net.read");
           setArrayI64ElementsToAnything(cl, 3, "fuzion.sys.net.read");
-          return new NumericValue(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc));
+          return cl._dfa._bool;
         });
     put("fuzion.sys.net.write"           , cl -> new NumericValue(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc)) );
     put("fuzion.sys.net.close0"          , cl -> new NumericValue(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc)) );


### PR DESCRIPTION
This was the reason why idiom115ex.fz failed with JVM backend, the DFA determined that there was no data in the array and so it stopped executing.

This patch also does two cleanups

- Add helper methods to DFA to set array elements for numeric arrays

- More consisent formatting of casts in jvm/runtime/Intrinsics.java: `(x[])y` ->
  `(x[]) y`