### PR TITLE
be/jvm: set flag abstract in case of interface

### DIFF
--- a/src/dev/flang/be/jvm/classfile/ClassFile.java
+++ b/src/dev/flang/be/jvm/classfile/ClassFile.java
@@ -1245,7 +1245,7 @@ public class ClassFile extends ANY implements ClassFileConstants
     _type = new ClassType(name);
     _version = DEFAULT_VERSION;
     _cpool = new CPool();
-    _flags = ACC_PUBLIC | (interfce ? ACC_INTERFACE : ACC_SUPER);
+    _flags = ACC_PUBLIC | (interfce ? (ACC_INTERFACE|ACC_ABSTRACT) : ACC_SUPER);
     _this = cpClass(name);
     _super = cpClass(supr == null ? "java/lang/Object" : supr);
   }


### PR DESCRIPTION
In newer jvm-specs:
"If the ACC_INTERFACE flag is set, the ACC_ABSTRACT flag must also be set, and the ACC_FINAL, ACC_SUPER, ACC_ENUM, and ACC_MODULE flags set must not be set."