### PR TITLE
jvm: fix result type of tagged unit type

### DIFF
--- a/src/dev/flang/be/jvm/Choices.java
+++ b/src/dev/flang/be/jvm/Choices.java
@@ -774,9 +774,9 @@ public class Choices extends ANY implements ClassFileConstants
                 .andThen(value)
                 .andThen(Expr.putfield(_names.javaClass(newcl),
                                        fn,
-                                       ft))
-                .is(_types.javaType(newcl));
+                                       ft));
             }
+          res = res.is(_types.javaType(newcl));
           break;
         }
       default: throw new Error("Unexpected choice kind in tag of JVM backend: " + kind(newcl));

--- a/src/dev/flang/be/jvm/classfile/Expr.java
+++ b/src/dev/flang/be/jvm/classfile/Expr.java
@@ -224,7 +224,8 @@ public abstract class Expr extends ByteCode
 
   /**
    * Flag to enable (or suppress, if false) comments in the bytecode, see
-   * comment(String).
+   * comment(String) for how to use this and dev.flang.be.jvm.JVM.CODE_COMMENTS
+   * for how to enable this.
    */
   public static boolean ENABLE_COMMENTS = false;
 


### PR DESCRIPTION
The result type of the `Expr` returned by `Choices.tag` was not set in cas the original value was a unit type.  This cause class file verification errors if the created choice value is then `drop()`ed, e.g., due to an assignment to an unused variable.

This fixed the generation of broken byte code for examples from flang.dev like `content/tutorial/examples/fibint.fz`.

Also added a comment to `Expr.ENABLE_COMMENTS` since I was confused about my own code about how to enable this.