### PR TITLE
tests: add default `all` rule

### DIFF
--- a/tests/negative.mk
+++ b/tests/negative.mk
@@ -32,6 +32,8 @@ FUZION_OPTIONS ?=
 FUZION = ../../bin/fz -XmaxErrors=-1 $(FUZION_OPTIONS)
 EXPECTED_ERRORS = `cat *.fz | grep "should.flag.an.error"  | sed "s ^.*//  g"| sort -n | uniq | wc -l | tr -d ' '`
 
+all: jvm c int
+
 int:
 	$(FUZION) $(NAME) 2>err.txt || echo -n
 	cat err.txt  | grep "should.flag.an.error" | sed "s ^.*//  g"| sort -n | uniq | wc -l | tr -d ' ' | grep ^$(EXPECTED_ERRORS)$$ && echo "test passed." || exit 1

--- a/tests/positive.mk
+++ b/tests/positive.mk
@@ -31,6 +31,8 @@
 FUZION_OPTIONS ?=
 FUZION = ../../bin/fz $(FUZION_OPTIONS)
 
+all: jvm c int
+
 int:
 	$(FUZION) $(NAME) 2>err.txt || (RC=$$? && cat err.txt && exit $$RC)
 

--- a/tests/simple.mk
+++ b/tests/simple.mk
@@ -41,6 +41,8 @@ ENV = \
   $(if $(FUZION_JAVA_STACK_SIZE), FUZION_JAVA_STACK_SIZE=$(FUZION_JAVA_STACK_SIZE),) \
   $(if $(FUZION_JAVA_OPTIONS)   , FUZION_JAVA_OPTIONS=$(FUZION_JAVA_OPTIONS)      ,) \
 
+all: jvm c int
+
 int:
 	$(ENV) ../check_simple_example.sh "$(FUZION_RUN)" $(FILE) || exit 1
 

--- a/tests/simple_inp.mk
+++ b/tests/simple_inp.mk
@@ -37,6 +37,8 @@ FILE = $(NAME).fz
 STDIN = $(NAME).fz.stdin
 FUZION_RUN = $(FUZION) $(FUZION_OPTIONS)
 
+all: jvm c int
+
 int:
 	cat $(STDIN) | ../check_simple_example.sh "$(FUZION_RUN)" $(FILE) || exit 1
 


### PR DESCRIPTION
saves a bit of typing when testing all backends at once.

Instead of:
`make int c jvm -C build/tests/some_test`
it now suffices to type:
`make -C build/tests/some_test`