### PR TITLE
doc/util/fe: First intergration of rules, error ids and reference manual

### DIFF
--- a/doc/ref_manual/demo_rule.txt
+++ b/doc/ref_manual/demo_rule.txt
@@ -1,0 +1,3 @@
+// tag::fuzion_rule_DOMAIN_DETAIL[]
+Rules in the Fuzion Reference Manual are identified by a *DOMAIN* combinded via `_` with a *DETAIL* that identifies the specific area the rule applies to.
+// end::fuzion_rule_DOMAIN_DETAIL[]

--- a/doc/ref_manual/fuzion_reference_manual.adoc
+++ b/doc/ref_manual/fuzion_reference_manual.adoc
@@ -18,11 +18,13 @@
 //
 //  Tokiwa Software GmbH, Germany
 //
-//  ASCIIdoc source of Fuzion Langauge Reference Manual
+//  ASCIIdoc source of the Fuzion Langauge Reference Manual
 //
 // -----------------------------------------------------------------------
 
-
+// This is the main asciidoc input file that defines the overall structure of the
+// reference manual.
+//
 = Fuzion Reference Manual [DRAFT]
 The Fuzion Team <info@tokiwa.software>
 include::../../version.txt[]
@@ -32,6 +34,7 @@ include::../../version.txt[]
 :sectanchors:
 :url-repo: https://github.com/tokiwa-software/fuzion/
 :sectnums:
+:icons: font
 :toc: macro
 
 toc::[]
@@ -40,11 +43,67 @@ toc::[]
 
 === Audience
 
-TBW
+CAUTION: *NYI*: Audience spec missing!
 
 === Conventions
 
-TBW
+This is work in progress. Areas where information is known to be preliminary,
+missing or wrong might be marked as follows:
+
+CAUTION: *NYI*: This spec is work in progress!
+
+Generally, *NYI* is used in this document, as well as through any other files
+related to the Fuzion project, to mark sections that need further work or future
+enhancements.  This is often equivalent to comments starting *TODO* or similar
+used in other projects.
+
+The specification contains a number of rules that must be implemented by the
+language implementations. These rules are identified by identifiers such as
+*DOMAIN_DETAIL*. Rules are shown as follows:
+
+:RULE_SRC: doc/ref_manual/demo_rule.txt
+:RULE_ID: DOMAIN_DETAIL
+include::rule.adoc[]
+
+
+== Input
+
+=== Input Sources
+
+Fuzion source code input may come from different sources including source code
+files, streams such as the standard input stream of a Unix shell command,
+interactive input in an interactive Read-Eval-Print-Loop (indexterm2:[REPL]), command line arguments, etc.
+
+For source code files, the following rule applies:
+
+:RULE_SRC: src/dev/flang/fe/SourceModule.java
+:RULE_ID: SRCF_DOTFZ
+include::rule.adoc[]
+
+=== Directories
+
+Source files may be organized in a hierarchy of directories.  Source files in
+sub-directories are automatically considered as input only if corresponding
+outer features exist:
+
+:RULE_SRC: src/dev/flang/fe/SourceModule.java
+:RULE_ID: SRCF_DIR
+include::rule.adoc[]
+
+
+=== Input encoding
+
+Fuzion input sources use UTF8 encoding.
+
+include::{GENERATED}/doc/unicode_version.adoc[]
+
+CAUTION: NYI: Actual Unicode version has not been fixed yet!
+
+:RULE_SRC: src/dev/flang/util/SourceFile.java
+:RULE_ID: SRCF_UTF8
+include::rule.adoc[]
+
+
 
 == Syntax
 
@@ -52,51 +111,54 @@ TBW
 
 ==== White Space
 
-TBW
+CAUTION: *NYI*: Text Missing
 
 ==== Keywords
 
-TBW: `this` `env` `check` `else` `if` `then` `is` `abstract` `intrinsic` `intrinsic_constructor` `native` `for` `in` `do` `fixed` `loop` `while` `until` `variant` `pre` `post` `inv` `var` `match` `value` `ref` `synchronized` `redef` `const` `leaf` `infix` `prefix` `postfix` `ternary` `index` `set` `private` `module` `public` `of` `type` `univers`
+CAUTION: *NYI*: Text Missing
+
+`this` `env` `check` `else` `if` `then` `is` `abstract` `intrinsic` `intrinsic_constructor` `native` `for` `in` `do` `fixed` `loop` `while` `until` `variant` `pre` `post` `inv` `var` `match` `value` `ref` `synchronized` `redef` `const` `leaf` `infix` `prefix` `postfix` `ternary` `index` `set` `private` `module` `public` `of` `type` `univers`
 
 ==== Identifiers
 
-TBW
+CAUTION: *NYI*: Text Missing
 
 ==== Literals
 
-TBW
+CAUTION: *NYI*: Text Missing
 
 ===== Numeric Literals
 
-TBW
+CAUTION: *NYI*: Text Missing
 
 ===== String Literals
 
-TBW
+CAUTION: *NYI*: Text Missing
 
 ==== Comments
 
-TBW
+CAUTION: *NYI*: Text Missing
 
 === Grammar
 
-TBW
+CAUTION: *NYI*: Text Missing
 
 == Semantics
 
-TBW
+CAUTION: *NYI*: Text Missing
 
 [appendix]
 == Definitions
 
-((Argument)):: TBW
-((Constructor)):: TBW
-((Feature)):: TBW
-((Field)):: TBW
-((Function)):: TBW
-((Routine)):: TBW
-((Type)):: TBW
-((Type Parameter)):: TBW
+((Argument)):: CAUTION: *NYI*: Text Missing
+((Constructor)):: CAUTION: *NYI*: Text Missing
+((Clazz)):: CAUTION: *NYI*: Text Missing
+((Feature)):: CAUTION: *NYI*: Text Missing
+((Field)):: CAUTION: *NYI*: Text Missing
+((Function)):: CAUTION: *NYI*: Text Missing
+((Routine)):: CAUTION: *NYI*: Text Missing
+((Type)):: CAUTION: *NYI*: Text Missing
+((Type Parameter)):: CAUTION: *NYI*: Text Missing
 
 [appendix]
 == File Formats

--- a/doc/ref_manual/rule.adoc
+++ b/doc/ref_manual/rule.adoc
@@ -1,0 +1,34 @@
+// This file is part of the Fuzion language implementation.
+//
+// The Fuzion language implementation is free software: you can redistribute it
+// and/or modify it under the terms of the GNU General Public License as published
+// by the Free Software Foundation, version 3 of the License.
+//
+// The Fuzion language implementation is distributed in the hope that it will be
+// useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+// License for more details.
+//
+// You should have received a copy of the GNU General Public License along with The
+// Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+//
+//
+//
+// -----------------------------------------------------------------------
+//
+//  Tokiwa Software GmbH, Germany
+//
+//  ASCIIdoc source rule.doc
+//
+// -----------------------------------------------------------------------
+//
+// This provides formatting of a Fuzion rule. It requires as input the following
+// values:
+//
+// {RULE_ID}    The rule identifier, e.g., SRCF_UTF8
+// {RULE_SRC}   The source file that contains that rule tagged by fuzion_rule_{RULE_ID}
+//
+
+[#{RULE_ID}]
+IMPORTANT: *{RULE_ID}*:
+include::{FZ_SRC}/{RULE_SRC}[tag=fuzion_rule_{RULE_ID}]

--- a/src/dev/flang/fe/SourceModule.java
+++ b/src/dev/flang/fe/SourceModule.java
@@ -354,6 +354,11 @@ public class SourceModule extends Module implements SrcModule, MirModule
    */
   boolean isValidSourceFile(Path p)
   {
+    /*
+    // tag::fuzion_rule_SRCF_DOTFZ[]
+Fuzion source files may have an arbitrary file name ending with the file name extension `.fz`.
+    // end::fuzion_rule_SRCF_DOTFZ[]
+    */
     try
       {
         return p.getFileName().toString().endsWith(".fz") &&
@@ -385,6 +390,16 @@ public class SourceModule extends Module implements SrcModule, MirModule
                 var d = dirExists(root, f);
                 if (d != null)
                   {
+                    /*
+                    // tag::fuzion_rule_SRCF_DIR[]
+Files in a sub-directories within a directory are considered as input only if
+the directory name equals the (((base name))) of a (((constructor))).  Then, the
+files matching rule xref:SRCF_DOTFZ[SRCF_DOTFZ] within that diretory are parsed as if they were
+part of the (((inner features))) declarations of the correpsonding
+((construtor)).
+                    // end::fuzion_rule_SRCF_DIR[]
+                    */
+
                     Files.list(d._dir)
                       .filter(p -> isValidSourceFile(p))
                       .sorted()

--- a/src/dev/flang/util/Errors.java
+++ b/src/dev/flang/util/Errors.java
@@ -163,6 +163,43 @@ public class Errors extends ANY
     }
   }
 
+  /*-----------------------------  enumss  ------------------------------*/
+
+
+  /**
+   * Abstract Error Identifier.
+   *
+   * This will be implemented by all error identifier enums.
+   */
+  public static interface Id
+  {
+    default void report(SourcePosition pos, String msg, String detail)
+    {
+      error(Id.this, pos, msg, detail);
+    }
+    String msgText();
+  }
+
+
+  /**
+   * Error related to source file rules block SRCF_*.
+   */
+  public enum SRCF implements Id
+  {
+    UTF8
+    {
+      public String msgText()
+      {
+        return "Bad UTF8 encoding found";
+      }
+      public void report(SourcePosition pos, String append_to_msg, String detail)
+      {
+        error(UTF8, pos, msgText() + append_to_msg, detail);
+      }
+    }
+  }
+
+
   /*--------------------------  constructors  ---------------------------*/
 
 
@@ -261,6 +298,24 @@ public class Errors extends ANY
   public static void error(String s)
   {
     error(s, null);
+  }
+
+
+  /**
+   * Record the given error found during compilation.
+   *
+   * @param id rule identifier for this error
+   *
+   * @param pos source code position where this error occurred, may be null
+   *
+   * @param msg the error message, should not contain any LF or any case specific details
+   *
+   * @param detail details for this error, may contain LFs and case specific details, may be null
+   */
+  public static void error(Id id, SourcePosition pos, String msg, String detail)
+  {
+    // NYI: id is currently ignored
+    error(pos, msg, detail);
   }
 
 

--- a/src/dev/flang/util/SourceFile.java
+++ b/src/dev/flang/util/SourceFile.java
@@ -249,6 +249,11 @@ public class SourceFile extends ANY
    */
   private int decodeCodePointAndSize(int pos)
   {
+    /*
+    // tag::fuzion_rule_SRCF_UTF8[]
+Fuzion input uses UTF8 encoding vesion {UNICODE_VERSION} from {UNICODE_SOURCE}[].  Improperly encoded input will be treated as an error.
+    // end::fuzion_rule_SRCF_UTF8[]
+    */
     int result;
     int sz;
     int b1 = _bytes[pos] & 0xff;
@@ -262,9 +267,9 @@ public class SourceFile extends ANY
       {
         if (pos + 2 > _bytes.length)
           {
-            Errors.error(sourcePos(pos),
-                         "Bad UTF8 encoding found at end-of-file: "+hex(b1),
-                         "Expected one continuation byte, but reached end of file.");
+            Errors.SRCF.UTF8.report(sourcePos(pos),
+                                    ": found end-of-file while decoding " + hex(b1),
+                                    "Expected one continuation byte, but reached end of file.");
             result = BAD_CODEPOINT;
             sz = 1;
           }
@@ -273,9 +278,9 @@ public class SourceFile extends ANY
             int b2 = _bytes[pos + 1] & 0xff;
             if ((b2 & 0xc0) != 0x80)
               {
-                Errors.error(sourcePos(pos),
-                             "Bad UTF8 encoding found: " + hex(b1) + " " + hex(b2),
-                             "Expected one continuation byte in the range 0x80..0xbf.");
+                Errors.SRCF.UTF8.report(sourcePos(pos),
+                                        ": while decoding " + hex(b1) + " " + hex(b2),
+                                        "Expected one continuation byte in the range 0x80..0xbf.");
                 result = BAD_CODEPOINT;
                 sz = 1;
               }
@@ -285,16 +290,16 @@ public class SourceFile extends ANY
                 sz = 2;
                 if (result == 0x00)
                   {
-                    Errors.error(sourcePos(pos),
-                                 "Bad UTF8 encoding found: " + hex(b1) + " " + hex(b2),
-                                 "Two-byte NUL-character encoding is allowed in modified UTF-8 only, not in standard UTF-8 encoding.");
+                    Errors.SRCF.UTF8.report(sourcePos(pos),
+                                            ": while decoding " + hex(b1) + " " + hex(b2),
+                                            "Two-byte NUL-character encoding is allowed in modified UTF-8 only, not in standard UTF-8 encoding.");
                     result = BAD_CODEPOINT;
                   }
                 else if (result < 0x80)
                   {
-                    Errors.error(sourcePos(pos),
-                                 "Bad UTF8 encoding found: " + hex(b1) + " " + hex(b2),
-                                 "Code point "+Integer.toHexString(result)+" uses overlong 2-byte encoding.");
+                    Errors.SRCF.UTF8.report(sourcePos(pos),
+                                            ": while decoding " + hex(b1) + " " + hex(b2),
+                                            "Code point "+Integer.toHexString(result)+" uses overlong 2-byte encoding.");
                     result = BAD_CODEPOINT;
                   }
               }
@@ -304,9 +309,9 @@ public class SourceFile extends ANY
       {
         if (pos + 3 > _bytes.length)
           {
-            Errors.error(sourcePos(pos),
-                         "Bad UTF8 encoding found at end-of-file: "+hex(b1),
-                         "Expected two continuation bytes, but reached end of file.");
+            Errors.SRCF.UTF8.report(sourcePos(pos),
+                                    ": found end-of-file while decoding " + hex(b1),
+                                    "Expected two continuation bytes, but reached end of file.");
             result = BAD_CODEPOINT;
             sz = _bytes.length - pos;;
           }
@@ -317,9 +322,9 @@ public class SourceFile extends ANY
             if ((b2 & 0xc0) != 0x80 ||
                 (b3 & 0xc0) != 0x80)
               {
-                Errors.error(sourcePos(pos),
-                             "Bad UTF8 encoding found: " + hex(b1) + " " + hex(b2) + " " + hex(b3),
-                             "Expected two continuation bytes in the range 0x80..0xbf.");
+                Errors.SRCF.UTF8.report(sourcePos(pos),
+                                        ": while decoding " + hex(b1) + " " + hex(b2) + " " + hex(b3),
+                                        "Expected two continuation bytes in the range 0x80..0xbf.");
                 result = BAD_CODEPOINT;
                 sz = ((b2 & 0xc0) != 0x80) ? 1 : 2;
               }
@@ -330,17 +335,17 @@ public class SourceFile extends ANY
                           ((b3 & 0x3f)      )   );
                 if (result < 0x800)
                   {
-                    Errors.error(sourcePos(pos),
-                                 "Bad UTF8 encoding found: " + hex(b1) + " " + hex(b2) + " " + hex(b3),
-                                 "Code point "+Integer.toHexString(result)+" uses overlong 3-byte encoding.");
+                    Errors.SRCF.UTF8.report(sourcePos(pos),
+                                            ": while decoding " + hex(b1) + " " + hex(b2) + " " + hex(b3),
+                                            "Code point "+Integer.toHexString(result)+" uses overlong 3-byte encoding.");
                     result = BAD_CODEPOINT;
                   }
                 else if (result >= 0xd800 && result <= 0xdfff)
                   {
-                    Errors.error(sourcePos(pos),
-                                 "Bad UTF8 encoding found: " + hex(b1) + " " + hex(b2) + " " + hex(b3),
-                                 "Code point "+Integer.toHexString(result)+" is invalid, values in the " +
-                                 "range 0xd800..0xdfff are reserved for UTF-16 surrogate halves.");
+                    Errors.SRCF.UTF8.report(sourcePos(pos),
+                                            ": while decoding " + hex(b1) + " " + hex(b2) + " " + hex(b3),
+                                            "Code point "+Integer.toHexString(result)+" is invalid, values in the " +
+                                            "range 0xd800..0xdfff are reserved for UTF-16 surrogate halves.");
                     result = BAD_CODEPOINT;
                   }
                 sz = 3;
@@ -351,9 +356,9 @@ public class SourceFile extends ANY
       {
         if (pos + 4 > _bytes.length)
           {
-            Errors.error(sourcePos(pos),
-                         "Bad UTF8 encoding found at end-of-file: "+hex(b1),
-                         "Expected three continuation bytes, but reached end of file.");
+            Errors.SRCF.UTF8.report(sourcePos(pos),
+                                    ": found end-of-file while decoding " + hex(b1),
+                                    "Expected three continuation bytes, but reached end of file.");
             result = BAD_CODEPOINT;
             sz = _bytes.length - pos;
           }
@@ -366,9 +371,9 @@ public class SourceFile extends ANY
                 (b3 & 0xc0) != 0x80 ||
                 (b4 & 0xc0) != 0x80)
               {
-                Errors.error(sourcePos(pos),
-                             "Bad UTF8 encoding found: " + hex(b1) + " " + hex(b2) + " " + hex(b3) + " " + hex(b4),
-                             "Expected three continuation bytes in the range 0x80..0xbf.");
+                Errors.SRCF.UTF8.report(sourcePos(pos),
+                                        ": while decoding " + hex(b1) + " " + hex(b2) + " " + hex(b3) + " " + hex(b4),
+                                        "Expected three continuation bytes in the range 0x80..0xbf.");
                 result = BAD_CODEPOINT;
                 sz = (((b2 & 0xc0) != 0x80) ? 1 :
                       ((b3 & 0xc0) != 0x80) ? 2 : 3);
@@ -381,17 +386,17 @@ public class SourceFile extends ANY
                           ((b4 & 0x3f)      )   );
                 if (result < 0x10000)
                   {
-                    Errors.error(sourcePos(pos),
-                                 "Bad UTF8 encoding found: " + hex(b1) + " " + hex(b2) + " " + hex(b3) + " " + hex(b4),
-                                 "Code point "+Integer.toHexString(result)+" uses overlong 4-byte encoding.");
+                    Errors.SRCF.UTF8.report(sourcePos(pos),
+                                            ": while decoding " + hex(b1) + " " + hex(b2) + " " + hex(b3) + " " + hex(b4),
+                                            "Code point "+Integer.toHexString(result)+" uses overlong 4-byte encoding.");
                     result = BAD_CODEPOINT;
                   }
                 else if (result > 0x10ffff)
                   {
-                    Errors.error(sourcePos(pos),
-                                 "Bad UTF8 encoding found: " + hex(b1) + " " + hex(b2) + " " + hex(b3) + " " + hex(b4),
-                                 "Code point "+Integer.toHexString(result)+" is outside of the allowed range for " +
-                                 "codepoints 0x000000..0x10ffff.");
+                    Errors.SRCF.UTF8.report(sourcePos(pos),
+                                            ": while decoding " + hex(b1) + " " + hex(b2) + " " + hex(b3) + " " + hex(b4),
+                                            "Code point "+Integer.toHexString(result)+" is outside of the allowed range for " +
+                                            "codepoints 0x000000..0x10ffff.");
                     result = BAD_CODEPOINT;
                   }
                 sz = 4;
@@ -400,31 +405,31 @@ public class SourceFile extends ANY
       }
     else if (0x80 <= b1 && b1 <= 0xbf)
       {
-        Errors.error(sourcePos(pos),
-                     "Bad UTF8 encoding found: "+hex(b1),
-                     "Stray continuation byte without preceding leading byte.");
+        Errors.SRCF.UTF8.report(sourcePos(pos),
+                                ": while decoding " + hex(b1),
+                                "Stray continuation byte without preceding leading byte.");
         result = BAD_CODEPOINT;
         sz = 1;
       }
     else if (0xf5 <= b1 && b1 <= 0xfd)
       {
-        Errors.error(sourcePos(pos),
-                     "Bad UTF8 encoding found:: "+hex(b1),
-                     "Code 0xf8..0xff are undefined.");
+        Errors.SRCF.UTF8.report(sourcePos(pos),
+                                ": while decoding " + hex(b1),
+                                "Code 0xf8..0xff are undefined.");
         result = BAD_CODEPOINT;
         sz = 1;
       }
     else if (0xfe <= b1 && b1 <= 0xff)
       {
-        Errors.error(sourcePos(pos),
-                     "Bad UTF8 encoding found:: "+hex(b1),
+        Errors.SRCF.UTF8.report(sourcePos(pos),
+                     "while decoding : " + hex(b1),
                      "Code 0xfe and 0xff are undefined.");
         result = BAD_CODEPOINT;
         sz = 1;
       }
     else
       {
-        throw new Error("Missing case: "+hex(b1));
+        throw new Error("Missing case: " + hex(b1));
       }
     return makeCodePointWithSize(result, sz);
   }


### PR DESCRIPTION
Rules of the Fuzion language may now be embedded in the source code, they will be wrapped by `rule.adoc` when generating the reference manual.

Rulese have an ID that consists of a domain and detail in that domain that is addressed by the rule.

Errors now may (and eventually will) have an ID that corresponds to the rule that is broken when this error is created.  Errors for the rule `SRCF_UTF8` have been changed to use their ID for error reporting.

Preliminary infrastructure to document the Unicode version Id in the reference manual was implemented.