### PR TITLE
ast/type: add method `isVoid`

### DIFF
--- a/src/dev/flang/air/Clazz.java
+++ b/src/dev/flang/air/Clazz.java
@@ -609,7 +609,7 @@ public class Clazz extends ANY implements Comparable<Clazz>
     for (var p: feature().inherits())
       {
         var pt = p.type();
-        var t1 = isRef() && pt.compareTo(Types.resolved.t_void) != 0 ? pt.asRef() : pt.asValue();
+        var t1 = isRef() && !pt.isVoid() ? pt.asRef() : pt.asValue();
         var t2 = _type.actualType(t1);
         var pc = Clazzes.clazz(t2);
         if (CHECKS) check

--- a/src/dev/flang/ast/AbstractCurrent.java
+++ b/src/dev/flang/ast/AbstractCurrent.java
@@ -56,7 +56,7 @@ public abstract class AbstractCurrent extends Expr
   public AbstractCurrent(AbstractType t)
   {
     if (PRECONDITIONS) require
-      (t != null);
+      (t != null && !t.isVoid());
 
     this._type = t;
   }

--- a/src/dev/flang/ast/AbstractType.java
+++ b/src/dev/flang/ast/AbstractType.java
@@ -305,7 +305,7 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
     var actual_type = actual.remove_type_parameter_used_for_this_type_in_type_feature();
     var result =
       target_type.compareTo(actual_type          ) == 0 ||
-      actual_type.compareTo(Types.resolved.t_void) == 0 ||
+      actual_type.isVoid() ||
       target_type == Types.t_ERROR                      ||
       actual_type == Types.t_ERROR;
     if (!result && !target_type.isGenericArgument() && isRef() && actual_type.isRef())
@@ -385,7 +385,7 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
     var result = containsError()                   ||
       actual.containsError()                       ||
       this  .compareTo(actual               ) == 0 ||
-      actual.compareTo(Types.resolved.t_void) == 0;
+      actual.isVoid();
     if (!result && !isGenericArgument())
       {
         if (actual.isGenericArgument())
@@ -971,8 +971,8 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
    */
   private boolean disjoint(AbstractType other)
   {
-    return this.compareTo(Types.resolved.t_void) == 0
-        || other.compareTo(Types.resolved.t_void) == 0
+    return this.isVoid()
+        || other.isVoid()
         || !this.isDirectlyAssignableFrom(other)
         && !other.isDirectlyAssignableFrom(this);
   }
@@ -1128,8 +1128,8 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
       this == Types.t_ERROR                      ? Types.t_ERROR     :
       that == Types.t_ERROR                      ? Types.t_ERROR     :
       that == null                               ? Types.t_ERROR     :
-      this.compareTo(Types.resolved.t_void) == 0 ? that              :
-      that.compareTo(Types.resolved.t_void) == 0 ? this              :
+      this.isVoid()                              ? that              :
+      that.isVoid()                              ? this              :
       this.isAssignableFrom(that)                ? this :
       that.isAssignableFrom(this)                ? that :
       this.isAssignableFrom(that.asRef())        ? this :
@@ -1137,12 +1137,21 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
 
     if (POSTCONDITIONS) ensure
       (result == Types.t_ERROR     ||
-       this.compareTo(Types.resolved.t_void) == 0 && result == that ||
-       that.compareTo(Types.resolved.t_void) == 0 && result == this ||
+       this.isVoid() && result == that ||
+       that.isVoid() && result == this ||
        (result.isAssignableFrom(this) || result.isAssignableFrom(this.asRef()) &&
         result.isAssignableFrom(that) || result.isAssignableFrom(that.asRef())    ));
 
     return result;
+  }
+
+
+  /**
+   * Is this the type denoting `void`?
+   */
+  public boolean isVoid()
+  {
+    return compareTo(Types.resolved.t_void) == 0;
   }
 
 

--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -1856,7 +1856,7 @@ public class Call extends AbstractCall
     // fields during recursion.  We use only the non-recursive (i.e., non-void)
     // ones:
     if (_type == null ||
-        t5.compareTo(Types.resolved.t_void) != 0 ||
+        !t5.isVoid() ||
         !(_calledFeature instanceof Feature cf) ||
         cf.impl()._kind != Impl.Kind.FieldActual)
       {

--- a/src/dev/flang/ast/Expr.java
+++ b/src/dev/flang/ast/Expr.java
@@ -484,7 +484,7 @@ public abstract class Expr extends HasGlobalIndex implements HasSourcePosition
   protected Expr addFieldForResult(Resolution res, AbstractFeature outer, AbstractType t)
   {
     var result = this;
-    if (t.compareTo(Types.resolved.t_void) != 0)
+    if (!t.isVoid())
       {
         var pos = pos();
         Feature r = new Feature(res,
@@ -537,7 +537,7 @@ public abstract class Expr extends HasGlobalIndex implements HasSourcePosition
     var result = this;
     var t = type();
 
-    if (t.compareTo(Types.resolved.t_void) != 0)
+    if (!t.isVoid())
       {
         if (needsBoxing(frmlT))
           {
@@ -554,7 +554,7 @@ public abstract class Expr extends HasGlobalIndex implements HasSourcePosition
 
     if (POSTCONDITIONS) ensure
       (Errors.count() > 0
-        || t.compareTo(Types.resolved.t_void) == 0
+        || t.isVoid()
         || frmlT.isGenericArgument()
         || frmlT.isThisType()
         || !result.needsBoxing(frmlT));

--- a/src/dev/flang/ast/ResolvedNormalType.java
+++ b/src/dev/flang/ast/ResolvedNormalType.java
@@ -279,7 +279,7 @@ public class ResolvedNormalType extends ResolvedType
     if (PRECONDITIONS) require
       (refOrVal != original._refOrVal,
        Types.resolved == null
-         || original.compareTo(Types.resolved.t_void) != 0
+         || !original.isVoid()
          || refOrVal == RefOrVal.LikeUnderlyingFeature
       );
 
@@ -421,7 +421,7 @@ public class ResolvedNormalType extends ResolvedType
   {
     if (PRECONDITIONS) require
       (this == Types.intern(this),
-       compareTo(Types.resolved.t_void) != 0);
+       !isVoid());
 
     AbstractType result = this;
     if (!isRef() && this != Types.t_ERROR)

--- a/src/dev/flang/fe/SourceModule.java
+++ b/src/dev/flang/fe/SourceModule.java
@@ -1440,7 +1440,7 @@ part of the (((inner features))) declarations of the correpsonding
             AstErrors.cannotRedefineChoice(f, o);
           }
         else if (!t1.isDirectlyAssignableFrom(t2) &&  // we (currently) do not tag the result in a redefined feature, see testRedefine
-                 t2.compareTo(Types.resolved.t_void) != 0 &&
+                 !t2.isVoid() &&
                  !isLegalCovariantThisType(o, f, t1, t2, fixed))
           {
             AstErrors.resultTypeMismatchInRedefinition(o, t1, f, isLegalCovariantThisType(o, f, t1, t2, true));

--- a/src/dev/flang/fuir/FUIR.java
+++ b/src/dev/flang/fuir/FUIR.java
@@ -1086,10 +1086,7 @@ hw25 is
             (cc.isInstantiated() || cc.feature().isOuterRef() || cc.feature().isTypeFeature())
             && cc != Clazzes.Const_String.getIfCreated()
             && !cc.isAbsurd()
-            && !cc.isBoxed()
-            // NYI: this should not depend on string comparison!
-            && !(cc.feature().qualifiedName().equals("void.absurd"))
-            ;
+            && !cc.isBoxed();
           };
         (result ? _needsCode : _doesNotNeedCode).set(cl - CLAZZ_BASE);
         return result;
@@ -2456,7 +2453,7 @@ hw25 is
       !ia.type().dependsOnGenerics() &&
       !ia.type().containsThisType() &&
       // some backends have special handling for array void.
-      ia.elementType().compareTo(Types.resolved.t_void) != 0 &&
+      !ia.elementType().isVoid() &&
       ia._elements
         .stream()
         .allMatch(el -> {


### PR DESCRIPTION
I find this to be significantly easier to read than `compareTo != 0`

Also removed a now unecessary string comparison checking for `void.absurd` feature.