### PR TITLE
fe: When printing types, use "xyz.this" not "xyz.this.type"

### DIFF
--- a/src/dev/flang/ast/AbstractType.java
+++ b/src/dev/flang/ast/AbstractType.java
@@ -1726,7 +1726,7 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
               + fname;
         if (isThisType())
           {
-            result = result + ".this.type";
+            result = result + ".this";
           }
         for (var g : generics())
           {

--- a/src/dev/flang/ast/ResolvedNormalType.java
+++ b/src/dev/flang/ast/ResolvedNormalType.java
@@ -533,7 +533,7 @@ public class ResolvedNormalType extends ResolvedType
       }
     if (isThisType())
       {
-        result = result + ".this.type";
+        result = result + ".this";
       }
     if (_generics != UnresolvedType.NONE)
       {

--- a/tests/call_with_ambiguous_result_type_negative/call.fz.expected_err
+++ b/tests/call_with_ambiguous_result_type_negative/call.fz.expected_err
@@ -4,9 +4,9 @@
 ---------^
 The result type of this call depends on the target type.  Since the target type is a 'ref' type that may represent a number of different actual dynamic types, the result type is not clearly defined.
 Called feature: 'call_with_ambiguous_result_type.r.g'
-Raw result type: 'call_with_ambiguous_result_type.this.type.r.this.type.e'
-Type depending on target: 'call_with_ambiguous_result_type.this.type.r.this.type'
-Target type: 'call_with_ambiguous_result_type.this.type.r'
-To solve this, you could try to use a value type as the target type of the call or change the result type of 'call_with_ambiguous_result_type.r.g' to no longer depend on 'call_with_ambiguous_result_type.this.type.r.this.type'.
+Raw result type: 'call_with_ambiguous_result_type.this.r.this.e'
+Type depending on target: 'call_with_ambiguous_result_type.this.r.this'
+Target type: 'call_with_ambiguous_result_type.this.r'
+To solve this, you could try to use a value type as the target type of the call or change the result type of 'call_with_ambiguous_result_type.r.g' to no longer depend on 'call_with_ambiguous_result_type.this.r.this'.
 
 one error.

--- a/tests/reg_issue1054_incompatible_contraint_generics/issue1054.fz.expected_err
+++ b/tests/reg_issue1054_incompatible_contraint_generics/issue1054.fz.expected_err
@@ -2,7 +2,7 @@
 --CURDIR--/issue1054.fz:30:3: error 1: Incompatible type parameter
   c (floaty f32) // bad
 --^
-formal type parameter 'T' with constraint 'ex.this.type.floaty f64'
-actual type parameter 'ex.this.type.floaty f32'
+formal type parameter 'T' with constraint 'ex.this.floaty f64'
+actual type parameter 'ex.this.floaty f32'
 
 one error.

--- a/tests/reg_issue1216_precondition_box_constructor/test_issue1216.fz.expected_err
+++ b/tests/reg_issue1216_precondition_box_constructor/test_issue1216.fz.expected_err
@@ -4,9 +4,9 @@
 ----^
 Actual type for argument #1 'minime' does not match expected type.
 In call to          : 'outer.f'
-expected formal type: 'outer.this.type'
-actual type found   : 'outer.this.type.b'
-assignable to       : 'outer.this.type.b'
+expected formal type: 'outer.this'
+actual type found   : 'outer.this.b'
+assignable to       : 'outer.this.b'
 for value assigned  : 'b'
 To solve this, you could change the type of 'minime' to a 'ref' type like 'ref outer'.
 

--- a/tests/reg_issue7_genericConstraint/checkGenericConstraint.fz.expected_err
+++ b/tests/reg_issue7_genericConstraint/checkGenericConstraint.fz.expected_err
@@ -2,7 +2,7 @@
 --CURDIR--/checkGenericConstraint.fz:41:8: error 1: Incompatible type parameter
   m := hm m32 m32     # should produce error, m32 is not compatible to H
 -------^^
-formal type parameter 'T' with constraint 'checkGenericConstraint.this.type.H'
-actual type parameter 'checkGenericConstraint.this.type.m32'
+formal type parameter 'T' with constraint 'checkGenericConstraint.this.H'
+actual type parameter 'checkGenericConstraint.this.m32'
 
 one error.


### PR DESCRIPTION
This was changed in the source code a while ago, so we have to change the error output accordingly.