### PR TITLE
fe: Find inherited type parameters in `SourceModule.lookupType`, fix #2169

### DIFF
--- a/src/dev/flang/fe/SourceModule.java
+++ b/src/dev/flang/fe/SourceModule.java
@@ -1135,11 +1135,15 @@ public class SourceModule extends Module implements SrcModule, MirModule
             var f = fo._feature;
             if (typeVisible(pos._sourceFile, f, true))
               {
-                (f.definesType() ? type_fs
-                                 : nontype_fs).add(f);
-                if (f.definesType())
+                if (f.definesType() ||
+                    f.isTypeParameter() && !f.isOpenTypeParameter())
                   {
+                    type_fs.add(f);
                     result = fo;
+                  }
+                else
+                  {
+                    nontype_fs.add(f);
                   }
               }
           }


### PR DESCRIPTION
Type parameters that are found are then handed down to get the actual type provided in the inheritance call.