### PR TITLE
call `addOuterRef` only once decl. of outer resolved

### DIFF
--- a/src/dev/flang/ast/AbstractFeature.java
+++ b/src/dev/flang/ast/AbstractFeature.java
@@ -927,7 +927,8 @@ public abstract class AbstractFeature extends Expr implements Comparable<Abstrac
       (result != null,
        Errors.any() || result.isRef() == isThisRef(),
        // does not hold if feature is declared repeatedly
-       Errors.any() || result.featureOfType() == this);
+       Errors.any() || result.featureOfType() == this,
+       result.featureOfType().generics().sizeMatches(result.generics()));
 
     return result;
   }

--- a/src/dev/flang/ast/Feature.java
+++ b/src/dev/flang/ast/Feature.java
@@ -760,7 +760,8 @@ public class Feature extends AbstractFeature
   public AbstractFeature outer()
   {
     if (PRECONDITIONS) require
-      (Errors.any() || isUniverse() || state().atLeast(State.FINDING_DECLARATIONS));
+      (Errors.any() || isUniverse() || state().atLeast(State.FINDING_DECLARATIONS),
+      !isFreeType() || _outer.arguments().contains(this));
 
     return _outer;
   }
@@ -2513,7 +2514,7 @@ public class Feature extends AbstractFeature
   public void addOuterRef(Resolution res)
   {
     if (PRECONDITIONS) require
-      (_state == State.FINDING_DECLARATIONS);
+      (_state.atLeast(State.FINDING_DECLARATIONS));
 
     if (hasOuterRef())
       {
@@ -2525,6 +2526,8 @@ public class Feature extends AbstractFeature
                                 outerRefType,
                                 outerRefName(),
                                 this);
+
+        whenResolvedTypes(()->_outerRef.scheduleForResolution(res));
       }
   }
 

--- a/src/dev/flang/ast/ResolvedNormalType.java
+++ b/src/dev/flang/ast/ResolvedNormalType.java
@@ -282,6 +282,9 @@ public class ResolvedNormalType extends ResolvedType
     this._unresolvedGenerics = original._unresolvedGenerics;
     this._outer             = original._outer;
     this._feature           = original._feature;
+
+    if (POSTCONDITIONS) ensure
+      (featureOfType().generics().sizeMatches(generics()));
   }
 
   /**

--- a/src/dev/flang/fe/SourceModule.java
+++ b/src/dev/flang/fe/SourceModule.java
@@ -564,7 +564,21 @@ public class SourceModule extends Module implements SrcModule, MirModule
     inner.setOuter(outer);
     inner.setState(State.FINDING_DECLARATIONS);
     inner.checkName();
-    inner.addOuterRef(_res);
+
+    if (outer == null)
+      {
+        inner.addOuterRef(_res);
+      }
+    else
+      {
+        // fixes issue #1787
+        // We need to wait until `inner` has its final type parameters.
+        // This may include type parameters received via free types.
+        // (Creating outer ref uses `createThisType()` which calls `generics()`.)
+        outer.whenResolvedDeclarations(() -> {
+          inner.addOuterRef(_res);
+        });
+      }
 
     if (outer != null)
       {


### PR DESCRIPTION
This ensures that free types have been identified and added to the type parameters of the outer feature.

fixes #1787