### PR TITLE
intern types at creation

### DIFF
--- a/src/dev/flang/air/Clazz.java
+++ b/src/dev/flang/air/Clazz.java
@@ -350,7 +350,7 @@ public class Clazz extends ANY implements Comparable<Clazz>
      */
     this._outer = normalizeOuter(actualType, outer);
     this._type = (actualType != Types.t_ERROR && this._outer != null)
-      ? Types.intern(ResolvedNormalType.newType(actualType, this._outer._type))
+      ? ResolvedNormalType.newType(actualType, this._outer._type)
       : actualType;
     this._dynamicBinding = null;
   }
@@ -642,7 +642,7 @@ public class Clazz extends ANY implements Comparable<Clazz>
       {
         t = this._outer.actualType(t);
       }
-    return Types.intern(t);
+    return t;
   }
 
 
@@ -718,7 +718,7 @@ public class Clazz extends ANY implements Comparable<Clazz>
           {
             o = replaceThisTypeForTypeFeature(o);
           }
-        t = Types.intern(new ResolvedNormalType(t, g, g, o, true));
+        t = ResolvedNormalType.create(t, g, g, o, true);
       }
     return t;
   }
@@ -1473,9 +1473,7 @@ public class Clazz extends ANY implements Comparable<Clazz>
     if (PRECONDITIONS) require
       (other != null,
        this .getClass() == Clazz.class,
-       other.getClass() == Clazz.class,
-       this ._type == Types.intern(this ._type),
-       other._type == Types.intern(other._type));
+       other.getClass() == Clazz.class);
 
     var result =
       this._select < other._select ? -1 :
@@ -1761,8 +1759,7 @@ public class Clazz extends ANY implements Comparable<Clazz>
   {
     if (PRECONDITIONS) require
       (isChoice(),
-       !staticTypeOfValue.dependsOnGenerics(),
-       staticTypeOfValue == Types.intern(staticTypeOfValue));
+       !staticTypeOfValue.dependsOnGenerics());
 
     int result = -1;
     int index = 0;

--- a/src/dev/flang/air/Clazzes.java
+++ b/src/dev/flang/air/Clazzes.java
@@ -288,8 +288,7 @@ public class Clazzes extends ANY
   public static Clazz create(AbstractType actualType, int select, Clazz outer)
   {
     if (PRECONDITIONS) require
-      (actualType == Types.intern(actualType),
-       Errors.any() || !actualType.dependsOnGenerics(),
+      (Errors.any() || !actualType.dependsOnGenerics(),
        Errors.any() || !actualType.containsThisType());
 
     Clazz o = outer;
@@ -1113,16 +1112,15 @@ public class Clazzes extends ANY
       (Errors.any() || !thiz.dependsOnGenerics(),
        !thiz.isThisType());
 
-    var t = Types.intern(thiz);
-    var result = _clazzesForTypes_.get(t);
+    var result = _clazzesForTypes_.get(thiz);
     if (result == null)
       {
         Clazz outerClazz = thiz.outer() != null
           ? outerClazz = clazz(thiz.outer())
           : null;
 
-        result = create(t, outerClazz);
-        _clazzesForTypes_.put(t, result);
+        result = create(thiz, outerClazz);
+        _clazzesForTypes_.put(thiz, result);
       }
 
     if (POSTCONDITIONS) ensure
@@ -1153,8 +1151,7 @@ public class Clazzes extends ANY
        outerClazz != null || thiz.featureOfType().outer() == null,
        Errors.any() || thiz == Types.t_ERROR || outerClazz == null || outerClazz.feature().inheritsFrom(thiz.featureOfType().outer()));
 
-    var t = Types.intern(thiz);
-    var result = create(t, select, outerClazz);
+    var result = create(thiz, select, outerClazz);
 
     return result;
   }

--- a/src/dev/flang/ast/AbstractFeature.java
+++ b/src/dev/flang/ast/AbstractFeature.java
@@ -480,19 +480,12 @@ public abstract class AbstractFeature extends Expr implements Comparable<Abstrac
           : createThisType();
         _selfType = result;
       }
-    if (state().atLeast(State.RESOLVED_TYPES))
-      {
-        result = Types.intern(result);
-      }
 
     if (POSTCONDITIONS) ensure
       (result != null,
        Errors.any() || result.isRef() == isThisRef(),
        // does not hold if feature is declared repeatedly
-       Errors.any() || result.featureOfType() == this,
-       true || // this condition is very expensive to check and obviously true:
-       !state().atLeast(State.RESOLVED_TYPES) || result == Types.intern(result)
-       );
+       Errors.any() || result.featureOfType() == this);
 
     return result;
   }
@@ -526,14 +519,13 @@ public abstract class AbstractFeature extends Expr implements Comparable<Abstrac
           {
             result = ResolvedNormalType.newType(result, of.thisType());
           }
-        result = Types.intern(result);
         if (innerFixed)
           {
             _thisTypeFixed = result;
           }
         else
           {
-            result = Types.intern(result.asThis());
+            result = result.asThis();
             _thisType = result;
           }
       }
@@ -883,18 +875,15 @@ public abstract class AbstractFeature extends Expr implements Comparable<Abstrac
     if (PRECONDITIONS) require
       (state().atLeast(State.FINDING_DECLARATIONS));
 
-    var o = isUniverse() || outer().isUniverse() ? null : Types.intern(outer().selfType()).asThis();
+    var o = isUniverse() || outer().isUniverse() ? null : outer().selfType().asThis();
     var g = generics().asActuals();
-    var result = new ResolvedNormalType(g, g, o, this);
+    var result = ResolvedNormalType.create(g, g, o, this);
 
     if (POSTCONDITIONS) ensure
       (result != null,
        Errors.any() || result.isRef() == isThisRef(),
        // does not hold if feature is declared repeatedly
-       Errors.any() || result.featureOfType() == this,
-       true || // this condition is very expensive to check and obviously true:
-       !state().atLeast(State.RESOLVED_TYPES) || result == Types.intern(result)
-       );
+       Errors.any() || result.featureOfType() == this);
 
     return result;
   }
@@ -1208,8 +1197,6 @@ public abstract class AbstractFeature extends Expr implements Comparable<Abstrac
                         a = Arrays.copyOf(a, a.length - 1 + frmlTs.size());
                         for (var tg : frmlTs)
                           {
-                            if (CHECKS) check
-                              (tg == Types.intern(tg));
                             a[i] = tg;
                             i++;
                           }
@@ -1223,7 +1210,7 @@ public abstract class AbstractFeature extends Expr implements Comparable<Abstrac
                             actualTypes = FormalGenerics.resolve(res, actualTypes, heir);
                           }
                         ti = ti.applyTypePars(c.calledFeature(), actualTypes);
-                        a[i] = Types.intern(ti);
+                        a[i] = ti;
                       }
                   }
               }
@@ -1433,8 +1420,6 @@ public abstract class AbstractFeature extends Expr implements Comparable<Abstrac
           (Errors.any() || frml.state().atLeast(State.RESOLVED_DECLARATIONS));
 
         var frmlT = frml.resultType();
-        if (CHECKS) check
-          (frmlT == Types.intern(frmlT));
 
         result[argnum] = frmlT;
         argnum++;

--- a/src/dev/flang/ast/AbstractType.java
+++ b/src/dev/flang/ast/AbstractType.java
@@ -398,7 +398,7 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
               {
                 for (var p: actual_type.featureOfType().inherits())
                   {
-                    var pt = Types.intern(actual_type.actualType(p.type()));
+                    var pt = actual_type.actualType(p.type());
                     if (actual_type.isRef())
                       {
                         pt = pt.asRef();
@@ -438,7 +438,7 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
           {
             if (CHECKS) check
               (Errors.any() || t != null);
-            result = result || t != null && Types.intern(t).isAssignableFrom(actual);
+            result = result || t != null && t.isAssignableFrom(actual);
           }
       }
     return result;
@@ -454,9 +454,7 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
   public boolean constraintAssignableFrom(AbstractType actual)
   {
     if (PRECONDITIONS) require
-      (Types.intern(this  ) == this,
-       Types.intern(actual) == actual,
-       this  .isGenericArgument() || this  .featureOfType() != null || Errors.any(),
+      (this  .isGenericArgument() || this  .featureOfType() != null || Errors.any(),
        actual.isGenericArgument() || actual.featureOfType() != null || Errors.any(),
        Errors.any() || this != Types.t_ERROR && actual != Types.t_ERROR);
 
@@ -487,7 +485,7 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
                   {
                     for (var p: actual.featureOfType().inherits())
                       {
-                        var pt = Types.intern(p.type().applyTypePars(actual));
+                        var pt = p.type().applyTypePars(actual);
                         if (constraintAssignableFrom(pt))
                           {
                             result = true;
@@ -895,11 +893,9 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
         int i1 = 0;
         for (var t1 : g)
           {
-            t1 = Types.intern(t1);
             int i2 = 0;
             for (var t2 : g)
               {
-                t2 = Types.intern(t2);
                 if (i1 < i2)
                   {
                     if (!t1.disjoint(t2) &&
@@ -1015,7 +1011,7 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
         result =
           (to == null && oo == null) ?  0 :
           (to == null && oo != null) ? -1 :
-          (to != null && oo == null) ? +1 : Types.intern(to).compareTo(Types.intern(oo));
+          (to != null && oo == null) ? +1 : to.compareTo(oo);
       }
     return result;
   }
@@ -1282,10 +1278,10 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
             if (CHECKS) check
               (!f.isThisRef());
 
-            result = Types.intern(new ResolvedNormalType(g,
-                                                         g,
-                                                         outer().typeType(res),
-                                                         f));
+            result = ResolvedNormalType.create(g,
+                                               g,
+                                               outer().typeType(res),
+                                               f);
           }
       }
     return result;
@@ -1407,7 +1403,7 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
             t = t.replace_type_parameter_of_type_origin(f);
           }
       }
-    return Types.intern(t);
+    return t;
   }
 
 
@@ -1463,7 +1459,7 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
         var no = o != null ? f.apply(o) : null;
         if (ng != g || no != o)
           {
-            result = new ResolvedNormalType(this, ng, unresolvedGenerics(), no);
+            result = ResolvedNormalType.create(this, ng, unresolvedGenerics(), no);
           }
       }
     return result;
@@ -1671,14 +1667,14 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
         var f = fi.next();
         var a = ai.next();
         var u = ui.hasNext() ? ui.next() : null;
-        var c = Types.intern(f.constraint());
+        var c = f.constraint();
         if (CHECKS) check
           (Errors.any() || f != null && a != null);
 
         if (f != null && a != null &&
             !c.isGenericArgument() && // See AstErrors.constraintMustNotBeGenericArgument,
                                       // will be checked in SourceModule.checkTypes(Feature)
-            !c.constraintAssignableFrom(Types.intern(a)))
+            !c.constraintAssignableFrom(a))
           {
             if (!f.typeParameter().isTypeFeaturesThisType())  // NYI: CLEANUP: #706: remove special handling for 'THIS_TYPE'
               {

--- a/src/dev/flang/ast/ArrayConstant.java
+++ b/src/dev/flang/ast/ArrayConstant.java
@@ -73,7 +73,7 @@ public class ArrayConstant extends Constant
     super(pos);
 
     this._elements = elements;
-    this._type = new ResolvedNormalType(Types.resolved.f_array.selfType(),
+    this._type = ResolvedNormalType.create(Types.resolved.f_array.selfType(),
                                         new List<>(et),
                                         new List<>(),
                                         Types.resolved.universe.selfType());

--- a/src/dev/flang/ast/Box.java
+++ b/src/dev/flang/ast/Box.java
@@ -82,7 +82,7 @@ public class Box extends Expr
        !(value instanceof Box));
 
     this._value = value;
-    var t = Types.intern(value.type());
+    var t = value.type();
     this._type = needsBoxingForGenericOrThis(frmlT) ? t : t.asRef();
   }
 

--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -470,7 +470,6 @@ public class Call extends AbstractCall
     result = targetTypeOrConstraint(res)
       .actualType(result)
       .applyTypePars(_calledFeature, _generics);
-    result = Types.intern(result);
 
     if (POSTCONDITIONS) ensure
       (result != null && result != Types.resolved.t_Const_String);
@@ -1270,8 +1269,6 @@ public class Call extends AbstractCall
   {
     int cnt = 1;
     var frmlT = frml.resultTypeRaw(res);
-    if (CHECKS) check
-      (frmlT == Types.intern(frmlT));
 
     var declF = _calledFeature.outer();
     var heir = _target.typeForCallTarget();
@@ -1454,17 +1451,16 @@ public class Call extends AbstractCall
     var t3 = tt.isGenericArgument() ? t2 : t2.resolve(res, tt.featureOfType());
     var t4 = adjustThisTypeForTarget(t3);
     var t5 = resolveForCalledFeature(res, t4, tt);
-    var t6 = Types.intern(t5);
     // call may be resolved repeatedly. In case of recursive use of FieldActual
     // (see #2182), we may see `void` as the result type of calls to argument
     // fields during recursion.  We use only the non-recursive (i.e., non-void)
     // ones:
     if (_type == null ||
-        t6 != Types.resolved.t_void ||
+        t5 != Types.resolved.t_void ||
         !(_calledFeature instanceof Feature cf) ||
         cf.impl()._kind != Impl.Kind.FieldActual)
       {
-        _type = t6;
+        _type = t5;
       }
   }
 
@@ -1602,7 +1598,7 @@ public class Call extends AbstractCall
       {
         var o = t.featureOfType().outer();
         t = o == null || o.isUniverse() ? t : ResolvedNormalType.newType(t, o.thisType());
-        t = Types.intern(t).asThis();
+        t = t.asThis();
       }
     else if (_calledFeature.isConstructor())
       {  /* specialize t for the target type here */

--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -384,7 +384,7 @@ public class Call extends AbstractCall
                AbstractType type)
   {
     if (PRECONDITIONS) require
-      (generics.stream().allMatch(g -> !g.containsError()));
+      (Errors.any() || generics.stream().allMatch(g -> !g.containsError()));
     this._pos = pos;
     this._name = name;
     this._select = select;

--- a/src/dev/flang/ast/Function.java
+++ b/src/dev/flang/ast/Function.java
@@ -405,7 +405,7 @@ public class Function extends ExprWithPos
         var fr = functionOrRoutine();
         var ug = generics(res);
         var generics = FormalGenerics.resolve(res, ug, outer);
-        _type = fr != null ? new ResolvedNormalType(generics, ug, null, fr).resolve(res, outer)
+        _type = fr != null ? ResolvedNormalType.create(generics, ug, null, fr).resolve(res, outer)
                            : Types.t_ERROR;
       }
     else

--- a/src/dev/flang/ast/InlineArray.java
+++ b/src/dev/flang/ast/InlineArray.java
@@ -121,12 +121,12 @@ public class InlineArray extends ExprWithPos
           }
         else
           {
-            _type =
-              t == null ? null :
-              Types.intern(new ResolvedNormalType(new List<>(t),
-                                                  new List<>(t),
-                                                  null,
-                                                  Types.resolved.f_array));
+            _type = t == null
+              ? null
+              : ResolvedNormalType.create(new List<>(t),
+                                          new List<>(t),
+                                          null,
+                                          Types.resolved.f_array);
           }
       }
     return _type;

--- a/src/dev/flang/ast/ResolvedNormalType.java
+++ b/src/dev/flang/ast/ResolvedNormalType.java
@@ -128,6 +128,9 @@ public class ResolvedNormalType extends ResolvedType
         t == Types.t_ERROR || (t.outer() == null) == (o == null));
   }
 
+  /**
+   * instantiate a new ResolvedNormalType and return its unique instance.
+   */
   public static ResolvedNormalType create(AbstractType t, List<AbstractType> g, List<AbstractType> ug, AbstractType o)
   {
     return (ResolvedNormalType)Types.intern(new ResolvedNormalType(t, g, ug, o));
@@ -163,6 +166,9 @@ public class ResolvedNormalType extends ResolvedType
         t == Types.t_ERROR || (t.outer() == null) == (o == null));
   }
 
+  /**
+   * instantiate a new ResolvedNormalType and return its unique instance.
+   */
   public static ResolvedNormalType create(AbstractType t, List<AbstractType> g, List<AbstractType> ug, AbstractType o, boolean fixOuterThisType)
   {
     return (ResolvedNormalType)Types.intern(new ResolvedNormalType(t, g, ug, o, fixOuterThisType));
@@ -188,6 +194,9 @@ public class ResolvedNormalType extends ResolvedType
     this(g, ug, o, f, refOrVal, true);
   }
 
+  /**
+   * instantiate a new ResolvedNormalType and return its unique instance.
+   */
   public static ResolvedNormalType create(List<AbstractType> g, List<AbstractType> ug, AbstractType o, AbstractFeature f, RefOrVal refOrVal)
   {
     return (ResolvedNormalType)Types.intern(new ResolvedNormalType(g, ug, o, f, refOrVal));
@@ -211,6 +220,9 @@ public class ResolvedNormalType extends ResolvedType
     this(g, ug, o, f, RefOrVal.LikeUnderlyingFeature);
   }
 
+  /**
+   * instantiate a new ResolvedNormalType and return its unique instance.
+   */
   public static ResolvedNormalType create(List<AbstractType> g, List<AbstractType> ug, AbstractType o, AbstractFeature f)
   {
     return (ResolvedNormalType)Types.intern(new ResolvedNormalType(g, ug, o, f));
@@ -269,6 +281,9 @@ public class ResolvedNormalType extends ResolvedType
     this._refOrVal = refOrVal;
   }
 
+  /**
+   * instantiate a new ResolvedNormalType and return its unique instance.
+   */
   public static ResolvedNormalType create(List<AbstractType> g,
                                           List<AbstractType> ug,
                                           AbstractType o,
@@ -299,6 +314,9 @@ public class ResolvedNormalType extends ResolvedType
     this._feature           = original._feature;
   }
 
+  /**
+   * instantiate a new ResolvedNormalType and return its unique instance.
+   */
   public static ResolvedNormalType create(ResolvedNormalType original, RefOrVal refOrVal)
   {
     return (ResolvedNormalType)Types.intern(new ResolvedNormalType(original, refOrVal));
@@ -338,6 +356,9 @@ public class ResolvedNormalType extends ResolvedType
     this._feature           = original._feature;
   }
 
+  /**
+   * instantiate a new ResolvedNormalType and return its unique instance.
+   */
   public static ResolvedNormalType create(ResolvedNormalType original, AbstractFeature originalOuterFeature)
   {
     return (ResolvedNormalType)Types.intern(new ResolvedNormalType(original, originalOuterFeature));

--- a/src/dev/flang/ast/ResolvedNormalType.java
+++ b/src/dev/flang/ast/ResolvedNormalType.java
@@ -103,12 +103,6 @@ public class ResolvedNormalType extends ResolvedType
   AbstractFeature _feature;
 
 
-  /**
-   * Cached result of calling Types.intern(this).
-   */
-  ResolvedNormalType _interned = null;
-
-
   /*--------------------------  constructors  ---------------------------*/
 
 
@@ -124,7 +118,7 @@ public class ResolvedNormalType extends ResolvedType
    *
    * @param o the actual outer type, or null, that replaces t.outer
    */
-  public ResolvedNormalType(AbstractType t, List<AbstractType> g, List<AbstractType> ug, AbstractType o)
+  private ResolvedNormalType(AbstractType t, List<AbstractType> g, List<AbstractType> ug, AbstractType o)
   {
     this(t, g, ug, o, false);
 
@@ -132,6 +126,11 @@ public class ResolvedNormalType extends ResolvedType
       ( (t.generics() instanceof FormalGenerics.AsActuals   ) || t.generics().size() == g.size(),
        !(t.generics() instanceof FormalGenerics.AsActuals aa) || aa.sizeMatches(g),
         t == Types.t_ERROR || (t.outer() == null) == (o == null));
+  }
+
+  public static ResolvedNormalType create(AbstractType t, List<AbstractType> g, List<AbstractType> ug, AbstractType o)
+  {
+    return (ResolvedNormalType)Types.intern(new ResolvedNormalType(t, g, ug, o));
   }
 
 
@@ -149,7 +148,7 @@ public class ResolvedNormalType extends ResolvedType
    *
    * @param fixOuterThisType NYI: CLEANUP: #737, see below, unclear why this is needed.
    */
-  public ResolvedNormalType(AbstractType t, List<AbstractType> g, List<AbstractType> ug, AbstractType o, boolean fixOuterThisType)
+  private ResolvedNormalType(AbstractType t, List<AbstractType> g, List<AbstractType> ug, AbstractType o, boolean fixOuterThisType)
   {
     this(g,
          ug,
@@ -162,6 +161,11 @@ public class ResolvedNormalType extends ResolvedType
       ( (t.generics() instanceof FormalGenerics.AsActuals   ) || t.generics().size() == g.size(),
        !(t.generics() instanceof FormalGenerics.AsActuals aa) || aa.sizeMatches(g),
         t == Types.t_ERROR || (t.outer() == null) == (o == null));
+  }
+
+  public static ResolvedNormalType create(AbstractType t, List<AbstractType> g, List<AbstractType> ug, AbstractType o, boolean fixOuterThisType)
+  {
+    return (ResolvedNormalType)Types.intern(new ResolvedNormalType(t, g, ug, o, fixOuterThisType));
   }
 
 
@@ -179,9 +183,14 @@ public class ResolvedNormalType extends ResolvedType
    *
    * @param refOrVal
    */
-  public ResolvedNormalType(List<AbstractType> g, List<AbstractType> ug, AbstractType o, AbstractFeature f, RefOrVal refOrVal)
+  private ResolvedNormalType(List<AbstractType> g, List<AbstractType> ug, AbstractType o, AbstractFeature f, RefOrVal refOrVal)
   {
     this(g, ug, o, f, refOrVal, true);
+  }
+
+  public static ResolvedNormalType create(List<AbstractType> g, List<AbstractType> ug, AbstractType o, AbstractFeature f, RefOrVal refOrVal)
+  {
+    return (ResolvedNormalType)Types.intern(new ResolvedNormalType(g, ug, o, f, refOrVal));
   }
 
 
@@ -197,9 +206,14 @@ public class ResolvedNormalType extends ResolvedType
    * @param f if this type corresponds to a feature, then this is the
    * feature, else null.
    */
-  public ResolvedNormalType(List<AbstractType> g, List<AbstractType> ug, AbstractType o, AbstractFeature f)
+  private ResolvedNormalType(List<AbstractType> g, List<AbstractType> ug, AbstractType o, AbstractFeature f)
   {
     this(g, ug, o, f, RefOrVal.LikeUnderlyingFeature);
+  }
+
+  public static ResolvedNormalType create(List<AbstractType> g, List<AbstractType> ug, AbstractType o, AbstractFeature f)
+  {
+    return (ResolvedNormalType)Types.intern(new ResolvedNormalType(g, ug, o, f));
   }
 
 
@@ -218,7 +232,7 @@ public class ResolvedNormalType extends ResolvedType
    * @param ref true iff this type should be a ref type, otherwise it will be a
    * value type.
    */
-  public ResolvedNormalType(List<AbstractType> g,
+  private ResolvedNormalType(List<AbstractType> g,
                             List<AbstractType> ug,
                             AbstractType o,
                             AbstractFeature f,
@@ -238,7 +252,7 @@ public class ResolvedNormalType extends ResolvedType
         // NYI: CLEANUP: #737: Undo the asThisType() calls done in This.java for
         // outer types. Is it possible to not create asThisType() in This.java
         // in the first place?
-        o = new ResolvedNormalType(ot, RefOrVal.LikeUnderlyingFeature);
+        o = ResolvedNormalType.create(ot, RefOrVal.LikeUnderlyingFeature);
       }
 
     if (o == null && f != null)
@@ -255,6 +269,16 @@ public class ResolvedNormalType extends ResolvedType
     this._refOrVal = refOrVal;
   }
 
+  public static ResolvedNormalType create(List<AbstractType> g,
+                                          List<AbstractType> ug,
+                                          AbstractType o,
+                                          AbstractFeature f,
+                                          RefOrVal refOrVal,
+                                          boolean fixOuterThisType)
+  {
+    return (ResolvedNormalType)Types.intern(new ResolvedNormalType(g, ug, o, f, refOrVal, fixOuterThisType));
+  }
+
 
   /**
    * Create a ref or value type from a given value / ref type.
@@ -263,7 +287,7 @@ public class ResolvedNormalType extends ResolvedType
    *
    * @param refOrVal must be UnresolvedType.RefOrVal.Boxed or UnresolvedType.RefOrVal.Val
    */
-  public ResolvedNormalType(ResolvedNormalType original, RefOrVal refOrVal)
+  private ResolvedNormalType(ResolvedNormalType original, RefOrVal refOrVal)
   {
     if (PRECONDITIONS) require
       (refOrVal != original._refOrVal);
@@ -273,6 +297,11 @@ public class ResolvedNormalType extends ResolvedType
     this._unresolvedGenerics = original._unresolvedGenerics;
     this._outer             = original._outer;
     this._feature           = original._feature;
+  }
+
+  public static ResolvedNormalType create(ResolvedNormalType original, RefOrVal refOrVal)
+  {
+    return (ResolvedNormalType)Types.intern(new ResolvedNormalType(original, refOrVal));
   }
 
 
@@ -285,7 +314,7 @@ public class ResolvedNormalType extends ResolvedType
    * @param originalOuterFeature the original feature, which is not a type
    * feature.
    */
-  ResolvedNormalType(ResolvedNormalType original, AbstractFeature originalOuterFeature)
+  private ResolvedNormalType(ResolvedNormalType original, AbstractFeature originalOuterFeature)
   {
     this._refOrVal          = original._refOrVal;
     if (original._generics.isEmpty())
@@ -309,11 +338,15 @@ public class ResolvedNormalType extends ResolvedType
     this._feature           = original._feature;
   }
 
+  public static ResolvedNormalType create(ResolvedNormalType original, AbstractFeature originalOuterFeature)
+  {
+    return (ResolvedNormalType)Types.intern(new ResolvedNormalType(original, originalOuterFeature));
+  }
 
   /**
    * Constructor for artificial built-in types.
    */
-  public ResolvedNormalType()
+  protected ResolvedNormalType()
   {
     this(UnresolvedType.NONE, UnresolvedType.NONE, null, null, RefOrVal.LikeUnderlyingFeature);
   }
@@ -358,7 +391,7 @@ public class ResolvedNormalType extends ResolvedType
       }
     else
       {
-        result = new ResolvedNormalType(t.generics(), t.unresolvedGenerics(), o, t.featureOfType(),
+        result = ResolvedNormalType.create(t.generics(), t.unresolvedGenerics(), o, t.featureOfType(),
                                         refOrVal(t),
                                         false);
       }
@@ -392,7 +425,7 @@ public class ResolvedNormalType extends ResolvedType
     AbstractType result = this;
     if (!isRef() && this != Types.t_ERROR)
       {
-        result = Types.intern(new ResolvedNormalType(this, RefOrVal.Boxed));
+        result = Types.intern(ResolvedNormalType.create(this, RefOrVal.Boxed));
       }
     return result;
   }
@@ -410,7 +443,7 @@ public class ResolvedNormalType extends ResolvedType
     AbstractType result = this;
     if (!isThisType() && !isChoice() && this != Types.t_ERROR && this != Types.t_ADDRESS)
       {
-        result = Types.intern(new ResolvedNormalType(this, RefOrVal.ThisType));
+        result = Types.intern(ResolvedNormalType.create(this, RefOrVal.ThisType));
       }
 
     if (POSTCONDITIONS) ensure
@@ -433,7 +466,7 @@ public class ResolvedNormalType extends ResolvedType
     AbstractType result = this;
     if (isRef() && this != Types.t_ERROR)
       {
-        result = Types.intern(new ResolvedNormalType(this, RefOrVal.Value));
+        result = Types.intern(ResolvedNormalType.create(this, RefOrVal.Value));
       }
     return result;
   }
@@ -640,7 +673,7 @@ public class ResolvedNormalType extends ResolvedType
    */
   public AbstractType applyTypePars(List<AbstractType> g2, AbstractType o2)
   {
-    return new ResolvedNormalType(this, g2, unresolvedGenerics(), o2);
+    return ResolvedNormalType.create(this, g2, unresolvedGenerics(), o2);
   }
 
 
@@ -655,16 +688,16 @@ public class ResolvedNormalType extends ResolvedType
    * @param originalOuterFeature the original feature, which is not a type
    * feature.
    */
-  ResolvedNormalType clone(AbstractFeature originalOuterFeature)
+  AbstractType clone(AbstractFeature originalOuterFeature)
   {
-    return
+    return (ResolvedNormalType)Types.intern(
       new ResolvedNormalType(this, originalOuterFeature)
       {
         AbstractFeature originalOuterFeature(AbstractFeature currentOuter)
         {
           return originalOuterFeature;
         }
-      };
+      });
   }
 
 

--- a/src/dev/flang/ast/ResolvedNormalType.java
+++ b/src/dev/flang/ast/ResolvedNormalType.java
@@ -446,7 +446,7 @@ public class ResolvedNormalType extends ResolvedType
     AbstractType result = this;
     if (!isRef() && this != Types.t_ERROR)
       {
-        result = Types.intern(ResolvedNormalType.create(this, RefOrVal.Boxed));
+        result = ResolvedNormalType.create(this, RefOrVal.Boxed);
       }
     return result;
   }
@@ -464,7 +464,7 @@ public class ResolvedNormalType extends ResolvedType
     AbstractType result = this;
     if (!isThisType() && !isChoice() && this != Types.t_ERROR && this != Types.t_ADDRESS)
       {
-        result = Types.intern(ResolvedNormalType.create(this, RefOrVal.ThisType));
+        result = ResolvedNormalType.create(this, RefOrVal.ThisType);
       }
 
     if (POSTCONDITIONS) ensure
@@ -487,7 +487,7 @@ public class ResolvedNormalType extends ResolvedType
     AbstractType result = this;
     if (isRef() && this != Types.t_ERROR)
       {
-        result = Types.intern(ResolvedNormalType.create(this, RefOrVal.Value));
+        result = ResolvedNormalType.create(this, RefOrVal.Value);
       }
     return result;
   }

--- a/src/dev/flang/ast/Types.java
+++ b/src/dev/flang/ast/Types.java
@@ -244,16 +244,16 @@ public class Types extends ANY
       f_Types_get                  = f_Types.get(mod, "get");
       f_Lazy                       = universe.get(mod, LAZY_NAME);
       f_Unary                      = universe.get(mod, UNARY_NAME);
-      t_array_i8                   = new ResolvedNormalType(f_array.selfType(), new List<>(t_i8 ), new List<>(), universe.selfType());
-      t_array_i16                  = new ResolvedNormalType(f_array.selfType(), new List<>(t_i16), new List<>(), universe.selfType());
-      t_array_i32                  = new ResolvedNormalType(f_array.selfType(), new List<>(t_i32), new List<>(), universe.selfType());
-      t_array_i64                  = new ResolvedNormalType(f_array.selfType(), new List<>(t_i64), new List<>(), universe.selfType());
-      t_array_u8                   = new ResolvedNormalType(f_array.selfType(), new List<>(t_u8 ), new List<>(), universe.selfType());
-      t_array_u16                  = new ResolvedNormalType(f_array.selfType(), new List<>(t_u16), new List<>(), universe.selfType());
-      t_array_u32                  = new ResolvedNormalType(f_array.selfType(), new List<>(t_u32), new List<>(), universe.selfType());
-      t_array_u64                  = new ResolvedNormalType(f_array.selfType(), new List<>(t_u64), new List<>(), universe.selfType());
-      t_array_f32                  = new ResolvedNormalType(f_array.selfType(), new List<>(t_f32), new List<>(), universe.selfType());
-      t_array_f64                  = new ResolvedNormalType(f_array.selfType(), new List<>(t_f64), new List<>(), universe.selfType());
+      t_array_i8                   = ResolvedNormalType.create(f_array.selfType(), new List<>(t_i8 ), new List<>(), universe.selfType());
+      t_array_i16                  = ResolvedNormalType.create(f_array.selfType(), new List<>(t_i16), new List<>(), universe.selfType());
+      t_array_i32                  = ResolvedNormalType.create(f_array.selfType(), new List<>(t_i32), new List<>(), universe.selfType());
+      t_array_i64                  = ResolvedNormalType.create(f_array.selfType(), new List<>(t_i64), new List<>(), universe.selfType());
+      t_array_u8                   = ResolvedNormalType.create(f_array.selfType(), new List<>(t_u8 ), new List<>(), universe.selfType());
+      t_array_u16                  = ResolvedNormalType.create(f_array.selfType(), new List<>(t_u16), new List<>(), universe.selfType());
+      t_array_u32                  = ResolvedNormalType.create(f_array.selfType(), new List<>(t_u32), new List<>(), universe.selfType());
+      t_array_u64                  = ResolvedNormalType.create(f_array.selfType(), new List<>(t_u64), new List<>(), universe.selfType());
+      t_array_f32                  = ResolvedNormalType.create(f_array.selfType(), new List<>(t_f32), new List<>(), universe.selfType());
+      t_array_f64                  = ResolvedNormalType.create(f_array.selfType(), new List<>(t_f64), new List<>(), universe.selfType());
       resolved = this;
       ((ArtificialBuiltInType) t_ADDRESS  ).resolveArtificialType(universe.get(mod, FuzionConstants.ANY_NAME));
       ((ArtificialBuiltInType) t_UNDEFINED).resolveArtificialType(universe);
@@ -328,31 +328,15 @@ public class Types extends ANY
     if (PRECONDITIONS) require
       (!(at instanceof UnresolvedType t) || Errors.any());
 
-    if (at instanceof ResolvedNormalType t)
+    if (at instanceof ResolvedNormalType t && t.unresolvedGenerics().isEmpty())
       {
-        var existing = t._interned;
+        var existing = types.get(t);
         if (existing == null)
           {
-            if (!t.isGenericArgument())
-              {
-                var o0 = t.outer();
-                var o1 = Types.intern(o0);
-                var g0 = t._generics;
-                var g1 = g0.map(tt -> intern(tt));
-                if (o1 != o0 || g1 != g0)
-                  {
-                    t = new ResolvedNormalType(g1, t.unresolvedGenerics(), o1, t._feature, t._refOrVal, false);
-                  }
-              }
-            existing = types.get(t);
-            if (existing == null)
-              {
-                types.put(t,t);
-                existing = t;
-              }
-            t._generics.freeze();
-            t._interned = existing;
+            types.put(t,t);
+            existing = t;
           }
+        t._generics.freeze();
         at = existing;
       }
     return at;

--- a/src/dev/flang/ast/UnresolvedType.java
+++ b/src/dev/flang/ast/UnresolvedType.java
@@ -336,16 +336,13 @@ public abstract class UnresolvedType extends AbstractType implements HasSourcePo
    */
   public AbstractType asRef()
   {
-    if (PRECONDITIONS) require
-      (this == Types.intern(this));
-
     // throw new Error("asRef not available for unresolved type");
     return this;
     /*
     AbstractType result = this;
     if (!isRef() && this != Types.t_ERROR)
       {
-        result = Types.intern(new ResolvedNormalType(this, RefOrVal.Boxed));
+        result = Types.intern(ResolvedNormalType.create(this, RefOrVal.Boxed));
       }
       return result;*/
   }
@@ -357,16 +354,13 @@ public abstract class UnresolvedType extends AbstractType implements HasSourcePo
    */
   public AbstractType asThis()
   {
-    if (PRECONDITIONS) require
-      (this == Types.intern(this));
-
     //throw new Error("asThis not available for unresolved type");
     return this;
     /*
     AbstractType result = this;
     if (!isThisType() && !isChoice() && this != Types.t_ERROR && this != Types.t_ADDRESS)
       {
-        result = Types.intern(new ResolvedNormalType(this, RefOrVal.ThisType));
+        result = Types.intern(ResolvedNormalType.create(this, RefOrVal.ThisType));
       }
 
     if (POSTCONDITIONS) ensure
@@ -384,16 +378,13 @@ public abstract class UnresolvedType extends AbstractType implements HasSourcePo
    */
   public AbstractType asValue()
   {
-    if (PRECONDITIONS) require
-      (this == Types.intern(this));
-
     //throw new Error("asValue not available for unresolved type");
     return this;
     /*
     AbstractType result = this;
     if (isRef() && this != Types.t_ERROR)
       {
-        result = Types.intern(new ResolvedNormalType(this, RefOrVal.Value));
+        result = Types.intern(ResolvedNormalType.create(this, RefOrVal.Value));
       }
     return result;
     */
@@ -679,7 +670,6 @@ public abstract class UnresolvedType extends AbstractType implements HasSourcePo
           {
             result = resolveFeature(res, outerfeat);
             result = result.resolveGenerics(this, res, outerfeat);
-            result = Types.intern(result);
           }
       }
     return result;
@@ -765,7 +755,7 @@ public abstract class UnresolvedType extends AbstractType implements HasSourcePo
         _resolved =
           result != null     ? result :
           f == Types.f_ERROR ? Types.t_ERROR
-                             : new ResolvedNormalType(generics(),
+                             : ResolvedNormalType.create(generics(),
                                                       unresolvedGenerics(),
                                                       o,
                                                       f,

--- a/src/dev/flang/ast/UnresolvedType.java
+++ b/src/dev/flang/ast/UnresolvedType.java
@@ -342,7 +342,7 @@ public abstract class UnresolvedType extends AbstractType implements HasSourcePo
     AbstractType result = this;
     if (!isRef() && this != Types.t_ERROR)
       {
-        result = Types.intern(ResolvedNormalType.create(this, RefOrVal.Boxed));
+        result = ResolvedNormalType.create(this, RefOrVal.Boxed);
       }
       return result;*/
   }
@@ -360,7 +360,7 @@ public abstract class UnresolvedType extends AbstractType implements HasSourcePo
     AbstractType result = this;
     if (!isThisType() && !isChoice() && this != Types.t_ERROR && this != Types.t_ADDRESS)
       {
-        result = Types.intern(ResolvedNormalType.create(this, RefOrVal.ThisType));
+        result = ResolvedNormalType.create(this, RefOrVal.ThisType);
       }
 
     if (POSTCONDITIONS) ensure
@@ -384,7 +384,7 @@ public abstract class UnresolvedType extends AbstractType implements HasSourcePo
     AbstractType result = this;
     if (isRef() && this != Types.t_ERROR)
       {
-        result = Types.intern(ResolvedNormalType.create(this, RefOrVal.Value));
+        result = ResolvedNormalType.create(this, RefOrVal.Value);
       }
     return result;
     */

--- a/src/dev/flang/fe/LibraryFeature.java
+++ b/src/dev/flang/fe/LibraryFeature.java
@@ -424,10 +424,7 @@ public class LibraryFeature extends AbstractFeature
       (result != null,
        Errors.any() || result.isRef() == isThisRef(),
        // does not hold if feature is declared repeatedly
-       Errors.any() || result.featureOfType() == this,
-       true || // this condition is very expensive to check and obviously true:
-       result == Types.intern(result)
-       );
+       Errors.any() || result.featureOfType() == this);
 
     return result;
   }


### PR DESCRIPTION
Types.intern was called all over the place. Now only in `ResolvedTypes.create()` and `ArtificialBuiltInType.resolveArtificialType`