### PR TITLE
ast: Also ran into this issue: sometime null gets propagated as expected type

### DIFF
--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -2688,7 +2688,11 @@ public class Call extends AbstractCall
         // NYI: Need to check why this is needed, it does not make sense to
         // propagate the target's type to target. But if removed,
         // tests/reg_issue16_chainedBool/ fails with C backend:
-        _target = _target.propagateExpectedType(res, outer, _target.typeForInferencing());
+        var t = _target.typeForInferencing();
+        if (t != null)
+          {
+            _target = _target.propagateExpectedType(res, outer, _target.typeForInferencing());
+          }
       }
   }
 


### PR DESCRIPTION
sorry, I lost the test case to reproduce this, so no regression test...:-(