### PR TITLE
fe: empty block not resulting in `unit`, needs call to `unit` added.

### DIFF
--- a/src/dev/flang/ast/Block.java
+++ b/src/dev/flang/ast/Block.java
@@ -301,6 +301,8 @@ public class Block extends AbstractBlock
   Expr box(AbstractType frmlT)
   {
     var r = removeResultExpression();
+    if (CHECKS) check
+      (r != null || Types.resolved.t_unit.compareTo(frmlT) == 0);
     if (r != null)
       {
         _expressions.add(r.box(frmlT));
@@ -381,6 +383,10 @@ public class Block extends AbstractBlock
     if (resExpr != null)
       {
         _expressions.add(resExpr.propagateExpectedType(res, outer, type));
+      }
+    else if (Types.resolved.t_unit.compareTo(type) != 0)
+      {
+        _expressions.add(new Call(pos(), "unit").resolveTypes(res, outer));
       }
     return this;
   }

--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -632,7 +632,7 @@ public class Call extends AbstractCall
   /**
    * Does this call a non-generic infix operator?
    */
-  boolean isInfixOperator()
+  private boolean isInfixOperator()
   {
     return
       _name.startsWith("infix ") &&
@@ -716,7 +716,7 @@ public class Call extends AbstractCall
    * @return true if everything is fine, false in case the target results in
    * void and we hence can replace the call by _target.
    */
-  boolean loadCalledFeatureUnlessTargetVoid(Resolution res, AbstractFeature thiz)
+  private boolean loadCalledFeatureUnlessTargetVoid(Resolution res, AbstractFeature thiz)
   {
     var targetVoid = false;
 
@@ -852,7 +852,7 @@ public class Call extends AbstractCall
   }
 
 
-  void resolveTypesOfActuals(Resolution res, AbstractFeature outer)
+  private void resolveTypesOfActuals(Resolution res, AbstractFeature outer)
   {
     // NYI: check why _actuals.listIterator cannot be done inside
     // whenResolvedTypes. If it could, the 'if calledFeature != null / Error
@@ -905,7 +905,7 @@ public class Call extends AbstractCall
    *
    * @param thiz the surrounding feature
    */
-  void findOperatorOnOuter(Resolution res, AbstractFeature thiz)
+  private void findOperatorOnOuter(Resolution res, AbstractFeature thiz)
   {
     if (_name.startsWith("infix "  ) ||
         _name.startsWith("prefix " ) ||
@@ -1759,7 +1759,7 @@ public class Call extends AbstractCall
    * @param foundAt the position of the expressions from which actual generics
    * were taken.
    */
-  void inferGenericsFromArgs(Resolution res, AbstractFeature outer, boolean[] checked, boolean[] conflict, List<List<Pair<SourcePosition, AbstractType>>> foundAt)
+  private void inferGenericsFromArgs(Resolution res, AbstractFeature outer, boolean[] checked, boolean[] conflict, List<List<Pair<SourcePosition, AbstractType>>> foundAt)
   {
     var cf = _calledFeature;
     // run two passes: first, ignore numeric literals and open generics, do these in second pass
@@ -1832,7 +1832,7 @@ public class Call extends AbstractCall
    *
    * @param outer the root feature that contains this call.
    */
-  void inferFormalArgTypesFromActualArgs(AbstractFeature outer)
+  private void inferFormalArgTypesFromActualArgs(AbstractFeature outer)
   {
     ListIterator<Expr> aargs = _actuals.listIterator();
     for (var frml : _calledFeature.valueArguments())
@@ -2102,7 +2102,7 @@ public class Call extends AbstractCall
    * @return true iff this is a expression that can produce the result of e (but
    * not necessarily the only one).
    */
-  boolean returnsThis(Expr e)
+  private boolean returnsThis(Expr e)
   {
     if (e instanceof If i)
       {

--- a/tests/reg_issue874ff/issue874.fz
+++ b/tests/reg_issue874ff/issue874.fz
@@ -327,8 +327,8 @@ say c.x
 d is
   y => 3
   x d.this is
-    d.this
     redef as_string => "d"
+    d.this
 
 t is
   e : d is


### PR DESCRIPTION
fixes #2266
because this then is later tagged to become a `choice unit ...`