### PR TITLE
lib/be effects: Use DFA for `fz -effects` and avoid panic in mutate, fix #2293

### DIFF
--- a/lib/Stream.fz
+++ b/lib/Stream.fz
@@ -164,12 +164,10 @@ public stream(public T type) ref : Sequence T is
   public redef as_array array T is
     m : mutate is
     m.go ()->
-      for
-        a := (mutate.array T).type.new m, {a.add x ; a}
+      a := (m.array T).type.new m
       while has_next
-        x := next
-      else
-        a.as_array
+        a.add next
+      a.as_array
 
 
   # create a stream that consists of all be the elements if this stream followed

--- a/lib/effect.fz
+++ b/lib/effect.fz
@@ -38,7 +38,7 @@ is
 
   match r
     _ effect_mode.plain   =>
-    i effect_mode.inst    => run i.f (_)->unit
+    i effect_mode.inst    => run i.f ()->unit
     _ effect_mode.repl    => replace
     _ effect_mode.default => default
     _ effect_mode.new     =>
@@ -60,19 +60,36 @@ is
   #
   private abortable(T type : Function unit, f T) unit is intrinsic
 
+
   # replace effect in the current context by this and abort current execution
-  public abort void is intrinsic
+  public abort void
+  pre
+    safety: abortable
+  is
+    intrinsic
+
+
+  # does this effect support abort?
+  #
+  # Redefining this to return `false` helps to detect unexptected calls to
+  # `abort` at runtime and ensure that the static analysis finds that there
+  # code executed with this effect will always return normally and produce
+  # a result. This is used, e.g, in `mutate` to avoid static analysis
+  # reporting `panic` as an effect of the use of a local mutate instance.
+  #
+  public abortable => true
+
 
   # set default effect in the current context to this if none is installed
   module default unit is intrinsic
 
   # execute the code of 'f' in the context of this effect
   #
-  module run(R type, f () -> R, def (unit /* NYI: unit type only to distingish 'f' and 'def' in static analysis, remove once 'fz -effects' uses DFA */)->R) R is
+  module run(R type, f () -> R, def ()->R) R is
     cf := Effect_Call f
     abortable cf
     match cf.res
-      nil => def unit
+      nil => def()
       x R => x
 
 
@@ -131,14 +148,18 @@ is
   # return an oucome with the abort wrapped in an error?).
   #
   public use(code ()->unit) unit is
-    abortable (Effect_Call code)
+    go code
+
 
   # install this effect and run code that produces a result of
   # type T. panic in case abort is called.
   #
   public go(T type, f ()->T) T is
-    fo () -> option T is ()->f()
-    r := run fo _->nil
-    match r
-      nil => panic "*** unexpected abort in {simple_effect.this.type}"
-      v T => v
+    if abortable
+      cf := Effect_Call ()->f()
+      abortable cf
+      match cf.res
+        nil => panic "*** unexpected abort in {simple_effect.this.type}"
+        x T => x
+    else
+      f()

--- a/lib/exit.fz
+++ b/lib/exit.fz
@@ -68,7 +68,7 @@ is
 
     # mutable value of the current exit code set
     #
-    exit_code := mut 0
+    exit_code := 0
 
 
     # exit with the given code
@@ -80,7 +80,7 @@ is
     # exit with the stored code
     #
     exit =>
-      fuzion.std.exit exit_code.get
+      fuzion.std.exit exit_code
 
 
     # set the stored exit code
@@ -89,17 +89,13 @@ is
       pre
         0 ≤ code ≤ 127
       post
-        code != 0 : !exit_code.open
+        exit_code = code
       is
-        if exit_code.open
-          exit_code <- code
-
-          if code != 0
-            exit_code.close
-            unit
+        if exit_code = 0
+          set exit_code := code
+          unit
         else
           error "exit code is already set"
-
 
 
 # exit with no argument returns exit.env, the currently installed

--- a/lib/io/buffered/reader.fz
+++ b/lib/io/buffered/reader.fz
@@ -36,7 +36,7 @@ public reader(private rp Read_Provider, buf_size i32, buffer array u8 | io.end_o
   # resulting 'outcome'.
   #
   public with(R type, f ()->R) outcome R is
-    try reader R ()->(run f (_ -> exit 1))
+    try reader R (() -> run f (() -> exit 1))
 
 
   # terminate immediately with the given error wrapped in 'option'.

--- a/lib/list.fz
+++ b/lib/list.fz
@@ -166,7 +166,7 @@ public list(public A type) : choice nil (Cons A (list A)), Sequence A is
   public redef as_array array A =>
     lm : mutate.
     lm.go ()->
-      e := mut list.this
+      e := lm.new list.this
       array A count _->
         res := e.get.first
         e <- e.get.force_tail

--- a/lib/mutate.fz
+++ b/lib/mutate.fz
@@ -55,6 +55,11 @@
 #
 public mutate : simple_effect is
 
+
+  # does this effect support abort?
+  public redef abortable => false
+
+
   # short-hand to access effect type
   #
   # NYI: This does not work yet
@@ -66,29 +71,35 @@ public mutate : simple_effect is
   #
   id := fuzion.sys.misc.unique_id
 
-  # 0 is used to indicate this is closed
-  #
-  # NYI: remove this check as soon as id is set by an intrinsic guaranteed not to be 0.
-  #
-  if id = u64 0
-    panic "*** mutate.id should never be 0"
 
   # common type for mutable data
+  #
   private:public mutable_element is
+
     # id used to verify that mutation made with the same effect
     # the mutable value was created with
     my_id := id
 
+
+    # check that this effect is the same as the currently installed effect of type
+    # `mutate.this`
+    #
+    private is_currently_installed =>  my_id = mutate.this.env.id
+
+
     # check that this effect is installed and replace it.
     #
-    private check_and_replace is
-      if my_id != mutate.this.env.id
-        panic "*** invalid mutate for {mutate.this.type}"
+    private check_and_replace
+    pre
+      safety: is_currently_installed
+    is
       mutate.this.env.replace
+
 
     # is this element open, i.e., can it be mutated?
     #
     public open => id != u64 0
+
 
     # stop any further mutations of this element
     #

--- a/lib/panic.fz
+++ b/lib/panic.fz
@@ -88,4 +88,4 @@ public Panic_Handler ref is
   #
   public use(R type, code, def ()->R) =>
     p := panic Panic_Handler.this unit
-    p.run code unit->def()
+    p.run code def

--- a/lib/try.fz
+++ b/lib/try.fz
@@ -41,7 +41,7 @@ is
   # resulting 'outcome'.
   #
   public on(R type, f ()->R) outcome R is
-    run (outcome R) (()->outcome f()) (_)->err.get
+    run (outcome R) (()->outcome f()) ()->err.get
 
   # terminate immediately with the given error wrapped in 'option'.
   #

--- a/src/dev/flang/fuir/analysis/dfa/Call.java
+++ b/src/dev/flang/fuir/analysis/dfa/Call.java
@@ -116,6 +116,15 @@ public class Call extends ANY implements Comparable<Call>, Context
   boolean _escapes = false;
 
 
+  /**
+   * If available, _codeblockId and _codeBlockIndex give an example call that
+   * resulted in creation of this Call.  This can be used to show the reason why
+   * a given call is present in showWhy().  Both are -1 if no call site is known.
+   */
+  int _codeblockId = -1;
+  int _codeblockIndex = -1;
+
+
   /*---------------------------  constructors  ---------------------------*/
 
 
@@ -317,7 +326,22 @@ public class Call extends ANY implements Comparable<Call>, Context
     var indent = _context.showWhy();
     System.out.println(indent + "  |");
     System.out.println(indent + "  +- performs call " + this);
+    if (_codeblockId != -1 && _codeblockIndex != -1)
+      {
+        System.out.println(_dfa._fuir.codeAtAsPos(_codeblockId,_codeblockIndex).show());
+      }
     return indent + "  ";
+  }
+
+
+  /**
+   * record code block id c and code block index i as a sample call site that
+   * lead to the creation of this Call. Used by showWhy().
+   */
+  void addCallSiteLocation(int c, int i)
+  {
+    _codeblockId = c;
+    _codeblockIndex = i;
   }
 
 

--- a/src/dev/flang/fuir/analysis/dfa/DFA.java
+++ b/src/dev/flang/fuir/analysis/dfa/DFA.java
@@ -389,6 +389,7 @@ public class DFA extends ANY
             if (_fuir.clazzNeedsCode(cc))
               {
                 var ca = newCall(cc, pre, tvalue.value(), args, _call._env, _call);
+                ca.addCallSiteLocation(c,i);
                 res = ca.result();
                 if (res != null && res != Value.UNIT && !_fuir.clazzIsRef(_fuir.clazzResultClazz(cc)))
                   {
@@ -866,7 +867,15 @@ public class DFA extends ANY
    *
    * NYI: this might need to be thread-local and not global!
    */
-  TreeMap<Integer, Value> _defaultEffects = new TreeMap<>();
+  public final TreeMap<Integer, Value> _defaultEffects = new TreeMap<>();
+
+
+  /**
+   * Map from effect-type to corresponding call that uses this effect.
+   *
+   * NYI: this might need to be thread-local and not global!
+   */
+  public final TreeMap<Integer, Call> _defaultEffectContexts = new TreeMap<>();
 
 
   /**
@@ -1081,21 +1090,25 @@ public class DFA extends ANY
     do
       {
         cnt++;
-        _options.verbosePrintln("DFA iteration #"+cnt+": --------------------------------------------------" +
-                                (!_options.verbose(2) ? "" : _calls.size()+","+_instances.size()+"; "+_changedSetBy));
+        if (_options.verbose(2))
+          {
+            _options.verbosePrintln(2,
+                                    "DFA iteration #"+cnt+": --------------------------------------------------" +
+                                    (!_options.verbose(3) ? "" : _calls.size()+","+_instances.size()+"; "+_changedSetBy));
+          }
         _changed = false;
         _changedSetBy = "*** change not set ***";
         iteration();
       }
     while (_changed && (true || cnt < 100) || false && (cnt < 50));
-    if (_options.verbose(3))
+    if (_options.verbose(4))
       {
-        _options.verbosePrintln(3, "DFA done:");
-        _options.verbosePrintln(3, "Instances: " + _instances.values());
-        _options.verbosePrintln(3, "Calls: ");
+        _options.verbosePrintln(4, "DFA done:");
+        _options.verbosePrintln(4, "Instances: " + _instances.values());
+        _options.verbosePrintln(4, "Calls: ");
         for (var c : _calls.values())
           {
-            _options.verbosePrintln(3, "  call: " + c);
+            _options.verbosePrintln(4, "  call: " + c);
           }
       }
     _reportResults = true;
@@ -1770,6 +1783,7 @@ public class DFA extends ANY
           if (old_e == null || Value.compare(old_e, new_e) != 0)
             {
               cl._dfa._defaultEffects.put(ecl, new_e);
+              cl._dfa._defaultEffectContexts.put(ecl, cl);
               if (!cl._dfa._changed)
                 {
                   cl._dfa._changedSetBy = "effect.default called: "+cl._dfa._fuir.clazzAsString(cl._cc);

--- a/src/dev/flang/tools/Fuzion.java
+++ b/src/dev/flang/tools/Fuzion.java
@@ -244,7 +244,7 @@ class Fuzion extends Tool
       }
       void process(FuzionOptions options, FUIR fuir)
       {
-        new Effects(fuir).find();
+        new Effects(options, fuir).find();
       }
     },
 
@@ -440,7 +440,7 @@ class Fuzion extends Tool
       var mir = fe.createMIR();                                                       f.timer("createMIR");
       var air = new MiddleEnd(fe._options, mir, fe.module() /* NYI: remove */).air(); f.timer("me");
       var fuir = new Optimizer(fe._options, air).fuir();                              f.timer("ir");
-      new Effects(fuir).check();                                                      f.timer("effectsCheck");
+      new Effects(fe._options, fuir).check();                                         f.timer("effectsCheck");
       process(fe._options, fuir);
     }
 


### PR DESCRIPTION
Before this patch, the effects reported for HelloWorld.fz were useless:

```
   > ./build/bin/fz -effects build/tests/hello/HelloWorld.fz
  ((i32.infix ..).as_stream.#anonymous9.map_to_stream String).#anonymous1.as_array.m
  ((list String).as_stream.map_to_stream String).#anonymous1.as_array.m
  ((list i32).as_stream.map_to_stream String).#anonymous1.as_array.m
  ((list u8).as_stream.map_to_stream String).#anonymous1.as_array.m
  (i32.infix ..).as_stream.#anonymous9.as_array.m
  (list String).as_stream.as_array.m
  (list i32).as_stream.as_array.m
  (list u8).as_stream.as_array.m
  exit
  io.err
  io.out
  mutate
  panic
```

This patch fixes this by switching the effects backend used by `fz -effects` to use DFA instead for CFG, which give higher analysis accuracy and avoids the many `...as_array.m` effects.

Then, `effect.abortable` was added as a feature that can be redefined to indicate that a given effect must not support `abort`.  This helps removing the reported `panic` effect and consequently also `io.err` and `exit`.

Finally, the use of `mutate` effect was removed from `exit` (which is an effect already any may as well use `set` and `list.as_array` (which used `mut` in a local mutate instance, which made the local mutate instance useless). Also, the use of `panic` in `mutate.check_and_replace` was replaced by a precondition.

A minor cleanup in the code using a local mutate instance in `Stream.as_array` is also part of this patch.

`fz -effects` now supports `-verbose=1`, which will print the reason and a sample call chain why the reported effects are there, this facilitates understanding the results significantly.  To reduce noise, verbose output of DFA was moved one verbosity level up.

The resulting output of `fz -effects HelloWorld.fz` now is

```
   > ./build/bin/fz -effects build/tests/hello/HelloWorld.fz
  io.out
```

While `-verbose` adds a nice explanation (plus some unrelated warnings that need to be fixed).

```
   > ./build/bin/fz -effects -verbose build/tests/hello/HelloWorld.fz
  []
  EFFECT type io.out default used is io.out
  program entry point
      |
      +- performs call HelloWorld => HelloWorld
        |
        +- performs call say a0=boxed(Const_String):Const_String => UNIT
  /home/fridi/fuzion/work/build/tests/hello/HelloWorld.fz:27:3:
    say "Hello World!"
  --^^^
          |
          +- performs call io.out => io.out embedded in io.out
  $FUZION/lib/say.fz:31:25:
  public say(s Any) => io.out.println s
  ------------------------^
            |
            +- performs call ((io.#type io).out.#type io.out).install_default => UNIT
  $FUZION/lib/io/out.fz:42:12:
    out.type.install_default
  -----------^
              |
              +- performs call io.out.default target=io.out => UNIT
  $FUZION/lib/io/out.fz:32:36:
      (io.out default_print_handler).default
  -----------------------------------^

  Elapsed time for phases: prep 66ms, fe 104ms, createMIR 1ms, me 91ms, ir 603ms, effectsCheck 104ms, be 256ms
  6 warnings.
```
