### PR TITLE
air: Make FeatureAndActuals.toString robust for `_f==null`

### DIFF
--- a/src/dev/flang/air/FeatureAndActuals.java
+++ b/src/dev/flang/air/FeatureAndActuals.java
@@ -197,7 +197,7 @@ public class FeatureAndActuals extends ANY implements Comparable<FeatureAndActua
   {
     return
       (_preconditionClazz ? "pre " : "") +
-      _f.qualifiedName() +
+      (_f == null ? "--" : _f.qualifiedName()) +
       (_tp != null ? _tp.toString(t -> " " + t.asStringWrapped())
                    : (_max ? " MAX" : " MIN"));
   }


### PR DESCRIPTION
Ran into this while trying to track down the reason for high memory usage.