### PR TITLE
parser: For each `Expr`, store the whole source range with the Expr, fix #2109

### DIFF
--- a/src/dev/flang/ast/AstErrors.java
+++ b/src/dev/flang/ast/AstErrors.java
@@ -123,7 +123,7 @@ public class AstErrors extends ANY
   }
   static String s(Expr e)
   {
-    return expr(e.pos().sourceText());
+    return expr(e.sourceRange().sourceText());
   }
   static String s(AbstractAssign a)
   {

--- a/src/dev/flang/parser/Lexer.java
+++ b/src/dev/flang/parser/Lexer.java
@@ -453,6 +453,12 @@ public class Lexer extends SourceFile
 
 
   /**
+   * End position of the previous token, -1 if none
+   */
+  private int _lastTokenEndPos = -1;
+
+
+  /**
    * Minimum indentation required for the current token: current() must have
    * indentation > _minIndent, while currentAtMinIndent() must have indentation
    * >= _minIndent.
@@ -532,6 +538,7 @@ public class Lexer extends SourceFile
     _curToken = original._curToken;
     _tokenPos = original._tokenPos;
     _lastTokenPos = original._lastTokenPos;
+    _lastTokenEndPos = original._lastTokenEndPos;
     _minIndent = original._minIndent;
     _minIndentStartPos = original._minIndentStartPos;
     _sameLine = original._sameLine;
@@ -828,6 +835,7 @@ public class Lexer extends SourceFile
   public void next()
   {
     _lastTokenPos = _tokenPos;
+    _lastTokenEndPos = tokenEndPos();
     _ignoredTokenBefore = false;
     nextRaw();
     while (ignore(currentNoLimit()))
@@ -932,6 +940,16 @@ public class Lexer extends SourceFile
   int lastTokenPos()
   {
     return _lastTokenPos;
+  }
+
+
+  /**
+   * The byte end position of the previous non-skip token in the source file.  -1 if
+   * this does not exist.
+   */
+  int lastTokenEndPos()
+  {
+    return _lastTokenEndPos;
   }
 
 

--- a/src/dev/flang/parser/Parser.java
+++ b/src/dev/flang/parser/Parser.java
@@ -2158,7 +2158,7 @@ simpleterm  : bracketTerm
                              var e = l.exponent();
                              var eb = l.exponentBase();
                              var o = l._originalString;
-                             result = new NumLiteral(sourcePos(p1).rangeTo(endPos), o, b, m, d, e, eb); break;
+                             result = new NumLiteral(sourceRange(p1, endPos), o, b, m, d, e, eb); break;
           case t_match     :         result = match();                                  break;
           case t_for       :
           case t_variant   :
@@ -2192,6 +2192,11 @@ simpleterm  : bracketTerm
       {
         result = call(result);
       }
+    var p2 = lastTokenEndPos();
+    if (p1 < p2) // in case or a parsing error, we might not have made any progress
+      {
+        result.setSourceRange(sourceRange(p1, p2));
+      }
     return result;
   }
 
@@ -2220,7 +2225,7 @@ stringTermB : '}any chars&quot;'
         if (isString(t))
           {
             var ps = string(multiLineIndentation);
-            var str = new StrConst(tokenSourcePos(), ps._v0);
+            var str = new StrConst(tokenSourcePos().rangeTo(tokenEndPos()), ps._v0);
             result = concatString(tokenSourcePos(), leftString, str);
             next();
             if (isPartialString(t))

--- a/tests/free_types_negative/test_free_types_negative.fz.expected_err
+++ b/tests/free_types_negative/test_free_types_negative.fz.expected_err
@@ -5,7 +5,7 @@
 Types inferred for first type parameter 'T':
 'String' found at --CURDIR--/test_free_types_negative.fz:49:11:
   c1 3.14 "e"        # 2. should flag an error, incompatible types inferred for `T`
-----------^
+----------^^^
 'f64' found at --CURDIR--/test_free_types_negative.fz:49:6:
   c1 3.14 "e"        # 2. should flag an error, incompatible types inferred for `T`
 -----^^^^
@@ -17,7 +17,7 @@ Types inferred for first type parameter 'T':
 Types inferred for first type parameter 'T':
 'String' found at --CURDIR--/test_free_types_negative.fz:52:11:
   c2 3.14 "e"        # 3. should flag an error, incompatible types inferred for `T`
-----------^
+----------^^^
 'f64' found at --CURDIR--/test_free_types_negative.fz:52:6:
   c2 3.14 "e"        # 3. should flag an error, incompatible types inferred for `T`
 -----^^^^
@@ -29,7 +29,7 @@ Types inferred for first type parameter 'T':
 Types inferred for first type parameter '#_0':
 'String' found at --CURDIR--/test_free_types_negative.fz:61:10:
   d 3.14 "e"         # 4. should flag an error, incompatible types inferred for same anonymous type
----------^
+---------^^^
 'f64' found at --CURDIR--/test_free_types_negative.fz:61:5:
   d 3.14 "e"         # 4. should flag an error, incompatible types inferred for same anonymous type
 ----^^^^
@@ -92,7 +92,7 @@ actual type parameter 'String'
 For the formal argument 'test_free_type_negative.f.v' the following incompatible actual arguments where found for type inference:
 actual is value of type 'String' at --CURDIR--/test_free_types_negative.fz:75:5:
   f "[1,3,5]" Any    # 5.a should flag an error since two calls with incompatible actual argument types
-----^
+----^^^^^^^^^
 actual is value of type 'f64' at --CURDIR--/test_free_types_negative.fz:76:5:
   f 3.14 "e"         # 5.b should flag an error since two calls with incompatible actual argument types
 ----^^^^

--- a/tests/reg_issue1945_ambiguity_for_lambda_result_neg/issue1945neg.fz.expected_err
+++ b/tests/reg_issue1945_ambiguity_for_lambda_result_neg/issue1945neg.fz.expected_err
@@ -10,7 +10,7 @@ While parsing: semicolon or flat line break, parse stack: semiOrFlatLF, exprs, b
 --^
 Feature not found: 'd' (one argument)
 Target feature: 'ambiguous_declaration'
-In call: 'd'
+In call: 'd ()'
 
 
 --CURDIR--/issue1945neg.fz:51:3: error 3: Could not find called feature
@@ -18,6 +18,6 @@ In call: 'd'
 --^
 Feature not found: 'l' (one argument)
 Target feature: 'ambiguous_declaration'
-In call: 'l'
+In call: 'l ()'
 
 3 errors.

--- a/tests/typeinference_for_formal_args_negative/typeinference_for_args_negative.fz.expected_err
+++ b/tests/typeinference_for_formal_args_negative/typeinference_for_args_negative.fz.expected_err
@@ -5,7 +5,7 @@
 For the formal argument 'typeinference_for_args_negative.a3.a' the following incompatible actual arguments where found for type inference:
 actual is value of type 'String' at --CURDIR--/typeinference_for_args_negative.fz:41:11:
   say (a3 "hello"     " world!")
-----------^
+----------^^^^^^^
 actuals are values of type 'f64' at --CURDIR--/typeinference_for_args_negative.fz:42:11:
   say (a3 1.0         " world!")
 ----------^^^
@@ -23,7 +23,7 @@ and at --CURDIR--/typeinference_for_args_negative.fz:44:11:
 For the formal argument 'typeinference_for_args_negative.a4.b' the following incompatible actual arguments where found for type inference:
 actual is value of type 'String' at --CURDIR--/typeinference_for_args_negative.fz:46:23:
   say (a4 "hello"     " world!")
-----------------------^
+----------------------^^^^^^^^^
 actual is value of type 'i32' at --CURDIR--/typeinference_for_args_negative.fz:47:33:
   say (a4 "1.0"       " world!".byte_length)
 --------------------------------^^^^^^^^^^^

--- a/tests/visibility_modules_negative/main.fz.expected_err
+++ b/tests/visibility_modules_negative/main.fz.expected_err
@@ -4,7 +4,7 @@
 ----^^^^^^^
 Feature not found: 'mod_pub' (no arguments)
 Target feature: 'b'
-In call: 'mod_pub'
+In call: 'b.mod_pub'
 To solve this, you might change the visibility of the feature 'mod_pub' (no arguments) at $FUZION/lib/b.fz:26:17:
   module:public mod_pub is
 ----------------^


### PR DESCRIPTION
This fixes the output in examples on flang.dev such as `ccontent/tutorial/examples/constants_string_example2.fz` and it gives more useful output in many other situation.

Updated expected error output for tests that are affected by this change.