### PR TITLE
ast/lib/tests: Cleanup in UnresolvedType.findGenerics

### DIFF
--- a/lib/Cons.fz
+++ b/lib/Cons.fz
@@ -38,4 +38,4 @@ public Cons(A, B type) ref is
 #
 # A cons is a cell that contains a head and a tail
 #
-public cons(redef A, B type, head A, tail B) : Cons A B is
+public cons(A, B type, head A, tail B) : Cons A B is

--- a/lib/Sequence.fz
+++ b/lib/Sequence.fz
@@ -36,7 +36,7 @@
 # to implement any of these results in an endless recursion when the Sequence
 # is used.
 #
-public Sequence(T type) ref is
+public Sequence(public T type) ref is
 
 
   # create a list from this Sequence.

--- a/lib/Stream.fz
+++ b/lib/Stream.fz
@@ -42,7 +42,7 @@
 # NYI: Check if stream should be replaced by a lazy list, which is a choice
 # of either nil or a tuple (head, tail). This should avoid the need to store
 # mutable state.
-public stream(redef T type) ref : Sequence T is
+public stream(T type) ref : Sequence T is
 
   as_list0 option (list T) := nil
 

--- a/lib/array.fz
+++ b/lib/array.fz
@@ -31,7 +31,7 @@
 # Note: This uses dummy unit-type args to avoid
 # name clash with routine array(T,length,init).
 #
-module:public array(redef T type,
+module:public array(T type,
       module internal_array fuzion.sys.internal_array T,
       _ unit,
       _ unit,

--- a/lib/array2.fz
+++ b/lib/array2.fz
@@ -52,7 +52,7 @@ public array2(T type,
 # one-dimensional immutable arrays with an additional access function with
 # two index parameters.
 #
-private:public array2(redef T type,
+private:public array2(T type,
        public length0, length1 i32,
        redef internal_array fuzion.sys.internal_array T,
        _ unit,

--- a/lib/array3.fz
+++ b/lib/array3.fz
@@ -56,7 +56,7 @@ public array3(T type,
 # one-dimensional immutable arrays with an additional access function with
 # three index parameters.
 #
-private:public array3(redef T type,
+private:public array3(T type,
        public length0, length1, length2 i32,
        redef internal_array fuzion.sys.internal_array T,
        _ unit,

--- a/lib/cache.fz
+++ b/lib/cache.fz
@@ -37,25 +37,25 @@
 #       cache_kex(val i32) is
 #       # similarly, here, i32 is the actual type we want to cache and cache_kex
 #       # is the wrapping cache key
-#     
+#
 #       # suppose now, that we have two functions fn and fm, which take no arguments but
 #       # which need a very long time for their calculations.
-#     
+#
 #       fn Function cache_key := (() ->
 #         time.nano.sleep (time.durations.seconds 2)
 #         cache_key (sorted_array_of [6,4,1,9]))
-#     
+#
 #       fm Function cache_kex := (() ->
 #         time.nano.sleep (time.durations.seconds 3)
 #         cache_kex 42)
-#     
+#
 #       # we define two more wrappers, which will actually call the functions if
 #       # their value is not in the cache, or return the stored value if already
 #       # computed
 #       from_cache => (cache cache_key fn).val
 #       #                              ^--- will only be computed the first time we run from_cache
 #       from_cachf => (cache cache_kex fm).val
-#     
+#
 #       say from_cache # will take two seconds
 #       say from_cache # will take virtually no time
 #       say from_cachf # will take three seconds
@@ -69,10 +69,10 @@ public cache(T type, f () -> T) T is
 
   # use wrapper type because we do not want to prevent
   # the use of `state` for type T
-  cache_item(T type, val T) is
+  cache_item(val T) is
 
-  if !(effect.type.is_installed (state unit (cache_item T)))
-    _ := state unit (cache_item T) unit (cache_item f()) effect_mode.default
+  if !(effect.type.is_installed (state unit cache_item))
+    _ := state unit cache_item unit (cache_item f()) effect_mode.default
 
-  state_get (cache_item T)
+  state_get cache_item
     .val

--- a/lib/container/Linked_List.fz
+++ b/lib/container/Linked_List.fz
@@ -23,7 +23,7 @@
 
 # abstract type for 'Linked_List'
 #
-public Linked_List(redef T type) ref : Sequence T is
+public Linked_List(T type) ref : Sequence T is
 
 
   # next is the following element of the linked list, or nil if there are

--- a/lib/container/Mutable_Linked_List.fz
+++ b/lib/container/Mutable_Linked_List.fz
@@ -31,7 +31,7 @@ private:public Mutable_Linked_List(# mutate effect to be used to create mutable 
                     LM type : mutate,
 
                     # type of data stored in this list
-                    redef T type,
+                    T type,
 
                     # the data stored in this element.
                     data T) ref : Linked_List T is

--- a/lib/container/hash_map.fz
+++ b/lib/container/hash_map.fz
@@ -26,7 +26,7 @@
 # hash_map -- an immutable hash map from keys HK to values V
 #
 public hash_map(HK type : property.hashable,
-        redef V type,
+        V type,
         ks array HK,
         vs array V) : Map HK V
   pre
@@ -132,4 +132,3 @@ is
   # empty -- convenience routine to create an empty instance of hash_map
   #
   public type.empty => container.hash_map HK V [] []
-

--- a/lib/container/ordered_map.fz
+++ b/lib/container/ordered_map.fz
@@ -33,7 +33,7 @@
 # keys.length.
 #
 public ordered_map(OK type : property.orderable,
-           redef V type,
+           V type,
            ks array OK,
            vs array V) : Map OK V
   pre

--- a/lib/container/ps_map.fz
+++ b/lib/container/ps_map.fz
@@ -51,7 +51,7 @@ private:public ps_map
    PK type : property.orderable,
 
    # value type
-   redef V type,
+   V type,
 
    # the array containg the sorted arrays, see below for details
    data fuzion.sys.internal_array (tuple PK V),

--- a/lib/container/sorted_array.fz
+++ b/lib/container/sorted_array.fz
@@ -38,7 +38,7 @@
 public sorted_array
   (
   # array element type
-  redef T type,
+  T type,
 
   # orginal, unsorted Sequence
   #

--- a/lib/effect.fz
+++ b/lib/effect.fz
@@ -109,7 +109,7 @@ is
 
 # helper instance for effect.abortable to wrap call to f() into a ()->unit
 #
-private Effect_Call(redef R type, f () -> R) ref : Function unit is
+private Effect_Call(R type, f () -> R) ref : Function unit is
   res option R := nil
   call =>
     set res := f()

--- a/lib/fuzion/java.fz
+++ b/lib/fuzion/java.fz
@@ -69,7 +69,7 @@ public fuzion.java is
 
   # A Java array
   #
-  public Array(redef T type, private redef Java_Ref Any) ref : Sequence T, Java_Object Java_Ref
+  public Array(T type, private redef Java_Ref Any) ref : Sequence T, Java_Object Java_Ref
   is
     length                  => array_length T Array.this
     redef finite            => true

--- a/lib/list.fz
+++ b/lib/list.fz
@@ -465,13 +465,17 @@ public list(A type) : choice nil (Cons A (list A)), Sequence A is
 
   # fmap lifts a function from A to B to a function from list A to list B
   #
-  public type.fmap(A, B type, f A -> B) list A -> list B is
+  public type.fmap(B type, f A -> B) list A -> list B is
     l -> l.map B f
 
 
   # monoid of lists with infix concatentation operation.
   #
-  public type.concat_monoid(A type) : Monoid (list A) is
+  # NYI: Name should be `concat_monoid`, we use `list_concat_monoid`
+  # to avoid clash with inherited `Sequence.type.concat_monoid`. Maybe
+  # the inherited one should be renamed once renmaing is supported.
+  #
+  public type.list_concat_monoid : Monoid (list A) is
 
     # associative operation
     #

--- a/lib/mutate.fz
+++ b/lib/mutate.fz
@@ -173,7 +173,7 @@ public mutate : simple_effect is
   # create a mutable array.
   #
   module:public array (# element type
-         redef T type,
+         T type,
 
          # length of the array to create
          public length i32,
@@ -307,7 +307,7 @@ public mut(T type, v T) => mut.new T v
 
 # an interface defining a mutable array
 #
-public Mutable_Array(redef T type) ref : Sequence T is
+public Mutable_Array(T type) ref : Sequence T is
 
   # add an element at the end of the sequence
   public add(t T) unit is abstract

--- a/lib/net/channel.fz
+++ b/lib/net/channel.fz
@@ -48,7 +48,7 @@ is
 
   # shorthand to replace the effect installed in env
   # and return a
-  replace(T type, a T) T is
+  replace(X type, a X) X is
     replace
     a
 

--- a/lib/oneway_monad.fz
+++ b/lib/oneway_monad.fz
@@ -31,7 +31,7 @@
 #
 public oneway_monad(
 
-  redef A type,
+  A type,
 
   OMA type : oneway_monad A OMA,
 

--- a/src/dev/flang/ast/AbstractType.java
+++ b/src/dev/flang/ast/AbstractType.java
@@ -100,7 +100,7 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
    *
    * @return new type this was replaced with in case generics were found.
    */
-  AbstractType findGenerics(AbstractFeature outerfeat)
+  AbstractType findGenerics(Resolution res, AbstractFeature outerfeat)
   {
     return this;
   }
@@ -1325,7 +1325,7 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
           { // a call of the form `T.f x` where `f` is declared as
             // `abc.type.f(arg abc.this.type)`, so replace
             // `abc.this.type` by `T`.
-            result = new Generic(tc.calledFeature()).type();
+            result = tc.calledFeature().genericType();
           }
       }
     else

--- a/src/dev/flang/ast/Env.java
+++ b/src/dev/flang/ast/Env.java
@@ -109,19 +109,6 @@ public class Env extends ExprWithPos
 
 
   /**
-   * Find all the types used in this that refer to formal generic arguments of
-   * this or any of this' outer classes.
-   *
-   * @param outer the root feature that contains this expression.
-   */
-  public void findGenerics(AbstractFeature outer)
-  {
-    // NYI: Check if qual starts with the name of a formal generic in outer or
-    // outer.outer..., flag an error if this is the case.
-  }
-
-
-  /**
    * determine the static type of all expressions and declared features in this feature
    *
    * @param res this is called during type resolution, res gives the resolution

--- a/src/dev/flang/ast/Expr.java
+++ b/src/dev/flang/ast/Expr.java
@@ -418,7 +418,7 @@ public abstract class Expr extends ANY implements HasSourcePosition
    *
    * @return the Type corresponding to this, Type.t_ERROR in case of an error.
    */
-  AbstractType asType(AbstractFeature outer, AbstractFeature tp)
+  AbstractType asType(Resolution res, AbstractFeature outer, AbstractFeature tp)
   {
     if (tp == null)
       {

--- a/src/dev/flang/ast/Generic.java
+++ b/src/dev/flang/ast/Generic.java
@@ -138,7 +138,7 @@ public class Generic extends ANY implements Comparable<Generic>
   public AbstractType constraint(Resolution res)
   {
     if (PRECONDITIONS) require
-      (res.state(feature()).atLeast(State.RESOLVED_DECLARATIONS));
+      (res.state(feature()).atLeast(State.RESOLVING_DECLARATIONS));
 
     res.resolveTypes(_typeParameter);
     return constraint();

--- a/src/dev/flang/ast/Resolution.java
+++ b/src/dev/flang/ast/Resolution.java
@@ -132,6 +132,15 @@ public class Resolution extends ANY
   /*----------------------------  variables  ----------------------------*/
 
 
+  /**
+   * FeatureVisitor to call findGenerics() on all types.
+   */
+  FeatureVisitor findGenerics = new FeatureVisitor()
+    {
+      public AbstractType action(AbstractType t, AbstractFeature outer) { return t.findGenerics(Resolution.this, outer); }
+    };
+
+
   final FuzionOptions _options;
 
 
@@ -440,7 +449,7 @@ public class Resolution extends ANY
       }
 
     if (POSTCONDITIONS) ensure
-      (state(af).atLeast(State.RESOLVED_DECLARATIONS));
+      (state(af).atLeast(State.RESOLVING_DECLARATIONS));
   }
 
 

--- a/src/dev/flang/ast/SrcModule.java
+++ b/src/dev/flang/ast/SrcModule.java
@@ -69,9 +69,11 @@ public interface SrcModule
   void findDeclaredOrInheritedFeatures(Feature outer);
   List<FeatureAndOuter> lookup(AbstractFeature thiz, String name, Expr use, boolean traverseOuter, boolean hidden);
   void checkTypes(Feature f);
-  FeatureAndOuter lookupType(SourcePosition pos, AbstractFeature outer, String name, boolean traverseOuter, boolean mayBeFreeType);
+  FeatureAndOuter lookupType(SourcePosition pos, AbstractFeature outer, String name, boolean traverseOuter, boolean ignoreNotFound, boolean mayBeOpen);
 
   void addTypeFeature(AbstractFeature outerType,
+                      Feature         innerType);
+  void addTypeParameter(AbstractFeature outerType,
                       Feature         innerType);
 
   /*----------------------  methods needed by AIR  ----------------------*/

--- a/src/dev/flang/fe/Module.java
+++ b/src/dev/flang/fe/Module.java
@@ -26,6 +26,7 @@ Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
 
 package dev.flang.fe;
 
+import dev.flang.ast.AbstractCall;
 import dev.flang.ast.AbstractFeature;
 import dev.flang.ast.AstErrors;
 import dev.flang.ast.FeatureName;
@@ -213,16 +214,17 @@ public abstract class Module extends ANY
                 if (CHECKS) check
                   (cf != outer);
 
+                var res = this instanceof SourceModule sm ? sm._res : null;
                 if (!f.isFixed())
                   {
-                    var newfn = cf.handDown(null, f, fn, p, outer);
+                    var newfn = cf.handDown(res, f, fn, p, outer);
                     addInheritedFeature(set, outer, p, newfn, f);
                   }
                 else
                   {
                     for (var f2 : f.redefines())
                       {
-                        var newfn = cf.handDown(null, f2, fn, p, outer);
+                        var newfn = cf.handDown(res, f2, fn, p, outer);
                         addInheritedFeature(set, outer, p, newfn, f2);
                       }
                   }

--- a/tests/free_types_negative/test_free_types_negative.fz.expected_err
+++ b/tests/free_types_negative/test_free_types_negative.fz.expected_err
@@ -1,5 +1,15 @@
 
---CURDIR--/test_free_types_negative.fz:49:3: error 1: Incompatible types found during type inference for type parameters
+--CURDIR--/test_free_types_negative.fz:121:7: error 1: Free type must not mask existing type.
+  y(a EXISTING_TYPE : numeric) =>             # 9. should flag an error, free type must not mask existing type
+------^^^^^^^^^^^^^
+The free type 'EXISTING_TYPE' masks an existing type defined by 'test_free_type_negative.EXISTING_TYPE'.
+The existing type was declared at --CURDIR--/test_free_types_negative.fz:120:3:
+  EXISTING_TYPE is
+--^^^^^^^^^^^^^
+To solve this, you may use a different name for free type 'EXISTING_TYPE'.
+
+
+--CURDIR--/test_free_types_negative.fz:49:3: error 2: Incompatible types found during type inference for type parameters
   c1 3.14 "e"        # 2. should flag an error, incompatible types inferred for `T`
 --^^
 Types inferred for first type parameter 'T':
@@ -11,7 +21,7 @@ Types inferred for first type parameter 'T':
 -----^^^^
 
 
---CURDIR--/test_free_types_negative.fz:52:3: error 2: Incompatible types found during type inference for type parameters
+--CURDIR--/test_free_types_negative.fz:52:3: error 3: Incompatible types found during type inference for type parameters
   c2 3.14 "e"        # 3. should flag an error, incompatible types inferred for `T`
 --^^
 Types inferred for first type parameter 'T':
@@ -23,7 +33,7 @@ Types inferred for first type parameter 'T':
 -----^^^^
 
 
---CURDIR--/test_free_types_negative.fz:61:3: error 3: Incompatible types found during type inference for type parameters
+--CURDIR--/test_free_types_negative.fz:61:3: error 4: Incompatible types found during type inference for type parameters
   d 3.14 "e"         # 4. should flag an error, incompatible types inferred for same anonymous type
 --^
 Types inferred for first type parameter '#_0':
@@ -35,7 +45,7 @@ Types inferred for first type parameter '#_0':
 ----^^^^
 
 
---CURDIR--/test_free_types_negative.fz:115:17: error 4: Could not find called feature
+--CURDIR--/test_free_types_negative.fz:115:17: error 5: Could not find called feature
   neg(x i33) => -x   # 8. should flag an error that is not too confusing
 ----------------^
 Feature not found: 'prefix -' (no arguments)
@@ -46,7 +56,7 @@ To solve this, you might replace the free type 'test_free_type_negative.neg.i33'
 --------^^^
 
 
---CURDIR--/test_free_types_negative.fz:142:9: error 5: Failed to infer actual type parameters
+--CURDIR--/test_free_types_negative.fz:142:9: error 6: Failed to infer actual type parameters
   say ((apply2             a,b->"$a $b").call true 3.14)   # 10. should flag an error, unable to infer actual type parameters
 --------^^^^^^
 In call to 'test_free_type_negative.apply2', no actual type parameters are given and inference of the type parameters failed.
@@ -54,22 +64,12 @@ Expected type parameters: 'A, B'
 Type inference failed for 2 type parameters 'A', 'B'
 
 
---CURDIR--/test_free_types_negative.fz:150:9: error 6: Failed to infer actual type parameters
+--CURDIR--/test_free_types_negative.fz:150:9: error 7: Failed to infer actual type parameters
   say ((apply3a         a,b->"$a $b").call true (u8 127))  # 11. should flag an error, unable to infer actual type parameters
 --------^^^^^^^
 In call to 'test_free_type_negative.apply3a', no actual type parameters are given and inference of the type parameters failed.
 Expected type parameters: 'A, B'
 Type inference failed for 2 type parameters 'A', 'B'
-
-
---CURDIR--/test_free_types_negative.fz:121:7: error 7: Free type must not mask existing type.
-  y(a EXISTING_TYPE : numeric) =>             # 9. should flag an error, free type must not mask existing type
-------^^^^^^^^^^^^^
-The free type 'EXISTING_TYPE' masks an existing type defined by 'test_free_type_negative.EXISTING_TYPE'.
-The existing type was declared at --CURDIR--/test_free_types_negative.fz:120:3:
-  EXISTING_TYPE is
---^^^^^^^^^^^^^
-To solve this, you may use a different name for free type 'EXISTING_TYPE'.
 
 
 --CURDIR--/test_free_types_negative.fz:35:3: error 8: Incompatible type parameter

--- a/tests/generics_negative/generics_negative.fz
+++ b/tests/generics_negative/generics_negative.fz
@@ -182,4 +182,14 @@ generics_negative is
     y.f 9 10 8            // 50. should flag an error: incompatible argument #2
     y.f 9 false "8"       // 51. should flag an error: incompatible argument #3
   opengenerics12
-  unit
+
+  ambiguousTypeParameterName =>
+    outer(X, Y, Z type) is
+      inner(X type, Y2 type, Z type)
+      is
+        x  := option X  nil      // 52. should flag an error: ambiguous type parameter
+        y  := option Y  nil
+        y2 := option Y2 nil
+        z  := option Z  nil      // 53. should flag an error: ambiguous type parameter
+
+  _ := ambiguousTypeParameterName

--- a/tests/local_mutate/test_local_mutate.fz
+++ b/tests/local_mutate/test_local_mutate.fz
@@ -261,7 +261,7 @@ test_local_mutate is
              LM type : mutate,
 
              # type of data stored in ring cells
-             redef T type,
+             T type,
 
              # the data stored in this cell.
              data T) ref : Ring T is

--- a/tests/reg_issue175_int_crash/issue175.fz
+++ b/tests/reg_issue175_int_crash/issue175.fz
@@ -47,5 +47,5 @@
 issue175 is
   m(K,V type, k K, v V) ref is
     e tuple K V := (k,v)
-  om(redef K, V type, k1 K, v1 V) : m K V k1 v1 is
+  om(K, V type, k1 K, v1 V) : m K V k1 v1 is
   x m String i32 := om "one" 1


### PR DESCRIPTION
The goal of this work is to unify `UnresolvedType.findGenerics` and `UnresolvedType.resolveFeature` into one single method that is performed in one pass.  This is a first, but big step that modifies `findGeneric` to use `lookupType`.

`AbstractFeature.getGeneric` has been removed.  New methods `AbstractFeature.generic` and `AbstractFeature.genericType` are added, but not as a replacement, but as a first steop to remove class `Generic`.

`findGenerics` now requires a `Resolution` argument, which hence has been added to a couple of methods that end up calling `findGenerics`. `Feature.findGenerics` was moved to `Resolution.findGenerics` for the same reason.

There are several semantic changes:

- Equally named type parameters in inner and outer features are still permitted, but they cause an error when used since the use is ambiguous. Disambiguation using `x.this.T` does not work yet.  Base library's `net.channel.replace.T` had to be renamed to avoid this ambiguity.

- type parameters are no longer inherited, so there is no need and it is no longer possible to `redef` an inherited type parameter that is just passed through to the parent. Base library features `cons`, `Effect_Call`, `mutatle.array`, `Mutable_Array`, `oneway_monad`, `stream`, `container.hash_map`, `container.Linked_list`, `container.Mutable_Linked_list`, `container.orderd_map`, `container.ps_map`, `container.sorted_array`, `fuzion.java.Array` were changed accordingly.

- visibility of type parameters is now taken into account, which is why `array(|2|3).T` and `Sequence.T` are now marked public (and some other type parameters in the base library should be made pulbic as well).

- Redundant (and conflicting) type parameters `cache_item.T`, `list.type.fmat.A`, `list.type.concat_monoid.A` were removed.

Tests were added to check that ambiguous type parameter accesses now result in an error (`tests/generics_negative`) and one test output was updated due to errors reported in a different order now.  Two tests had `redef` in front of type parameters that had to be removed.