### PR TITLE
air: harden code against previous errors

### DIFF
--- a/src/dev/flang/air/Clazz.java
+++ b/src/dev/flang/air/Clazz.java
@@ -2192,7 +2192,7 @@ public class Clazz extends ANY implements Comparable<Clazz>
                                _outer;
 
     if (CHECKS) check
-      (res != null);
+      (Errors.any() || res != null);
 
     return res;
   }
@@ -2429,7 +2429,7 @@ public class Clazz extends ANY implements Comparable<Clazz>
   {
     if (PRECONDITIONS) require
       (t != null,
-       !t.isOpenGeneric() || (select >= 0),
+       Errors.any() || !t.isOpenGeneric() || (select >= 0),
        inh != null);
 
     for (AbstractCall c : inh)
@@ -2473,10 +2473,11 @@ public class Clazz extends ANY implements Comparable<Clazz>
       (t != null,
        Errors.any() || t != Types.t_ERROR,
        Errors.any() || (t.isOpenGeneric() == (select >= 0)),
+       Errors.any() || inh != null,
        pos != null);
 
     var o = feature();
-    var t1 = handDownThroughInheritsCalls(t, select, inh);
+    var t1 = inh == null ? t : handDownThroughInheritsCalls(t, select, inh);
     var oc = this;
     while (!o.isUniverse() && o != null && oc != null &&
 
@@ -2494,14 +2495,19 @@ public class Clazz extends ANY implements Comparable<Clazz>
       {
         var f = oc.feature();
         var inh2 = oc.feature().tryFindInheritanceChain(o);
-        t1 = handDownThroughInheritsCalls(t1, select, inh2);
-        t1 = t1.applyTypeParsLocally(oc._type, select);
-        if (inh2.size() > 0)
+        if (CHECKS) check
+          (Errors.any() || inh2 != null);
+        if (inh2 != null)
           {
-            o = oc.feature();
+            t1 = handDownThroughInheritsCalls(t1, select, inh2);
+            t1 = t1.applyTypeParsLocally(oc._type, select);
+            if (inh2.size() > 0)
+              {
+                o = oc.feature();
+              }
           }
         t1 = t1.replace_this_type_by_actual_outer(oc._type);
-        oc = oc.getOuter(o,pos);
+        oc = oc.getOuter(o, pos);
         o = o.outer();
       }
 

--- a/src/dev/flang/ast/AbstractType.java
+++ b/src/dev/flang/ast/AbstractType.java
@@ -829,7 +829,17 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
           {
             if (g.isOpen())
               {
-                result = g.replaceOpen(actualGenerics).get(select);
+                var tl = g.replaceOpen(actualGenerics);
+                if (CHECKS) check
+                  (Errors.any() || select >= 0 && select <= tl.size());
+                if (select >= 0 && select <= tl.size())
+                  {
+                    result = tl.get(select);
+                  }
+                else
+                  {
+                    result = Types.t_ERROR;
+                  }
               }
             else
               {


### PR DESCRIPTION
Open type parameter select-indices might be wrong as a consequence of earlier compilation errors.