### PR TITLE
ast, air: No unnecessary parentheses in Strings for types, improve #2293

### DIFF
--- a/src/dev/flang/air/Clazz.java
+++ b/src/dev/flang/air/Clazz.java
@@ -59,6 +59,7 @@ import dev.flang.util.Errors;
 import dev.flang.util.HasSourcePosition;
 import dev.flang.util.List;
 import dev.flang.util.SourcePosition;
+import dev.flang.util.StringHelpers;
 import dev.flang.util.YesNo;
 
 
@@ -1382,10 +1383,7 @@ public class Clazz extends ANY implements Comparable<Clazz>
    */
   public String toStringWrapped()
   {
-    var s = toString();
-    return s.contains(" ")
-           ? "(" + s + ")"
-           : s;
+    return StringHelpers.wrapInParentheses(toString());
   }
 
 

--- a/src/dev/flang/ast/AbstractType.java
+++ b/src/dev/flang/ast/AbstractType.java
@@ -38,6 +38,7 @@ import dev.flang.util.FuzionConstants;
 import dev.flang.util.HasSourcePosition;
 import dev.flang.util.List;
 import dev.flang.util.SourcePosition;
+import dev.flang.util.StringHelpers;
 import dev.flang.util.YesNo;
 
 
@@ -1649,10 +1650,7 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
    */
   public String toStringWrapped()
   {
-    var s = toString();
-    return s.contains(" ")
-           ? "(" + s + ")"
-           : s;
+    return StringHelpers.wrapInParentheses(toString());
   }
 
 
@@ -1661,9 +1659,7 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
    */
   public String asStringWrapped()
   {
-    var s = asString();
-    return s.contains(" ") ? "(" + s + ")"
-                           :       s      ;
+    return StringHelpers.wrapInParentheses(asString());
   }
 
 

--- a/src/dev/flang/ast/Expr.java
+++ b/src/dev/flang/ast/Expr.java
@@ -35,6 +35,7 @@ import dev.flang.util.HasSourcePosition;
 import dev.flang.util.List;
 import dev.flang.util.SourcePosition;
 import dev.flang.util.SourceRange;
+import dev.flang.util.StringHelpers;
 
 
 /**
@@ -687,9 +688,7 @@ public abstract class Expr extends ANY implements HasSourcePosition
    */
   public String toStringWrapped()
   {
-    return toString().contains(" ")
-           ? "(" + toString() + ")"
-           : toString();
+    return StringHelpers.wrapInParentheses(toString());
   }
 
 

--- a/src/dev/flang/util/StringHelpers.java
+++ b/src/dev/flang/util/StringHelpers.java
@@ -1,0 +1,107 @@
+/*
+
+This file is part of the Fuzion language implementation.
+
+The Fuzion language implementation is free software: you can redistribute it
+and/or modify it under the terms of the GNU General Public License as published
+by the Free Software Foundation, version 3 of the License.
+
+The Fuzion language implementation is distributed in the hope that it will be
+useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+License for more details.
+
+You should have received a copy of the GNU General Public License along with The
+Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+*/
+
+/*-----------------------------------------------------------------------
+ *
+ * Tokiwa Software GmbH, Germany
+ *
+ * Source code of class ANY
+ *
+ *---------------------------------------------------------------------*/
+
+package dev.flang.util;
+
+/**
+ * StringHelpers contains String related methods that turned out useful in the
+ * Fuzion implementation.
+ *
+ * @author Fridtjof Siebert (siebert@tokiwa.software)
+ */
+public class StringHelpers extends ANY
+{
+
+
+  /*----------------------------  constants  ----------------------------*/
+
+
+  /*--------------------------  static methods  -------------------------*/
+
+
+  /**
+   * wrap given string in parentheses iff it contains white space (@see
+   * isWhiteSpace) that is not already wrapped in parentheses.
+   *
+   * @param s a string like "a b" or "(a b).c"
+   *
+   * @return a string without any white space that is not wrapped in
+   * parentheses, e.g., "(a b)" or "(a b).c" (for the examples above).
+   */
+  public static String wrapInParentheses(String s)
+  {
+    return containsWhiteSpaceOutsideParentheses(s) ? "(" + s + ")"
+                                                   : s;
+  }
+
+
+  /**
+   * Is the given character a white space character. white space is SPACE, TAB,
+   * LF, CR, or FF.
+   *
+   * @param c a character
+   *
+   + @return true iff c is white space.
+   */
+  public static boolean isWhiteSpace(char c)
+  {
+    return switch (c)
+      {
+      case  '\t', '\n', '\f', '\r', ' ' -> true;
+      default                           -> false;
+      };
+  }
+
+
+  /**
+   * Does the given String contain white space (@sww isWhiteSpace) that is not
+   * wrapped in parentheses?
+   *
+   * @param s a String like "a b" or "(a b).c"
+   *
+   * @return true iff s contains unwrapped white space as in "a b", false if it
+   * does not as in "(a b).c".
+   */
+  public static boolean containsWhiteSpaceOutsideParentheses(String s)
+  {
+    var result = false;
+    int level = 0;
+    for(var i = 0; i < s.length(); i++)
+      {
+        var c = s.charAt(i);
+        switch (s.charAt(i))
+          {
+          case '(' : level ++; break;
+          case ')' : level --; break;
+          default  : result = result || level == 0 && isWhiteSpace(c); break;
+          }
+      }
+    return result;
+  }
+
+}
+
+/* end of file */


### PR DESCRIPTION
This does not fix the issue, but avoids cascades for `()` in the output.