### PR TITLE
AoC PR: lib: performance and API improvements for stdin and reader

### DIFF
--- a/lib/io/buffered/reader.fz
+++ b/lib/io/buffered/reader.fz
@@ -49,24 +49,31 @@ public reader(private rp Read_Provider, buf_size i32, buffer array u8 | io.end_o
   # in case the buffer is empty it fills the buffer
   # before returning it.
   #
-  public read array u8 | io.end_of_file is
+  public read => read buf_size
+
+
+  # read returns the current buffer or end of file.
+  # in case the buffer is empty it fills the buffer
+  # with up to max_n bytes before returning it.
+  #
+  public read(max_n i32) array u8 | io.end_of_file is
     match buffer
       b array =>
         if b.is_empty
-          fill_buffer
+          fill_buffer max_n
         buffer
       io.end_of_file => io.end_of_file
 
 
 
-  # fill the currently empty buffer
+  # fill the currently empty buffer with up to max_n bytes
   #
-  private fill_buffer
+  private fill_buffer(max_n i32)
   pre match buffer
         a array => a.is_empty
         io.end_of_file => false
   is
-    match rp.read buf_size
+    match rp.read max_n
       a array =>
         set buffer := a
         replace
@@ -84,7 +91,7 @@ public reader(private rp Read_Provider, buf_size i32, buffer array u8 | io.end_o
   is
     match buffer
       b array =>
-        set buffer := (b.drop n).as_array
+        set buffer := (b.slice n b.length).as_array
         replace
       io.end_of_file =>
 
@@ -111,7 +118,7 @@ reader =>
 
 
 # read n bytes using the currently installed byte reader effect
-# if the returned sequence is or count is less than n, end of file has been reached.
+# if the returned sequence is empty or count is less than n, end of file has been reached.
 #
 public read_bytes(n i32) Sequence u8 ! reader is
 
@@ -119,21 +126,19 @@ public read_bytes(n i32) Sequence u8 ! reader is
 
   mi.go ()->
 
-    res := (mutate.array (array u8)).type.new mi
+    res := (mutate.array u8).type.new mi
 
-    while ((res.flat_map_sequence u8 x->x).count < n &&
-      match reader.read
-        io.end_of_file => false
-        a (array u8) =>
-          reader.discard a.count
-          res.add a
-          true
-      )
-
-    res
-      .flat_map_sequence u8 x->x
-      .as_array
-
+    for n_read := 0, n_read + r
+    while n_read < n
+      r := match reader.read   # NYI: we should limit the number of byted read by reader.read, we can exceed n!
+          io.end_of_file => -1
+          a (array u8) =>
+            reader.discard a.length
+            for b in a do
+              res.add b
+            a.length
+    until r < 0
+    res.as_array
 
 
 # read string, up to n codepoints or until end of file
@@ -202,7 +207,7 @@ public read_line String ! reader is
   mi : mutate is
 
   mi.go String ()->
-    res := (mutate.array (array u8)).type.new mi
+    res := (mutate.array u8).type.new mi
 
     while
       match reader.read
@@ -211,16 +216,18 @@ public read_line String ! reader is
         a array =>
 
           # trailing carriage returns are dropped
-          add_to_res(a array u8) is
+          add_to_res(a Sequence u8) is
             if !a.is_empty
-              res.add (if a.last = character_encodings.ascii.cr
-                        (a.slice 0 a.count-1).as_array
+              a1 := if a.last = character_encodings.ascii.cr
+                        (a.slice 0 a.count-1)
                       else
-                        a)
+                        a
+              for b in a1 do
+                res.add b
 
           match (container.searchable_sequence a).index_of character_encodings.ascii.lf
             idx i32 =>
-              add_to_res (a.slice 0 idx).as_array
+              add_to_res (a.slice 0 idx)
               reader.discard idx+1
               false
             nil =>
@@ -228,11 +235,26 @@ public read_line String ! reader is
               reader.discard_all
               true
 
-    bytes :=
-      res
-        .flat_map_sequence u8 x->x
-        .as_array
-
     ref : String
-      utf8 Sequence u8 is
-        bytes
+      utf8 Sequence u8 := res.as_array
+
+
+# Read input fully into an array of bytes until end_of_file is reached
+#
+public read_fully array u8 ! reader =>
+  for
+    r Sequence u8 := [], r++n
+    n := (io.buffered.read_bytes 8192)
+  while n.count > 0 else
+    r.as_array
+
+
+# Read input fully and split it at linefeed (ASCII 10) characters. Delete
+# any trailing carriage returns (ASCII 13) from the resulting strings.
+#
+public read_lines array String ! reader =>
+  (String.type.from_bytes read_fully).split "\n"
+                                     .map s->
+                                       s.ends_with "\r" ? TRUE  => s.substring 0 s.byte_length-1
+                                                        | FALSE => s
+                                     .as_array

--- a/lib/io/stdin.fz
+++ b/lib/io/stdin.fz
@@ -38,14 +38,16 @@ public stdin io.buffered.reader is
 
   read_provider : io.Read_Provider is
     read(count i32) choice (array u8) io.end_of_file error is
-      arr := fuzion.sys.internal_array_init u8 1
-      v := fuzion.sys.fileio.read fuzion.sys.stdin.stdin0 arr.data 1
+      arr := fuzion.sys.internal_array_init u8 count
+      v := fuzion.sys.fileio.read fuzion.sys.stdin.stdin0 arr.data count
       if v < -1
         error "an error occurred while reading stdin"
       else if v <= 0
         io.end_of_file
+      else if v < count
+        array u8 v i->arr[i]
       else
         arr.as_array
 
 
-  io.buffered.reader read_provider 1 []
+  io.buffered.reader read_provider 1024 []


### PR DESCRIPTION
There are three changes in this patch:

 1. big preformance improvements by avoiding list iteration
 2. smaller performance improvements by reading several bytes at once
 3. additioonal convenience APIs for reading a file fully

Replaced `while (mutate.flat_map_sequence u8 x->x).count < n` by `n_read < n`. This was by far the biggest performance issue when reading bytes since it required time in O(n²).

Replaced `drop` in `reader.discard` by `slice` which is O(1) and does not cause deep recursion.

Add a version of io.buffered.reader.read with an argument max_n that gives the desired number of bytes to be read.

io.stdin.read_provider.read no longer restrics the number of bytes to just one, but tries to read count bytes. This change currently breaks the C backend since the C intrinsic apparently attempts to read all bytes until count or end-of-file is reached.  The C backend should instead check the number of bytes that are available to read without blocking and read only those unless there are none available. Only then it should block until data is available and then read all available data up to the given limit of bytes.

I will create an issue for this C backend problem to be fixed later.

Added two convenience features `io.buffered.read_fully` and `io.buffered.read_lines` to read all bytes into a large array or read all lines of a file into an array of Strings, respectively.