### PR TITLE
air: Consider all type features as instantiated

### DIFF
--- a/src/dev/flang/air/Clazz.java
+++ b/src/dev/flang/air/Clazz.java
@@ -1975,7 +1975,7 @@ public class Clazz extends ANY implements Comparable<Clazz>
   public boolean isInstantiated()
   {
     return _checkingInstantiatedHeirs > 0 || (isOuterInstantiated() || isChoice()
-      || _outer.isRef() && _outer.hasInstantiatedHeirs() || _outer.feature().isTypeFeature()) && _isInstantiated;
+      || _outer.isRef() && _outer.hasInstantiatedHeirs()) && _isInstantiated || feature().isTypeFeature();
   }
 
 


### PR DESCRIPTION
The problem was that intrinsic `effect.type.is_installed` was not found to be called since its outer feature was not found to be instantiated.  This patch changes this to treat all type features as implicitly instantiated.

This fixed the JVM and C backend failures for `idiom87ex.fz`: Here. the call to `effect.type.is_installed` was the only place that could create a bool values but was not found to be called, so `true` and `false` were both effectively `void` resutling in no code generatored for any case in a match of boolean (where an `if` is just syntax sugor for such a match).