### PR TITLE
me: Replace runtime clazzes by clazz-local map of actual clazzes, fix #2408

### DIFF
--- a/src/dev/flang/ast/AbstractAssign.java
+++ b/src/dev/flang/ast/AbstractAssign.java
@@ -65,9 +65,6 @@ public abstract class AbstractAssign extends Expr
   boolean _indexVarAllowed = false;
 
 
-  public int _tid = -1;  // NYI: Used by dev.flang.be.interpreter, REMOVE!
-
-
   /*--------------------------  constructors  ---------------------------*/
 
 

--- a/src/dev/flang/ast/AbstractCall.java
+++ b/src/dev/flang/ast/AbstractCall.java
@@ -56,17 +56,6 @@ public abstract class AbstractCall extends Expr
   /*----------------------------  variables  ----------------------------*/
 
 
-  // NYI: Move _sid to target?
-  public int _sid = -1;  // NYI: Used by dev.flang.be.interpreter, REMOVE!
-
-
-  // For a call to parent in an inherits clause, these are the ids of the
-  // argument fields for the parent feature.
-  //
-  // NYI: remove, used in FUIR.  This should be replaced by explicit assignments to fields
-  public int _parentCallArgFieldIds = -1;
-
-
   // used if this call is turned into a compile time constant in FUIR.
   public Object innerClazz;
 

--- a/src/dev/flang/ast/AbstractCase.java
+++ b/src/dev/flang/ast/AbstractCase.java
@@ -47,7 +47,7 @@ import dev.flang.util.SourcePosition;
  *
  * @author Fridtjof Siebert (siebert@tokiwa.software)
  */
-public abstract class AbstractCase extends ANY implements HasSourcePosition
+public abstract class AbstractCase extends HasGlobalIndex implements HasSourcePosition
 {
 
 
@@ -58,13 +58,6 @@ public abstract class AbstractCase extends ANY implements HasSourcePosition
    * The sourcecode position of this case, used for error messages.
    */
   protected final SourcePosition _pos;
-
-
-  /**
-   * Counter for a unique id for this case expression. This is used to store data
-   * in the runtime clazz for this case.
-   */
-  public int _runtimeClazzId = -1;  // NYI: Used by dev.flang.be.interpreter, REMOVE!
 
 
   /*--------------------------  constructors  ---------------------------*/

--- a/src/dev/flang/ast/AbstractMatch.java
+++ b/src/dev/flang/ast/AbstractMatch.java
@@ -53,13 +53,6 @@ public abstract class AbstractMatch extends Expr
   AbstractType _type;
 
 
-  /**
-   * Id to store the match's subject's clazz in the static outer clazz at
-   * runtime.
-   */
-  public int _runtimeClazzId = -1;  // NYI: Used by dev.flang.be.interpreter, REMOVE!
-
-
   /*--------------------------  constructors  ---------------------------*/
 
 

--- a/src/dev/flang/ast/Box.java
+++ b/src/dev/flang/ast/Box.java
@@ -56,14 +56,6 @@ public class Box extends Expr
   private final AbstractType _type;
 
 
-  /**
-   * Clazz index for value clazz that is being boxed and, at
-   * _valAndRefClazzId+1, reference clazz that is the result clazz of the
-   * boxing.
-   */
-  public int _valAndRefClazzId = -1;  // NYI: Used by dev.flang.be.interpreter, REMOVE!
-
-
   /*--------------------------  constructors  ---------------------------*/
 
 

--- a/src/dev/flang/ast/Case.java
+++ b/src/dev/flang/ast/Case.java
@@ -78,13 +78,6 @@ public class Case extends AbstractCase
   public Block code() { return _code; }
 
 
-  /**
-   * Counter for a unique id for this case expression. This is used to store data
-   * in the runtime clazz for this case.
-   */
-  public int _runtimeClazzId = -1;  // NYI: Used by dev.flang.be.interpreter, REMOVE!
-
-
   /*--------------------------  constructors  ---------------------------*/
 
 

--- a/src/dev/flang/ast/Env.java
+++ b/src/dev/flang/ast/Env.java
@@ -48,12 +48,6 @@ public class Env extends ExprWithPos
   AbstractType _type;
 
 
-  // id of the clazz of the monad as stored in outer clazz.
-  //
-  // NYI: remove, used in interpreter.
-  public int _clazzId = -1;
-
-
   /*--------------------------  constructors  ---------------------------*/
 
 

--- a/src/dev/flang/ast/Expr.java
+++ b/src/dev/flang/ast/Expr.java
@@ -43,7 +43,7 @@ import dev.flang.util.StringHelpers;
  *
  * @author Fridtjof Siebert (siebert@tokiwa.software)
  */
-public abstract class Expr extends ANY implements HasSourcePosition
+public abstract class Expr extends HasGlobalIndex implements HasSourcePosition
 {
 
   /*----------------------------  constants  ----------------------------*/

--- a/src/dev/flang/ast/HasGlobalIndex.java
+++ b/src/dev/flang/ast/HasGlobalIndex.java
@@ -1,0 +1,103 @@
+/*
+
+This file is part of the Fuzion language implementation.
+
+The Fuzion language implementation is free software: you can redistribute it
+and/or modify it under the terms of the GNU General Public License as published
+by the Free Software Foundation, version 3 of the License.
+
+The Fuzion language implementation is distributed in the hope that it will be
+useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+License for more details.
+
+You should have received a copy of the GNU General Public License along with The
+Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+*/
+
+/*-----------------------------------------------------------------------
+ *
+ * Tokiwa Software GmbH, Germany
+ *
+ * Source of class HasGlobalIndex
+ *
+ *---------------------------------------------------------------------*/
+
+package dev.flang.ast;
+
+import dev.flang.util.ANY;
+import dev.flang.util.Errors;
+
+
+/**
+ * HasGlobalIndex is parent of Fuzion AST elements that can map to a uniq global
+ * index.  This index is used during the middle end to replace types by actual
+ * clazzes.
+ *
+ * NYI: CLEANUP #2411: Once the middle end works on .fum file data only, this
+ * will no longer be needed.
+ *
+ * @author Fridtjof Siebert (siebert@tokiwa.software)
+ */
+public abstract class HasGlobalIndex extends ANY
+{
+
+
+  /*----------------------------  constants  ----------------------------*/
+
+
+  /*
+   * Range of global indices that can be used for AST elements created by the
+   * parser.  These are initalized by dev.flang.fe.FrontEnd.
+   */
+  public static int FIRST_GLOBAL_INDEX = -1;
+  public static int LAST_GLOBAL_INDEX = -1;
+
+
+  /*--------------------------  static fields  --------------------------*/
+
+
+  /**
+   * Next global index to be used
+   */
+  private static int _curGix_ = 0;
+
+
+  /*-----------------------------  fields  ------------------------------*/
+
+
+  /**
+   * Next global index to be used
+   */
+  private int _gix = _curGix_++;
+
+
+  /*------------------------------  methods  ----------------------------*/
+
+
+  /**
+   * Unique global index of this element in the AST.
+   */
+  public int globalIndex()
+  {
+    var result = _gix + FIRST_GLOBAL_INDEX;
+    if (result > LAST_GLOBAL_INDEX)
+      {
+        Errors.fatal("NYI: Implementation limitation: Max number of source code expressions reached: count is " + _gix +" max supported is "+(LAST_GLOBAL_INDEX - FIRST_GLOBAL_INDEX)+".");
+      }
+    return _gix + FIRST_GLOBAL_INDEX;
+  }
+
+
+  /**
+   * Reset static fields
+   */
+  public static void reset()
+  {
+    _curGix_ = 0;
+  }
+
+}
+
+/* end of file */

--- a/src/dev/flang/ast/If.java
+++ b/src/dev/flang/ast/If.java
@@ -67,14 +67,6 @@ public class If extends ExprWithPos
   public AbstractType _type;
 
 
-  /**
-   * Id to store the if condition's clazz in the static outer clazz at runtime.
-   * The clazz could be bool or ref bool.
-   */
-  public int _runtimeClazzId = -1;  // NYI: Used by dev.flang.be.interpreter, REMOVE!
-
-
-
   /*--------------------------  constructors  ---------------------------*/
 
 

--- a/src/dev/flang/ast/InlineArray.java
+++ b/src/dev/flang/ast/InlineArray.java
@@ -70,12 +70,6 @@ public class InlineArray extends ExprWithPos
 
 
   /**
-   * Clazz index for array clazz
-   */
-  public int _arrayClazzId = -1;  // NYI: Used by dev.flang.be.interpreter, REMOVE!
-
-
-  /**
    * The code for initializing this array.
    */
   private Expr _code;

--- a/src/dev/flang/ast/Tag.java
+++ b/src/dev/flang/ast/Tag.java
@@ -57,14 +57,6 @@ public class Tag extends Expr
   public AbstractType _taggedType;
 
 
-  /**
-   * Clazz index for value clazz that is being boxed and, at
-   * _valAndRefClazzId+1, reference clazz that is the result clazz of the
-   * boxing.
-   */
-  public int _valAndTaggedClazzId = -1;  // NYI: Used by dev.flang.be.interpreter, REMOVE!
-
-
   /*--------------------------  constructors  ---------------------------*/
 
 

--- a/src/dev/flang/fe/FrontEnd.java
+++ b/src/dev/flang/fe/FrontEnd.java
@@ -43,6 +43,7 @@ import dev.flang.mir.MIR;
 import dev.flang.ast.AbstractFeature;
 import dev.flang.ast.Call;
 import dev.flang.ast.Expr;
+import dev.flang.ast.HasGlobalIndex;
 import dev.flang.ast.Feature;
 import dev.flang.ast.FeatureAndOuter;
 import dev.flang.ast.FeatureName;
@@ -75,6 +76,13 @@ public class FrontEnd extends ANY
    * Offset added to global indices to detect false usage of these early on.
    */
   static int GLOBAL_INDEX_OFFSET = 0x40000000;
+  static
+  {
+    // NYI: CLEANUP: #2411: Temporary solution to give global indices to the AST
+    // parts created by parser
+    HasGlobalIndex.FIRST_GLOBAL_INDEX = 0x10000000;
+    HasGlobalIndex.LAST_GLOBAL_INDEX = GLOBAL_INDEX_OFFSET-1;
+  }
 
 
   /*-----------------------------  classes  -----------------------------*/
@@ -152,6 +160,7 @@ public class FrontEnd extends ANY
     FeatureName.reset();
     Expr.reset();
     Call.reset();
+    HasGlobalIndex.reset();
     var universe = new Universe();
     _universe = universe;
 

--- a/src/dev/flang/fe/LibraryCall.java
+++ b/src/dev/flang/fe/LibraryCall.java
@@ -171,6 +171,15 @@ public abstract class LibraryCall extends AbstractCall
 
 
   /**
+   * Unique global index of this Call.
+   */
+  public int globalIndex()
+  {
+    return _libModule.globalIndex(_index);
+  }
+
+
+  /**
    * toString
    *
    * @return

--- a/src/dev/flang/fe/LibraryFeature.java
+++ b/src/dev/flang/fe/LibraryFeature.java
@@ -188,7 +188,7 @@ public class LibraryFeature extends AbstractFeature
   /**
    * Unique global index of this feature.
    */
-  int globalIndex()
+  public int globalIndex()
   {
     return _libModule.globalIndex(_index);
   }


### PR DESCRIPTION
The use of unique ids for all AST elements that need runtime clazz information plus arrays large enough to hold all these ideas in every clazz instance results in memory demand quadratic to the code size resulting in the high memory demand for arrays used in ryu.fz and reported in #2408.

This patch replaces these large arrays by per-clazz TreeMaps that contain only those actual clazzes that are actually needed for that clazz.

This also adds some NYI-comments related to #2411 and #2412.

This removes caching of Callable created in the interpreter, so this might have a negative impact on interpreter performance.  We might to re-introduce a caching mechanism if this turns out to be very costly.