### PR TITLE
lib: Make io.buffered.read_bytes public

### DIFF
--- a/lib/io/buffered/reader.fz
+++ b/lib/io/buffered/reader.fz
@@ -113,7 +113,7 @@ reader =>
 # read n bytes using the currently installed byte reader effect
 # if the returned sequence is or count is less than n, end of file has been reached.
 #
-read_bytes(n i32) Sequence u8 ! reader is
+public read_bytes(n i32) Sequence u8 ! reader is
 
   mi : mutate is
 


### PR DESCRIPTION
I needed this in Advent-of-Code since read_string/read_line do not distingish empty lines from end-of-file, see #2284