### PR TITLE
cleanup `resultTypeRaw` `resultTypeIfPresent`

### DIFF
--- a/bin/aspell.dict
+++ b/bin/aspell.dict
@@ -1086,7 +1086,6 @@ resultExpressionIndex
 resultField
 resulttype
 resultType
-resultTypeRaw
 returnType
 ReturnType
 rhs

--- a/src/dev/flang/ast/AbstractAssign.java
+++ b/src/dev/flang/ast/AbstractAssign.java
@@ -222,7 +222,7 @@ public abstract class AbstractAssign extends Expr
   {
     return  _assignedField != Types.f_ERROR
          && res.state(_assignedField).atLeast(State.RESOLVED_TYPES)
-         && _assignedField.resultTypeRaw(res) != null;
+         && _assignedField.resultTypeIfPresent(res) != null;
   }
 
 

--- a/src/dev/flang/ast/AbstractFeature.java
+++ b/src/dev/flang/ast/AbstractFeature.java
@@ -901,42 +901,16 @@ public abstract class AbstractFeature extends Expr implements Comparable<Abstrac
 
 
   /**
-   * resultTypeRaw returns the result type of this feature using the
+   * resultTypeIfPresent returns the result type of this feature using the
    * formal generic argument.
    *
    * @return this feature's result type using the formal generics, null in
    * case the type is currently unknown (in particular, in case of a type
    * inference from a field declared later).
    */
-  AbstractType resultTypeRaw(Resolution res)
+  AbstractType resultTypeIfPresent(Resolution res)
   {
     return resultType();
-  }
-
-
-  /**
-   * resultTypeRaw returns the result type of this feature with given
-   * actual generics applied.
-   *
-   * @param generics the actual generic arguments to create the type, or null if
-   * generics should not be replaced.
-   *
-   * @return this feature's result type using the given actual generics, null in
-   * case the type is currently unknown (in particular, in case of a type
-   * inference to a field declared later).
-   */
-  AbstractType resultTypeRaw(Resolution res, List<AbstractType> actualGenerics)
-  {
-    if (CHECKS) check
-      (res.state(this).atLeast(State.RESOLVING_TYPES));
-
-    var result = resultTypeRaw(res);
-    if (result != null)
-      {
-        result = result.applyTypePars(this, actualGenerics);
-      }
-
-    return result;
   }
 
 
@@ -948,14 +922,15 @@ public abstract class AbstractFeature extends Expr implements Comparable<Abstrac
    *
    * @param res Resolution instance use to resolve this for types.
    *
-   * @param generics the generics argument to be passed to resultTypeRaw
+   * @param generics the generic arguments to be applied to resultType.
    *
    * @return the result type, Types.resolved.t_void if none and null in case the
    * type must be inferenced and is not available yet.
    */
   AbstractType resultTypeIfPresent(Resolution res, List<AbstractType> generics)
   {
-    return resultTypeRaw(res, generics);
+    return resultType()
+      .applyTypePars(this, generics);
   }
 
 

--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -1269,7 +1269,7 @@ public class Call extends AbstractCall
   private void resolveFormalArg(Resolution res, int argnum, AbstractFeature frml)
   {
     int cnt = 1;
-    var frmlT = frml.resultTypeRaw(res);
+    var frmlT = frml.resultTypeIfPresent(res);
     if (CHECKS) check
       (frmlT == Types.intern(frmlT));
 

--- a/src/dev/flang/ast/Destructure.java
+++ b/src/dev/flang/ast/Destructure.java
@@ -314,7 +314,6 @@ public class Destructure extends Expr
             if (tf != null && tf.isOpenGeneric())
               {
                 Generic g = tf.genericArgument();
-                var frmlTs = g.replaceOpen(t.generics());
                 int select = 0;
                 for (var tfs : g.replaceOpen(t.generics()))
                   {

--- a/src/dev/flang/ast/Feature.java
+++ b/src/dev/flang/ast/Feature.java
@@ -2333,6 +2333,7 @@ public class Feature extends AbstractFeature
         result = resultTypeIfPresent(res);
         if (result instanceof UnresolvedType rt)
           {
+            // NYI try to remove this visitation with findGenerics, see PR: #2210
             result = rt.visit(Feature.findGenerics,outer());
           }
         result = result == null ? null : result.applyTypePars(this, generics);

--- a/src/dev/flang/ast/Feature.java
+++ b/src/dev/flang/ast/Feature.java
@@ -1671,7 +1671,7 @@ public class Feature extends AbstractFeature
           }
         choiceTypeCheckAndInternalFields(res);
 
-        _resultType = resultTypeRaw(res);
+        _resultType = resultTypeIfPresent(res);
         if (_resultType == null)
           {
             AstErrors.failedToInferResultType(this);
@@ -2241,14 +2241,15 @@ public class Feature extends AbstractFeature
 
 
   /**
-   * resultTypeRaw returns the result type of this feature using the
+   * resultTypeIfPresent returns the result type of this feature using the
    * formal generic argument.
    *
    * @return this feature's result type using the formal generics, null in
    * case the type is currently unknown (in particular, in case of a type
    * inference from a field declared later).
    */
-  AbstractType resultTypeRaw(Resolution res)
+  @Override
+  AbstractType resultTypeIfPresent(Resolution res)
   {
     AbstractType result;
 
@@ -2261,7 +2262,7 @@ public class Feature extends AbstractFeature
       }
     else if (outer() != null && this == outer().resultField())
       {
-        result = outer().resultTypeRaw(res);
+        result = outer().resultTypeIfPresent(res);
       }
     else if (_impl._kind == Impl.Kind.FieldDef    ||
              _impl._kind == Impl.Kind.FieldActual ||
@@ -2313,11 +2314,12 @@ public class Feature extends AbstractFeature
    *
    * @param res Resolution instance use to resolve this for types.
    *
-   * @param generics the generics argument to be passed to resultTypeRaw
+   * @param generics the generic arguments to be applied to resultType.
    *
    * @return the result type, Types.resolved.t_void if none and null in case the
    * type must be inferenced and is not available yet.
    */
+  @Override
   AbstractType resultTypeIfPresent(Resolution res, List<AbstractType> generics)
   {
     AbstractType result = Types.resolved.t_void;
@@ -2328,11 +2330,12 @@ public class Feature extends AbstractFeature
           {
             res.resolveTypes(this);
           }
-        result = resultTypeRaw(res, generics);
+        result = resultTypeIfPresent(res);
         if (result instanceof UnresolvedType rt)
           {
             result = rt.visit(Feature.findGenerics,outer());
           }
+        result = result == null ? null : result.applyTypePars(this, generics);
         _resultTypeIfPresentRecursion = false;
       }
     return result;
@@ -2346,12 +2349,13 @@ public class Feature extends AbstractFeature
    *
    * @return the result type, t_ERROR in case of an error. Never null.
    */
+  @Override
   public AbstractType resultType()
   {
     if (PRECONDITIONS) require
       (Errors.any() || _state.atLeast(State.RESOLVED_TYPES));
 
-    var result = _state.atLeast(State.RESOLVED_TYPES) ? resultTypeRaw(null) : null;
+    var result = _state.atLeast(State.RESOLVED_TYPES) ? resultTypeIfPresent(null) : null;
     if (result == null)
       {
         if (CHECKS) check


### PR DESCRIPTION
resultTypeRaw(res) is now called resultTypeIfPresent(res)

fixes #2198