### PR TITLE
ast: Avoid subsequent errors in case error is merged during type inference

### DIFF
--- a/src/dev/flang/ast/AstErrors.java
+++ b/src/dev/flang/ast/AstErrors.java
@@ -1634,12 +1634,15 @@ public class AstErrors extends ANY
 
   static void incompatibleTypesDuringTypeInference(SourcePosition pos, Generic g, List<Pair<SourcePosition, AbstractType>> foundAt)
   {
-    error(pos,
-          "Incompatible types found during type inference for type parameters",
-          "Types inferred for " + ordinal(g.index()+1) + " type parameter " + s(g) + ":\n" +
-          foundAt.stream()
+    if (!any() || foundAt.stream().noneMatch(p -> p._v1 == Types.t_ERROR))
+      {
+        error(pos,
+              "Incompatible types found during type inference for type parameters",
+              "Types inferred for " + ordinal(g.index()+1) + " type parameter " + s(g) + ":\n" +
+              foundAt.stream()
                  .map(p -> s(p._v1) + " found at " + p._v0.show() + "\n")
                  .collect(Collectors.joining()));
+      }
   }
 
   static void failedToInferActualGeneric(SourcePosition pos, AbstractFeature cf, List<Generic> missing)

--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -1958,7 +1958,10 @@ public class Call extends AbstractCall
             var gt = _generics.get(i);
             var nt = gt == Types.t_UNDEFINED ? actualType
                                              : gt.union(actualType);
-            if (nt == Types.t_ERROR)
+            if (nt == Types.t_ERROR &&
+                // if there was an earlier error, do not treat this as a conflict:
+                !(gt         == Types.t_ERROR ||
+                  actualType == Types.t_ERROR    ))
               {
                 conflict[i] = true;
               }


### PR DESCRIPTION
This PR is slightly redundant since it adds code to prevent these subsequent errors at two locations, in AstErrors and and Call, just to make it more robust.

This fixs the jenkins failure of examples/examples/man_or_boy2.fz due to additional error output.