### PR TITLE
jvm: reduce code size of calls by combining precondition and routine call

### DIFF
--- a/src/dev/flang/be/jvm/CodeGen.java
+++ b/src/dev/flang/be/jvm/CodeGen.java
@@ -997,8 +997,7 @@ class CodeGen
                     .andThen(c._v0);
                 }
               result = result
-                //.andThen(_types.invokeStaticCombindedPreAndCall(constCl));  // does not work since features used in precondition may be missing
-                .andThen(_types.invokeStatic(constCl, false));
+                .andThen(_types.invokeStaticCombindedPreAndCall(constCl));
 
               yield new Pair<>(result, Expr.UNIT);
             }

--- a/src/dev/flang/be/jvm/CodeGen.java
+++ b/src/dev/flang/be/jvm/CodeGen.java
@@ -981,11 +981,10 @@ class CodeGen
           if (!_fuir.clazzIsChoice(constCl))
             {
               var b = ByteBuffer.wrap(d);
-              var result = _jvm.new0(constCl);
+              var result = Expr.UNIT;
               var offset = 0;
               for (int index = 0; index < _fuir.clazzArgCount(constCl); index++)
                 {
-                  var f = _fuir.clazzArg(constCl, index);
                   var fr = _fuir.clazzArgClazz(constCl, index);
                   var n = _fuir.clazzArgFieldBytes(constCl, index);
                   var bytes = b.slice(offset, n);
@@ -993,12 +992,14 @@ class CodeGen
                   bytes.get(bb);
                   offset += n;
                   var c = createConstant(fr, bb);
-                  result = result                                  // Stack: constCl
-                    .andThen(Expr.DUP)                             //        constCl, constCl
-                    .andThen(c._v0)                                //        constCl, constCl, val
-                    .andThen(c._v1)                                //        constCl, constCl, val
-                    .andThen(_jvm.putfield(f));                    //        constCl
+                  result = result
+                    .andThen(c._v1)
+                    .andThen(c._v0);
                 }
+              result = result
+                //.andThen(_types.invokeStaticCombindedPreAndCall(constCl));  // does not work since features used in precondition may be missing
+                .andThen(_types.invokeStatic(constCl, false));
+
               yield new Pair<>(result, Expr.UNIT);
             }
           else

--- a/src/dev/flang/be/jvm/JVM.java
+++ b/src/dev/flang/be/jvm/JVM.java
@@ -1142,7 +1142,8 @@ should be avoided as much as possible.
                   .andThen(javaTypeOfTarget(cl).load(0));
                 for(var i = 0; i<_fuir.clazzArgCount(cl); i++)
                   {
-                    var jti = _types.javaType(_fuir.clazzResultClazz(_fuir.clazzArgClazz(cl, i)));
+                    var at = _fuir.clazzArgClazz(cl, i);
+                    var jti = _types.resultType(at);
                     bc_combined = bc_combined
                       .andThen(jti.load(argSlot(cl, i)));
                   }

--- a/src/dev/flang/be/jvm/JVM.java
+++ b/src/dev/flang/be/jvm/JVM.java
@@ -1126,7 +1126,91 @@ should be avoided as much as possible.
                                        new List<>(), new List<>());
 
         cf.method(cf.ACC_STATIC | cf.ACC_PUBLIC, name, _types.descriptor(cl, pre), new List<>(code_cl));
+
+        // If both precondition and routine exists, create a helper that calls both combined
+        if (!pre && _fuir.hasPrecondition(cl))
+          {
+            var bc_combined = Expr.UNIT;
+            var jt = _types.javaType(_fuir.clazzResultClazz(cl));
+
+            // In a loop, generate two calls, one for the precondition (preCond
+            // == true), then for the actual routine (preCond == false):
+            var preCond = true;
+            do
+              {
+                bc_combined = bc_combined
+                  .andThen(javaTypeOfTarget(cl).load(0));
+                for(var i = 0; i<_fuir.clazzArgCount(cl); i++)
+                  {
+                    var jti = _types.javaType(_fuir.clazzResultClazz(_fuir.clazzArgClazz(cl, i)));
+                    bc_combined = bc_combined
+                      .andThen(jti.load(argSlot(cl, i)));
+                  }
+                bc_combined = bc_combined
+                  .andThen(Expr.invokeStatic(_names.javaClass(cl),
+                                             _names.function(cl, preCond),
+                                             _types.descriptor(cl, preCond),
+                                             preCond ? PrimitiveType.type_void : jt));
+                preCond = !preCond;
+              }
+            while (!preCond);
+
+            bc_combined = bc_combined
+              .andThen(jt.return0());
+
+            var code_comb = cf.codeAttribute("combined precondition and code of " + _fuir.clazzAsString(cl),
+                                             numLocals(cl, pre) /* NYI, num locals! */,
+                                             bc_combined,
+                                             new List<>(), new List<>());
+            cf.method(cf.ACC_STATIC | cf.ACC_PUBLIC, Names.COMBINED_NAME, _types.descriptor(cl, false), new List<>(code_comb));
+          }
       }
+  }
+
+
+
+  /**
+   * Get the slot of the local var for argument #i.
+   *
+   * The Java method cl receives its target and arguments in the first local var
+   * slots on the Java stack.  This helper determines the slot number of a given
+   * argument.
+   *
+   * @param cl the clazz we are compiling.
+   *
+   * @param i the local variable index whose slot we are looking for.
+   *
+   * @return the slot that contains arg #i on a call to the Java code for `cl`.
+   */
+  public int argSlot(int cl, int i)
+  {
+    if (PRECONDITIONS) require
+      (0 <= i,
+       i < _fuir.clazzArgCount(cl));
+
+    var l = javaTypeOfTarget(cl).stackSlots();
+    for (var j = 0; j < i; j++)
+      {
+        var t = _fuir.clazzArgClazz(cl, j);
+        l = l + _types.javaType(t).stackSlots();
+      }
+    return l;
+  }
+
+
+  /**
+   * Get the Java type for target (outer ref) in the given routine.  Note that
+   * the slot number of the target ref is always 0.
+   *
+   * @param cl the clazz we are compiling.
+   *
+   * @return the Java type of the outer ref, PrimitiveType.type_void if none.
+   */
+  public JavaType javaTypeOfTarget(int cl)
+  {
+    var o = _fuir.clazzOuterRef(cl);
+    return o == -1 ? PrimitiveType.type_void
+                   : _types.javaType(_fuir.clazzResultClazz(o));
   }
 
 

--- a/src/dev/flang/be/jvm/Names.java
+++ b/src/dev/flang/be/jvm/Names.java
@@ -149,8 +149,9 @@ public class Names extends ANY implements ClassFileConstants
   private static final String INTERFACE_PREFIX = "fzI_";
   private static final String DYNAMIC_FUNCTION_PREFIX = "fzD_";
 
-  static final String PRECONDITION_NAME = "fzPrecondition";
-  static final String ROUTINE_NAME      = "fzRoutine";
+  static final String PRECONDITION_NAME = "fzPrecondition";           // method with code for the precondition
+  static final String ROUTINE_NAME      = "fzRoutine";                // method with code for the routine
+  static final String COMBINED_NAME     = "fzPreconditionAndRoutine"; // method that calls precondition followed by routine, to reduce code size
   static
   {
     if (CHECKS) check

--- a/src/dev/flang/be/jvm/Types.java
+++ b/src/dev/flang/be/jvm/Types.java
@@ -239,7 +239,8 @@ public class Types extends ANY implements ClassFileConstants
   Expr invokeStaticCombindedPreAndCall(int cc)
   {
     var cls   = _names.javaClass(cc);
-    var fname = Names.COMBINED_NAME;
+    var fname = _fuir.clazzContract(cc, FUIR.ContractKind.Pre, 0) >= 0 ? Names.COMBINED_NAME
+                                                                       : Names.ROUTINE_NAME;
     return Expr.invokeStatic(cls,
                              fname,
                              descriptor(cc, false),

--- a/src/dev/flang/be/jvm/Types.java
+++ b/src/dev/flang/be/jvm/Types.java
@@ -236,6 +236,15 @@ public class Types extends ANY implements ClassFileConstants
                              descriptor(cc, preCalled),
                              resultType(cc, preCalled));
   }
+  Expr invokeStaticCombindedPreAndCall(int cc)
+  {
+    var cls   = _names.javaClass(cc);
+    var fname = Names.COMBINED_NAME;
+    return Expr.invokeStatic(cls,
+                             fname,
+                             descriptor(cc, false),
+                             resultType(cc, false));
+  }
 
 
 

--- a/src/dev/flang/fuir/analysis/dfa/DFA.java
+++ b/src/dev/flang/fuir/analysis/dfa/DFA.java
@@ -1927,6 +1927,10 @@ public class DFA extends ANY
 
           // register calls for constant creation even though
           // not every backend actually performs these calls.
+          if (_fuir.hasPrecondition(constCl))
+            {
+              newCall(constCl, true, _universe, args, null /* new environment */, context);
+            }
           newCall(constCl, false, _universe, args, null /* new environment */, context);
 
           yield result;

--- a/tests/unicode/skip_jvm
+++ b/tests/unicode/skip_jvm
@@ -1,2 +1,0 @@
-NYI results in code size of bytecode created for `character_encodings.unicode.data.lower_case_mappings` is 107131, the maximum allowed length is 65535
-see: #2159


### PR DESCRIPTION
This reduces the code size significantly whenever a call can be bound statically to the static type, i.e., the precondition and the routine that is called come from the same clazz.

 Since initialization of structured constants now uses the new combined method that checks the precondition as well, this fixes the missing preconditions checks for these constants. However, these checks are now performed earlier and the stack trace does not show the position of the faulty call.

This enhances #2159, but there is still room for improvement, in particular we should split up the static initializer of class `fzC_universe` in case of too many too large constants. 

