### PR TITLE
ast: relax precondition of Feature.outer() for fix #2167

### DIFF
--- a/src/dev/flang/ast/Feature.java
+++ b/src/dev/flang/ast/Feature.java
@@ -751,7 +751,7 @@ public class Feature extends AbstractFeature
   public AbstractFeature outer()
   {
     if (PRECONDITIONS) require
-      (isUniverse() || state().atLeast(State.FINDING_DECLARATIONS));
+      (Errors.any() || isUniverse() || state().atLeast(State.FINDING_DECLARATIONS));
 
     return _outer;
   }


### PR DESCRIPTION
The example from #2167 still creates one subsequent error `Internally referenced feature 'Y' not found`, but this might be acceptable for now.