### PR TITLE
air: replace Clazz.actualClazz by Clazz.handDown(), fix #2214

### DIFF
--- a/src/dev/flang/air/Clazz.java
+++ b/src/dev/flang/air/Clazz.java
@@ -2374,7 +2374,7 @@ public class Clazz extends ANY implements Comparable<Clazz>
 
 
   /**
-   * Hnd down a list of types along a given inheritance chain.
+   * Hand down a list of types along a given inheritance chain.
    *
    * @param tl the original list of types to be handed down
    *

--- a/src/dev/flang/air/Clazz.java
+++ b/src/dev/flang/air/Clazz.java
@@ -483,7 +483,7 @@ public class Clazz extends ANY implements Comparable<Clazz>
       }
     else
       {
-        var t = actualType(f.selfType()).asRef();
+        var t = this._type.actualType(f.selfType()).asRef();
         return normalize2(t);
       }
   }
@@ -557,7 +557,9 @@ public class Clazz extends ANY implements Comparable<Clazz>
     for (var p: feature().inherits())
       {
         var pt = p.type();
-        var pc = actualClazz(isRef() && pt != Types.resolved.t_void ? pt.asRef() : pt.asValue());
+        var t1 = isRef() && pt != Types.resolved.t_void ? pt.asRef() : pt.asValue();
+        var t2 = _type.actualType(t1);
+        var pc = Clazzes.clazz(t2);
         if (CHECKS) check
           (Errors.any() || pc.isVoidType() || isRef() == pc.isRef());
         result.add(pc);
@@ -595,71 +597,6 @@ public class Clazz extends ANY implements Comparable<Clazz>
         _parents = result;
       }
     return result;
-  }
-
-
-  /**
-   * Convert a given type to the actual type within this class. An
-   * actual type does not refer to any formal generic arguments.
-   *
-   * @param t the original type
-   */
-  public AbstractType actualType(AbstractType t)
-  {
-    if (PRECONDITIONS) require
-      (t != null,
-       Errors.any() || !t.isOpenGeneric());
-
-    return actualType(t, -1);
-  }
-
-
-  /**
-   * Convert a given type to the actual type within this class. An
-   * actual type does not refer to any formal generic arguments.
-   *
-   * @param t the original type
-   *
-   * @param select specifies the actual type parameter in case
-   * t.isOpenGeneric().
-   */
-  public AbstractType actualType(AbstractType t, int select)
-  {
-    if (PRECONDITIONS) require
-      (t != null,
-       Errors.any() || ((select >= 0) == t.isOpenGeneric()));
-
-    if (t.isOpenGeneric())
-      {
-        var types = replaceOpen(t, feature());
-        if (CHECKS) check
-          (Errors.any() || select >= 0 && select < types.size());
-        t = 0 <= select && select < types.size() ? types.get(select) : Types.t_ERROR;
-      }
-
-    t = this._type.actualType(t);
-    if (this._outer != null)
-      {
-        t = this._outer.actualType(t);
-      }
-    return t;
-  }
-
-
-  /**
-   * Convert a given type to the actual runtime clazz within this class. The
-   * formal generics arguments will first be replaced via actualType(t), and the
-   * Clazz will be created from the result.
-   *
-   * @param t the original type
-   */
-  public Clazz actualClazz(AbstractType t)
-  {
-    if (PRECONDITIONS) require
-      (t != null,
-       Errors.any() || !t.isOpenGeneric());
-
-    return Clazzes.clazz(actualType(t));
   }
 
 
@@ -1169,7 +1106,6 @@ public class Clazz extends ANY implements Comparable<Clazz>
             t = f.selfType();   // e.g., `(Types.get T).T`
             if (CHECKS)
               check(Errors.any() || fa._tp.isEmpty());  // there should not be an actual type parameters to a type parameter
-            t = actualType(t);  // e.g., `(Types.get (array f64)).T`
           }
         else
           {
@@ -1189,7 +1125,6 @@ public class Clazz extends ANY implements Comparable<Clazz>
                   }
 
                 t = aaf.selfType().applyTypePars(aaf, fa._tp);
-                t = actualType(t);
               }
           }
         if (t == null)
@@ -1198,6 +1133,7 @@ public class Clazz extends ANY implements Comparable<Clazz>
           }
         else
           {
+            t = _type.actualType(t);  // e.g., `(Types.get (array f64)).T` -> `array f64`
 
 /*
   We have the following possibilities when calling a feature `f` declared in do `on`
@@ -1363,7 +1299,7 @@ public class Clazz extends ANY implements Comparable<Clazz>
       {
         result =
           field.isOuterRef() &&
-          field.outer().isOuterRefAdrOfValue() ? actualClazz(Types.t_ADDRESS)
+          field.outer().isOuterRefAdrOfValue() ? Clazzes.clazz(Types.t_ADDRESS)
                                                : lookup(new FeatureAndActuals(field), select, Clazzes.isUsedAt(field), false).resultClazz();
         if (select < 0)
           {
@@ -1504,9 +1440,9 @@ public class Clazz extends ANY implements Comparable<Clazz>
   /**
    * visit all the code in f, including inherited features, by fc.
    */
-  private void inspectCode(List<AbstractCall> inh, AbstractFeature f, AbstractFeature child)
+  private void inspectCode(List<AbstractCall> inh, AbstractFeature f)
   {
-    var fc = new EV(inh, f, child);
+    var fc = new EV(inh, f);
     f.visitExpressions(fc);
     Stream
       .concat(f.contract().req.stream(), f.contract().ens.stream())
@@ -1543,7 +1479,7 @@ public class Clazz extends ANY implements Comparable<Clazz>
             var inh1 = new List<AbstractCall>();
             inh1.add(c);
             inh1.addAll(inh);
-            inspectCode(inh1, cf, child);
+            inspectCode(inh1, cf);
           }
       }
   }
@@ -1552,27 +1488,26 @@ public class Clazz extends ANY implements Comparable<Clazz>
   class EV implements ExpressionVisitor
   {
     List<AbstractCall> _inh;
-    AbstractFeature _f, _child;
-    EV(List<AbstractCall> inh, AbstractFeature f, AbstractFeature child)
+    AbstractFeature _f;
+    EV(List<AbstractCall> inh, AbstractFeature f)
       {
         _inh = inh;
         _f = f;
-        _child = child;
       }
     public void action (Expr e)
     {
-      if      (e instanceof AbstractAssign   a) { Clazzes.findClazzes(a, Clazz.this, _inh, _child); }
-      else if (e instanceof AbstractCall     c) { Clazzes.findClazzes(c, Clazz.this, _inh, _child); }
-      else if (e instanceof AbstractConstant c) { Clazzes.findClazzes(c, Clazz.this, _inh, _child); }
-      else if (e instanceof If               i) { Clazzes.findClazzes(i, Clazz.this, _inh, _child); }
-      else if (e instanceof InlineArray      i) { Clazzes.findClazzes(i, Clazz.this, _inh, _child); }
-      else if (e instanceof Env              b) { Clazzes.findClazzes(b, Clazz.this, _inh, _child); }
-      else if (e instanceof AbstractMatch    m) { Clazzes.findClazzes(m, Clazz.this, _inh, _child); }
-      else if (e instanceof Tag              t) { Clazzes.findClazzes(t, Clazz.this, _inh, _child); }
+      if      (e instanceof AbstractAssign   a) { Clazzes.findClazzes(a, Clazz.this, _inh); }
+      else if (e instanceof AbstractCall     c) { Clazzes.findClazzes(c, Clazz.this, _inh); }
+      else if (e instanceof AbstractConstant c) { Clazzes.findClazzes(c, Clazz.this, _inh); }
+      else if (e instanceof If               i) { Clazzes.findClazzes(i, Clazz.this, _inh); }
+      else if (e instanceof InlineArray      i) { Clazzes.findClazzes(i, Clazz.this, _inh); }
+      else if (e instanceof Env              b) { Clazzes.findClazzes(b, Clazz.this, _inh); }
+      else if (e instanceof AbstractMatch    m) { Clazzes.findClazzes(m, Clazz.this, _inh); }
+      else if (e instanceof Tag              t) { Clazzes.findClazzes(t, Clazz.this, _inh); }
     }
     public void action(AbstractCase c)
     {
-      Clazzes.findClazzes(c, Clazz.this, _inh, _child);
+      Clazzes.findClazzes(c, Clazz.this, _inh);
     }
   }
 
@@ -1584,7 +1519,7 @@ public class Clazz extends ANY implements Comparable<Clazz>
     if (this._type != Types.t_ADDRESS)
       {
         var f = feature();
-        inspectCode(new List<>(), f, f);
+        inspectCode(new List<>(), f);
 
         for (AbstractFeature ff: _module.allInnerAndInheritedFeatures(f))
           {
@@ -1752,7 +1687,7 @@ public class Clazz extends ANY implements Comparable<Clazz>
         result = new ArrayList<>();
         for (var t : actualGenerics(feature().choiceGenerics()))
           {
-            result.add(actualClazz(t));
+            result.add(Clazzes.clazz(t));
           }
       }
     else
@@ -2088,7 +2023,7 @@ public class Clazz extends ANY implements Comparable<Clazz>
         // the inherits call
         if (outer == null)
           {
-            outer = Clazzes.clazz(target, this, new List<>(), feature());
+            outer = Clazzes.clazz(target, this, new List<>());
           }
         if (CHECKS) check
           (result == null || result == outer);
@@ -2281,10 +2216,10 @@ public class Clazz extends ANY implements Comparable<Clazz>
     else
       {
         var ft = f.resultType();
-        result = Clazzes.down(f.resultType(), _select, this, new List<>(), feature(), feature());
+        result = handDown(f.resultType(), _select, new List<>(), feature());
         if (result.feature().isTypeFeature())
           {
-            var ac = Clazzes.down(result._type.generics().get(0), this, new List<>(), feature(), feature());
+            var ac = handDown(result._type.generics().get(0), new List<>(), feature());
             result = ac.typeClazz();
           }
       }
@@ -2381,7 +2316,7 @@ public class Clazz extends ANY implements Comparable<Clazz>
 
                 gi = gi.featureOfType().isThisRef() ? gi.asRef() : gi.asValue();
               }
-            result[i] = actualClazz(gi);
+            result[i] = Clazzes.clazz(gi);
           }
       }
     return result;
@@ -2424,75 +2359,131 @@ public class Clazz extends ANY implements Comparable<Clazz>
   }
 
 
-  List<AbstractType> handDownAllLevels2(List<AbstractType> t0, List<AbstractCall> inh, AbstractFeature child, HasSourcePosition pos)
+  /**
+   * Helper for `handDown`: Change type `t`'s type parameters along the
+   * inheritance chain `inh`.
+   *
+   * ex: in this code
+   *
+   *    a(T type) is
+   *      x T => ...
+   *    b(U type) : a Sequence U  is
+   *    c(V type) : b option V is
+   *
+   * the result type `T` of `x` if used within `c` must be handed down via the inheritance chain
+   *
+   *    `a Sequence U'
+   *    'b option B'
+   *
+   * so it will be replaced by `Sequence (option V)`.
+   *
+   * @param t the type to hand down
+   *
+   * @param select if t is an open generic parameter, this specifies the actual
+   * argument to select.
+   *
+   * @param inh the inheritance call chain
+   *
+   * @return the type `t` as seen after inheritance
+   */
+  AbstractType handDownThroughInheritsCalls(AbstractType t, int select, List<AbstractCall> inh)
   {
-    var t = AbstractFeature.handDownStatic(inh, t0, child);
-    var o = child;
-    var oc = this;
-    while (!o.isUniverse() && o != null && oc != null &&
-            /* This case, then stop at io.out.#type vs. io.out
+    if (PRECONDITIONS) require
+      (t != null,
+       !t.isOpenGeneric() || (select >= 0),
+       inh != null);
 
-oc: (((io.#type io).out.#type io.out).default_print_handler).println of: io.Print_Handler.println false false
-oc: ((io.#type io).out.#type io.out).default_print_handler of: io.Print_Handler true true
-oc: (io.#type io).out.#type io.out of: io true true
-oc: io.#type io of: universe true true
-
-             */
-           !(oc.feature().isTypeFeature() && !o.isTypeFeature()))
+    for (AbstractCall c : inh)
       {
-        var f = oc.feature();
-        if (oc.feature().isConstructor())
-          {
-            var inh2 = oc.feature().tryFindInheritanceChain(o);
-            t = AbstractFeature.handDownStatic(inh2, t, o);
-          }
-        if (oc.feature().isConstructor()) // NYI: remove!
-          {
-            var ocf = oc;
-            var t1 = t.flatMap(x -> x.applyTypeParsNoInheritanceOpen(ocf._type));
-            var t2 = t1.map(x -> x.replace_this_type_by_actual_outer(ocf._type));
-            t = t2;
-          }
-        oc = oc.getOuter(o,pos);
-        o = o.outer();
+        t = t.applyTypeParsLocally(c.calledFeature(),
+                                   c.actualTypeParameters(), select);
       }
     return t;
   }
 
 
-  AbstractType handDownAllLevels2(AbstractType t0, List<AbstractCall> inh, AbstractFeature child, HasSourcePosition pos)
+  /**
+   * Hand down the given type along the given inheritance chain and along all
+   * inheritance chains of outer clazzes such that it has the actual type
+   * parameters in this clazz.
+   *
+   * @param t the original type
+   *
+   * @param select in case t is an open generic, the variant of the actual type
+   * that is to be chosen.  -1 otherwise.
+   *
+   * @param inh the inheritance change that brought is here. This is usually an
+   * empty list, only in case this is used in a (recursively) inlined inherits
+   * call, then inh gives the sequence of inherits calls from bottom (child) to
+   * top (parent).  E.g., in
+   *
+   *    sum(T type : numeric, a, b T) is
+   *       res := a + b
+   *
+   *    sum_of_3_and_5 : sum i32 3 5 is
+   *
+   * the type `T` used in `res := a + b` gets replaced by `i32` when this code
+   * is inlined to the constructor of `sum_of_3_and_5` via the inherits call
+   * `sum i32 3 5`.
+   *
+   * @param pos a source code position, used to report errors.
+   */
+  Clazz handDown(AbstractType t, int select, List<AbstractCall> inh, HasSourcePosition pos)
   {
-    var t = AbstractFeature.handDownStatic(inh, t0, child);
-    var o = child;
+    if (PRECONDITIONS) require
+      (t != null,
+       Errors.any() || t != Types.t_ERROR,
+       Errors.any() || (t.isOpenGeneric() == (select >= 0)),
+       pos != null);
+
+    var o = feature();
+    var t1 = handDownThroughInheritsCalls(t, select, inh);
     var oc = this;
     while (!o.isUniverse() && o != null && oc != null &&
-            /* This case, then stop at io.out.#type vs. io.out
 
-oc: (((io.#type io).out.#type io.out).default_print_handler).println of: io.Print_Handler.println false false
-oc: ((io.#type io).out.#type io.out).default_print_handler of: io.Print_Handler true true
-oc: (io.#type io).out.#type io.out of: io true true
-oc: io.#type io of: universe true true
+           /* In case of type features, we can have the following loop
 
-             */
-           !(oc.feature().isTypeFeature() && !o.isTypeFeature()))
+                oc: (((io.#type io).out.#type io.out).default_print_handler).println o: io.Print_Handler.println
+                oc: ( (io.#type io).out.#type io.out).default_print_handler          o: io.Print_Handler
+                oc:   (io.#type io).out.#type io.out                                 o: io
+                oc:    io.#type io                                                   o: universe
+
+              here, stop at (io.#type io).out.#type vs. io:
+            */
+           !(oc.feature().isTypeFeature() && !o.isTypeFeature())
+           )
       {
         var f = oc.feature();
-        if (oc.feature().isConstructor())
+        var inh2 = oc.feature().tryFindInheritanceChain(o);
+        t1 = handDownThroughInheritsCalls(t1, select, inh2);
+        t1 = t1.applyTypeParsLocally(oc._type, select);
+        if (inh2.size() > 0)
           {
-            var inh2 = oc.feature().tryFindInheritanceChain(o);
-            t = AbstractFeature.handDownStatic(inh2, t, o);
+            o = oc.feature();
           }
-        if (oc.feature().isConstructor()) // NYI: remove!
-          {
-            var t1 = t.applyTypeParsNoInheritance(oc._type);
-            var t2 = t1.replace_this_type_by_actual_outer(oc._type);
-            t = t2;
-          }
+        t1 = t1.replace_this_type_by_actual_outer(oc._type);
         oc = oc.getOuter(o,pos);
         o = o.outer();
       }
-    return t;
+
+    var t2 = replaceThisType(t1);
+    return Clazzes.clazz(t2);
   }
+
+
+  /**
+   * Convenience version of `handDown` with `select` set to `-1`.
+   */
+  Clazz handDown(AbstractType t, List<AbstractCall> inh, HasSourcePosition pos)
+  {
+    if (PRECONDITIONS) require
+      (t != null,
+       Errors.any() || t != Types.t_ERROR,
+       pos != null);
+
+    return handDown(t, -1, inh, pos);
+  }
+
 
   /**
    * For an open generic type ft find the actual type parameters within this

--- a/src/dev/flang/air/Clazzes.java
+++ b/src/dev/flang/air/Clazzes.java
@@ -718,6 +718,9 @@ public class Clazzes extends ANY
    * @param ec the expected result clazz of e
    *
    * @param outerClazz the current clazz
+   *
+   * @param inh the inherintance chain that brought the code here (in case it is
+   * an inlined inherits call).
    */
   static void propagateExpectedClazz(Expr e, Clazz ec, Clazz outerClazz, List<AbstractCall> inh)
   {
@@ -1008,10 +1011,8 @@ public class Clazzes extends ANY
   /**
    * Determine the result clazz of an Expr.
    *
-   * NYI: Temporary solution, will be replaced by dynamic calls.
-   *
-   * This is fairly inefficient compared to dynamic
-   * binding.
+   * @param inh the inherintance chain that brought the code here (in case it is
+   * an inlined inherits call).
    */
   public static Clazz clazz(Expr e, Clazz outerClazz, List<AbstractCall> inh)
   {

--- a/src/dev/flang/air/Clazzes.java
+++ b/src/dev/flang/air/Clazzes.java
@@ -1032,7 +1032,7 @@ public class Clazzes extends ANY
         var tclazz = clazz(c.target(), outerClazz, inh);
         if (tclazz != c_void.get())
           {
-            var at = AbstractFeature.handDownStatic(inh, c.actualTypeParameters(), outerClazz.feature());
+            var at = outerClazz.handDownThroughInheritsCalls(c.actualTypeParameters(), inh);
             var inner = tclazz.lookup(new FeatureAndActuals(c.calledFeature(),
                                                             outerClazz.actualGenerics(at),
                                                             false),

--- a/src/dev/flang/ast/AbstractFeature.java
+++ b/src/dev/flang/ast/AbstractFeature.java
@@ -1205,25 +1205,28 @@ public abstract class AbstractFeature extends Expr implements Comparable<Abstrac
 
         if (inh != null)
           {
-            a = AbstractFeature.handDownStatic(res, inh, a, heir);
+            a = AbstractFeature.handDownInheritance(res, inh, a, heir);
           }
       }
     return a;
   }
 
-  public static List<AbstractType> handDownStatic(List<AbstractCall> inh, List<AbstractType> a, AbstractFeature heir)
-  {
-    for (AbstractCall c : inh)
-      {
-        var f = c.calledFeature();
-        var actualTypes = c.actualTypeParameters();
-        a = a.flatMap(t -> t.isOpenGeneric()
-                           ? t.genericArgument().replaceOpen(actualTypes)
-                           : new List<>(t.applyTypePars(f, actualTypes)));
-      }
-    return a;
-  }
-  public static AbstractType[] handDownStatic(Resolution res, List<AbstractCall> inh, AbstractType[] a, AbstractFeature heir)
+
+  /**
+   * Helper for handDown() to hadn down an array of types along a given inheritance chain.
+   *
+   * @param res the resolution instance
+   *
+   * @param inh the inheritance chain from the parent down to the child
+   *
+   * @param a the original array of types that is to be handed down
+   *
+   * @param heir the feature that inherits the types
+   *
+   * @return a new array of types as they are visible in heir. The length might
+   * be different due to open type parameters being replaced by a list of types.
+   */
+  static AbstractType[] handDownInheritance(Resolution res, List<AbstractCall> inh, AbstractType[] a, AbstractFeature heir)
   {
     for (AbstractCall c : inh)
       {
@@ -1244,10 +1247,7 @@ public abstract class AbstractFeature extends Expr implements Comparable<Abstrac
             else
               {
                 var actualTypes = c.actualTypeParameters();
-                if (res != null)
-                  {
-                    actualTypes = FormalGenerics.resolve(res, actualTypes, heir);
-                  }
+                actualTypes = FormalGenerics.resolve(res, actualTypes, heir);
                 ti = ti.applyTypePars(c.calledFeature(), actualTypes);
                 a[i] = ti;
               }

--- a/src/dev/flang/ast/AbstractFeature.java
+++ b/src/dev/flang/ast/AbstractFeature.java
@@ -1205,7 +1205,26 @@ public abstract class AbstractFeature extends Expr implements Comparable<Abstrac
 
         if (inh != null)
           {
-            for (AbstractCall c : heir.findInheritanceChain(outer()))
+            a = AbstractFeature.handDownStatic(res, inh, a, heir);
+          }
+      }
+    return a;
+  }
+
+  public static AbstractType handDownStatic(List<AbstractCall> inh, AbstractType a, AbstractFeature heir)
+  {
+    return handDownStatic(null, inh, new AbstractType[] { a }, heir)[0];
+  }
+  public static List<AbstractType> handDownStatic(List<AbstractCall> inh, List<AbstractType> a, AbstractFeature heir)
+  {
+    var ar1 = a.toArray(new AbstractType[a.size()]);
+    var ar2 = handDownStatic(null, inh, ar1, heir);
+    var al = new List<AbstractType>(ar2);
+    return al;
+  }
+  public static AbstractType[] handDownStatic(Resolution res, List<AbstractCall> inh, AbstractType[] a, AbstractFeature heir)
+  {
+            for (AbstractCall c : inh)
               {
                 for (int i = 0; i < a.length; i++)
                   {
@@ -1233,10 +1252,9 @@ public abstract class AbstractFeature extends Expr implements Comparable<Abstrac
                       }
                   }
               }
-          }
-      }
-    return a;
+            return a;
   }
+
 
 
   /**
@@ -1256,7 +1274,7 @@ public abstract class AbstractFeature extends Expr implements Comparable<Abstrac
     if (PRECONDITIONS) require
       (!t.isOpenGeneric(),
        heir != null,
-       res.state(heir).atLeast(State.CHECKING_TYPES1));
+       res == null || res.state(heir).atLeast(State.CHECKING_TYPES1));
 
     var a = handDown(res, new AbstractType[] { t }, heir);
 
@@ -1268,7 +1286,7 @@ public abstract class AbstractFeature extends Expr implements Comparable<Abstrac
 
 
   /**
-   * Find the chain of inheritance calls from this to its parent f.
+   * Find the chain of inheritance calls from this to its parent ancestor.
    *
    * NYI: Repeated inheritance handling is still missing, there might be several
    * different inheritance chains, need to check if they lead to the same result

--- a/src/dev/flang/be/interpreter/Intrinsics.java
+++ b/src/dev/flang/be/interpreter/Intrinsics.java
@@ -646,12 +646,7 @@ public class Intrinsics extends ANY
         {
           String in = innerClazz.feature().qualifiedName();   // == _fuir.clazzIntrinsicName(cl);
           var statique = in.equals("fuzion.java.get_static_field0");
-          var actualGenerics = innerClazz._type.generics();
-          if ((actualGenerics == null) || (actualGenerics.size() != 1))
-            {
-              Errors.fatal("fuzion.java.get_static_field called with wrong number of actual generic arguments");
-            }
-          Clazz resultClazz = innerClazz.actualClazz(actualGenerics.getFirst());
+          Clazz resultClazz = innerClazz.actualGenerics()[0];
           return args ->
             {
               Instance clazzOrThizI = (Instance) args.get(1);
@@ -669,8 +664,7 @@ public class Intrinsics extends ANY
           String in = innerClazz.feature().qualifiedName();   // == _fuir.clazzIntrinsicName(cl);
           var virtual     = in.equals("fuzion.java.call_v0");
           var constructor = in.equals("fuzion.java.call_c0");
-          var actualGenerics = innerClazz._type.generics();
-          Clazz resultClazz = innerClazz.actualClazz(actualGenerics.getFirst());
+          Clazz resultClazz = innerClazz.actualGenerics()[0];
           return args ->
             {
               int a = 1;

--- a/src/dev/flang/be/interpreter/Layout.java
+++ b/src/dev/flang/be/interpreter/Layout.java
@@ -33,6 +33,7 @@ import dev.flang.ast.AbstractFeature;
 import dev.flang.ast.Types;
 
 import dev.flang.air.Clazz;
+import dev.flang.air.Clazzes;
 
 import dev.flang.util.ANY;
 
@@ -147,7 +148,7 @@ class Layout extends ANY
             var ff = f.feature();
             // NYI: Ugly special handling, clean up:
             var fc =
-              ff.isOuterRef() && ff.outer().isOuterRefAdrOfValue()  ? f.actualClazz(Types.t_ADDRESS)
+              ff.isOuterRef() && ff.outer().isOuterRefAdrOfValue()  ? Clazzes.clazz(Types.t_ADDRESS)
                                                                     : f.resultClazz();
             int fsz;
             if        (fc.isRef()) { fsz = 1;

--- a/src/dev/flang/util/List.java
+++ b/src/dev/flang/util/List.java
@@ -452,6 +452,15 @@ public class List<T>
       }
     return g;
   }
+  public List<T> flatMap(Function<T,List<T>> f)
+  {
+    var result = new List<T>();
+    for (var i = 0; i < size(); i++)
+      {
+        result.addAll(f.apply(get(i)));
+      }
+    return result;
+  }
 
 
   /**

--- a/src/dev/flang/util/List.java
+++ b/src/dev/flang/util/List.java
@@ -452,6 +452,15 @@ public class List<T>
       }
     return g;
   }
+
+
+  /**
+   * Create a mapping of this list by applying f to all elements and
+   * concatenating the resulting lists.
+   *
+   * @return a new list that is the concatenation of the results of applying f
+   * to all elements.
+   */
   public List<T> flatMap(Function<T,List<T>> f)
   {
     var result = new List<T>();

--- a/tests/reg_issue2214/Makefile
+++ b/tests/reg_issue2214/Makefile
@@ -1,0 +1,25 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test Makefile
+#
+# -----------------------------------------------------------------------
+
+override NAME = issue_2214
+include ../simple.mk

--- a/tests/reg_issue2214/issue_2214.fz
+++ b/tests/reg_issue2214/issue_2214.fz
@@ -1,0 +1,102 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test issue_2214
+#
+# -----------------------------------------------------------------------
+
+# the example from issue #2214 and variants
+#
+# The problem in all these examples is that a feature (a.m, map_broken)
+#
+
+
+
+# the original code from issue #2214, only added is some output and a `call` to
+# avoid missing implementation error:
+#
+scenario1 =>
+
+  u : Unary unit i32 is
+    call(i i32) =>
+  _ := (a i32).m u
+
+  a(T type) is
+    m(B type, f T->B) : a B is
+      say "T is $T"
+      say "B is $B"
+
+scenario1
+
+# This is the original Stream.map implementation that as used in the primes example.
+#
+scenario2 =>
+
+  stream.issue_2214_stream_map_broken(B type, f T -> B) : stream B is
+    has_next => stream.this.has_next
+    next B is f stream.this.next
+
+  primes is
+
+    primes6(n u64) =>   # pure sieve using persistent bitset
+      sieve (i u64, a bitset) String is
+        s  := if (a.has i) "" else "$i ";
+        ap := if (a.has i) a  else a ∪ (((i..n):i)
+                                          .as_stream
+                                          .issue_2214_stream_map_broken (x -> e bitset := nil; e.put x)
+                                          .fold bitset.type.union)
+        s + (if (i < n) sieve i+1 ap else "")
+      sieve 2 nil
+
+    say "Primes using bitset"; say "{primes6 100}"  # NYI: only 100 since this is currently very inefficent
+
+  _ := primes
+
+scenario2
+
+/*
+# NYI: A variant of screnario2 using Sequence.
+#
+#
+scenario3 =>
+
+  Sequence.issue_2214_seq_map_broken(B type, f T -> B) : Sequence B is
+    redef as_list list B =>
+      r list B := match Sequence.this.as_list
+        _ nil => panic "nil" # nil #res list B := nil; res
+        c Cons => panic "cons" # (f c.head) : (c.tail.issue_2214_seq_map_broken B x->(f.call x))
+      r
+
+  primes is
+
+    primes6(n u64) =>   # pure sieve using persistent bitset
+      sieve (i u64, a bitset) String is
+        s  := if (a.has i) "" else "$i ";
+        ap := if (a.has i) a  else a ∪ (((i..n):i)
+                                          .issue_2214_seq_map_broken (x -> e bitset := nil; e.put x)
+                                          .fold bitset.type.union)
+        s + (if (i < n) sieve i+1 ap else "")
+      sieve 2 nil
+
+    say "Primes using bitset"; say "{primes6 100}"  # NYI: only 100 since this is currently very inefficent
+
+  _ := primes
+
+scenario3
+*/

--- a/tests/reg_issue2214/issue_2214.fz.expected_out
+++ b/tests/reg_issue2214/issue_2214.fz.expected_out
@@ -1,0 +1,4 @@
+T is Type of 'i32'
+B is Type of 'unit'
+Primes using bitset
+2 3 5 7 11 13 17 19 23 29 31 37 41 43 47 53 59 61 67 71 73 79 83 89 97 


### PR DESCRIPTION
The problem with `Clazz.actualClazz` was that it replaces all generics found in parents and in outer features.  This is a problem when a feature inherits from one of its outer features since there are two possible values of the actual generics and for the examplein #2214, the wrong one was used.

With this patch, `Clazzes.down` now hands down an inherted type along the inheritance change in each nesting level of features, so we have much better control how inherited types are replaced by the actual values provided in the inherts-call.

This patch also adds a test case with the code from #2214 plus the flang.dev example `primes6_broken_map.fz` that showed this problem since a long time.