### PR TITLE
ast: Set type of `StrConst` to `String` to avoid confusion

### DIFF
--- a/src/dev/flang/air/Clazzes.java
+++ b/src/dev/flang/air/Clazzes.java
@@ -1071,7 +1071,7 @@ public class Clazzes extends ANY
 
     else if (e instanceof AbstractConstant c)
       {
-        result = outerClazz.actualClazz(c.type());
+        result = outerClazz.actualClazz(c.typeOfConstant());
       }
 
     else if (e instanceof Tag t)

--- a/src/dev/flang/ast/AbstractConstant.java
+++ b/src/dev/flang/ast/AbstractConstant.java
@@ -51,6 +51,21 @@ public abstract class AbstractConstant extends Expr
 
 
   /**
+   * The type of the constant.  This may be different to the the user-visible
+   * `type()` of this constant, in particular, for a constnat string, `type()`
+   * returns `String`, while `typeOfConstant` is the actual child of `String`
+   * used for constants: `Const_String`.
+   *
+   * @return the type to be used to create the constant value. Is assignment
+   * compatible to `type()`.
+   */
+  public AbstractType typeOfConstant()
+  {
+    return type();
+  }
+
+
+  /**
    * Serialized form of the data of this constant.
    */
   public abstract byte[] data();

--- a/src/dev/flang/ast/StrConst.java
+++ b/src/dev/flang/ast/StrConst.java
@@ -88,6 +88,19 @@ public class StrConst extends Constant
   @Override
   public AbstractType type()
   {
+    return Types.resolved.t_string;
+  }
+
+
+  /**
+   * The type of the constant that is created is not `String`, but
+   * `Const_String`.
+   *
+   * @return Types.resolved.t_Const_String
+   */
+  @Override
+  public AbstractType typeOfConstant()
+  {
     return Types.resolved.t_Const_String;
   }
 

--- a/src/dev/flang/be/interpreter/Interpreter.java
+++ b/src/dev/flang/be/interpreter/Interpreter.java
@@ -359,7 +359,7 @@ public class Interpreter extends ANY
         result = _cachedConsts_.get(i);
         if (result == null)
           {
-            var t = i.type();
+            var t = i.typeOfConstant();
             var d = i.data();
             if      (t.compareTo(Types.resolved.t_bool  ) == 0) { result = new boolValue(d[0] != 0                                                           ); }
             else if (t.compareTo(Types.resolved.t_i8    ) == 0) { result = new i8Value  (ByteBuffer.wrap(d).order(ByteOrder.LITTLE_ENDIAN).get      ()       ); }

--- a/src/dev/flang/fe/LibraryOut.java
+++ b/src/dev/flang/fe/LibraryOut.java
@@ -720,7 +720,7 @@ class LibraryOut extends ANY
    *   |        | length | byte          | data of the constant                          |
    *   +--------+--------+---------------+-----------------------------------------------+
    */
-        type(c.type());
+        type(c.typeOfConstant());
         var d = c.data();
         _data.writeInt(d.length);
         _data.write(d);

--- a/src/dev/flang/fuir/FUIR.java
+++ b/src/dev/flang/fuir/FUIR.java
@@ -1757,7 +1757,7 @@ hw25 is
 
     Clazz clazz;
     var ic = _codeIds.get(c).get(ix);
-    var t = ((Expr) ic).type();
+    var t = ((AbstractConstant) ic).typeOfConstant();
     if      (t.compareTo(Types.resolved.t_bool        ) == 0) { clazz = Clazzes.bool        .getIfCreated(); }
     else if (t.compareTo(Types.resolved.t_i8          ) == 0) { clazz = Clazzes.i8          .getIfCreated(); }
     else if (t.compareTo(Types.resolved.t_i16         ) == 0) { clazz = Clazzes.i16         .getIfCreated(); }


### PR DESCRIPTION
I found it inconsistent to have a difference in the type of type inference and for type checking, so I changed this back to return `String` just like `typeForInferencing`.

To create instances of `Const_String` for these constants in later phases, there used be be special handling in the interpreter, DFA, etc.  Now, instead, there is a new method `AbsractConstant.typeOfConstant` that is redefined by `StrConst` to return `Const_String`. This method is now used in later phases when the typeo the value to be created for a constant is required.

I will extend the tutorial on flang.dev to explain this a little better.