### PR TITLE
ast/tests: join findGenerics with resolve in UnresolvedType

### DIFF
--- a/src/dev/flang/ast/AbstractFeature.java
+++ b/src/dev/flang/ast/AbstractFeature.java
@@ -443,7 +443,7 @@ public abstract class AbstractFeature extends Expr implements Comparable<Abstrac
                       {
                         if (res != null)
                           {
-                            af.visit(res.findGenerics);
+                            af.visit(res.resolveTypesOnly);
                           }
                         t = af.returnType().functionReturnType();
                       }

--- a/src/dev/flang/ast/AbstractFeature.java
+++ b/src/dev/flang/ast/AbstractFeature.java
@@ -464,7 +464,7 @@ public abstract class AbstractFeature extends Expr implements Comparable<Abstrac
   /**
    * Get instance of Generic that corresponds to this type parameter.
    *
-   * NYI: Since there is a 1-to-1 correspondance between type parameter features
+   * NYI: Since there is a 1-to-1 correspondent between type parameter features
    * and Generic we could remove Generic completely.
    *
    * @param name the name of a formal generic argument.

--- a/src/dev/flang/ast/AbstractType.java
+++ b/src/dev/flang/ast/AbstractType.java
@@ -90,38 +90,6 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
 
 
   /**
-   * Find all the types used in this that refer to formal generic arguments of
-   * this or any of this' outer classes.
-   *
-   * This is only needed for ast.Type, for fe.LibraryType
-   * this is a NOP.
-   *
-   * @param feat the root feature that contains this type.
-   *
-   * @return new type this was replaced with in case generics were found.
-   */
-  AbstractType findGenerics(Resolution res, AbstractFeature outerfeat)
-  {
-    return this;
-  }
-
-
-  /**
-   * resolve 'abc.this' within a type feature of `abc`.  This is only needed for
-   * ast.Type, for fe.LibraryType this is a NOP.
-   *
-   * @param feat the outer feature this type is declared in.
-   *
-   * @return new type in case this refers to 'abc.this', replaced by type
-   * parameter THIS#TYPE if in type feature.
-   */
-  AbstractType resolveThisType(AbstractFeature outerfeat)
-  {
-    return this;
-  }
-
-
-  /**
    * resolve this type. This is only needed for ast.Type, for fe.LibraryType
    * this is a NOP.
    *
@@ -148,25 +116,6 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
    * @param outerfeat the outer feature this type is declared in.
    */
   AbstractType resolveGenerics(HasSourcePosition pos, Resolution res, AbstractFeature outerfeat)
-  {
-    return this;
-  }
-
-
-  /**
-   * For a Type that is not a generic argument, resolve the feature of that
-   * type.  Unlike Type.resolve(), this does not check the generic arguments, so
-   * this can be used for type inferencing for the actual generics as in a match
-   * case.
-   *
-   * This is only needed for ast.Type, for fe.LibraryType this is a NOP.
-   *
-   * @param feat the outer feature this type is declared in, used for resolution
-   * of generic parameters etc.
-   *
-   * @return new type this was replaced with in case generics were found.
-   */
-  AbstractType resolveFeature(Resolution res, AbstractFeature outerfeat)
   {
     return this;
   }
@@ -200,27 +149,6 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
       (checkedForGeneric());
 
     return isGenericArgument() && genericArgument().isOpen();
-  }
-
-
-  /**
-   * Check if this.isOpenGeneric(). If so, create a compile-time error.
-   *
-   * @return true iff !isOpenGeneric()
-   */
-  public boolean ensureNotOpen(HasSourcePosition pos)
-  {
-    boolean result = true;
-
-    if (PRECONDITIONS) require
-      (checkedForGeneric());
-
-    if (isOpenGeneric())
-      {
-        AstErrors.illegalUseOfOpenFormalGeneric(pos.pos(), genericArgument());
-        result = false;
-      }
-    return result;
   }
 
 

--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -719,10 +719,13 @@ public class Call extends AbstractCall
   boolean loadCalledFeatureUnlessTargetVoid(Resolution res, AbstractFeature thiz)
   {
     var targetVoid = false;
+
     if (PRECONDITIONS) require
-      (res.state(thiz) == State.RESOLVING_INHERITANCE
+      (thiz.isTypeParameter()   // NYI: type parameters apparently inherit ANY and are not resolved yet. Type parameters should not inherit anything and this special handling should go.
+       ||
+       (res.state(thiz) == State.RESOLVING_INHERITANCE
        ? res.state(thiz.outer()).atLeast(State.RESOLVING_DECLARATIONS)
-       : res.state(thiz)        .atLeast(State.RESOLVED_DECLARATIONS));
+       : res.state(thiz)        .atLeast(State.RESOLVING_DECLARATIONS)));
 
     if (_calledFeature == null)
       {
@@ -1010,7 +1013,7 @@ public class Call extends AbstractCall
                                          _target instanceof Universe ||
                                          _target instanceof Current     ? null
                                                                         : _target.asType(res, outer, tp));
-    return result.visit(res.findGenerics, outer);
+    return result.resolve(res, outer);
   }
 
 
@@ -2219,10 +2222,10 @@ public class Call extends AbstractCall
               }
           }
         inferFormalArgTypesFromActualArgs(outer);
-        if (_calledFeature.generics().errorIfSizeOrTypeDoesNotMatch(_generics,
-                                                                    pos(),
-                                                                    "call",
-                                                                    "Called feature: "+_calledFeature.qualifiedName()+"\n"))
+        if (_calledFeature.generics().errorIfSizeDoesNotMatch(_generics,
+                                                              pos(),
+                                                              "call",
+                                                              "Called feature: "+_calledFeature.qualifiedName()+"\n"))
           {
             var cf = _calledFeature;
             var t = isTailRecursive(outer) ? Types.resolved.t_void // a tail recursive call will not return and execute further

--- a/src/dev/flang/ast/Case.java
+++ b/src/dev/flang/ast/Case.java
@@ -167,6 +167,23 @@ public class Case extends AbstractCase
     _field = f;
     _types = l;
     _code  = c;
+    if (f != null)
+      {
+        if (f.returnType().functionReturnType() instanceof UnresolvedType ut)
+          {
+            ut.doIgnoreEmptyActualTypePars();
+          }
+      }
+    if (l != null)
+      {
+        for (var t : l)
+          {
+            if (t instanceof UnresolvedType ut)
+              {
+                ut.doIgnoreEmptyActualTypePars();
+              }
+          }
+      }
   }
 
 
@@ -286,12 +303,8 @@ public class Case extends AbstractCase
     var original_t = t;
     List<AbstractType> matches = new List<>();
     int i = 0;
-    t = t.resolveFeature(res, outer);
+    t = t.resolve(res, outer);
     var inferGenerics = !t.isGenericArgument() && t.generics().isEmpty() && t.featureOfType().generics() != FormalGenerics.NONE;
-    if (!inferGenerics)
-      {
-        t = t.resolve(res, outer);
-      }
     var hasErrors = t.containsError();
     check
       (!hasErrors || Errors.any());

--- a/src/dev/flang/ast/Feature.java
+++ b/src/dev/flang/ast/Feature.java
@@ -1229,7 +1229,7 @@ public class Feature extends AbstractFeature
              * this or any of this' outer classes.
              */
             resolveArgumentTypes(res);
-            visit(res.findGenerics);
+            visit(res.resolveTypesOnly);
           }
 
         _state = State.RESOLVED_DECLARATIONS;
@@ -1324,7 +1324,7 @@ public class Feature extends AbstractFeature
         _state = State.RESOLVING_TYPES;
 
         resolveArgumentTypes(res);
-        visit(new ResolveTypes(res));
+        visit(res.resolveTypesFully);
 
         if (hasThisType())
           {
@@ -1334,7 +1334,7 @@ public class Feature extends AbstractFeature
 
         if (_impl._kind == Impl.Kind.FieldActual)
           {
-            _impl.visitInitialValues(new ResolveTypes(res));
+            _impl.visitInitialValues(res.resolveTypesFully);
           }
 
         _state = State.RESOLVED_TYPES;
@@ -2337,11 +2337,7 @@ public class Feature extends AbstractFeature
             res.resolveTypes(this);
           }
         result = resultTypeIfPresent(res);
-        if (result instanceof UnresolvedType rt)
-          {
-            // NYI try to remove this visitation with findGenerics, see PR: #2210
-            result = rt.visit(res.findGenerics,outer());
-          }
+        result = result == null ? null : result.resolve(res, outer());
         result = result == null ? null : result.applyTypePars(this, generics);
         _resultTypeIfPresentRecursion = false;
       }

--- a/src/dev/flang/ast/FormalGenerics.java
+++ b/src/dev/flang/ast/FormalGenerics.java
@@ -119,8 +119,8 @@ public class FormalGenerics extends ANY
 
 
   /**
-   * Check if the given actualGenerics match the formal generics in this. IF
-   * not, create a compiler error.
+   * Check if the number of actualGenerics match this FormalGenerics. If not,
+   * create a compiler error.
    *
    * @param actualGenerics the actual generics to check
    *
@@ -134,25 +134,23 @@ public class FormalGenerics extends ANY
    *
    * @return true iff size and type of actualGenerics does match
    */
-  public boolean errorIfSizeOrTypeDoesNotMatch(List<AbstractType> actualGenerics,
-                                               SourcePosition pos,
-                                               String detail1,
-                                               String detail2)
+  public boolean errorIfSizeDoesNotMatch(List<AbstractType> actualGenerics,
+                                         SourcePosition pos,
+                                         String detail1,
+                                         String detail2)
   {
     if (PRECONDITIONS) require
       (Errors.any() || !actualGenerics.contains(Types.t_ERROR));
 
-    boolean result = true;
-    if (!sizeMatches(actualGenerics))
+    var result = sizeMatches(actualGenerics);
+    if (!result)
       {
-        result = false;
         AstErrors.wrongNumberOfGenericArguments(this,
                                                 actualGenerics,
                                                 pos,
                                                 detail1,
                                                 detail2);
       }
-    // NYI: check that generics match the generic constraints
     return result;
   }
 

--- a/src/dev/flang/ast/OuterType.java
+++ b/src/dev/flang/ast/OuterType.java
@@ -68,7 +68,7 @@ public class OuterType extends UnresolvedType
   {
     if (PRECONDITIONS) require
       (outerfeat != null,
-       res.state(outerfeat).atLeast(State.RESOLVED_DECLARATIONS));
+       res.state(outerfeat).atLeast(State.RESOLVING_DECLARATIONS));
 
     return outerfeat.outer().thisType(false);
   }

--- a/src/dev/flang/ast/Resolution.java
+++ b/src/dev/flang/ast/Resolution.java
@@ -133,12 +133,23 @@ public class Resolution extends ANY
 
 
   /**
-   * FeatureVisitor to call findGenerics() on all types.
+   * FeatureVisitor to call resolve() on all types.
+   *
+   * This is used during state RESOLVING_DECLARATIONS to find called features.
    */
-  FeatureVisitor findGenerics = new FeatureVisitor()
+  FeatureVisitor resolveTypesOnly = new FeatureVisitor()
     {
-      public AbstractType action(AbstractType t, AbstractFeature outer) { return t.findGenerics(Resolution.this, outer); }
+      public AbstractType action(AbstractType t, AbstractFeature outer) { return t.resolve(Resolution.this, outer); }
     };
+
+
+  /**
+   * FeatureVisitor to call resolveTypes() on Expr-essions and resolve() on all
+   * types.
+   *
+   * This is used during state RESOLVING_TYPES.
+   */
+  FeatureVisitor resolveTypesFully = new Feature.ResolveTypes(this);
 
 
   final FuzionOptions _options;
@@ -487,8 +498,7 @@ public class Resolution extends ANY
    */
   Expr resolveType(Expr e, AbstractFeature outer)
   {
-    var rt = new Feature.ResolveTypes(this);
-    return e.visit(rt, outer);
+    return e.visit(resolveTypesFully, outer);
   }
 
 

--- a/src/dev/flang/ast/ResolvedNormalType.java
+++ b/src/dev/flang/ast/ResolvedNormalType.java
@@ -662,7 +662,7 @@ public class ResolvedNormalType extends ResolvedType
         ResolvedType _resolved = null;
 
         /**
-         * This is a bit ugly, even though this type is a ResovledType, the generics are not.
+         * This is a bit ugly, even though this type is a ResolvedType, the generics are not.
          */
         AbstractType resolve(Resolution res, AbstractFeature outerfeat)
         {

--- a/src/dev/flang/ast/ResolvedNormalType.java
+++ b/src/dev/flang/ast/ResolvedNormalType.java
@@ -579,65 +579,6 @@ public class ResolvedNormalType extends ResolvedType
 
 
   /**
-   * resolve this type
-   *
-   * @param res this is called during type resolution, res gives the resolution
-   * instance.
-   *
-   * @param feat the outer feature this type is declared in, used
-   * for resolution of generic parameters etc.
-   */
-  AbstractType resolve(Resolution res, AbstractFeature outerfeat)
-  {
-    if (PRECONDITIONS) require
-      (outerfeat != null,
-       outerfeat != null && res.state(outerfeat).atLeast(State.RESOLVED_DECLARATIONS));
-
-    // NYI: cleanup: Basically, resolution should no longer be needed here, but
-    // be done on UnresolvedType. Need to check how we can move this to
-    // Unresolvedtype.
-    var result = resolveGenerics(declarationPos(), res, outerfeat);
-    result = Types.intern(result);
-    return result;
-  }
-
-
-  /**
-   * For a normal type, resolve the actual type parameters.
-   *
-   * @param pos source code position of the unresolved types whose generics we
-   * are resolving.
-   *
-   * @param res the resolution instance
-   *
-   * @param outerfeat the outer feature this type is declared in.
-   */
-  AbstractType resolveGenerics(HasSourcePosition pos, Resolution res, AbstractFeature outerfeat)
-  {
-    AbstractType result = this;
-    if (isThisType() && _generics.isEmpty())
-      {
-        this._generics = _feature.generics().asActuals();
-        this._generics.freeze();
-      }
-    this._generics = FormalGenerics.resolve(res, _generics, outerfeat);
-    this._generics.freeze();
-    if (CHECKS) check
-      (Errors.any() || _feature != null);
-    if (result.containsError() ||
-        _feature != null &&
-        !_feature.generics().errorIfSizeOrTypeDoesNotMatch(_generics,
-                                                           pos.pos(),
-                                                           "type",
-                                                           "Type: " + toString() + "\n"))
-      {
-        result = Types.t_ERROR;
-      }
-    return result;
-  }
-
-
-  /**
    * For a resolved normal type, return the underlying feature.
    *
    * @return the underlying feature.
@@ -711,13 +652,28 @@ public class ResolvedNormalType extends ResolvedType
    */
   AbstractType clone(AbstractFeature originalOuterFeature)
   {
-    return (ResolvedNormalType)Types.intern(
+    return (ResolvedNormalType) Types.intern(
       new ResolvedNormalType(this, originalOuterFeature)
       {
         AbstractFeature originalOuterFeature(AbstractFeature currentOuter)
         {
           return originalOuterFeature;
         }
+        ResolvedType _resolved = null;
+
+        /**
+         * This is a bit ugly, even though this type is a ResovledType, the generics are not.
+         */
+        AbstractType resolve(Resolution res, AbstractFeature outerfeat)
+        {
+          if (_resolved == null)
+            {
+              _resolved = UnresolvedType.finishResolve(res, outerfeat, this, declarationPos(), _feature, _generics, unresolvedGenerics(), outer(), _refOrVal, false);
+            }
+          return _resolved;
+        }
+
+
       });
   }
 

--- a/src/dev/flang/ast/SrcModule.java
+++ b/src/dev/flang/ast/SrcModule.java
@@ -69,7 +69,7 @@ public interface SrcModule
   void findDeclaredOrInheritedFeatures(Feature outer);
   List<FeatureAndOuter> lookup(AbstractFeature thiz, String name, Expr use, boolean traverseOuter, boolean hidden);
   void checkTypes(Feature f);
-  FeatureAndOuter lookupType(SourcePosition pos, AbstractFeature outer, String name, boolean traverseOuter, boolean ignoreNotFound, boolean mayBeOpen);
+  FeatureAndOuter lookupType(SourcePosition pos, AbstractFeature outer, String name, boolean traverseOuter, boolean ignoreNotFound);
 
   void addTypeFeature(AbstractFeature outerType,
                       Feature         innerType);

--- a/src/dev/flang/ast/Types.java
+++ b/src/dev/flang/ast/Types.java
@@ -111,7 +111,7 @@ public class Types extends ANY
   public static AbstractType t_UNDEFINED;
 
   /* artificial type for Expr with unknown type due to compilation error */
-  public static AbstractType t_ERROR;
+  public static ResolvedType t_ERROR;
 
   /* artificial feature used when feature is not known due to compilation error */
   public static Feature f_ERROR = new Feature(true);

--- a/src/dev/flang/ast/UnresolvedType.java
+++ b/src/dev/flang/ast/UnresolvedType.java
@@ -140,7 +140,7 @@ public abstract class UnresolvedType extends AbstractType implements HasSourcePo
 
   /**
    * If set, resolution of this type should not check if the actual type
-   * parameters are valid.  This is set for types usind in a match case when the
+   * parameters are valid.  This is set for types used in a match case when the
    * actual type parameters are inferred from the subject type as in
    *
    *   x list i32 := [1,2,3].as_list
@@ -735,7 +735,7 @@ public abstract class UnresolvedType extends AbstractType implements HasSourcePo
 
 
   /**
-   * Called by Case.java for case entries that may infer atual type parameters
+   * Called by Case.java for case entries that may infer actual type parameters
    * from the subjects.
    */
   void doIgnoreEmptyActualTypePars()

--- a/src/dev/flang/ast/UnresolvedType.java
+++ b/src/dev/flang/ast/UnresolvedType.java
@@ -139,6 +139,21 @@ public abstract class UnresolvedType extends AbstractType implements HasSourcePo
 
 
   /**
+   * If set, resolution of this type should not check if the actual type
+   * parameters are valid.  This is set for types usind in a match case when the
+   * actual type parameters are inferred from the subject type as in
+   *
+   *   x list i32 := [1,2,3].as_list
+   *   match x
+   *     c Cons => ...
+   *     nil    => ...
+   *
+   *  where `Cons` stands for `Cons i32 (list i32)`.
+   */
+  boolean _ignoreActualTypePars = false;
+
+
+  /**
    * Once this unresolved type was resolved into a ResolvedParametricType or
    * ResolvedNormalType, this will be set to the resolution result to avoid
    * repeated resolution.
@@ -181,7 +196,7 @@ public abstract class UnresolvedType extends AbstractType implements HasSourcePo
     if (PRECONDITIONS) require
       (Errors.any() ||  (t.generics() instanceof FormalGenerics.AsActuals   ) || t.generics().size() == g.size(),
        Errors.any() || !(t.generics() instanceof FormalGenerics.AsActuals aa) || aa.sizeMatches(g),
-        t == Types.t_ERROR || (t.outer() == null) == (o == null));
+       (t.outer() == null) == (o == null));
   }
 
 
@@ -474,11 +489,7 @@ public abstract class UnresolvedType extends AbstractType implements HasSourcePo
   {
     String result;
 
-    if (this == Types.t_ERROR)
-      {
-        result = Errors.ERROR_STRING;
-      }
-    else if (Types.INTERNAL_NAMES.contains(_name))
+    if (Types.INTERNAL_NAMES.contains(_name))
       {
         result = _name;
       }
@@ -525,69 +536,211 @@ public abstract class UnresolvedType extends AbstractType implements HasSourcePo
 
 
   /**
-   * Find all the types used in this that refer to formal generic arguments of
-   * this or any of this' outer classes.
+   * resolve this type, i.e., find or create the corresponding instance of
+   * ResolvedType of this and all outer types and type arguments this depends on.
    *
-   * @param feat the root feature that contains this type.
+   * @param res this is called during type resolution, res gives the resolution
+   * instance.
    *
-   * @return this type with all generic arguments that were found replaced by
-   * instances of TypeParameter.
+   * @param feat the outer feature this type is declared in. Lookup of
+   * unqualified types will happen in this feature.
    */
-  AbstractType findGenerics(Resolution res, AbstractFeature outerfeat)
+  AbstractType resolve(Resolution res, AbstractFeature outerfeat)
   {
     if (PRECONDITIONS) require
-      (res != null);
+      (res != null,
+       outerfeat != null);
 
-    // NYI   if (PRECONDITIONS) require
-    //      (!outerfeat.state().atLeast(Feature.State.RESOLVED_DECLARATIONS));
+    res.resolveDeclarations(outerfeat);
 
-    AbstractType result = this;
-    var ot = outer();
-    if (ot != null)
+    if (CHECKS) check
+      (outerfeat.state().atLeast(State.RESOLVING_DECLARATIONS));
+
+    if (_resolved == null)
       {
-        if (ot.isGenericArgument())
-          {
-            AstErrors.formalGenericAsOuterType(pos(), this);
-          }
-      }
-    else if (!(this instanceof BuiltInType))
-      {
-        Generic generic = null;
         if (!outerfeat.state().atLeast(State.RESOLVING_DECLARATIONS))
           {
             res.resolveDeclarations(outerfeat);
           }
-        if (outerfeat.state().atLeast(State.RESOLVING_DECLARATIONS) || outerfeat.isUniverse())
-          {
-            var fo = res._module.lookupType(pos(), outerfeat, _name, ot == null && _name != FuzionConstants.TYPE_FEATURE_THIS_TYPE, true, true);
-            if (fo != null && fo._feature.isTypeParameter())
-              {
-                generic = fo._feature.generic();
-              }
-          }
-        if (generic != null)
-          {
-            result = generic.type();
-            if (!_generics.isEmpty())
-              {
-                AstErrors.formalGenericWithGenericArgs(pos(), this, generic);
-              }
-
-            if (!(outerfeat instanceof Feature of && (of.isLastArgType(this) || of.isLastArgType(result))))
-              {
-                result.ensureNotOpen(pos());
-              }
-
-            _resolved = result;
-          }
       }
-    if (result == this)
+    if (_resolved == null)
       {
-        _generics = _generics.map(t -> t.findGenerics(res, outerfeat));
-        _generics.freeze();
+        _resolved = resolveThisType(res, outerfeat);
+      }
+    if (_resolved == null)
+      {
+        var of = outerfeat;
+        var o = _outer;
+        var inTypeFeature = false;
+        if (o != null && !o.isThisType())
+          {
+            o = o.resolve(res, of);
+            var ot2 = o.isGenericArgument() ? o.genericArgument().constraint(res) // see tests/reg_issue1943 for examples
+                                            : o;
+            of = ot2.featureOfType();
+          }
+        else
+          {
+            inTypeFeature = of != originalOuterFeature(of);
+          }
+
+        var ot = outer();
+        if (ot != null && ot.isGenericArgument())
+          {
+            AstErrors.formalGenericAsOuterType(pos(), this);
+          }
+
+        var mayBeFreeType = mayBeFreeType() && outerfeat.isValueArgument();
+
+        if (_resolved == null)
+          {
+            var traverseOuter = ot == null && _name != FuzionConstants.TYPE_FEATURE_THIS_TYPE;
+            var fo = res._module.lookupType(pos(), of, _name, traverseOuter, mayBeFreeType || inTypeFeature);
+            if (_resolved == null && (fo == null || !fo._feature.isTypeParameter() && inTypeFeature))
+              { // if we are in a type feature, type lookup happens in the
+                // original feature, except for type parameters that we just
+                // checked in the type feature (of).
+                of = originalOuterFeature(of);
+                fo = res._module.lookupType(pos(), of, _name, traverseOuter, mayBeFreeType);
+              }
+            if (_resolved == null)
+              {
+                if (fo == FeatureAndOuter.ERROR)
+                  {
+                    _resolved = Types.t_ERROR;
+                  }
+                else if (fo == null)
+                  {
+                    _resolved = addAsFreeType(res, outerfeat);
+                  }
+                else if (isFreeType())
+                  {
+                    AstErrors.freeTypeMustNotMaskExistingType(this, fo._feature);
+                    _resolved = Types.t_ERROR;
+                  }
+                else
+                  {
+                    var f = fo._feature;
+                    var generics = generics();
+                    if (o == null && f.isTypeParameter())
+                      {
+                        if (!generics.isEmpty())
+                          {
+                            AstErrors.formalGenericWithGenericArgs(pos(), this, f.generic());
+                          }
+                        var gt = f.genericType();
+                        if (gt.isOpenGeneric() && !(outerfeat instanceof Feature off && off.isLastArgType(this)))
+                          {
+                            AstErrors.illegalUseOfOpenFormalGeneric(pos(), gt.genericArgument());
+                            _resolved = Types.t_ERROR;
+                          }
+                        else
+                          {
+                            _resolved = gt;
+                          }
+                      }
+                    else
+                      {
+                        if (o == null && !fo._outer.isUniverse())
+                          {
+                            o = fo._outer.thisType(fo.isNextInnerFixed());
+                          }
+                        _resolved = finishResolve(res, outerfeat, this, this, f, generics, generics(), o, _refOrVal, _ignoreActualTypePars);
+                      }
+                  }
+              }
+          }
+      }
+    return _resolved;
+  }
+
+
+  /**
+   * Perform the last steps of resolve() for a normal type (not a type
+   * parameter).
+   *
+   *  - if refOrVal is ThisType, set generics to the formal generics used as
+   *    actuals.
+   *
+   *  - otherwise, resolve the formal generics and check that their number
+   *    matches what is required
+   *
+   * Finally, create instance of ResolvedNomralType
+   *
+   * @param res The resolution instance
+   *
+   * @param outerfeat the feature that contains this type
+   *
+   * @param thiz the original, unresolved type. Used for error reporting.
+   *
+   * @param pos the position of this type, used for error reporting.
+   *
+   * @param f the features this type is built from
+   *
+   * @param generics the actual type parameters
+   *
+   * @param unresolvedGenerics the original, unresolved actual type
+   * parameters. Used for error reporting to obtain the original source code
+   * position.
+   *
+   * @param o the resolved outer type
+   *
+   * @param refOrVal Select the type variant: value, boxed, thisType
+   *
+   * @param ignoreActualTypePars if true no errors will be reported in case the
+   * number of actual type parameters does not match the formal type parameters.
+   *
+   * @return an instance of ResolvedNormalType representing the given type.
+   */
+  static ResolvedType finishResolve(Resolution res,
+                                    AbstractFeature outerfeat,
+                                    AbstractType thiz,
+                                    HasSourcePosition pos,
+                                    AbstractFeature f,
+                                    List<AbstractType> generics,
+                                    List<AbstractType> unresolvedGenerics,
+                                    AbstractType o,
+                                    RefOrVal refOrVal,
+                                    boolean ignoreActualTypePars)
+  {
+    if (!ignoreActualTypePars)
+      {
+        if (refOrVal == RefOrVal.ThisType && generics.isEmpty())
+          {
+            generics = f.generics().asActuals();
+          }
+        else
+          {
+            generics = FormalGenerics.resolve(res, generics, outerfeat);
+            if (!f.generics().errorIfSizeDoesNotMatch(generics,
+                                                      pos.pos(),
+                                                      "type",
+                                                      "Type: " + thiz.toString() + "\n"))
+              {
+                f = Types.f_ERROR;
+              }
+          }
+        generics.freeze();
       }
 
-    return result;
+    return
+      f == Types.f_ERROR ? Types.t_ERROR
+                         : ResolvedNormalType.create(generics,
+                                                     unresolvedGenerics,
+                                                     o,
+                                                     f,
+                                                     refOrVal,
+                                                     false);
+  }
+
+
+  /**
+   * Called by Case.java for case entries that may infer atual type parameters
+   * from the subjects.
+   */
+  void doIgnoreEmptyActualTypePars()
+  {
+    _ignoreActualTypePars = _generics.isEmpty();
   }
 
 
@@ -605,9 +758,13 @@ public abstract class UnresolvedType extends AbstractType implements HasSourcePo
    *   a.type.b.type.c.d
    *
    * then we replace 'b.this.type' by the type parameter of a.b.type.
+   *
    * @param res
    *
    * @param outerfeat the outer feature this type is declared in.
+   *
+   * @return null if no matching this type was found, the resolved type
+   * otherwise.
    */
   AbstractType resolveThisType(Resolution res, AbstractFeature outerfeat)
   {
@@ -615,7 +772,7 @@ public abstract class UnresolvedType extends AbstractType implements HasSourcePo
       (outerfeat != null,
        outerfeat != null && res.state(outerfeat).atLeast(State.RESOLVING_DECLARATIONS));
 
-    AbstractType result = this;
+    AbstractType result = null;
     var o = outerfeat;
     while (isThisType() && o != null)
       {
@@ -647,133 +804,6 @@ public abstract class UnresolvedType extends AbstractType implements HasSourcePo
        (_outer instanceof UnresolvedType ot                   &&
         !ot.isThisType()                            &&
         ot.isMatchingTypeFeature(outerfeat.outer())   )    );
-  }
-
-
-  /**
-   * resolve this type
-   *
-   * @param res this is called during type resolution, res gives the resolution
-   * instance.
-   *
-   * @param feat the outer feature this type is declared in, used
-   * for resolution of generic parameters etc.
-   */
-  AbstractType resolve(Resolution res, AbstractFeature outerfeat)
-  {
-    if (PRECONDITIONS) require
-      (outerfeat != null,
-       outerfeat != null && res.state(outerfeat).atLeast(State.RESOLVING_DECLARATIONS));
-
-    AbstractType result = resolveThisType(res, outerfeat);
-    if (result == this)
-      {
-        result = findGenerics(res, outerfeat);
-        if (!(outerfeat instanceof Feature of && of.isLastArgType(this)))
-          {
-            result.ensureNotOpen(pos());
-          }
-        if (result == this)
-          {
-            result = resolveFeature(res, outerfeat);
-            result = result.resolveGenerics(this, res, outerfeat);
-          }
-      }
-    return result;
-  }
-
-
-  /**
-   * For a Type that is not a generic argument, resolve the feature of that
-   * type.  Unlike Type.resolve(), this does not check the generic arguments, so
-   * this can be used for type inferencing for the actual generics as in a match
-   * case.
-   *
-   * @param feat the outer feature this type is declared in, used
-   * for resolution of generic parameters etc.
-   */
-  AbstractType resolveFeature(Resolution res, AbstractFeature outerfeat)
-  {
-    if (PRECONDITIONS) require
-      (outerfeat != null,
-       outerfeat != null && res.state(outerfeat).atLeast(State.RESOLVED_DECLARATIONS));
-
-    findGenerics(res, outerfeat);
-    if (_resolved == null)
-      {
-        AbstractType result = null;
-        var of = originalOuterFeature(outerfeat);
-        var o = _outer;
-        if (o != null && !isThisType() && !o.isThisType())
-          {
-            o = o.resolve(res, of);
-            var ot = o.isGenericArgument() ? o.genericArgument().constraint(res) // see tests/reg_issue1943 for examples
-                                           : o;
-            of = ot.featureOfType();
-          }
-        AbstractFeature f = Types.f_ERROR;
-        if (this instanceof QualThisType q)
-          {
-            // resolve the feature for a type `a.this.type`, so `a` has to be one of the outer features.
-            f = This.getThisFeature(pos(), this, q._qual, of.isTypeFeature() ? of.typeFeatureOrigin() : of);
-            var f0o = f.outer();
-            o = f0o == null || f0o.isUniverse() ? null : f0o.thisType(false);
-          }
-        else
-          {
-            if (CHECKS) check
-              (!isThisType());
-            var mayBeFreeType = mayBeFreeType() && outerfeat.isValueArgument();
-            var fo = res._module.lookupType(pos(), of, _name, o == null, mayBeFreeType, false);
-            if (fo == null)
-              {
-                result = addAsFreeType(res, outerfeat);
-              }
-            else if (isFreeType())
-              {
-                AstErrors.freeTypeMustNotMaskExistingType(this, fo._feature);
-              }
-            else
-              {
-                f = fo._feature;
-                if (o == null && f.isTypeParameter())
-                  {
-                    var generic = f.generic();
-                    if (!_generics.isEmpty())
-                      {
-                        AstErrors.formalGenericWithGenericArgs(pos(), this, generic);
-                      }
-                    var results = f.outer().handDown(res, new AbstractType[] { generic.type() }, of);
-
-                    if (CHECKS) check
-                      (!f.isOpenTypeParameter(), // lookupType would not give us an open type parameter
-                       results.length == 1);     // a non-open type parameter results in exactly one type
-
-                    result = results[0];
-                  }
-                else if (o == null && !fo._outer.isUniverse())
-                  {
-                    o = fo._outer.thisType(fo.isNextInnerFixed());
-                  }
-              }
-          }
-        _outer = o;
-
-        _resolved =
-          result != null     ? result :
-          f == Types.f_ERROR ? Types.t_ERROR
-                             : ResolvedNormalType.create(generics(),
-                                                      unresolvedGenerics(),
-                                                      o,
-                                                      f,
-                                                      _refOrVal,
-                                                      false);
-      }
-    if (!(outerfeat instanceof Feature of && of.isLastArgType(this)))
-      {
-        _resolved.ensureNotOpen(pos());
-      }
-    return _resolved;
   }
 
 

--- a/src/dev/flang/fe/SourceModule.java
+++ b/src/dev/flang/fe/SourceModule.java
@@ -251,7 +251,7 @@ public class SourceModule extends Module implements SrcModule, MirModule
         new Types.Resolved(this,
                            (name) ->
                              {
-                               return lookupType(SourcePosition.builtIn, _universe, name, false)
+                               return lookupType(SourcePosition.builtIn, _universe, name, false, false)
                                 ._feature
                                 .selfType();
                              },
@@ -507,7 +507,7 @@ public class SourceModule extends Module implements SrcModule, MirModule
          var q = inner._qname;
          var n = q.get(at);
          var o =
-           n != FuzionConstants.TYPE_NAME ? lookupType(inner.pos(), outer, n, at == 0)._feature
+           n != FuzionConstants.TYPE_NAME ? lookupType(inner.pos(), outer, n, at == 0, false)._feature
                                           : outer.typeFeature(_res);
          if (at < q.size()-2)
            {
@@ -1108,35 +1108,6 @@ public class SourceModule extends Module implements SrcModule, MirModule
    * (i.e., use is qualified with outer).
    *
    * @return FeatureAndOuter tuple of the found type's declaring feature,
-   * FeatureAndOuter.ERROR in case of an error.
-   */
-  public FeatureAndOuter lookupType(SourcePosition pos, AbstractFeature outer, String name, boolean traverseOuter)
-  {
-    return lookupType(pos, outer, name, traverseOuter, false, false);
-  }
-
-
-  /**
-   * Lookup the feature that is referenced in a non-generic type.  There might
-   * be several features with the given name and different argument counts.
-   * Then, only the feature that is a constructor defines the type.
-   *
-   * If there are several such constructors, the type is ambiguous and an error
-   * will be produced.
-   *
-   * Also, if there is no such type, an error will be produced.
-   *
-   * @param pos the position of the type.
-   *
-   * @param outer the outer feature of the type
-   *
-   * @param name the name of the type
-   *
-   * @param traverseOuter true to collect all the features found in outer and
-   * outer's outer (i.e., use is unqualified), false to search in outer only
-   * (i.e., use is qualified with outer).
-   *
-   * @return FeatureAndOuter tuple of the found type's declaring feature,
    * FeatureAndOuter.ERROR in case of an error, null in case no type was found
    * and ignoreNotFound is true.
    */
@@ -1144,8 +1115,7 @@ public class SourceModule extends Module implements SrcModule, MirModule
                                     AbstractFeature outer,
                                     String name,
                                     boolean traverseOuter,
-                                    boolean ignoreNotFound,
-                                    boolean mayBeOpen)
+                                    boolean ignoreNotFound)
   {
     if (PRECONDITIONS) require
       (Errors.any() || outer != Types.f_ERROR);
@@ -1162,8 +1132,7 @@ public class SourceModule extends Module implements SrcModule, MirModule
             var f = fo._feature;
             if (typeVisible(pos._sourceFile, f, true))
               {
-                if (f.definesType() ||
-                    f.isTypeParameter() && (mayBeOpen || !f.isOpenTypeParameter()))
+                if (f.definesType() || f.isTypeParameter())
                   {
                     type_fs.add(f);
                     result = fo;

--- a/tests/generics_negative/generics_negative.fz
+++ b/tests/generics_negative/generics_negative.fz
@@ -175,10 +175,10 @@ generics_negative is
     x.f 3 true 5
     x.f "String" false 7  // 47. should flag an error: incompatible argument #1
     x.f 4 3 7             // 48. should flag an error: incompatible argument #2
-    x.f 4 false "false"   // 49. should flag an error: incompatible argument #3
+    x.f 4 false "false"   // 49.a should flag an error: incompatible argument #3
     y F i32 bool i32 := x
     y.f 3 true 5
-    y.f "String" false 8  // 49. should flag an error: incompatible argument #1
+    y.f "String" false 8  // 49.b should flag an error: incompatible argument #1
     y.f 9 10 8            // 50. should flag an error: incompatible argument #2
     y.f 9 false "8"       // 51. should flag an error: incompatible argument #3
   opengenerics12

--- a/tests/reg_issue309_check_constraints_of_types/issue309.fz
+++ b/tests/reg_issue309_check_constraints_of_types/issue309.fz
@@ -26,9 +26,9 @@
 
 issue309 is
   a is
-  b Set a is abstract          // 1. should flag an error: Incompatible type parameter
+  b container.Set a is abstract          // 1. should flag an error: Incompatible type parameter
 
-  b(T type) Set T is abstract  // 2. should flag an error: Incompatible type parameter
+  b(T type) container.Set T is abstract  // 2. should flag an error: Incompatible type parameter
 
   c(T type : property.equatable) is
   d c a is abstract            // 3. should flag an error: Incompatible type parameter

--- a/tests/visibility_modules_negative/main.fz.expected_err
+++ b/tests/visibility_modules_negative/main.fz.expected_err
@@ -1,5 +1,14 @@
 
---CURDIR--/main.fz:67:5: error 1: Could not find called feature
+--CURDIR--/main.fz:54:22: error 1: Type not found
+  priv3 : Sequence a.mod is // should flag an error a.mod is not visible in this file
+---------------------^^^
+Type 'mod' was not found, no corresponding feature nor formal type parameter exists
+Type that was not found: 'mod'
+in feature: 'a'
+To solve this, check the spelling of the type you have used.
+
+
+--CURDIR--/main.fz:67:5: error 2: Could not find called feature
   b.mod_pub // should flag an error should not be callable
 ----^^^^^^^
 Feature not found: 'mod_pub' (no arguments)
@@ -8,15 +17,6 @@ In call: 'b.mod_pub'
 To solve this, you might change the visibility of the feature 'mod_pub' (no arguments) at $FUZION/lib/b.fz:26:17:
   module:public mod_pub is
 ----------------^
-
-
---CURDIR--/main.fz:54:22: error 2: Type not found
-  priv3 : Sequence a.mod is // should flag an error a.mod is not visible in this file
----------------------^^^
-Type 'mod' was not found, no corresponding feature nor formal type parameter exists
-Type that was not found: 'mod'
-in feature: 'a'
-To solve this, check the spelling of the type you have used.
 
 
 --CURDIR--/main.fz:28:18: error 3: Feature specifying type visibility does not define a type.


### PR DESCRIPTION
This is a major cleanup of the spaghetti style code that performs type resolution.  Methods `findGenerics` and `resolveFeature` are now both part for `UnresolvedType.resolve` and no longer needed in `AbstractType`.

Other methods like `AbstractType.resolveThisType`, `AbstractType.ensureNotOpen`, `ResolvedNomralType.resolve`, `ResolvedNormalType.resolveGenerics` and one varaint of `SourceModule.lookupType` could also be removed.

One important special handling remains after this patch: For type inference within match cases, a `clone()` of a partially resolved `ResolvedNormalType` is created that later gets its actual type parameters resolved.

Tests were changed as follows:

- Added `a` and `b` to the error case `49` in `tests/generics_negative` since that case appeared twice.

- Fixed undesired compilation errors in `tests/reg_issue309` since `Set` was moved to `container.Set`.

- Updated expected error output for `tests/visibility_modules_negative` sice the order of visibility checks for types has changed.