### PR TITLE
lib: add list/Sequence.scan to create list of folds or prefix lists

### DIFF
--- a/lib/Sequence.fz
+++ b/lib/Sequence.fz
@@ -288,6 +288,15 @@ public Sequence(T type) ref is
   public fold (m Monoid T) => as_list.fold m.e m
 
 
+  # map this Sequence to a list that contains the result of folding
+  # all prefixes using the given monoid.
+  #
+  # e.g., for a Sequence of i32 s, s.scan i32.sum creates a list of
+  # partial sums (0..).map x->(s.take x).fold i32.sum
+  #
+  public scan (m Monoid T) => as_list.scan m.e m
+
+
   # reduce this Sequence to R with an initial value init
   # and a reducing function f.
   # the reduction is finished once f yields abort or

--- a/lib/list.fz
+++ b/lib/list.fz
@@ -197,7 +197,7 @@ public list(A type) : choice nil (Cons A (list A)), Sequence A is
 
   # fold the elements of this list using the given monoid.
   #
-  # e.g., to sum the elements of a list of i32, use l.fold i32.sum
+  # e.g., to sum the elements of a list of i32, use l.fold i32.type.sum
   #
   public redef fold (m Monoid A) => fold m.e m
 
@@ -208,6 +208,25 @@ public list(A type) : choice nil (Cons A (list A)), Sequence A is
   #
   public fold (s A, m Monoid A) A is (list.this ? nil    => s
                                                 | c Cons => c.tail.fold (m.op s c.head) m)
+
+
+  # map this Sequence to a list that contains the result of folding
+  # all prefixes using the given monoid.
+  #
+  # e.g., for a Sequence of i32 s, s.scan i32.type.sum creates a list of
+  # partial sums (0..).map x->(s.take x).fold i32.type.sum
+  #
+  public redef scan (m Monoid A) => scan m.e m
+
+
+  # map this Sequence to a list that contains the result of folding
+  # all prefixes using the given monoid and initial value
+  #
+  # Used to scan a list tail-recursively
+  #
+  public scan (s A, m Monoid A) list A is (list.this ? nil    => nil
+                                                     | c Cons => acc := m.op s c.head
+                                                                 list acc (c.tail.scan acc m))
 
 
   # Lazily take the first n elements of a list, alternatively the whole list if it


### PR DESCRIPTION
The name is inspired by Haskell, I am not fully happy with it but did not find a better name yet.  An example:
```
  [1,2,3,4,5].scan i32.type.sum
```
results in
```
  [1,3,6,10,15]
```
Also fixes a typo in the comment of `fold`.