### PR TITLE
lib: Redefine count and drop for array backed sequences

### DIFF
--- a/lib/Sequence.fz
+++ b/lib/Sequence.fz
@@ -81,6 +81,8 @@ public Sequence(public T type) ref is
   # count the number of elements in this Sequence.  Note that this typically
   # runs forever if executed on an endless list
   #
+  # For lists that are not array backed, this might require time in O(count).
+  #
   public count
   pre
     analysis: finite  # in practice, we do not always have this information
@@ -213,6 +215,9 @@ public Sequence(public T type) ref is
 
   # create a list that consists of the elements of this Sequence except the first
   # n elements
+  #
+  # NOTE: this may have performance in O(n) unless it is backed by an immutable array.
+  #
   #
   public drop (n i32) => as_list.drop n
 

--- a/lib/array.fz
+++ b/lib/array.fz
@@ -61,6 +61,15 @@ module:public array(
   public redef is_array_backed => true
 
 
+  # create a list that consists of the elements of this Sequence except the first
+  # n elements
+  #
+  # For arrays, this has perfornace in O(1).
+  #
+  public redef drop (n i32) =>
+    as_list (max 0 n)
+
+
   # a sequence of all valid indices to access this array. Useful e.g., for
   # `for`-loops:
   #
@@ -172,6 +181,15 @@ module:public array(
       #
       public redef count => to-from
 
+
+      # create a list that consists of the elements of this Sequence except the first
+      # n elements
+      #
+      # For arrays, this has perfornace in O(1).
+      #
+      public redef drop (n i32) =>
+        array.this.slice from+(max 0 n) to
+                  .as_list
 
 
   # create a cons cell for a list of this array starting at the given

--- a/lib/mutate.fz
+++ b/lib/mutate.fz
@@ -335,6 +335,6 @@ public Mutable_Array(public T type) ref : Sequence T is
   # count the number of elements in this Sequence.
   #
   # Since we know the exact length, this is redefined to achive O(1) performance instead
-  # of O(n) for couting the elements.
+  # of O(n) for counting the elements.
   #
   public redef count => length

--- a/lib/mutate.fz
+++ b/lib/mutate.fz
@@ -308,6 +308,9 @@ public mut(T type, v T) => mut.new T v
 
 # an interface defining a mutable array
 #
+# NYI: Remove Sequence parent. Since Sequence is supposed to be immutable,
+# we should maybe not pretend to be a Sequence.
+#
 public Mutable_Array(public T type) ref : Sequence T is
 
   # add an element at the end of the sequence
@@ -321,3 +324,17 @@ public Mutable_Array(public T type) ref : Sequence T is
 
   # the length of the array
   public length i32 is abstract
+
+
+  # is this Sequence known to be array backed? If so, this means that operations
+  # like index[] are fast.
+  #
+  public redef is_array_backed => true
+
+
+  # count the number of elements in this Sequence.
+  #
+  # Since we know the exact length, this is redefined to achive O(1) performance instead
+  # of O(n) for couting the elements.
+  #
+  public redef count => length


### PR DESCRIPTION
The redefinition of `count` in `Mutable_Array` now has O(1) performance.

Similarly, redefine `Sequence.drop` in `array` and result of `array.slice`. This improves the performance of `drop n` from O(n) to O(1).

I did not add a redefinition of `drop` to `Mutable_Array`, I am not sure if `Mutable_Array` should be a `Sequence` at all.