### PR TITLE
jvm: enable `env_vars.get` since this is required in the Fuzion tutorial

### DIFF
--- a/src/dev/flang/be/jvm/runtime/Intrinsics.java
+++ b/src/dev/flang/be/jvm/runtime/Intrinsics.java
@@ -833,7 +833,6 @@ public class Intrinsics extends ANY
 
   public static boolean fuzion_sys_env_vars_has0(Object s)
   {
-    Runtime.unsafeIntrinsic();
     return System.getenv(Runtime.utf8ByteArrayDataToString((byte[]) s)) != null;
   }
 


### PR DESCRIPTION
HelloWorld_random.fz uses this.

Please describe your changes here.

