### PR TITLE
workflow: windows builds, add step `build libgc`

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -51,8 +51,6 @@ jobs:
             git
             mingw-w64-ucrt-x86_64-clang
             diffutils
-            libgc
-            libgc-devel
 
       - name: install choco packages
         shell: powershell
@@ -61,7 +59,18 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v2.6.0
 
       - name: echo versions
-        run: export PATH="/ucrt64/bin/:/c/Program Files/OpenJDK/jdk-17/bin:$PATH" && clang --version && javac --version
+        run: |
+          export PATH="/ucrt64/bin/:/c/Program Files/OpenJDK/jdk-17/bin:$PATH"
+          clang --version
+          javac --version
+
+      - name: build libgc
+        run: |
+          export PATH="/ucrt64/bin/:/c/Program Files/OpenJDK/jdk-17/bin:$PATH"
+          ./bin/windows_install_boehm_gc.sh
 
       - name: run tests
-        run: export PATH="/ucrt64/bin/:/c/Program Files/OpenJDK/jdk-17/bin:$PATH" && make run_tests
+        run: |
+          export PATH="/ucrt64/bin/:/c/Program Files/OpenJDK/jdk-17/bin:$PATH"
+          export FUZION_CLANG_INSTALLED_DIR="D:/a/_temp/msys64/ucrt64/bin"
+          make run_tests

--- a/.github/workflows/windows_c.yml
+++ b/.github/workflows/windows_c.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           update: true
           path-type: minimal
-          msystem: CLANG64
+          msystem: UCRT64
 # git is used in Makefile: JAVA_FILE_TOOLS_VERSION
           install: >-
             make
@@ -32,14 +32,26 @@ jobs:
 
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v2.6.0
 
-      - name: set PATH
-        run: echo "/ucrt64/bin/:/c/Program Files/OpenJDK/jdk-17/bin:$PATH" >> $GITHUB_PATH
+      # NYI this does not work :-( but why?
+      # - name: set PATH
+      #   run: echo "/ucrt64/bin/:/c/Program Files/OpenJDK/jdk-17/bin:$PATH" >> $GITHUB_PATH
 
       - name: echo PATH
         run: echo "$PATH"
 
       - name: echo versions
-        run: clang --version && javac --version
+        run: |
+          export PATH="/ucrt64/bin/:/c/Program Files/OpenJDK/jdk-17/bin:$PATH"
+          clang --version
+          javac --version
+
+      - name: build libgc
+        run: |
+          export PATH="/ucrt64/bin/:/c/Program Files/OpenJDK/jdk-17/bin:$PATH"
+          ./bin/windows_install_boehm_gc.sh
 
       - name: run tests
-        run: make run_tests_c
+        run:  |
+          export PATH="/ucrt64/bin/:/c/Program Files/OpenJDK/jdk-17/bin:$PATH"
+          export FUZION_CLANG_INSTALLED_DIR="D:/a/_temp/msys64/ucrt64/bin"
+          make run_tests_c

--- a/README.md
+++ b/README.md
@@ -164,11 +164,12 @@ Check [flang.dev](https://flang.dev) for language and implementation design.
 1) Install chocolatey: [chocolatey.org](https://chocolatey.org/install)
 2) In Powershell:
     1) choco install git openjdk make msys2 diffutils
-    2) [Environment]::SetEnvironmentVariable("Path","c:\tools\msys64\mingw64\bin;" + $env:Path , "User")
+    2) [Environment]::SetEnvironmentVariable("Path","c:\tools\msys64\ucrt64\bin;" + $env:Path , "User")
 3) In file C:\tools\msys64\msys2_shell.cmd change line: 'rem set MSYS2_PATH_TYPE=inherit' to 'set MSYS2_PATH_TYPE=inherit'
 4) In msys2 shell (execute C:\tools\msys64\msys2_shell.cmd):
     1) pacman -S mingw-w64-x86_64-clang
     2) make
+5) execute ./bin/windows_install_boehm_gc.sh
 
 ## Build
 

--- a/bin/windows_install_boehm_gc.sh
+++ b/bin/windows_install_boehm_gc.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of windows_install_boehm_gc.sh bash script
+#
+# -----------------------------------------------------------------------
+
+set -euo pipefail
+
+mkdir -p build
+cd build
+wget https://www.hboehm.info/gc/gc_source/gc-8.2.4.tar.gz
+echo "3d0d3cdbe077403d3106bb40f0cbb563413d6efdbb2a7e1cd6886595dec48fc2 gc-8.2.4.tar.gz" | sha256sum --check --status
+tar xf gc-8.2.4.tar.gz
+cd gc-8.2.4
+./configure --prefix=/ucrt64/
+make
+make install

--- a/src/dev/flang/be/c/C.java
+++ b/src/dev/flang/be/c/C.java
@@ -739,6 +739,15 @@ public class C extends ANY
     if (isWindows())
       {
         command.addAll("-lMswsock", "-lAdvApi32", "-lWs2_32");
+
+        if(_options._useBoehmGC)
+          {
+            command.addAll(
+              System.getenv("FUZION_CLANG_INSTALLED_DIR") == null
+                ? "C:\\tools\\msys64\\ucrt64\\bin\\libgc-1.dll"
+                : System.getenv("FUZION_CLANG_INSTALLED_DIR") + "\\libgc-1.dll"
+            );
+          }
       }
 
     _options.verbosePrintln(" * " + command.toString("", " ", ""));
@@ -797,6 +806,8 @@ public class C extends ANY
   {
     cf.print(
        "#define _POSIX_C_SOURCE 200809L\n" +
+       // we need to include winsock2.h before windows.h
+       (_options._useBoehmGC ? "#define GC_DONT_INCLUDE_WINDOWS_H\n"   : "")+
        (_options._useBoehmGC ? "#define GC_THREADS\n#include <gc.h>\n" : "")+
        "#include <stdlib.h>\n"+
        "#include <stdio.h>\n"+


### PR DESCRIPTION
also added a script to download and build `libgc`

Three tests seem to be failing on windows, currently:
 ./build/tests/atomic: failed
./build/tests/lock_free_stack: failed
./build/tests/sockets: failed