### PR TITLE
be/jvm: Intrinsix do not add synthethic methods as _availableIntrinsics

### DIFF
--- a/src/dev/flang/be/jvm/Intrinsix.java
+++ b/src/dev/flang/be/jvm/Intrinsix.java
@@ -78,7 +78,10 @@ public class Intrinsix extends ANY implements ClassFileConstants
   {
     for (var m : Intrinsics.class.getDeclaredMethods())
       {
-        _availableIntrinsics.add(m.getName());
+        if (!m.isSynthetic())
+          {
+            _availableIntrinsics.add(m.getName());
+          }
       }
   }
 


### PR DESCRIPTION
i got this warning before this patch:
`warning 1: JVM backend implements intrinsic 'lambda$fuzion_sys_process_create$0', even though this is never used.`