### PR TITLE
rename: `clazzObject` -> `clazzAny`

### DIFF
--- a/src/dev/flang/ast/Partial.java
+++ b/src/dev/flang/ast/Partial.java
@@ -26,7 +26,6 @@ Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
 
 package dev.flang.ast;
 
-import dev.flang.util.Errors;
 import dev.flang.util.FuzionConstants;
 import dev.flang.util.List;
 import dev.flang.util.SourcePosition;

--- a/src/dev/flang/ast/Types.java
+++ b/src/dev/flang/ast/Types.java
@@ -36,7 +36,6 @@ import java.util.TreeSet;
 import dev.flang.util.ANY;
 import dev.flang.util.Errors;
 import dev.flang.util.FuzionConstants;
-import dev.flang.util.List;
 
 /*---------------------------------------------------------------------*/
 

--- a/src/dev/flang/be/c/C.java
+++ b/src/dev/flang/be/c/C.java
@@ -422,7 +422,7 @@ public class C extends ANY
       var hasTag    = !_fuir.clazzIsChoiceOfOnlyRefs(subjClazz);
       var refEntry  = uniyon.field(CNames.CHOICE_REF_ENTRY_NAME);
       var ref       = hasTag ? refEntry                   : _names.newTemp();
-      var getRef    = hasTag ? CStmnt.EMPTY               : CStmnt.decl(_types.clazz(_fuir.clazzObject()), (CIdent) ref, refEntry);
+      var getRef    = hasTag ? CStmnt.EMPTY               : CStmnt.decl(_types.clazz(_fuir.clazzAny()), (CIdent) ref, refEntry);
       var tag       = hasTag ? sub.field(CNames.TAG_NAME) : ref.castTo("int64_t");
       var tcases    = new List<CStmnt>(); // cases depending on tag value or ref cast to int64
       var rcases    = new List<CStmnt>(); // cases depending on clazzId of ref type
@@ -502,11 +502,11 @@ public class C extends ANY
                            "Found in choice type '" + _fuir.clazzAsString(newcl)+ "'\n");
             }
           value = CExpr.int32const(tagNum);
-          valuecl = _fuir.clazzObject();
+          valuecl = _fuir.clazzAny();
         }
       if (_fuir.clazzIsRef(valuecl))
         {
-          value = value.castTo(_types.clazz(_fuir.clazzObject()));
+          value = value.castTo(_types.clazz(_fuir.clazzAny()));
         }
       var o = CStmnt.seq(CStmnt.lineComment("Tag a value to be of choice type " + _fuir.clazzAsString(newcl) +
                                             " static value type " + _fuir.clazzAsString(valuecl)),

--- a/src/dev/flang/be/c/CTypes.java
+++ b/src/dev/flang/be/c/CTypes.java
@@ -244,7 +244,7 @@ public class CTypes extends ANY
             for (int i = 0; i < _fuir.clazzNumChoices(cl); i++)
               {
                 var cc = _fuir.clazzChoice(cl, i);
-                findDeclarationOrder(_fuir.clazzIsRef(cc) ? _fuir.clazzObject() : cc, result, visited);
+                findDeclarationOrder(_fuir.clazzIsRef(cc) ? _fuir.clazzAny() : cc, result, visited);
               }
             if (_fuir.clazzIsRef(cl))
               {
@@ -292,7 +292,7 @@ public class CTypes extends ANY
               }
             if (_fuir.clazzIsChoiceWithRefs(cl))
               {
-                uls.add(CStmnt.decl(clazz(_fuir.clazzObject()), _names.CHOICE_REF_ENTRY_NAME));
+                uls.add(CStmnt.decl(clazz(_fuir.clazzAny()), _names.CHOICE_REF_ENTRY_NAME));
               }
             els.add(CStmnt.unyon(uls, _names.CHOICE_UNION_NAME));
           }

--- a/src/dev/flang/fuir/FUIR.java
+++ b/src/dev/flang/fuir/FUIR.java
@@ -753,11 +753,11 @@ public class FUIR extends IR
 
 
   /**
-   * Get the id of clazz Object.
+   * Get the id of clazz Any.
    *
-   * @return clazz id of clazz Object
+   * @return clazz id of clazz Any
    */
-  public int clazzObject()
+  public int clazzAny()
   {
     return id(Clazzes.any.get());
   }

--- a/src/dev/flang/fuir/analysis/dfa/Call.java
+++ b/src/dev/flang/fuir/analysis/dfa/Call.java
@@ -26,7 +26,6 @@ Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
 
 package dev.flang.fuir.analysis.dfa;
 
-import java.nio.charset.StandardCharsets;
 
 import dev.flang.fuir.FUIR;
 

--- a/src/dev/flang/fuir/analysis/dfa/DFA.java
+++ b/src/dev/flang/fuir/analysis/dfa/DFA.java
@@ -34,7 +34,6 @@ import java.util.TreeMap;
 import java.util.TreeSet;
 
 import dev.flang.fuir.FUIR;
-import dev.flang.fuir.FUIR.SpecialClazzes;
 import dev.flang.fuir.analysis.AbstractInterpreter;
 
 import dev.flang.util.ANY;

--- a/src/dev/flang/fuir/analysis/dfa/SysArray.java
+++ b/src/dev/flang/fuir/analysis/dfa/SysArray.java
@@ -79,7 +79,7 @@ public class SysArray extends Value implements Comparable<SysArray>
    */
   public SysArray(DFA dfa, byte[] data, int elementClazz)
   {
-    super(dfa._fuir.clazzObject());
+    super(dfa._fuir.clazzAny());
 
     if (PRECONDITIONS) require
       (data != null);
@@ -125,7 +125,7 @@ public class SysArray extends Value implements Comparable<SysArray>
    */
   public SysArray(DFA dfa, Value el)
   {
-    super(dfa._fuir.clazzObject());
+    super(dfa._fuir.clazzAny());
 
     _dfa = dfa;
     _data = new byte[0];

--- a/src/dev/flang/parser/OpExpr.java
+++ b/src/dev/flang/parser/OpExpr.java
@@ -28,7 +28,6 @@ package dev.flang.parser;
 
 import java.util.ArrayList;
 
-import dev.flang.ast.Actual;
 import dev.flang.ast.Call;
 import dev.flang.ast.Expr;
 import dev.flang.ast.NumLiteral;
@@ -37,7 +36,6 @@ import dev.flang.ast.ParsedName;
 
 import dev.flang.util.ANY;
 import dev.flang.util.FuzionConstants;
-import dev.flang.util.List;
 
 /**
  * OpExpr <description>


### PR DESCRIPTION
In lib this renaming has been done a long time ago. It is now confusing to have it named Object in FUIR.