### PR TITLE
interpreter: change implementation `array_to_java_object0`

### DIFF
--- a/lib/fuzion/java.fz
+++ b/lib/fuzion/java.fz
@@ -198,12 +198,12 @@ public fuzion.java is
   # convert a Sequence to a Java Array object
   #
   public array_to_java_object(T type, a Sequence T) Array T is
-    array_to_java_object0 T a.as_array.internal_array.data
+    array_to_java_object0 T a.as_array.internal_array
 
 
   # intrinsic to convert an array to a Java Array object
   #
-  private array_to_java_object0(T type, a fuzion.sys.Pointer) Array T is intrinsic_constructor
+  private array_to_java_object0(T type, a fuzion.sys.internal_array T) Array T is intrinsic_constructor
 
 
   # convert a string to a Java String object

--- a/src/dev/flang/be/interpreter/Intrinsics.java
+++ b/src/dev/flang/be/interpreter/Intrinsics.java
@@ -701,7 +701,12 @@ public class Intrinsics extends ANY
         });
     putUnsafe("fuzion.java.array_to_java_object0", (interpreter, innerClazz) -> args ->
         {
-          var arrA = args.get(1).arrayData();
+          var argz = args.get(1);
+          var argfields = innerClazz.argumentFields();
+          var argsArray = argfields[argfields.length - 1];
+          var sac = argsArray.resultClazz();
+          var argzData = Interpreter.getField(Types.resolved.f_fuzion_sys_array_data, sac, argz, false);
+          var arrA = argzData.arrayData();
           var res = arrA._array;
           Clazz resultClazz = innerClazz.resultClazz();
           return JavaInterface.javaObjectToInstance(res, resultClazz);

--- a/tests/javaBase/javaHello.fz
+++ b/tests/javaBase/javaHello.fz
@@ -65,3 +65,10 @@ javaHello : Java is
       say "string has {bytes.count} bytes: $bytes"
       javaString2 := java.lang.__jString.new bytes 6 bytes.count-6                # create Java string from bytes subset,
       say "Hello "+javaString2                                                 # append Java string to Fuzion string and print it
+
+  # convert fuzion arrays to java arrays
+  #
+  say (fuzion.java.array_to_java_object [1,2,3])
+  say (fuzion.java.array_to_java_object [java.lang.System.out])
+  # NYI does not work yet: error 1: Used abstract feature 'String.utf8' is not implemented by 'String'
+  # say (fuzion.java.array_to_java_object ["1","2","3"])

--- a/tests/javaBase/javaHello.fz.expected_out
+++ b/tests/javaBase/javaHello.fz.expected_out
@@ -5,3 +5,5 @@ Hello Java 🌍!
 Hello Java 🌍!
 string has 16 bytes: [72,101,108,108,111,32,74,97,118,97,32,-16,-97,-116,-115,33]
 Hello Java 🌍!
+[1,2,3]
+[instance[Java.java.io.PrintStream]]


### PR DESCRIPTION
- instead of the pointer pass whole `internal_array` to backend
- this will be needed for the c-backend since there we need to know the length of the array