### PR TITLE
lib: fix O(n³) performance of String.split follwed by Sequence.filter, fix #2323

### DIFF
--- a/lib/Sequence.fz
+++ b/lib/Sequence.fz
@@ -67,6 +67,12 @@ public Sequence(public T type) ref is
   public finite => false
 
 
+  # is this Sequence known to be array backed? If so, this means that operations
+  # like index[] are fast.
+  #
+  public is_array_backed => false
+
+
   # is this Sequence empty?
   #
   public is_empty => as_list.is_empty
@@ -120,9 +126,24 @@ public Sequence(public T type) ref is
 
   # collect the contents of this Sequence into an array
   #
-  public as_array array T is
-    s := as_stream
-    array T count i->s.next
+  public as_array array T =>
+    as_list.as_array
+
+
+  # create an array backed version of this sequence in case this is not array
+  # backed.  This will ensure that operations like index[] or drop perform
+  # in constant time.
+  #
+  # returns Sequence.this if is_array_backed.
+  #
+  public as_array_backed Sequence T
+  post
+    result.is_array_backed
+  =>
+    if is_array_backed
+      Sequence.this
+    else
+      as_array
 
 
   # create a list and call 'for_each f' on it

--- a/lib/String.fz
+++ b/lib/String.fz
@@ -418,6 +418,15 @@ public String ref : property.equatable, property.hashable, property.orderable is
     (container.searchable_sequence utf8).find substring.utf8
 
 
+  # find (utf8-byte-) index of 'substring' witin this string.
+  #
+  public find(substring String,
+              # start search at this index
+              from i32)
+  =>
+    (container.searchable_sequence (utf8.drop from)).find substring.utf8
+
+
   # find (utf8-byte-) index of last occurrence of 'substring'
   # within this string.
   public find_last(substring String) option i32 is
@@ -468,9 +477,11 @@ public String ref : property.equatable, property.hashable, property.orderable is
     if l.is_empty
       nil
     else
+      h :=  String.type.from_bytes (l.take_while (c -> !c.is_ascii_white_space)).as_array
+      t := (String.type.from_bytes (l.drop_while (c -> !c.is_ascii_white_space))).split
       ref : Cons String (list String)
-        head =>  String.type.from_bytes (l.take_while (c -> !c.is_ascii_white_space))
-        tail => (String.type.from_bytes (l.drop_while (c -> !c.is_ascii_white_space))).split
+        head => h
+        tail => t
 
 
   # split string at s
@@ -533,21 +544,8 @@ public String ref : property.equatable, property.hashable, property.orderable is
         nil => true
         n u32 => n > (u32 0)
     is
-      match (find s)
-        nil => String.this.as_string : ()->nil
-        idx i32 =>
-          ref : Cons String (list String)
-            head => substring 0 (if split_after then idx + s.byte_length else idx)
-            tail =>
-              rest := substring (idx + s.byte_length) String.this.byte_length
-
-              match limit
-                nil => rest.split0 s nil split_after
-                n u32 =>
-                  if n > u32 1
-                    rest.split0 s (n - 1) split_after
-                  else
-                    [rest].as_list
+      (container.searchable_sequence utf8).split0 s.utf8 limit split_after
+          .map x->(String.type.from_bytes x)
 
 
   # remove leading and trailing white space from this string
@@ -705,7 +703,7 @@ public String ref : property.equatable, property.hashable, property.orderable is
   # The performance of iterating the utf8 bytes of a string is O(l+n) for an
   # array of length l created by concatenating n sub-strings.
   #
-  public type.from_mutable_array(a Mutable_Array Any) ref : String is
+  public type.from_mutable_array(a Mutable_Array Any) ref : String is  // NYI: Remove?
 
     redef utf8 Sequence u8 is
       a.flat_map_sequence u8 ai->ai.as_string.utf8
@@ -721,7 +719,7 @@ public String ref : property.equatable, property.hashable, property.orderable is
   #
   public type.from_bytes(utf8_bytes Sequence u8) String is
     ref : String
-      redef utf8 => utf8_bytes
+      redef utf8 := utf8_bytes.as_array_backed
 
 
   # create string from the given codepoints
@@ -731,6 +729,7 @@ public String ref : property.equatable, property.hashable, property.orderable is
       utf8 Sequence u8 is
         codepoints
           .flat_map_sequence u8 (x -> x.utf8)
+          .as_array_backed
 
 
   # NYI: remove the convenience functions when Fuzion supports char literals

--- a/lib/array.fz
+++ b/lib/array.fz
@@ -55,6 +55,12 @@ module:public array(
   public redef finite => true
 
 
+  # is this Sequence known to be array backed? If so, this means that operations
+  # like index[] are fast.
+  #
+  public redef is_array_backed => true
+
+
   # a sequence of all valid indices to access this array. Useful e.g., for
   # `for`-loops:
   #
@@ -154,6 +160,13 @@ module:public array(
       #
       public redef finite => true
 
+
+      # is this Sequence known to be array backed? If so, this means that operations
+      # like index[] are fast.
+      #
+      public redef is_array_backed => true
+
+
       # redefines Sequence.count for array.slice,
       # reducing complexity from O(n) to O(1).
       #
@@ -237,8 +250,8 @@ module:public array(
 
   # collect the contents of this Sequence into an array
   #
-  public redef as_array array T is
-    array T internal_array unit unit unit
+  public redef fixed as_array array T is
+    array.this
 
 
   # array -- create initialized one-dimensional immutable array

--- a/lib/container/searchable_sequence.fz
+++ b/lib/container/searchable_sequence.fz
@@ -124,6 +124,40 @@ is
                   else                   (searchable_sequence c1.tail       ).count_matches l)
 
 
+  # split sequence at s, if there is no limit, otherwise if limit is an integer n,
+  # for at most n occurrences of s
+  #
+  # if split_after is true, all but the last element of the resulting list include
+  # the separator
+  #
+  # helper feature which unifies the code of the different split features in one
+  #
+  module split0(s Sequence A, limit option u32, split_after bool) list (Sequence A)
+    pre
+      !s.is_empty,
+      match limit
+        nil => true
+        n u32 => n > (u32 0)
+    is
+      match (find s)
+        nil     => from : nil
+        idx i32 =>
+          ref : Cons (Sequence A) (list (Sequence A))
+            head Sequence A := from.take (if split_after then idx + s.count else idx)
+            tail =>
+              rest := from.drop (idx + s.count)
+              srest := searchable_sequence rest
+
+              match limit
+                nil => srest.split0 s nil split_after
+                n u32 =>
+                  if n > u32 1
+                    srest.split0 s (n - 1) split_after
+                  else
+                    res Sequence A := rest;
+                    res : nil
+
+
   # equality check implementation for inherited property.equatable
   #
   public fixed type.equality(a, b container.searchable_sequence A) bool is

--- a/lib/list.fz
+++ b/lib/list.fz
@@ -161,6 +161,18 @@ public list(public A type) : choice nil (Cons A (list A)), Sequence A is
                | c Cons => force_tail.last
 
 
+  # collect the contents of this list into an array
+  #
+  public redef as_array array A =>
+    lm : mutate.
+    lm.go ()->
+      e := mut list.this
+      array A count _->
+        res := e.get.first
+        e <- e.get.force_tail
+        res
+
+
   # map the list to a new list applying function f to all elements
   #
   # This performs a lazy mapping, f is called only when the elements


### PR DESCRIPTION
This patch first moves `String.split0` to `container.searchable_sequence` such that it can operate on the underlying utf8 `Sequence` directly.

Then, when creating a `String` from the resulting sequence, `String.type.from_bytes` now makes sure the resulting String uses an array backed utf8 `Sequence`.

For this, `Sequence` was extended with features `is_array_backed` and `as_array_backed` and `array` and the result of `array.slice` now are array backed.

The resulting performance increase using the example from #2323 is impressive, we now create arrays of 2Mio elements in 25s compared to 1K in 152s, four orders of magnitude:

```
> ./build/bin/fz -XjavaProf test_split.fz
1:	Time per iteration: cycle  555µs	split   16ms	filter   25ms	as_array   12ms	TOTAL:   55ms
2:	Time per iteration: cycle 6529ns	split  147µs	filter  274µs	as_array 2624µs	TOTAL: 6105µs
4:	Time per iteration: cycle 1868ns	split   50µs	filter   93µs	as_array 1286µs	TOTAL: 5729µs
8:	Time per iteration: cycle 1073ns	split   19µs	filter   32µs	as_array  742µs	TOTAL: 6361µs
16:	Time per iteration: cycle  711ns	split 9977ns	filter   20µs	as_array  543µs	TOTAL: 9184µs
32:	Time per iteration: cycle  299ns	split 4655ns	filter 5069ns	as_array  393µs	TOTAL:   12ms
64:	Time per iteration: cycle  104ns	split  938ns	filter 1939ns	as_array  382µs	TOTAL:   24ms
128:	Time per iteration: cycle   70ns	split  701ns	filter 1477ns	as_array  302µs	TOTAL:   38ms
256:	Time per iteration: cycle   30ns	split  812ns	filter  563ns	as_array  228µs	TOTAL:   58ms
512:	Time per iteration: cycle   10ns	split  122ns	filter  124ns	as_array  104µs	TOTAL:   53ms
1024:	Time per iteration: cycle    5ns	split   24ns	filter   52ns	as_array   44µs	TOTAL:   45ms
2048:	Time per iteration: cycle    2ns	split   12ns	filter   11ns	as_array   31µs	TOTAL:   65ms
4096:	Time per iteration: cycle    1ns	split    8ns	filter    6ns	as_array   24µs	TOTAL:   99ms
8192:	Time per iteration: cycle    0ns	split    3ns	filter    4ns	as_array   22µs	TOTAL:  185ms
16384:	Time per iteration: cycle    0ns	split    1ns	filter    1ns	as_array   22µs	TOTAL:  370ms
32768:	Time per iteration: cycle    0ns	split    0ns	filter    0ns	as_array   13µs	TOTAL:  451ms
65536:	Time per iteration: cycle    0ns	split    0ns	filter    0ns	as_array   11µs	TOTAL:  726ms
131072:	Time per iteration: cycle    0ns	split    0ns	filter    0ns	as_array   11µs	TOTAL: 1452ms
262144:	Time per iteration: cycle    0ns	split    0ns	filter    0ns	as_array   12µs	TOTAL: 3146ms
524288:	Time per iteration: cycle    0ns	split    0ns	filter    0ns	as_array   12µs	TOTAL: 6429ms
1048576:	Time per iteration: cycle    0ns	split    0ns	filter    0ns	as_array   12µs	TOTAL:   12s
2097152:	Time per iteration: cycle    0ns	split    0ns	filter    0ns	as_array   11µs	TOTAL:   25s
 + pid8007-fuzion-XjavaProf-flamegraph.svg

```
The resulting flame graph shows no deep recursing during the execution phase.