### PR TITLE
docs: group features by kind

### DIFF
--- a/assets/docs/style.css
+++ b/assets/docs/style.css
@@ -153,7 +153,6 @@ Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
 }
 
 .fd .sidenav{
-  overflow-y: auto;
   max-height: 100vh;
   padding-right: 15px;
 }
@@ -164,6 +163,10 @@ Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
   font-size: 2em;
 }
 
+.fd .sidenav nav{
+  min-width: 25ch;
+}
+
 .fd .sidenav nav ul{
   list-style: none;
   padding-left: 0;
@@ -171,4 +174,10 @@ Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
 
 .fd .sidenav nav li{
   line-height: 1;
+}
+
+.fd .sidenav nav .fd-feat-kind{
+  font-style: italic;
+  font-weight: 600;
+  font-size: x-small;
 }

--- a/src/dev/flang/tools/docs/Docs.java
+++ b/src/dev/flang/tools/docs/Docs.java
@@ -37,8 +37,8 @@ import java.nio.file.Path;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.LinkedList;
+import java.util.Map;
 import java.util.Queue;
-import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
@@ -50,6 +50,7 @@ import dev.flang.fe.FrontEnd;
 import dev.flang.fe.FrontEndOptions;
 import dev.flang.mir.MIR;
 import dev.flang.tools.FuzionHome;
+import dev.flang.tools.docs.Util.Kind;
 import dev.flang.util.FuzionConstants;
 import dev.flang.util.List;
 
@@ -62,7 +63,7 @@ public class Docs
   private static final Comparator<? super AbstractFeature> byFeatureName = Comparator.comparing(
     af -> af.featureName().toString(),
     (name1, name2) -> {
-      var caseInsensitive = name1.compareToIgnoreCase(name2);
+      var caseInsensitive = name1.compareTo(name2);
       if (caseInsensitive != 0)
         {
           return caseInsensitive;
@@ -272,7 +273,7 @@ public class Docs
   private void run(DocsOptions config)
   {
     // declared features are sorted by feature name
-    var mapOfDeclaredFeatures = new HashMap<AbstractFeature, SortedSet<AbstractFeature>>();
+    var mapOfDeclaredFeatures = new HashMap<AbstractFeature, Map<Kind, TreeSet<AbstractFeature>>>();
 
     breadthFirstTraverse(feature -> {
       if (ignoreFeature(feature, config.ignoreVisibility()))
@@ -281,8 +282,7 @@ public class Docs
         }
       var s = declaredFeatures(feature)
         .filter(af -> !ignoreFeature(af, config.ignoreVisibility()))
-        .collect(Collectors.toCollection(
-          () -> new TreeSet<>(byFeatureName)));
+        .collect(Collectors.groupingBy(x -> Kind.classify(x), Collectors.toCollection(() -> new TreeSet<>(byFeatureName))));
       mapOfDeclaredFeatures.put(feature, s);
     }, universe);
 

--- a/src/dev/flang/tools/docs/Util.java
+++ b/src/dev/flang/tools/docs/Util.java
@@ -129,4 +129,19 @@ public class Util
         || af.visibility() == Visi.PUB;
   }
 
+
+  static enum Kind {
+    Constructor,
+    Type,
+    Other;
+
+    static Kind classify(AbstractFeature af) {
+      return af.definesType()
+          ? !af.isChoice() && af.visibility().featureVisibility() == Visi.PUB
+              ? Kind.Constructor
+              : Kind.Type
+          : Kind.Other;
+    }
+  }
+
 }


### PR DESCRIPTION
this changes multiple small things in the api docs:
- group features by kind: constructor, function, type.
- hide arguments for types
- in the nav, display only constructors and types
- styling changes
- sort does not ignore case anymore

this is how it looks:
![Screen Shot 2024-01-09 at 15 24 42](https://github.com/tokiwa-software/fuzion/assets/88769212/e66cdce3-80af-4c48-af8f-9e023167ee47)
