### PR TITLE
me: Replace `clazz`/`innerClazz`/`runtimeClazz` in AST by Clazz.actualClazzes

### DIFF
--- a/src/dev/flang/air/Clazz.java
+++ b/src/dev/flang/air/Clazz.java
@@ -131,9 +131,9 @@ public class Clazz extends ANY implements Comparable<Clazz>
     {
       if      (e instanceof AbstractAssign   a) { Clazzes.findClazzes(a, _originalFeature, Clazz.this, _inh); }
       else if (e instanceof AbstractCall     c) { Clazzes.findClazzes(c, _originalFeature, Clazz.this, _inh); }
-      else if (e instanceof AbstractConstant c) { Clazzes.findClazzes(c, Clazz.this, _inh); }
+      else if (e instanceof AbstractConstant c) { Clazzes.findClazzes(c, _originalFeature, Clazz.this, _inh); }
       else if (e instanceof If               i) { Clazzes.findClazzes(i, _originalFeature, Clazz.this, _inh); }
-      else if (e instanceof InlineArray      i) { Clazzes.findClazzes(this, i, Clazz.this, _inh); }
+      else if (e instanceof InlineArray      i) { Clazzes.findClazzes(i, _originalFeature, Clazz.this, _inh); }
       else if (e instanceof Env              b) { Clazzes.findClazzes(b, _originalFeature, Clazz.this, _inh); }
       else if (e instanceof AbstractMatch    m) { Clazzes.findClazzes(m, _originalFeature, Clazz.this, _inh); }
       else if (e instanceof Tag              t) { Clazzes.findClazzes(t, _originalFeature, Clazz.this, _inh); }

--- a/src/dev/flang/ast/AbstractCall.java
+++ b/src/dev/flang/ast/AbstractCall.java
@@ -53,13 +53,6 @@ public abstract class AbstractCall extends Expr
   public static final List<AbstractType> NO_GENERICS = new List<>();
 
 
-  /*----------------------------  variables  ----------------------------*/
-
-
-  // used if this call is turned into a compile time constant in FUIR.
-  public Object innerClazz;
-
-
   /*-------------------------- constructors ---------------------------*/
 
 
@@ -170,8 +163,11 @@ public abstract class AbstractCall extends Expr
       {
         throw new UnsupportedOperationException("Unimplemented method 'visit'");
       }
+
+      @Override
+      public Expr origin() { return AbstractCall.this; }
+
     };
-    result.runtimeClazz = innerClazz;
     return result;
   }
 

--- a/src/dev/flang/ast/AbstractConstant.java
+++ b/src/dev/flang/ast/AbstractConstant.java
@@ -35,14 +35,6 @@ package dev.flang.ast;
 public abstract class AbstractConstant extends Expr
 {
 
-  /**
-   * The clazz this abstract constant will result in.
-   *
-   * Not null only for calls that are turned into compile time constants.
-   */
-  public Object runtimeClazz;
-
-
   /*--------------------------  constructors  ---------------------------*/
 
 
@@ -102,6 +94,17 @@ public abstract class AbstractConstant extends Expr
    */
   @Override
   public AbstractConstant asCompileTimeConstant()
+  {
+    return this;
+  }
+
+
+  /**
+   * Origin of this constant. This is either this constant itself for a
+   * BoolConst, NumLiteral or StrConst, or the instance of AbstractCall or
+   * InlineArray this was created from.
+   */
+  public Expr origin()
   {
     return this;
   }

--- a/src/dev/flang/ast/InlineArray.java
+++ b/src/dev/flang/ast/InlineArray.java
@@ -75,10 +75,6 @@ public class InlineArray extends ExprWithPos
   private Expr _code;
 
 
-  // used if this array is turned into a compile time constant in FUIR.
-  public Object clazz;
-
-
   /*--------------------------  constructors  ---------------------------*/
 
 
@@ -267,6 +263,10 @@ public class InlineArray extends ExprWithPos
       {
         e.visitExpressions(v);
       }
+    if (_code != null)
+      {
+        _code.visitExpressions(v);
+      }
   }
 
 
@@ -376,9 +376,10 @@ public class InlineArray extends ExprWithPos
         return r;
       }
 
-    };
+      @Override
+      public Expr origin() { return InlineArray.this; }
 
-    result.runtimeClazz = clazz;
+    };
 
     return result;
   }

--- a/src/dev/flang/fuir/analysis/AbstractInterpreter.java
+++ b/src/dev/flang/fuir/analysis/AbstractInterpreter.java
@@ -675,7 +675,7 @@ public class AbstractInterpreter<VALUE, RESULT> extends ANY
         }
       case Const:
         {
-          var constCl = _fuir.constClazz(c, i);
+          var constCl = _fuir.constClazz(cl, c, i);
           var d = _fuir.constData(c, i);
           var r = _processor.constData(constCl, d);
 


### PR DESCRIPTION
There were two problems here, first one is architectural: AST should not contain fields relevant for the later phases. Second, having only one clazz will fail as soon as a constant's type depends on actual type parameters of any surrounding features. E.g., an `option T` might have an `as_array` feature that uses an empty array constant to return for the `nil` option.  The clazz of the type of this constant will be different for `option i32` and `option bool`.

This patch uses `Clazz.saveActualClazzes()` to store the clazz of a constant. To be able to do this late during FUIR, `AbstractConstant` now contains an `origin` method to get the original `AbstractCall` or `InlineArray` instance to obtain the clazz of the result type.

Also did some further cleanup:

 - Moved code to visit the code of an `InlineArray` from `Clazzes.findClazzes` to `InlineArray.java`.

 - FUIR.constData can no longer be called on a Call or InlineArray (it probably never was).

 - FUIR.toStack() was simplified slightly for AbstractCall and InlineArray, in particular an unused, constant InlineArray will now be dumped completely.