### PR TITLE
lib: Make type parameters of public types public

### DIFF
--- a/lib/Cons.fz
+++ b/lib/Cons.fz
@@ -27,7 +27,7 @@
 #
 # A Cons is a ref to a cell that contains a head and a tail
 #
-public Cons(A, B type) ref is
+public Cons(public A, B type) ref is
 
   public head A is abstract
 

--- a/lib/Function.fz
+++ b/lib/Function.fz
@@ -27,7 +27,8 @@
 #
 # R is the result type of the function, A are the argument types of the function
 #
-public Function(R type, A type...) ref is
+public Function(public R type,
+                public A type...) ref is
 
   # call this function on given arguments A...
   #

--- a/lib/Lazy.fz
+++ b/lib/Lazy.fz
@@ -23,4 +23,4 @@
 
 # Lazy
 #
-public Lazy(T type) ref : Function T is
+public Lazy(public T type) ref : Function T is

--- a/lib/Monoid.fz
+++ b/lib/Monoid.fz
@@ -30,7 +30,7 @@
 # (string/concat/""), etc.
 #
 #
-public Monoid(T type /* : property.equatable */) ref
+public Monoid(public T type /* : property.equatable */) ref
 
 /* NYI: quantor intrinsics not supported yet:
 

--- a/lib/Stream.fz
+++ b/lib/Stream.fz
@@ -42,7 +42,7 @@
 # NYI: Check if stream should be replaced by a lazy list, which is a choice
 # of either nil or a tuple (head, tail). This should avoid the need to store
 # mutable state.
-public stream(T type) ref : Sequence T is
+public stream(public T type) ref : Sequence T is
 
   as_list0 option (list T) := nil
 

--- a/lib/Unary.fz
+++ b/lib/Unary.fz
@@ -28,7 +28,7 @@
 # For unary functions, function composition is possible if the result type of
 # the first function matches the argument type of the second function.
 #
-public Unary(T, U type) ref : Function T U is
+public Unary(public T, U type) ref : Function T U is
 
 
   # function composition

--- a/lib/abort.fz
+++ b/lib/abort.fz
@@ -28,4 +28,5 @@
 # contains the final value of a computation.
 # used e.g. in Sequence.reduce
 #
-public abort(T type, public val T) is
+public abort(public T type,
+             public val T) is

--- a/lib/array.fz
+++ b/lib/array.fz
@@ -31,7 +31,8 @@
 # Note: This uses dummy unit-type args to avoid
 # name clash with routine array(T,length,init).
 #
-module:public array(T type,
+module:public array(
+      public T type,
       module internal_array fuzion.sys.internal_array T,
       _ unit,
       _ unit,

--- a/lib/array2.fz
+++ b/lib/array2.fz
@@ -52,7 +52,8 @@ public array2(T type,
 # one-dimensional immutable arrays with an additional access function with
 # two index parameters.
 #
-private:public array2(T type,
+private:public array2(
+       public T type,
        public length0, length1 i32,
        redef internal_array fuzion.sys.internal_array T,
        _ unit,

--- a/lib/array3.fz
+++ b/lib/array3.fz
@@ -56,7 +56,8 @@ public array3(T type,
 # one-dimensional immutable arrays with an additional access function with
 # three index parameters.
 #
-private:public array3(T type,
+private:public array3(
+       public T type,
        public length0, length1, length2 i32,
        redef internal_array fuzion.sys.internal_array T,
        _ unit,

--- a/lib/choice.fz
+++ b/lib/choice.fz
@@ -103,7 +103,7 @@
 # A choice type with no actual generic arguments is isomorphic to 'void', i.e, it
 # is a type that has an empty set of possible values.
 #
-public choice(CHOICE_ELEMENT_TYPE type...) is
+public choice(public CHOICE_ELEMENT_TYPE type...) is
 
 #  a(X type) X
 #    pre

--- a/lib/container/Linked_List.fz
+++ b/lib/container/Linked_List.fz
@@ -23,7 +23,7 @@
 
 # abstract type for 'Linked_List'
 #
-public Linked_List(T type) ref : Sequence T is
+public Linked_List(public T type) ref : Sequence T is
 
 
   # next is the following element of the linked list, or nil if there are

--- a/lib/container/Map.fz
+++ b/lib/container/Map.fz
@@ -25,7 +25,7 @@
 
 # Map -- an abstract map from keys K to values V
 #
-public Map(K, V type) ref is
+public Map(public K, V type) ref is
 
   # number of entries in this map
   #

--- a/lib/container/Set.fz
+++ b/lib/container/Set.fz
@@ -25,7 +25,7 @@
 
 # Set -- an abstract set of values
 #
-public Set(E type : property.equatable) ref : Sequence E is
+public Set(public E type : property.equatable) ref : Sequence E is
 
 
   # is this sequence known to be finite?  For infinite sequences, features like

--- a/lib/container/ctrie.fz
+++ b/lib/container/ctrie.fz
@@ -266,7 +266,10 @@ private root_node(CTK type : property.hashable, CTV type) : choice (Indirection_
 
 
 # the ctrie
-private:public ctrie(CTK type : property.hashable, CTV type, private root concur.atomic (root_node CTK CTV), private read_only bool) : Map CTK CTV
+private:public ctrie(public CTK type : property.hashable,
+                     public CTV type,
+                     private root concur.atomic (root_node CTK CTV),
+                     private read_only bool) : Map CTK CTV
 is
 
   # the data structure as human readable string

--- a/lib/container/float_sequence.fz
+++ b/lib/container/float_sequence.fz
@@ -31,7 +31,8 @@
 
 # float_sequence -- a Sequence whose elements inherit from float
 #
-public float_sequence(F type : float, redef from Sequence F) : numeric_sequence F from is
+public float_sequence(public F type : float,
+                      redef from Sequence F) : numeric_sequence F from is
 
   # create a list from this Sequence.
   #

--- a/lib/container/hash_map.fz
+++ b/lib/container/hash_map.fz
@@ -25,8 +25,9 @@
 
 # hash_map -- an immutable hash map from keys HK to values V
 #
-public hash_map(HK type : property.hashable,
-        V type,
+public hash_map(
+        public HK type : property.hashable,
+        public V  type,
         ks array HK,
         vs array V) : Map HK V
   pre

--- a/lib/container/mutable_tree_map.fz
+++ b/lib/container/mutable_tree_map.fz
@@ -24,7 +24,10 @@
 
 # mutable_tree_map -- a mutable map using an AVL tree
 #
-private:public mutable_tree_map(LM type : mutate, KEY type : property.orderable, VAL type) : Map KEY VAL is
+private:public mutable_tree_map(public LM  type : mutate,
+                                public KEY type : property.orderable,
+                                public VAL type                      ) : Map KEY VAL
+is
 
 
   # the root entry of this map
@@ -34,7 +37,7 @@ private:public mutable_tree_map(LM type : mutate, KEY type : property.orderable,
   #
   # if this map is entry, this is nil
   #
-  private root := LM.env.new (option (Entry LM KEY VAL)) nil
+  private root := LM.env.new (option Entry) nil
 
 
   # returns the size of the map, i.e. the number of elements it contains
@@ -103,7 +106,7 @@ private:public mutable_tree_map(LM type : mutate, KEY type : property.orderable,
     # in this step, the helper feature to actually add the mapping
     # is called first. then the AVL rebalancing is done
     #
-    private put_recursively(node option (Entry LM KEY VAL)) tuple (option (Entry LM KEY VAL)) (option VAL) is
+    private put_recursively(node option Entry) tuple (option Entry) (option VAL) is
       (new_node, old_val) := insert_or_modify_entries node
       (rebalance new_node, old_val)
 
@@ -116,10 +119,10 @@ private:public mutable_tree_map(LM type : mutate, KEY type : property.orderable,
     # in this step, the actual addition of the mapping to the binary
     # tree is done, but this might violate the AVL invariants.
     #
-    private insert_or_modify_entries(node option (Entry LM KEY VAL)) tuple (option (Entry LM KEY VAL)) (option VAL) is
+    private insert_or_modify_entries(node option Entry) tuple (option Entry) (option VAL) is
       match node
         nil =>
-          new_node := Entry LM KEY VAL k v
+          new_node := Entry k v
           (option new_node, option VAL nil)
         e Entry =>
           if k < e.key
@@ -132,7 +135,7 @@ private:public mutable_tree_map(LM type : mutate, KEY type : property.orderable,
             (option e, old_val)
           else
             old_val := e.val
-            new_node := Entry LM KEY VAL k v
+            new_node := Entry k v
             new_node.left <- e.left.get
             new_node.right <- e.right.get
             (option new_node, option old_val)
@@ -156,7 +159,7 @@ private:public mutable_tree_map(LM type : mutate, KEY type : property.orderable,
     # in this step, the helper feature to actually remove the
     # mapping is called first. then the AVL rebalancing is done
     #
-    private remove_recursively(k KEY, node option (Entry LM KEY VAL)) tuple (option (Entry LM KEY VAL)) (option VAL) is
+    private remove_recursively(k KEY, node option Entry) tuple (option Entry) (option VAL) is
       (new_node, old_val) := remove_or_modify_entries k node
       (rebalance new_node, old_val)
 
@@ -167,7 +170,7 @@ private:public mutable_tree_map(LM type : mutate, KEY type : property.orderable,
     # minimal here means the node with the smallest key, by the given
     # ordering of the keys
     #
-    minimum(node option (Entry LM KEY VAL)) option (Entry LM KEY VAL) is
+    minimum(node option Entry) option Entry is
       node ? nil => nil
            | e Entry =>
              e.left.get ? nil => e
@@ -181,9 +184,9 @@ private:public mutable_tree_map(LM type : mutate, KEY type : property.orderable,
     # in this step, the actual removal of the mapping from the binary
     # tree is done, but this might violate the AVL invariants.
     #
-    private remove_or_modify_entries(k KEY, node option (Entry LM KEY VAL)) tuple (option (Entry LM KEY VAL)) (option VAL) is
+    private remove_or_modify_entries(k KEY, node option Entry) tuple (option Entry) (option VAL) is
       match node
-        nil => (option (Entry LM KEY VAL) nil, option VAL nil)
+        nil => (option Entry nil, option VAL nil)
         e Entry =>
           if k < e.key
             (node, old_val) := remove_recursively k e.left.get
@@ -203,7 +206,7 @@ private:public mutable_tree_map(LM type : mutate, KEY type : property.orderable,
                   r Entry =>
                     m := minimum e.right.get
 
-                    new_node := Entry LM KEY VAL m.get.key m.get.val
+                    new_node := Entry m.get.key m.get.val
                     new_node.left <- l
 
                     (nr, old_val) := remove_recursively m.get.key e.right.get
@@ -221,11 +224,11 @@ private:public mutable_tree_map(LM type : mutate, KEY type : property.orderable,
   # this determines the balance factor of the given node and applies
   # the appropriate rotations
   #
-  private rebalance(node option (Entry LM KEY VAL)) option (Entry LM KEY VAL) is
+  private rebalance(node option Entry) option Entry is
     # returns the height of the subtree whose root is the given
     # node, or -1 if an empty subtree is given
     #
-    private height(node option (Entry LM KEY VAL)) i32 is
+    private height(node option Entry) i32 is
       match node
         nil => -1
         e Entry => e.height.get
@@ -234,7 +237,7 @@ private:public mutable_tree_map(LM type : mutate, KEY type : property.orderable,
     # returns the (AVL) balance factor of the given node, or
     # 0 if a nil node is given
     #
-    private balance_factor(node option (Entry LM KEY VAL)) i32 is
+    private balance_factor(node option Entry) i32 is
       match node
         nil => 0
         e Entry => (height e.right.get) - (height e.left.get)
@@ -243,7 +246,7 @@ private:public mutable_tree_map(LM type : mutate, KEY type : property.orderable,
     # recalculates and updates the heights of the subtrees in the
     # subtree whose root is the given node
     #
-    private fix_height(node option (Entry LM KEY VAL)) =>
+    private fix_height(node option Entry) =>
       match node
         nil =>
         e Entry =>
@@ -255,7 +258,7 @@ private:public mutable_tree_map(LM type : mutate, KEY type : property.orderable,
 
     # rotate right at the given node
     #
-    private rotate_right(node option (Entry LM KEY VAL)) option (Entry LM KEY VAL) is
+    private rotate_right(node option Entry) option Entry is
       # because this feature is only called when the tree is out of balance,
       # i.e. the left subtree has more nodes than the right one, we can safely
       # assume here that node and node.left are not nil.
@@ -272,7 +275,7 @@ private:public mutable_tree_map(LM type : mutate, KEY type : property.orderable,
 
     # rotate left at the given node
     #
-    private rotate_left(node option (Entry LM KEY VAL)) option (Entry LM KEY VAL) is
+    private rotate_left(node option Entry) option Entry is
       # because this feature is only called when the tree is out of balance,
       # i.e. the right subtree has more nodes than the left one, we can safely
       # assume here that node and node.right are not nil.
@@ -320,8 +323,8 @@ private:public mutable_tree_map(LM type : mutate, KEY type : property.orderable,
   # f. the latter takes the last result of the computation and the node
   # currently visited and combines this information in some way.
   #
-  private fold(B type, init B, f (B, Entry LM KEY VAL) -> B) B is
-    fold0(init B, node option (Entry LM KEY VAL)) B is
+  private fold(B type, init B, f (B, Entry) -> B) B is
+    fold0(init B, node option Entry) B is
       node ? nil => init
            | n Entry => fold0 (f (fold0 init n.left.get) n) n.right.get
 

--- a/lib/container/mutable_tree_map/Entry.fz
+++ b/lib/container/mutable_tree_map/Entry.fz
@@ -24,17 +24,17 @@
 
 # Entry -- an entry of a mutable tree map
 #
-module Entry(LM type : mutate, K type : property.orderable, V type, module key K, module val V) ref is
+module Entry(module key KEY, module val VAL) ref is
 
 
   # reference to the left subtree at this entry, or, if it is empty, nil
   #
-  module left := LM.env.new (option (Entry LM K V)) nil
+  module left := LM.env.new (option Entry) nil
 
 
   # reference to the right subtree at this entry, or if it is empty, nil
   #
-  module right := LM.env.new (option (Entry LM K V)) nil
+  module right := LM.env.new (option Entry) nil
 
 
   # height of the subtree whose root is this entry
@@ -45,23 +45,23 @@ module Entry(LM type : mutate, K type : property.orderable, V type, module key K
   # get the value stored in this submap at key k, nil if k is not a key
   # in this submap
   #
-  module get(k K) option V is
+  module get(k KEY) option VAL is
     if k < key
-      left.get.bind V (e -> e.get k)
+      left.get.bind VAL (e -> e.get k)
     else if key < k
-      right.get.bind V (e -> e.get k)
+      right.get.bind VAL (e -> e.get k)
     else
       val
 
 
   # get a sequence of all key/value pairs in this Entry
   #
-  module items Sequence (tuple K V) is
+  module items Sequence (tuple KEY VAL) is
 
     head := (key, val)
 
-    tail Lazy (list (tuple K V)) := ()->
-      (left.get.map x->x.items).get (list (tuple K V)).type.empty ++
-        (right.get.map x->x.items).get (list (tuple K V)).type.empty
+    tail Lazy (list (tuple KEY VAL)) := ()->
+      (left.get.map x->x.items).get (list (tuple KEY VAL)).type.empty ++
+        (right.get.map x->x.items).get (list (tuple KEY VAL)).type.empty
 
     list head tail

--- a/lib/container/numeric_sequence.fz
+++ b/lib/container/numeric_sequence.fz
@@ -25,8 +25,10 @@
 
 # numeric_sequence -- a Sequence whose elements inherit from numeric
 #
-public numeric_sequence(N type : numeric, redef from Sequence N) : searchable_sequence N from, property.equatable is
-
+public numeric_sequence(public N type : numeric,
+                        redef from Sequence N   ) : searchable_sequence N from,
+                                                    property.equatable
+is
 
   # the arithmetic mean of the sequence
   # https://en.wikipedia.org/wiki/Arithmetic_mean

--- a/lib/container/ordered_map.fz
+++ b/lib/container/ordered_map.fz
@@ -32,8 +32,9 @@
 # performance of creation of the map is in O(n log n) where n is
 # keys.length.
 #
-public ordered_map(OK type : property.orderable,
-           V type,
+public ordered_map(
+           public OK type : property.orderable,
+           public V  type,
            ks array OK,
            vs array V) : Map OK V
   pre

--- a/lib/container/searchable_sequence.fz
+++ b/lib/container/searchable_sequence.fz
@@ -26,7 +26,9 @@
 # searchable_sequence -- a Sequence whose elements inherit from property.equatable
 #
 #
-public searchable_sequence(A type : property.equatable, from Sequence A) : Sequence A, property.equatable
+public searchable_sequence(public A type : property.equatable,
+                           from Sequence A                   ) : Sequence A,
+                                                                 property.equatable
 is
 
   # create a list from this searchable_sequence.

--- a/lib/fuzion/java.fz
+++ b/lib/fuzion/java.fz
@@ -69,7 +69,8 @@ public fuzion.java is
 
   # A Java array
   #
-  public Array(T type, private redef Java_Ref Any) ref : Sequence T, Java_Object Java_Ref
+  public Array(public T type,
+               private redef Java_Ref Any) ref : Sequence T, Java_Object Java_Ref
   is
     length                  => array_length T Array.this
     redef finite            => true

--- a/lib/io/file/open.fz
+++ b/lib/io/file/open.fz
@@ -25,7 +25,9 @@
 # effect for manipulating open files
 # T is used to distinguish several open files
 #
-module:public open(T type, private fd i64, public file_name String) : simple_effect is
+module:public open(public T type,
+                   private fd i64,
+                   public file_name String) : simple_effect is
 
   # writes the content of an array of bytes to a file opened as fd
   #

--- a/lib/list.fz
+++ b/lib/list.fz
@@ -41,7 +41,7 @@
 #
 #
 #
-public list(A type) : choice nil (Cons A (list A)), Sequence A is
+public list(public A type) : choice nil (Cons A (list A)), Sequence A is
 # NYI: #530 (review comment): The following should work but causes an error:
 # list(A type) : nil | Cons A (list A), Sequence A is
 

--- a/lib/monad.fz
+++ b/lib/monad.fz
@@ -34,7 +34,8 @@
 # applied to generic types.
 #
 #
-public monad (A type, MA type : monad A MA) is
+public monad (public A type,
+              public MA type : monad A MA) is
 
 
   # monadic operator within the same monad

--- a/lib/mutate.fz
+++ b/lib/mutate.fz
@@ -100,7 +100,7 @@ public mutate : simple_effect is
   # 'mutate' effect in the current environment
   #
   public new (
-    T type,
+    public T type,
 
     # initial value, will be updated by 'put' or 'infix <-'.
     private mutable_value T
@@ -172,8 +172,9 @@ public mutate : simple_effect is
 
   # create a mutable array.
   #
-  module:public array (# element type
-         T type,
+  module:public array (
+         # element type
+         public T type,
 
          # length of the array to create
          public length i32,
@@ -307,7 +308,7 @@ public mut(T type, v T) => mut.new T v
 
 # an interface defining a mutable array
 #
-public Mutable_Array(T type) ref : Sequence T is
+public Mutable_Array(public T type) ref : Sequence T is
 
   # add an element at the end of the sequence
   public add(t T) unit is abstract

--- a/lib/num/complex.fz
+++ b/lib/num/complex.fz
@@ -28,7 +28,8 @@
 # complex provides complex numbers based on a numeric type (e.g. f64, i32).
 # A complex number consists of a real and an imaginary part.
 #
-public complex (C type : numeric,
+public complex (
+         public C type : numeric,
          public real,    # real part
                 imag C   # imaginary part
          ) : numeric

--- a/lib/num/fraction.fz
+++ b/lib/num/fraction.fz
@@ -35,7 +35,8 @@
 # there are currently no checks or preconditions for overflows in the numerator
 # or the denominator.
 #
-public fraction(B type : integer,
+public fraction(
+         public B type : integer,
          public numerator,
                 denominator B
         ) : numeric

--- a/lib/num/matrix.fz
+++ b/lib/num/matrix.fz
@@ -27,7 +27,8 @@
 #
 # matrix provides matrix operations based on an arbitray numeric type
 #
-public matrix(M type : numeric, e array2 M) : property.equatable
+public matrix(public M type : numeric,
+              e array2 M) : property.equatable
 is
 
 

--- a/lib/num/ryu.fz
+++ b/lib/num/ryu.fz
@@ -31,7 +31,7 @@
 #
 # NYI lacks documentation
 #
-public ryū(T type : float) is
+public ryū(public T type : float) is
 
   five := T.from_u32 5
 
@@ -1006,4 +1006,3 @@ public ryū(T type : float) is
 
     if is_negative then "-" else ""
       + (if scientific_notation then scientific else full)
-

--- a/lib/num_option.fz
+++ b/lib/num_option.fz
@@ -29,9 +29,9 @@
 # value: nil.  Any operation on nil will result in nil for a
 # numeric result or false for a boolean result.
 #
-public num_option(T type : numeric) :
-  choice T nil,
-  monad T (num_option T)
+public num_option(public T type : numeric)
+  : choice T nil,
+    monad T (num_option T)
 is
 
   # Does this option contain a value of type T?

--- a/lib/option.fz
+++ b/lib/option.fz
@@ -27,9 +27,9 @@
 #
 # option represents an optional value of type T
 #
-public option(T type) :
-  choice T nil,
-  monad T (option T)
+public option(public T type)
+  : choice T nil,
+    monad T (option T)
 is
 
   # Does this option contain a value of type T?

--- a/lib/outcome.fz
+++ b/lib/outcome.fz
@@ -49,7 +49,7 @@
 # compatible to  'outcome data IO_Error Permission_Error', so everything
 # is fine.
 #
-public outcome(T type) :
+public outcome(public T type) :
   choice T error, /* ...  NYI: this should be open generic! */
   monad T (outcome T)
 is

--- a/lib/transducer.fz
+++ b/lib/transducer.fz
@@ -43,7 +43,8 @@
 # TA   result     type
 # B    input      type
 # C    transduced type
-public transducer(TA,B,C type, td ((TA,B) -> TA) ->  (TA,C) -> TA) is
+public transducer(public TA, B, C type,
+                  td ((TA,B) -> TA) ->  (TA,C) -> TA) is
 
   # use the transducer with reducing function `rf`.
   public call(rf (TA,B) -> TA) =>

--- a/lib/try.fz
+++ b/lib/try.fz
@@ -28,7 +28,7 @@
 # try provides an operation 'raise' that immediately stops execution and
 # returns an 'error' wrapped in an 'outcome'.
 #
-public try (T type) : effect effect_mode.plain
+public try (public T type) : effect effect_mode.plain
 is
 
   # mutuable field to receive the error in case raise is called

--- a/lib/tuple.fz
+++ b/lib/tuple.fz
@@ -118,4 +118,5 @@
 # A tuple type with no actual generic arguments is isomorphic to 'unit', i.e, it
 # is a type that has only one single value: '()'.
 #
-public tuple(A type..., public values A) is
+public tuple(public A type...,
+             public values A) is


### PR DESCRIPTION
Since the lookup of type parameters now takes visibility into account this is required and caused some tests on flang.dev to fail.

Making type parameters public enables code in other modules to access these type parameters in features added, e.g.,
```
  array.show_type => say "this is an array of $T"
```
Also removed redundant type parameters in `container.mutable_tree_map.Entry` and improved some formatting.