### PR TITLE
when checking arg/result-type visibility use effective visibility

### DIFF
--- a/src/dev/flang/fe/SourceModule.java
+++ b/src/dev/flang/fe/SourceModule.java
@@ -1433,7 +1433,7 @@ public class SourceModule extends Module implements SrcModule, MirModule
       {
         if (!arg.isTypeFeaturesThisType())
           {
-            var s = arg.resultType().moreRestrictiveVisibility(f.visibility().featureVisibility());
+            var s = arg.resultType().moreRestrictiveVisibility(effectiveFeatureVisibility(f));
             if (!s.isEmpty())
               {
                 AstErrors.argTypeMoreRestrictiveVisbility(f, arg, s);
@@ -1450,12 +1450,35 @@ public class SourceModule extends Module implements SrcModule, MirModule
    */
   private void checkResultTypeVisibility(Feature f)
   {
-    var s = f.resultType().moreRestrictiveVisibility(f.visibility().featureVisibility());
+    var s = f.resultType().moreRestrictiveVisibility(effectiveFeatureVisibility(f));
     if (!s.isEmpty())
       {
         AstErrors.resultTypeMoreRestrictiveVisibility(f, s);
       }
   }
+
+
+  /**
+   * Returns the effective visibility of a feature.
+   *
+   * Example:
+   * A feature might be marked as public but one its
+   * outer features type visibility is private.
+   * Then the features effective visibility is also private.
+   */
+  private Visi effectiveFeatureVisibility(Feature f)
+  {
+    var result = f.visibility().featureVisibility();
+    var o = f.outer();
+    while (o != null)
+      {
+        var ov = o.visibility().typeVisibility();
+        result = ov.ordinal() < result.ordinal() ? ov : result;
+        o = o.outer();
+      }
+    return result;
+  }
+
 
 
   /*---------------------------  library file  --------------------------*/

--- a/tests/atomic/test_atomic.fz
+++ b/tests/atomic/test_atomic.fz
@@ -56,8 +56,8 @@ test_atomic is
   test(T type : property.equatable, a, b, c, d T) =>
     test0 a b c d (v1,v2)->v1=v2
 
-  public p(x, y i64) : property.equatable is
-    public fixed type.equality(a, b test_atomic.p) => a.x = b.x && a.y = b.y
+  p(x, y i64) : property.equatable is
+    fixed type.equality(a, b test_atomic.p) => a.x = b.x && a.y = b.y
     redef as_string => "$x,$y"
 
   test 1 2 3 4

--- a/tests/equals/test_equals.fz
+++ b/tests/equals/test_equals.fz
@@ -104,12 +104,12 @@ test_equals_types is
 
   # define a color choice type:
   #
-  public color : choice of red, blue.
+  color : choice of red, blue.
 
   # Has_color provides an equality relation for instances that provide
   # a 'col' feature
   #
-  public Has_color ref : property.equatable is
+  Has_color ref : property.equatable is
 
     # the color of this instance
     #
@@ -117,7 +117,7 @@ test_equals_types is
 
     # equality relation comparing the value produced by 'col'
     #
-    public fixed type.equality(a, b test_equals_types.Has_color) =>
+    fixed type.equality(a, b test_equals_types.Has_color) =>
 
       # NYI: There is currently no easy way to compare choice types, so we do exhaustive
       # matches:
@@ -136,7 +136,7 @@ test_equals_types is
 
   # a colored_text is a string with an associated color:
   #
-  public colored_text(
+  colored_text(
 
     # the color
     col color,
@@ -148,6 +148,6 @@ test_equals_types is
 
     # equality relation comparing color and strings
     #
-    public fixed type.equality(a, b test_equals_types.colored_text) =>
+    fixed type.equality(a, b test_equals_types.colored_text) =>
       (test_equals_types.eq_color a b &&
        String.type.equality       a b   )

--- a/tests/reg_issue293_confusion_of_type_and_value_params/issue293.fz
+++ b/tests/reg_issue293_confusion_of_type_and_value_params/issue293.fz
@@ -51,7 +51,7 @@ issue293 is
 
 
   # a reducing function takes a previous result and a value and returns a new result
-  public reducing_fn(TACC, T type) ref : Function TACC TACC T is
+  reducing_fn(TACC, T type) ref : Function TACC TACC T is
 
   # TACC result     type
   # B    input      type

--- a/tests/type_feature/test_type_feature.fz
+++ b/tests/type_feature/test_type_feature.fz
@@ -26,13 +26,13 @@
 hasTypeArg is
   type.showTypeArgs String is abstract
 
-public ex(T, U type) : hasTypeArg, property.equatable is
+ex(T, U type) : hasTypeArg, property.equatable is
   type.showTypeArgs => "T:$T U:$U"
-  public fixed type.equality(a, b ex T U) bool is false
+  fixed type.equality(a, b ex T U) bool is false
 
-public ex2(T, U type: property.equatable, a, b T, c U) : hasTypeArg, property.equatable is
+ex2(T, U type: property.equatable, a, b T, c U) : hasTypeArg, property.equatable is
   type.showTypeArgs => "T:$T U:$U"
-  public fixed type.equality(a, b ex2 T U) bool is
+  fixed type.equality(a, b ex2 T U) bool is
     (a.a = b.a &&
      a.b = b.b &&
      a.c = b.c   )


### PR DESCRIPTION
... instead of the features visibility

fixes #2239

also reverts the changes of visibility in some tests that where previously necessary.