### PR TITLE
partially revert #2436 name mangling

### DIFF
--- a/src/dev/flang/tools/fzjava/FeatureWriter.java
+++ b/src/dev/flang/tools/fzjava/FeatureWriter.java
@@ -129,7 +129,8 @@ class FeatureWriter extends ANY
           {
             s = "_k_" + s;
           }
-        else if (s.equals("Sequence") ||
+        else if (s.equals(FuzionConstants.ANY_NAME) ||
+                 s.equals("Sequence") ||
                  s.equals(FuzionConstants.STRING_NAME) ||
                  s.equals("array"   ) ||
                  s.equals("split"   )    )


### PR DESCRIPTION
Unfortunately pull request #2436 took things a little too far since there are fields with the name `Any` in java. E.g. sun.java2d.loops.CompositeType.Any