### PR TITLE
lib: remove `as_stream` where not necessary

### DIFF
--- a/lib/Sequence.fz
+++ b/lib/Sequence.fz
@@ -158,11 +158,6 @@ public Sequence(public T type) ref is
   public infix | (f T -> unit) => for_each f
 
 
-  # create a stream, postfix operator synonym for as_stream
-  #
-  public postfix | => as_stream
-
-
   # apply 'f' to each element 'e' as long as 'f e'
   #
   public for_while(f T -> bool) unit =>

--- a/lib/has_interval.fz
+++ b/lib/has_interval.fz
@@ -59,14 +59,6 @@ public has_interval : integer is
       while x ≤ upper
         f x
 
-    # create a stream of all the elements of this interval, in order.
-    public redef as_stream =>
-      ref : stream has_interval.this
-        x := num_option lower
-        public redef has_next bool => x.exists && (x.val ≤ upper)
-        public redef next has_interval.this => res := x.val; set x := x +? has_interval.this.type.one; res
-
-
     # does this range contain the given value?
     #
     public contains (e has_interval.this) => lower ≤ e ≤ upper

--- a/tests/partial_application_negative/partial_application_negative.fz.expected_err
+++ b/tests/partial_application_negative/partial_application_negative.fz.expected_err
@@ -81,7 +81,7 @@ In call: '3.postfix*'
 Feature not found: 'map' (no arguments)
 Target feature: 'has_interval.infix ..'
 In call: 'map'
-To solve this, you might change the actual number of arguments to match the feature 'map' (2 arguments) at $FUZION/lib/Sequence.fz:306:10:
+To solve this, you might change the actual number of arguments to match the feature 'map' (2 arguments) at $FUZION/lib/Sequence.fz:301:10:
   public map(B type, f Unary B T) Sequence B =>
 ---------^
 


### PR DESCRIPTION
This is in preparation of removing `Stream` in its entirety.
