### PR TITLE
tests: When running the tests sequentially, sort them alphabetically

### DIFF
--- a/bin/run_tests.sh
+++ b/bin/run_tests.sh
@@ -32,7 +32,7 @@ set -euo pipefail
 
 BUILD_DIR=$1
 TARGET=$2
-TESTS=$(find "$BUILD_DIR"/tests -name Makefile -print0 | xargs -0 -n1 dirname)
+TESTS=$(find "$BUILD_DIR"/tests -name Makefile -print0 | xargs -0 -n1 dirname | sort)
 VERBOSE="${VERBOSE:-""}"
 
 rm -rf "$BUILD_DIR"/run_tests.results


### PR DESCRIPTION
This makes the runs more reproducable and helps finding the culprit in case one test runs very slowly (and ^C does not print the name of the running thread, only the previous ones).