### PR TITLE
be/c: enable garbage collector by default

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -51,6 +51,8 @@ jobs:
             git
             mingw-w64-ucrt-x86_64-clang
             diffutils
+            libgc
+            libgc-devel
 
       - name: install choco packages
         shell: powershell

--- a/src/dev/flang/tools/Fuzion.java
+++ b/src/dev/flang/tools/Fuzion.java
@@ -75,7 +75,7 @@ class Fuzion extends Tool
 
 
   static String  _binaryName_ = null;
-  static boolean _useBoehmGC_ = false;
+  static boolean _useBoehmGC_ = true;
   static boolean _xdfa_ = true;
   static String _cCompiler_ = null;
   static String _cFlags_ = null;
@@ -102,7 +102,7 @@ class Fuzion extends Tool
     {
       String usage()
       {
-        return "[-o=<file>] [-useGC] [-Xdfa=(on|off)] [-CC=<c compiler>] [-CFlags=\"list of c compiler flags\"] ";
+        return "[-o=<file>] [-Xgc=(on|off)] [-Xdfa=(on|off)] [-CC=<c compiler>] [-CFlags=\"list of c compiler flags\"] ";
       }
       boolean handleOption(Fuzion f, String o)
       {
@@ -112,9 +112,9 @@ class Fuzion extends Tool
             _binaryName_ = o.substring(3);
             result = true;
           }
-        else if (o.equals("-useGC"))
+        else if (o.startsWith("-Xgc="))
           {
-            _useBoehmGC_ = true;
+            _useBoehmGC_ = parseOnOffArg(o);
             result = true;
           }
         else if (o.startsWith("-Xdfa="))


### PR DESCRIPTION
Tests are still all green on my machine.
MacOS/Windows actions will likely be broken after merging this PR even though gc-packages are already included to be installed.
Include-path and library-path probably need to be set correctly and the documentation of the libgc packages is rather limited unfortunately.