### PR TITLE
jvm: Fix `Choices.kind(bool)` to `boollike`

### DIFF
--- a/src/dev/flang/be/jvm/Choices.java
+++ b/src/dev/flang/be/jvm/Choices.java
@@ -131,39 +131,37 @@ public class Choices extends ANY implements ClassFileConstants
     int units = 0;
     int refs = 0;
     boolean overlappingRefs = false;
+    for (var i = 0; i < _fuir.clazzNumChoices(cl); i++)
+      {
+        var tc = _fuir.clazzChoice(cl, i);
+        if (!_fuir.clazzIsVoidType(tc))
+          {
+            nonVoid++;
+            if (_fuir.clazzIsUnitType(tc))
+              {
+                units++;
+              }
+            else if (_fuir.clazzIsRef(tc))
+              {
+                refs++;
+                for (var j = 0; j < i; j++)
+                  {
+                    var tcj = _fuir.clazzChoice(cl, j);
+                    if (overlappingRefs(tc, tcj))
+                      {
+                        overlappingRefs = true;
+                      }
+                  }
+              }
+          }
+      }
+
     if (_fuir.clazzIs(cl, FUIR.SpecialClazzes.c_bool))
       { // very small examples may use only `TRUE` or only `FALSE`, or none of
         // these values, which would then turn `bool` into a `unitlike` or even
         // `voidlike` choice, but we do not want to deal with this exotic case:
         nonVoid = 2;
         units = 2;
-      }
-    else
-      {
-        for (var i = 0; i < _fuir.clazzNumChoices(cl); i++)
-          {
-            var tc = _fuir.clazzChoice(cl, i);
-            if (!_fuir.clazzIsVoidType(tc))
-              {
-                nonVoid++;
-                if (_fuir.clazzIsUnitType(tc))
-                  {
-                    units++;
-                  }
-                else if (_fuir.clazzIsRef(tc))
-                  {
-                    refs++;
-                    for (var j = 0; j < i; j++)
-                      {
-                        var tcj = _fuir.clazzChoice(cl, j);
-                        if (overlappingRefs(tc, tcj))
-                          {
-                            overlappingRefs = true;
-                          }
-                      }
-                  }
-              }
-          }
       }
 
     if      (nonVoid == 0                               ) { return ImplKind.voidlike; }

--- a/src/dev/flang/be/jvm/Choices.java
+++ b/src/dev/flang/be/jvm/Choices.java
@@ -131,25 +131,35 @@ public class Choices extends ANY implements ClassFileConstants
     int units = 0;
     int refs = 0;
     boolean overlappingRefs = false;
-    for (var i = 0; i < _fuir.clazzNumChoices(cl); i++)
+    if (_fuir.clazzIs(cl, FUIR.SpecialClazzes.c_bool))
+      { // very small examples may use only `TRUE` or only `FALSE`, or none of
+        // these values, which would then turn `bool` into a `unitlike` or even
+        // `voidlike` choice, but we do not want to deal with this exotic case:
+        nonVoid = 2;
+        units = 2;
+      }
+    else
       {
-        var tc = _fuir.clazzChoice(cl, i);
-        if (!_fuir.clazzIsVoidType(tc))
+        for (var i = 0; i < _fuir.clazzNumChoices(cl); i++)
           {
-            nonVoid++;
-            if (_fuir.clazzIsUnitType(tc))
+            var tc = _fuir.clazzChoice(cl, i);
+            if (!_fuir.clazzIsVoidType(tc))
               {
-                units++;
-              }
-            else if (_fuir.clazzIsRef(tc))
-              {
-                refs++;
-                for (var j = 0; j < i; j++)
+                nonVoid++;
+                if (_fuir.clazzIsUnitType(tc))
                   {
-                    var tcj = _fuir.clazzChoice(cl, j);
-                    if (overlappingRefs(tc, tcj))
+                    units++;
+                  }
+                else if (_fuir.clazzIsRef(tc))
+                  {
+                    refs++;
+                    for (var j = 0; j < i; j++)
                       {
-                        overlappingRefs = true;
+                        var tcj = _fuir.clazzChoice(cl, j);
+                        if (overlappingRefs(tc, tcj))
+                          {
+                            overlappingRefs = true;
+                          }
                       }
                   }
               }


### PR DESCRIPTION
In very small tests that use type `bool` but do not use both `TRUE` and `FALSE`, the choice kind would get set to `unitlike` or even `voidlike` resulting in errors since bool is otherwise hard-coded as type `Z` in the JVM backend.

This patch hard-wires the choice kind for `bool` to `boollike` to avoid this.

This fixes failures of examples from flang.dev like `content/design/examples/tya_const.fz`.