### PR TITLE
be/c: add clazz id in comment for structs

### DIFF
--- a/src/dev/flang/be/c/CTypes.java
+++ b/src/dev/flang/be/c/CTypes.java
@@ -267,7 +267,7 @@ public class CTypes extends ANY
     CStmnt result = CStmnt.EMPTY;
     if (needsTypeDeclaration(cl))
       {
-        var l = new List<CStmnt>(CStmnt.lineComment("for " + _fuir.clazzAsStringNew(cl)));
+        var l = new List<CStmnt>(CStmnt.lineComment("for clazz#" + _fuir.clazzId2num(cl) + ": " + _fuir.clazzAsStringNew(cl)));
         var els = new List<CStmnt>();
         if (_fuir.clazzIsRef(cl))
           {


### PR DESCRIPTION
```
// for clazz#1: value Any
struct fzT_Any
{
};
// for clazz#0: Any
struct fzT__RAny
{
  uint32_t clazzId;
  fzT_Any fields;
};
// for clazz#5324: (exit.#type#1 exit).default_exit_handler#0
struct fzT__L5324exit_oHtyp__u_handler
{
};
...
```