### PR TITLE
fe/lib: Support partial application w/ type parameters, add `infix |>`,... fix #2354

### DIFF
--- a/lib/pipes.fz
+++ b/lib/pipes.fz
@@ -1,0 +1,146 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion standard library infix pipe features
+#
+#  Author: Fridtjof Siebert (siebert@tokiwa.software)
+#
+# -----------------------------------------------------------------------
+
+
+# infix |> -- pipe with one argument
+#
+# This allows changing the order of function application: instead of
+#
+#   l := sum ([1,2,3,4].map **2)
+#
+# you can write
+#
+#   l := [1,2,3].map **2 |> sum
+#
+# which often correponds more naturally to the data flow through the code.
+#
+public infix |> (A, R type, a A, f A->R) =>
+  f a
+
+
+# infix ||> -- pipe with a two-tuple argument, destructuring the tuple into arguments
+#
+# This allows changing the order of function application: instead of
+#
+#   f(a,b i32) => a+b
+#   l1 := [1,2,3,4]
+#   l2 := [4,3,2,1}
+#   l := l1.pairs l2
+#          .map p->{(p1,p2) := p; f p1 p2}
+#
+# you can write
+#
+#   l1 := [1,2,3,4]
+#   l2 := [4,3,2,1}
+#   l := l1.pairs l2
+#          .map (p -> p ||> f)
+#
+# which often correponds more naturally to the data flow through the code.
+#
+public infix ||> (A, B, R type, a (A,B), f (A,B)->R) =>
+  f a.values.0 a.values.1
+
+
+# infix |||> -- pipe with a three-tuple argument, destructuring the tuple into arguments
+#
+# This allows changing the order of function application: instead of
+#
+#   f(a,b,c i32) => a+b+c
+#   t := (1,2,3)
+#   r := f t.values.0 t.values.1 t.values.2
+#
+# you can write
+#
+#   f(a,b,c i32) => a+b+c
+#   t := (1,2,3)
+#   r := t |||> f
+#
+# which often correponds more naturally to the data flow through the code.
+#
+public infix |||> (A, B, C, R type, a (A,B,C), f (A,B,C)->R) =>
+  f a.values.0 a.values.1 a.values.2
+
+
+# infix ||||> -- pipe with a four-tuple argument, destructuring the tuple into arguments
+#
+# This allows changing the order of function application: instead of
+#
+#   f(a,b,c,d i32) => a+b+c+d
+#   t := (1,2,3,4)
+#   r := f t.values.0 t.values.1 t.values.2 t.values.3
+#
+# you can write
+#
+#   f(a,b,c,d i32) => a+b+c+d
+#   t := (1,2,3,4)
+#   r := t ||||> f
+#
+# which often correponds more naturally to the data flow through the code.
+#
+public infix ||||> (A, B, C, D, R type, a (A,B,C,D), f (A,B,C,D)->R) =>
+  f a.values.0 a.values.1 a.values.2 a.values.3
+
+
+# infix |||||> -- pipe with a five-tuple argument, destructuring the tuple into arguments
+#
+# This allows changing the order of function application: instead of
+#
+#   f(a,b,c,d,e i32) => a+b+c+d+e
+#   t := (1,2,3,4,5)
+#   r := f t.values.0 t.values.1 t.values.2 t.values.3 t.values.4
+#
+# you can write
+#
+#   f(a,b,c,d,e i32) => a+b+c+d+e
+#   t := (1,2,3,4,5)
+#   r := t |||||> f
+#
+# which often correponds more naturally to the data flow through the code.
+#
+public infix |||||> (A, B, C, D, E, R type, a (A,B,C,D,E), f (A,B,C,D,E)->R) =>
+  f a.values.0 a.values.1 a.values.2 a.values.3 a.values.4
+
+
+# infix ||||||> -- pipe with a six-tuple argument, destructuring the tuple into arguments
+#
+# This allows changing the order of function application: instead of
+#
+#   f(a,b,c,d,e,f i32) => a+b+c+d+e+f
+#   t := (1,2,3,4,5,6)
+#   r := f t.values.0 t.values.1 t.values.2 t.values.3 t.values.4 t.values.5
+#
+# you can write
+#
+#   f(a,b,c,d,e,f i32) => a+b+c+d+e+f
+#   t := (1,2,3,4,5,6)
+#   r := t ||||||> f
+#
+# which often correponds more naturally to the data flow through the code.
+#
+public infix ||||||> (A, B, C, D, E, F, R type, a (A,B,C,D,E,F), f (A,B,C,D,E,F)->R) =>
+  f a.values.0 a.values.1 a.values.2 a.values.3 a.values.4 a.values.5
+
+
+# a six-tuple is large enough for two 3-D coordinates, so let's stop here for now....

--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -945,19 +945,33 @@ public class Call extends AbstractCall
     if (PRECONDITIONS) require
       (expectedType.isFunctionType());
 
+    // NYI: CLEANUP: The logic in this method seems overly complex, there might be potential to simplify!
     Expr l = this;
-    if (_calledFeature != null &&
-        partiallyApplicableAlternative(res, outer, expectedType) != null)
+    if (partiallyApplicableAlternative(res, outer, expectedType) != null)
       {
-        res.resolveTypes(_calledFeature);
-        var rt = _calledFeature.resultTypeIfPresent(res);
-        if (rt != null && (!rt.isAnyFunctionType() || rt.arity() != expectedType.arity()))
+        if (_calledFeature != null)
           {
-            l = applyPartially(res, outer, expectedType);
+            res.resolveTypes(_calledFeature);
+            var rt = _calledFeature.resultTypeIfPresent(res);
+            if (rt != null && (!rt.isAnyFunctionType() || rt.arity() != expectedType.arity()))
+              {
+                l = applyPartially(res, outer, expectedType);
+              }
+          }
+        else
+          {
+            if (_pendingError == null)
+              {
+                l = resolveTypes(res, outer);  // this enssures _calledFeature is set such that possible ambiguity is reported
+              }
+            if (l == this)
+              {
+                l = applyPartially(res, outer, expectedType);
+              }
           }
       }
     else if (_pendingError != null                   || /* nothing found */
-             newNameForPartial(expectedType) != null    /* must search for a different name */)
+             newNameForPartial(expectedType) != null    /* search for a different name */)
       {
         l = applyPartially(res, outer, expectedType);
       }
@@ -995,7 +1009,7 @@ public class Call extends AbstractCall
         var targetFeature = traverseOuter ? outer : targetFeature(res, outer);
         var fos = res._module.lookup(targetFeature, name, this, traverseOuter, false);
         var calledName = FeatureName.get(name, n);
-        result = FeatureAndOuter.filter(fos, pos(), FeatureAndOuter.Operation.CALL, calledName, ff -> ff.typeArguments().isEmpty() && ff.valueArguments().size() == n);
+        result = FeatureAndOuter.filter(fos, pos(), FeatureAndOuter.Operation.CALL, calledName, ff -> ff.valueArguments().size() == n);
       }
     return result;
   }
@@ -1086,6 +1100,7 @@ public class Call extends AbstractCall
    */
   public Expr applyPartially(Resolution res, AbstractFeature outer, AbstractType t)
   {
+    checkPartialAmbiguity(res, outer, t);
     Expr result;
     var n = t.arity();
     if (mustNotContainDeclarations("a partially applied function call", outer))
@@ -2718,16 +2733,15 @@ public class Call extends AbstractCall
   public Expr propagateExpectedType(Resolution res, AbstractFeature outer, AbstractType t)
   {
     Expr r = this;
-    if (t.isFunctionType() && !_wasImplicitImmediateCall)
+    if (t.isFunctionType()         &&
+        !_wasImplicitImmediateCall &&
+        _type != Types.t_ERROR     &&
+        (_type == null || !_type.isAnyFunctionType()))
       {
-        checkPartialAmbiguity(res, outer, t);
-        if (_type != Types.t_ERROR && (_type == null || !_type.isAnyFunctionType()))
+        r = propagateExpectedTypeForPartial(res, outer, t);
+        if (r != this)
           {
-            r = propagateExpectedTypeForPartial(res, outer, t);
-            if (r != this)
-              {
-                r.propagateExpectedType(res, outer, t);
-              }
+            r.propagateExpectedType(res, outer, t);
           }
       }
     return r;

--- a/tests/partial_application_negative/partial_application_negative.fz.expected_err
+++ b/tests/partial_application_negative/partial_application_negative.fz.expected_err
@@ -15,42 +15,7 @@ Target feature: 'i32'
 In call: '3.postfix*'
 
 
---CURDIR--/partial_application_negative.fz:42:47: error 3: Could not find called feature
-  test "data.map 3.prefix*   " (data.map    3.prefix*) "[3,6,9,12,15,18,21,24,27,30]"    // 1. should flag an error, do not change named prefix call to infix call
-----------------------------------------------^^^^^^^
-Feature not found: 'prefix *' (one argument)
-Target feature: 'i32'
-In call: '3.prefix*'
-
-
---CURDIR--/partial_application_negative.fz:43:38: error 4: Failed to infer actual type parameters
-  test "data.map 3.prefix-   " (data.map    3.prefix-) "[3,6,9,12,15,18,21,24,27,30]"    // 2. should flag an error, do not change named prefix call to infix call
--------------------------------------^^^
-In call to 'has_interval.infix ...map', no actual type parameters are given and inference of the type parameters failed.
-Expected type parameters: 'B'
-Type inference failed for one type parameter 'B'
-
-
---CURDIR--/partial_application_negative.fz:44:47: error 5: Could not find called feature
-  test "data.map 3.postfix*  " (data.map    3.postfix*) "[3,6,9,12,15,18,21,24,27,30]"  // 3. should flag an error, do not change named prefix call to infix call
-----------------------------------------------^^^^^^^^
-Feature not found: 'postfix *' (one argument)
-Target feature: 'i32'
-In call: '3.postfix*'
-
-
---CURDIR--/partial_application_negative.fz:77:38: error 6: Could not find called feature
-  test "data.map  .as_string " (data.map  .as_string ) "[1,2,3,4,5,6,7,8,9,10]"  // 11. should flag an error: dot-call partials require parentheses
--------------------------------------^^^
-Feature not found: 'map' (no arguments)
-Target feature: 'has_interval.infix ..'
-In call: 'map'
-To solve this, you might change the actual number of arguments to match the feature 'map' (2 arguments) at $FUZION/lib/has_interval.fz:122:12:
-    public map(B type, f Unary B has_interval.this)  => map_sequence f
------------^
-
-
---CURDIR--/partial_application_negative.fz:60:8: error 7: Ambiguity between direct and partially applied call target
+--CURDIR--/partial_application_negative.fz:60:8: error 3: Ambiguity between direct and partially applied call target
   test ambig             // 6. should flag an error: Ambiguous call to `ambig (0 arguments)` or `ambig (1 arguments)`
 -------^^^^^
 This call can be resolved in two ways, either as a direct call to 'partial_application_negative.ambig' declared at --CURDIR--/partial_application_negative.fz:53:3:
@@ -62,7 +27,7 @@ or by partially applying arguments to a call to 'partial_application_negative.am
 To solve this, rename one of the ambiguous features.
 
 
---CURDIR--/partial_application_negative.fz:61:9: error 8: Ambiguity between direct and partially applied call target
+--CURDIR--/partial_application_negative.fz:61:9: error 4: Ambiguity between direct and partially applied call target
   test (ambig 42   )     // 7. should flag an error: Ambiguous call to `ambig (1 arguments)` or `ambig (2 arguments)`
 --------^^^^^
 This call can be resolved in two ways, either as a direct call to 'partial_application_negative.ambig' declared at --CURDIR--/partial_application_negative.fz:54:3:
@@ -74,7 +39,7 @@ or by partially applying arguments to a call to 'partial_application_negative.am
 To solve this, rename one of the ambiguous features.
 
 
---CURDIR--/partial_application_negative.fz:62:9: error 9: Ambiguity between direct and partially applied call target
+--CURDIR--/partial_application_negative.fz:62:9: error 5: Ambiguity between direct and partially applied call target
   test (ambig 47 11)     // 8. should flag an error: Ambiguous call to `ambig (2 arguments)` or `ambig (3 arguments)`
 --------^^^^^
 This call can be resolved in two ways, either as a direct call to 'partial_application_negative.ambig' declared at --CURDIR--/partial_application_negative.fz:55:3:
@@ -84,6 +49,41 @@ or by partially applying arguments to a call to 'partial_application_negative.am
   ambig(x,y,z i32)   String     => "$x $y $z"
 --^^^^^.
 To solve this, rename one of the ambiguous features.
+
+
+--CURDIR--/partial_application_negative.fz:42:47: error 6: Could not find called feature
+  test "data.map 3.prefix*   " (data.map    3.prefix*) "[3,6,9,12,15,18,21,24,27,30]"    // 1. should flag an error, do not change named prefix call to infix call
+----------------------------------------------^^^^^^^
+Feature not found: 'prefix *' (one argument)
+Target feature: 'i32'
+In call: '3.prefix*'
+
+
+--CURDIR--/partial_application_negative.fz:43:38: error 7: Failed to infer actual type parameters
+  test "data.map 3.prefix-   " (data.map    3.prefix-) "[3,6,9,12,15,18,21,24,27,30]"    // 2. should flag an error, do not change named prefix call to infix call
+-------------------------------------^^^
+In call to 'has_interval.infix ...map', no actual type parameters are given and inference of the type parameters failed.
+Expected type parameters: 'B'
+Type inference failed for one type parameter 'B'
+
+
+--CURDIR--/partial_application_negative.fz:44:47: error 8: Could not find called feature
+  test "data.map 3.postfix*  " (data.map    3.postfix*) "[3,6,9,12,15,18,21,24,27,30]"  // 3. should flag an error, do not change named prefix call to infix call
+----------------------------------------------^^^^^^^^
+Feature not found: 'postfix *' (one argument)
+Target feature: 'i32'
+In call: '3.postfix*'
+
+
+--CURDIR--/partial_application_negative.fz:77:38: error 9: Could not find called feature
+  test "data.map  .as_string " (data.map  .as_string ) "[1,2,3,4,5,6,7,8,9,10]"  // 11. should flag an error: dot-call partials require parentheses
+-------------------------------------^^^
+Feature not found: 'map' (no arguments)
+Target feature: 'has_interval.infix ..'
+In call: 'map'
+To solve this, you might change the actual number of arguments to match the feature 'map' (2 arguments) at $FUZION/lib/has_interval.fz:122:12:
+    public map(B type, f Unary B has_interval.this)  => map_sequence f
+-----------^
 
 
 --CURDIR--/partial_application_negative.fz:72:21: error 10: Ambiguity between direct and partially applied call target


### PR DESCRIPTION
First, this adds the ability to use partial application with functions that have type parameters.

Then, this adds `infix |>`, `infix ||>`, as functions with type parameters to the universe.