### PR TITLE
be/interpreter: Replace `Clazz.bool.get` by `Clazz.bool.getIfCreated`

### DIFF
--- a/src/dev/flang/be/interpreter/Interpreter.java
+++ b/src/dev/flang/be/interpreter/Interpreter.java
@@ -432,7 +432,7 @@ public class Interpreter extends ANY
             refVal = getChoiceRefVal(sf, staticSubjectClazz, sub);
             tag = ChoiceIdAsRef.get(staticSubjectClazz, refVal);
           }
-        else if (staticSubjectClazz == Clazzes.bool.get())
+        else if (staticSubjectClazz == Clazzes.bool.getIfCreated())
           {
             tag = sub.boolValue() ? 1 : 0;
           }


### PR DESCRIPTION
This fixes a precondition failure in flang.dev's
`tutorial/examples/assignment_example4.fz` since this example does not create a clazz for bool.