### PR TITLE
ast/tests: Delay resolution of features with args whose types are inferred

### DIFF
--- a/src/dev/flang/ast/Impl.java
+++ b/src/dev/flang/ast/Impl.java
@@ -160,7 +160,6 @@ public class Impl extends ANY
    */
   public Impl(SourcePosition pos, Expr e, Kind kind)
   {
-    check (kind != Kind.FieldActual || pos != null);
     this._code = switch (kind)
       {
       case Routine, RoutineDef, Of -> e;

--- a/src/dev/flang/ast/Impl.java
+++ b/src/dev/flang/ast/Impl.java
@@ -96,6 +96,7 @@ public class Impl extends ANY
    */
   final List<Expr> _initialValues;
 
+
   /**
    * For FieldActual: The outer features for all the actual values that were
    * found for this argument field.
@@ -159,6 +160,7 @@ public class Impl extends ANY
    */
   public Impl(SourcePosition pos, Expr e, Kind kind)
   {
+    check (kind != Kind.FieldActual || pos != null);
     this._code = switch (kind)
       {
       case Routine, RoutineDef, Of -> e;
@@ -436,6 +438,82 @@ public class Impl extends ANY
   }
 
 
+
+  /**
+   * Visitor used by typeFromInitialValues for Kind.FieldActual to detect that
+   * an initial value has a circular dependency on the formal argument we are
+   * trying to resolve. In case of such a circular dependency, ignore that
+   * initial value.
+   */
+  class FindCircularDependency extends FeatureVisitor
+  {
+
+    /**
+     * The circular dependencies we found, might be useful for nicer error
+     * output.
+     */
+    final List<Call> _circularDependencies = new List<>();
+
+    /**
+     * Flag that is set once we found a circular dependency.
+     */
+    boolean _foundCircle = false;
+
+    /**
+     * The formal argument we are trying to obtain the type for.
+     */
+    final AbstractFeature _formalArg;
+
+    /**
+     * Constructor that will immediately run the analysis.
+     *
+     * @param formalArg the formal argument we are trying to check for circular
+     * dependencies.q
+     *
+     * @param iv the initial value found for formalArg that we are trying to
+     * check for circular dependencies.
+     *
+     * @param outer the outer feature iv was found in.
+     */
+    FindCircularDependency(AbstractFeature formalArg, Expr iv, AbstractFeature outer)
+    {
+      _formalArg = formalArg;
+      iv.visit(this, outer);
+    }
+
+
+    /**
+     * A circular dependency happens through a call, so we check calls:
+     */
+    @Override
+    public Expr action(Call c, AbstractFeature outer)
+    {
+      if (c.calledFeatureKnown())
+        {
+          var cf = c.calledFeature();
+          if (cf instanceof Feature cff && cff.impl()._kind == Kind.FieldActual)
+            {
+              var ivs = cff.impl()._initialValues;
+              if (ivs.isEmpty() || cf == _formalArg || cf.outer() == _formalArg.outer())
+                {
+                  _circularDependencies.add(c);
+                  _foundCircle = true;
+                }
+              else
+                {
+                  for (var iv : ivs)
+                    {
+                      iv.visit(this, outer);
+                    }
+                }
+            }
+        }
+      return c;
+    }
+
+  }
+
+
   /**
    * Determine the type of a FieldActual by forming the union of the types of
    * all actual values added by addInitialValue.
@@ -459,7 +537,11 @@ public class Impl extends ANY
         var io = _outerOfInitialValues.get(i);
         if (res != null)
           {
-            iv.visit(new Feature.ResolveTypes(res),io);
+            var cd = new FindCircularDependency(formalArg, iv, io);
+            if (!cd._foundCircle)
+              { // type resolution would result in an error in case there is a circle.
+                iv.visit(new Feature.ResolveTypes(res),io);
+              }
           }
         var t = iv.typeForInferencing();
         if (t != null)

--- a/src/dev/flang/ast/Impl.java
+++ b/src/dev/flang/ast/Impl.java
@@ -438,7 +438,6 @@ public class Impl extends ANY
   }
 
 
-
   /**
    * Visitor used by typeFromInitialValues for Kind.FieldActual to detect that
    * an initial value has a circular dependency on the formal argument we are

--- a/src/dev/flang/ast/Resolution.java
+++ b/src/dev/flang/ast/Resolution.java
@@ -295,9 +295,6 @@ public class Resolution extends ANY
    */
   boolean requiresCall(Feature f)
   {
-    if (PRECONDITIONS) require
-      (f.state().atLeast(State.RESOLVED_INHERITANCE));
-
     return
       f.valueArguments().stream()
         .anyMatch(a -> a instanceof Feature af &&

--- a/src/dev/flang/ast/Resolution.java
+++ b/src/dev/flang/ast/Resolution.java
@@ -172,6 +172,12 @@ public class Resolution extends ANY
   final LinkedList<Feature> forDeclarations = new LinkedList<>();
 
   /**
+   * List of features waiting for calls since argument types are inferred from
+   * actual arguments. These will need to be resolved for declarations next.
+   */
+  final LinkedList<Feature> _waitingForCalls = new LinkedList<>();
+
+  /**
    * List of features scheduled for type resolution
    */
   final LinkedList<Feature> forType = new LinkedList<>();
@@ -246,7 +252,58 @@ public class Resolution extends ANY
     if (PRECONDITIONS) require
       (f.state() == State.RESOLVED_INHERITANCE);
 
-    forDeclarations.add(f);
+    if (requiresCall(f))
+      {
+        _waitingForCalls.add(f);
+      }
+    else
+      {
+        forDeclarations.add(f);
+      }
+  }
+
+
+  /**
+   * If there are features in waitingForCalls that still require calls for type
+   * resolution, then try to find those that meanwhile have found a call.  Only
+   * if none were found, start resolving those without calls (i.e., argument
+   * types will end up being void).
+   *
+   * @param waitingForCalls a list of features that await any calls to be found
+   * before they coudl be resolved.
+   */
+  Feature resolveDelayed()
+  {
+    var f = _waitingForCalls.removeFirst();
+    var first = f;
+    var cycling = false;
+    while (requiresCall(f) && !cycling)
+      {
+        _waitingForCalls.add(f);
+        f = _waitingForCalls.removeFirst();
+        cycling = f == first;
+      }
+    return f;
+  }
+
+
+  /**
+   * Does given feature have value arguments whose type is inferred from a call.
+   * If so, we delay type resolution for f until when such a call is found.
+   *
+   * @param f a feature that was resolved for declarations.
+   */
+  boolean requiresCall(Feature f)
+  {
+    if (PRECONDITIONS) require
+      (f.state().atLeast(State.RESOLVED_INHERITANCE));
+
+    return
+      f.valueArguments().stream()
+        .anyMatch(a -> a instanceof Feature af &&
+                  af.impl()._kind == Impl.Kind.FieldActual &&
+                  af.impl()._initialValues.isEmpty()           ) ||
+      f.outer() instanceof Feature of && !of.isUniverse() && requiresCall(of);
   }
 
 
@@ -408,6 +465,13 @@ public class Resolution extends ANY
       {
         Feature f = forBoxing.removeFirst();
         f.box(this);
+      }
+    else if (!_waitingForCalls.isEmpty())
+      {
+        // there are some features that still require calls for type resolution,
+        // so try to find those fot which we have found a call meanwhile.  Only if none
+        // was found, start resolving declarations anyways.
+        resolveDelayed().resolveDeclarations(this);
       }
     else if (!forCheckTypes1.isEmpty())
       {

--- a/src/dev/flang/parser/Parser.java
+++ b/src/dev/flang/parser/Parser.java
@@ -975,7 +975,7 @@ argType     : type
                                     for (var s : n)
                                       {
                                         result.add(new Feature(s._pos, v, m, t, s._name, c,
-                                                               i == null ? new Impl(Impl.Kind.FieldActual)
+                                                               i == null ? new Impl(s._pos, null, Impl.Kind.FieldActual)
                                                                          : i));
                                       }
                                   }

--- a/tests/typeinference_for_formal_args/Makefile
+++ b/tests/typeinference_for_formal_args/Makefile
@@ -1,0 +1,25 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test Makefile
+#
+# -----------------------------------------------------------------------
+
+override NAME = typeinference_for_formal_args
+include ../simple.mk

--- a/tests/typeinference_for_formal_args/typeinference_for_formal_args.fz
+++ b/tests/typeinference_for_formal_args/typeinference_for_formal_args.fz
@@ -31,7 +31,7 @@ typeinference_for_formal_args is
       say "PASSED: $msg: got '$got'"
     else
       say "FAILED: $msg: got '$got' expected '$exp'"
-#      _ := set_exit_code 1
+      _ := set_exit_code 1
 
 
   # hide the calls deep inside a lambda such that

--- a/tests/typeinference_for_formal_args/typeinference_for_formal_args.fz
+++ b/tests/typeinference_for_formal_args/typeinference_for_formal_args.fz
@@ -1,0 +1,140 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test partial_application
+#
+# -----------------------------------------------------------------------
+
+# this test checks different scenarios for type inference for formal
+# arguments
+#
+typeinference_for_formal_args is
+
+  test(msg String, got Any, exp String) =>
+    if $got = exp
+      say "PASSED: $msg: got '$got'"
+    else
+      say "FAILED: $msg: got '$got' expected '$exp'"
+#      _ := set_exit_code 1
+
+
+  # hide the calls deep inside a lambda such that
+  # these will usually be resolved later:
+  #
+  scenario1 =>
+    p is
+      in_p => test "called p.in_p" "" ""; true
+    q is
+      in_q => test "called q.in_q" "" ""; true
+    r is
+      in_r => test "called r.in_r" "" ""; true
+
+    called_with_p(a) => a.in_p
+    called_with_q(a) => a.in_q
+    called_with_r(a) => a.in_r
+
+    _ := [1].filter x->(called_with_p p)
+    _ := [1].filter x->(called_with_q q)
+    _ := [1].filter x->(called_with_r r)
+
+  scenario1
+
+
+  # do a recursive ping/pong before providing the actual type
+  #
+  scenario2 =>
+
+    ping(x) =>
+      if (x > 0) pong x
+      true
+    pong(y) => ping y-1; false
+
+    test "ping poing" ([1,2,3].filter x->(ping 3)) "[1,2,3]"
+
+  scenario2
+
+
+  # access the type before a call is made:
+  #
+  scenario3 =>
+
+    f(fa option m2) =>
+      a := [1,2,3].map x->(m1 $x)
+      q => fa.get.y
+      t(p Sequence T) => test "scenario3: type of m2.y is " $T "Type of 'String'"
+      t ((1..0).map_sequence x->q)
+
+    m1(x) is
+      _ := inner
+      inner => m2 x
+
+    m2(y) is
+
+    f nil
+
+  scenario3
+
+
+  # access the type before a call is made:
+  #
+  # NYI: #2308. This currently results in 'm2.y' being type 'void', which is not correct.
+  # Maybe type inference for formal argument types should be forbidden in constructors.
+  #
+  scenario4 =>
+
+    f(fa option m2) =>
+      a := [1,2,3].map x->(m1 $x)
+      q => fa.get.y
+      t(p Sequence T) => test "scenario4: type of m2.y is " $T "Type of 'void'"
+      t ((1..0).map_sequence x->q)
+
+    m1(x) is
+      #  _ := inner     # -- this is commented out, so there is no call to `m2` at all...
+      inner => m2 x
+
+    m2(y) is
+
+    f nil
+
+  scenario4
+
+
+  # access the type before a call is made:
+  #
+  # NYI: #2308. This currently results in 'm2.y' being type 'void', which is not correct.
+  # Maybe type inference for formal argument types should be forbidden in constructors.
+  #
+  scenario5 =>
+
+    f(fa option m2) =>
+      q => fa.get.y
+      t(p Sequence T) =>
+        test "scenario4: type of m2.y is " $T "Type of 'void'"
+        a := [1,2,3].map x->(m1 $x)
+      t ((1..0).map_sequence x->q)
+
+    m1(x) is
+      _ := inner
+      inner => m2 x
+
+    m2(y) is
+
+    f nil
+
+  scenario5

--- a/tests/typeinference_for_formal_args/typeinference_for_formal_args.fz.expected_out
+++ b/tests/typeinference_for_formal_args/typeinference_for_formal_args.fz.expected_out
@@ -1,0 +1,7 @@
+PASSED: called p.in_p: got ''
+PASSED: called q.in_q: got ''
+PASSED: called r.in_r: got ''
+PASSED: ping poing: got '[1,2,3]'
+PASSED: scenario3: type of m2.y is : got 'Type of 'String''
+PASSED: scenario4: type of m2.y is : got 'Type of 'void''
+PASSED: scenario4: type of m2.y is : got 'Type of 'void''


### PR DESCRIPTION
This fixes #2290 by first resolving everything else before we are resolving a feature whose argument types are inferred from actual arguments.

Since type inference can results in some awful circles here, I had to add a check for such circles to avoid type inference in case of such a circle.  For now, a circle is just ignored expecting this to occur only in case of recursion. Consequently, only types provided when entering this recursion will be considered for type inference for arguments.

This patch adds a number of tricky type inference tests that model the example from #2290 and indirect recursion.

Also, test scenarios were added where inference is used without any actual calls and the type ends up being `void`, which is wrong.  This should be revisited within #2308.

I also added code to the parser to add a `SourcePosition` to each `Impl` which helps during debugging.