### PR TITLE
lib: fix mutation of array when calling intrinsic fuzion.sys.net.accept

### DIFF
--- a/lib/fuzion/sys/net.fz
+++ b/lib/fuzion/sys/net.fz
@@ -86,8 +86,12 @@ module net is
   # accept a new connection for given socket descriptor, wrapper for accept intrinsic.
   # returns an error or a new descriptor.
   module accept(sd i64) outcome i64 is
-    arr array i64 := [0]
-    if accept sd arr.internal_array.data then arr[0] else error "accept failed, error number: {arr[0]}"
+    iarr := fuzion.sys.internal_array_init i64 1
+    arr := iarr.as_array
+    if accept sd iarr.data then
+      arr[0]
+    else
+      error "accept failed, error number: {arr[0]}"
 
 
   # open and connect a client socket


### PR DESCRIPTION
For some strange reason, this only fails occasionally when running tests/sockets on my machine.