### PR TITLE
lib: add `log`, alternative to `say` that returns its argument

### DIFF
--- a/lib/float.fz
+++ b/lib/float.fz
@@ -241,7 +241,7 @@ public float : numeric is
   public type.log (base, val float.this) float.this
   pre base > zero
   is
-    (log val) / (log base)
+    (float.this.type.log val) / (float.this.type.log base)
 
 
   # trigonometric
@@ -266,13 +266,13 @@ public float : numeric is
 
   public type.asinh(val float.this) float.this is
     # ln(x+sqrt(x^2+1))
-    log (val + sqrt (val ** two + one))
+    float.this.type.log (val + sqrt (val ** two + one))
   public type.acosh(val float.this) float.this is
     # ln(x+sqrt(x^2-1))
-    log (val + sqrt (val ** two - one))
+    float.this.type.log (val + sqrt (val ** two - one))
   public type.atanh(val float.this) float.this is
     # 1/2*ln((1+x)/(1-x))
-    log ((one + val)/(one - val)) / two
+    float.this.type.log ((one + val)/(one - val)) / two
 
 
   # equality

--- a/lib/log.fz
+++ b/lib/log.fz
@@ -1,0 +1,29 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion standard library feature log
+#
+# -----------------------------------------------------------------------
+
+# Use say to print `s` to stdout and return `s`.
+#
+# In contrast to `say`, `log` returns its argument
+# which makes `log` compose better in same cases.
+#
+public log(s T) => say s; s


### PR DESCRIPTION
depends on previous PR