### PR TITLE
me: Reduce recursion depth of CFG and DFA

### DIFF
--- a/src/dev/flang/fuir/analysis/dfa/DFA.java
+++ b/src/dev/flang/fuir/analysis/dfa/DFA.java
@@ -767,7 +767,7 @@ public class DFA extends ANY
    * Maximum recursive analysis of newly created Calls, see `analyzeNewCall` for
    * details.
    */
-  private static int MAX_NEW_CALL_RECURSION = 20;
+  private static int MAX_NEW_CALL_RECURSION = 10;
 
 
   /*-------------------------  static methods  --------------------------*/

--- a/src/dev/flang/fuir/cfg/CFG.java
+++ b/src/dev/flang/fuir/cfg/CFG.java
@@ -35,6 +35,7 @@ import dev.flang.fuir.FUIR;
 import dev.flang.util.ANY;
 import dev.flang.util.Errors;
 import dev.flang.util.Graph;
+import dev.flang.util.List;
 
 
 /**
@@ -105,6 +106,12 @@ public class CFG extends ANY
   TreeSet<Integer> _calledClazzes = new TreeSet<>();
 
 
+  /**
+   * Newly found classes for which createCallGraph still must be called.
+   */
+  List<Integer> _newCalledClazzesToBeProcessed = new List<>();
+
+
   /*---------------------------  constructors  ---------------------------*/
 
 
@@ -129,7 +136,12 @@ public class CFG extends ANY
   public void createCallGraph()
   {
     var cl = _fuir.mainClazzId();
-    createCallGraph(cl);
+    _newCalledClazzesToBeProcessed.add(cl);
+    while (_newCalledClazzesToBeProcessed.size() > 0)
+      {
+        var ncl = _newCalledClazzesToBeProcessed.removeLast();
+        createCallGraph(ncl);
+      }
     Errors.showAndExit();
   }
 
@@ -667,7 +679,7 @@ public class CFG extends ANY
             if (!_calledClazzes.contains(cc))
               {
                 _calledClazzes.add(cc);
-                createCallGraph(cc);
+                _newCalledClazzesToBeProcessed.add(cc);
               }
           }
       }

--- a/src/dev/flang/util/List.java
+++ b/src/dev/flang/util/List.java
@@ -325,6 +325,15 @@ public class List<T>
 
 
   /**
+   * Remove the last element of the list.
+   */
+  public T removeLast()
+  {
+    return remove(size()-1);
+  }
+
+
+  /**
    * A collector for this List to be used in Stream.collect(...)
    * @param <U>
    * @return


### PR DESCRIPTION
CFG was the deepest recursion when translating a small application, while DFA was at second position.  This significantly flattens recursion shown in -XjavaProf-generated flame graphs.  This might also improve performance by better memory access locality.