### PR TITLE
AoC PR: lib: remove `say` without arguments

### DIFF
--- a/lib/container/ps_map.fz
+++ b/lib/container/ps_map.fz
@@ -214,7 +214,7 @@ O(n log n).
         sep := "", " "
     do
       yak (sep + e)
-    say
+    say ""
 
 
   # create sorted array of all keys in this map

--- a/lib/say.fz
+++ b/lib/say.fz
@@ -29,8 +29,3 @@
 # an object followed by a line break.
 #
 public say(s Any) => io.out.println s
-
-
-# A handy shortcut for stdout.println, output a line break.
-#
-public say => io.out.println


### PR DESCRIPTION
Not having this allows piping and partial application using `say` as in `"Hello" |> say`. To output a line feed, one can still used `say ""`.