### PR TITLE
ast: Suppress feature-not-found as subsequent error

### DIFF
--- a/src/dev/flang/ast/Feature.java
+++ b/src/dev/flang/ast/Feature.java
@@ -2033,7 +2033,7 @@ public class Feature extends AbstractFeature
         void found()
         {
           if (PRECONDITIONS) require
-            (curres[1] == null);
+            (curres[1] == null || curres[1] == Types.f_ERROR);
 
           curres[1] = curres[0];
         }

--- a/src/dev/flang/ast/Feature.java
+++ b/src/dev/flang/ast/Feature.java
@@ -2050,7 +2050,7 @@ public class Feature extends AbstractFeature
             { // NYI: Special handling for anonymous inner features that currently do not appear as expressions
               found();
             }
-          else if (c == Call.ERROR)
+          else if (c == Call.ERROR && curres[1] == null)
             {
               curres[1] = Types.f_ERROR;
             }

--- a/src/dev/flang/ast/Feature.java
+++ b/src/dev/flang/ast/Feature.java
@@ -2044,15 +2044,15 @@ public class Feature extends AbstractFeature
             { // Found the call, so we got the result!
               found();
             }
-          else
+          else if (c.calledFeatureKnown() &&
+                   c.calledFeature() instanceof Feature cf && cf.isAnonymousInnerFeature() &&
+                   c.calledFeature() == inner)
+            { // NYI: Special handling for anonymous inner features that currently do not appear as expressions
+              found();
+            }
+          else if (c == Call.ERROR)
             {
-              // NYI: Special handling for anonymous inner features that currently do not appear as expressions
-              if (c.calledFeatureKnown() &&
-                  c.calledFeature() instanceof Feature cf && cf.isAnonymousInnerFeature() &&
-                  c.calledFeature() == inner)
-                {
-                  found();
-                }
+              curres[1] = Types.f_ERROR;
             }
           return c;
         }


### PR DESCRIPTION
Feature lookup in the current scope via Feature.findFieldDefInScope failed to find the use of a field if that use was within a call that had an error such that the arguments where no longer iterated.

Now, in case of an existing error in a call the current scope, a failed feature lookup is no longer reported.

This removes additional errors that are currently reported by flang.dev's examples/examples/man_or_boy2.fz.