### PR TITLE
return `t_ERROR` instead of `t_UNDEFINED` when `union` fails

### DIFF
--- a/src/dev/flang/ast/AbstractMatch.java
+++ b/src/dev/flang/ast/AbstractMatch.java
@@ -141,7 +141,7 @@ public abstract class AbstractMatch extends Expr
         var t = c.code().typeForInferencing();
         result = result == null || t == null ? null : result.union(t);
       }
-    if (result == Types.t_UNDEFINED)
+    if (result == Types.t_ERROR)
       {
         new IncompatibleResultsOnBranches(pos(),
                                           "Incompatible types in cases of match expression",
@@ -151,7 +151,6 @@ public abstract class AbstractMatch extends Expr
                                             public boolean hasNext() { return it.hasNext(); }
                                             public Expr next() { return it.next().code(); }
                                           });
-        result = Types.t_ERROR;
       }
     return result;
   }

--- a/src/dev/flang/ast/AbstractType.java
+++ b/src/dev/flang/ast/AbstractType.java
@@ -966,11 +966,11 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
 
   /**
    * Find a type that is assignable from values of two types, this and t. If no
-   * such type exists, return Types.t_UNDEFINED.
+   * such type exists, return Types.t_ERROR.
    *
    * @param that another type or null
    *
-   * @return a type that is assignable both from this and that, or Types.t_UNDEFINED if none
+   * @return a type that is assignable both from this and that, or Types.t_ERROR if none
    * exists.
    */
   AbstractType union(AbstractType that)
@@ -978,18 +978,16 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
     AbstractType result =
       this == Types.t_ERROR                      ? Types.t_ERROR     :
       that == Types.t_ERROR                      ? Types.t_ERROR     :
-      this == Types.t_UNDEFINED                  ? Types.t_UNDEFINED :
-      that == Types.t_UNDEFINED                  ? Types.t_UNDEFINED :
+      that == null                               ? Types.t_ERROR     :
       this.compareTo(Types.resolved.t_void) == 0 ? that              :
       that.compareTo(Types.resolved.t_void) == 0 ? this              :
       this.isAssignableFrom(that)                ? this :
       that.isAssignableFrom(this)                ? that :
       this.isAssignableFrom(that.asRef())        ? this :
-      that.isAssignableFrom(this.asRef())        ? that : Types.t_UNDEFINED;
+      that.isAssignableFrom(this.asRef())        ? that : Types.t_ERROR;
 
     if (POSTCONDITIONS) ensure
-      (result == Types.t_UNDEFINED ||
-       result == Types.t_ERROR     ||
+      (result == Types.t_ERROR     ||
        this.compareTo(Types.resolved.t_void) == 0 && result == that ||
        that.compareTo(Types.resolved.t_void) == 0 && result == this ||
        (result.isAssignableFrom(this) || result.isAssignableFrom(this.asRef()) &&

--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -1947,10 +1947,9 @@ public class Call extends AbstractCall
             var gt = _generics.get(i);
             var nt = gt == Types.t_UNDEFINED ? actualType
                                              : gt.union(actualType);
-            if (nt == Types.t_UNDEFINED)
+            if (nt == Types.t_ERROR)
               {
                 conflict[i] = true;
-                nt = Types.t_ERROR;
               }
             _generics = _generics.setOrClone(i, nt);
             addPair(foundAt, i, pos, actualType);

--- a/src/dev/flang/ast/If.java
+++ b/src/dev/flang/ast/If.java
@@ -185,12 +185,11 @@ public class If extends ExprWithPos
           : t;
         result = result.union(t);
       }
-    if (result==Types.t_UNDEFINED)
+    if (result==Types.t_ERROR)
       {
         new IncompatibleResultsOnBranches(pos(),
                                           "Incompatible types in branches of if expression",
                                           branches());
-        result = Types.t_ERROR;
       }
     return result;
   }

--- a/src/dev/flang/ast/Impl.java
+++ b/src/dev/flang/ast/Impl.java
@@ -473,7 +473,7 @@ public class Impl extends ANY
           {
             AstErrors.noActualCallFound(formalArg);
           }
-        else if (result == Types.t_UNDEFINED)
+        else if (result == Types.t_ERROR)
           {
             var types = new List<AbstractType>();
             var positions = new TreeMap<AbstractType, List<SourcePosition>>();
@@ -498,10 +498,6 @@ public class Impl extends ANY
           }
       }
 
-    if (result == Types.t_UNDEFINED)
-      {
-        result = Types.t_ERROR;
-      }
     return result;
   }
 

--- a/src/dev/flang/ast/InlineArray.java
+++ b/src/dev/flang/ast/InlineArray.java
@@ -112,7 +112,7 @@ public class InlineArray extends ExprWithPos
               t  == null ? null :
               et == null ? null : t.union(et);
           }
-        if (t == Types.t_UNDEFINED)
+        if (t == Types.t_ERROR)
           {
             new IncompatibleResultsOnBranches(pos(),
                                               "Incompatible types in array elements",


### PR DESCRIPTION
before t_UNDEFINED was used in two ways:
- a failure of a union of two types
- type that was/is not inferred yet.