### PR TITLE
util: Fixes two issues with the stacks produced by -XjavaProf option

### DIFF
--- a/src/dev/flang/util/Profiler.java
+++ b/src/dev/flang/util/Profiler.java
@@ -182,10 +182,10 @@ public class Profiler extends ANY
                       }
                   }
               }
-            else
+            else if (st.length > 0)
               {
                 StringBuilder sb = new StringBuilder();
-                for (var i = st.length-1; i>0; i--)
+                for (var i = st.length-1; i>=0; i--)
                   {
                     var s = st[i];
                     if (sb.length() > 0)


### PR DESCRIPTION
First, this filters out stacks that are empty and contain no information. Seems like they come from threads that do not execute any Java code.

Second, the stack frames were always missing the innermost entry, so this is added now.