### PR TITLE
doc: Add String escapes table to ref manual.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -387,6 +387,7 @@ REF_MANUAL_SOURCES = $(wildcard $(FZ_SRC)/doc/ref_manual/*.adoc) \
                      $(BUILD_DIR)/generated/doc/codepoints_numeric.adoc \
                      $(BUILD_DIR)/generated/doc/codepoints_op.adoc \
                      $(BUILD_DIR)/generated/doc/keywords.adoc \
+                     $(BUILD_DIR)/generated/doc/stringEscapes.adoc \
                      $(JAVA_FILES_UTIL) \
                      $(JAVA_FILES_PARSER) \
                      $(JAVA_FILES_FE)
@@ -1107,6 +1108,10 @@ $(BUILD_DIR)/generated/doc/codepoints_op.adoc: $(CLASS_FILES_PARSER)
 $(BUILD_DIR)/generated/doc/keywords.adoc: $(CLASS_FILES_PARSER)
 	mkdir -p $(@D)
 	$(JAVA) -cp $(CLASSES_DIR) dev.flang.parser.Lexer -keywords >$@
+
+$(BUILD_DIR)/generated/doc/stringEscapes.adoc: $(CLASS_FILES_PARSER)
+	mkdir -p $(@D)
+	$(JAVA) -cp $(CLASSES_DIR) dev.flang.parser.Lexer -stringLiteralEscapes >$@
 
 $(REF_MANUAL_PDF): $(REF_MANUAL_SOURCES) $(BUILD_DIR)/generated/doc/fum_file.adoc $(FUZION_EBNF)
 	mkdir -p $(@D)

--- a/doc/ref_manual/fuzion_reference_manual.adoc
+++ b/doc/ref_manual/fuzion_reference_manual.adoc
@@ -298,7 +298,16 @@ CAUTION: *NYI*: Text Missing
 
 ===== String Literals
 
+[#string_literal]
 CAUTION: *NYI*: Text Missing
+
+String literals support the following escape sequence to include special characters:
+
+====
+include::{GENERATED}/doc/stringEscapes.adoc[]
+====
+
+
 
 === Grammar
 
@@ -315,18 +324,40 @@ CAUTION: *NYI*: Text Missing
 [appendix]
 == Glossary
 
+[#fuzion_abstract]
+((Abstract Feature)):: CAUTION: *NYI*: Text Missing
+
 ((Argument)):: CAUTION: *NYI*: Text Missing
 
+[#fuzion_choice]
+((Choice)):: CAUTION: *NYI*: Text Missing
+
+[#fuzion_constructor]
 ((Constructor)):: CAUTION: *NYI*: Text Missing
 
 ((Clazz)):: CAUTION: *NYI*: Text Missing
 
 [#fuzion_feature]
-((Feature)):: CAUTION: *NYI*: Text Missing
+((Feature)):: A feature is the most fundamental entity of Fuzion.  A feature can
+be declared and can be called.  Features generalize fairly different concepts
+found in other programming languages such as functions, methods, constructors,
+classes, structs, records, packages, interfaces, fields, and local variables.
+A Fuzion feature may be one of the following variants: a xref:fuzion_constructor[constructor],
+a xref:fuzion_function[function], a xref:fuzion_field[field], a xref:fuzion_choice[choice],
+a xref:fuzion_typeparameter[type parameter], an xref:fuzion_abstract[abstract feature],
+an xref:fuzion_intrinsic[intrinsic], a xref:fuzion_native[native feature].
 
+[#fuzion_field]
 ((Field)):: CAUTION: *NYI*: Text Missing
 
+[#fuzion_function]
 ((Function)):: CAUTION: *NYI*: Text Missing
+
+[#fuzion_intrinsic]
+((Intrinsic Feature)):: CAUTION: *NYI*: Text Missing
+
+[#fuzion_native]
+((Native Feature)):: CAUTION: *NYI*: Text Missing
 
 [#input_source]
 ((Input Source)):: An input source is a stream of bytes that contains Fuzion
@@ -336,6 +367,7 @@ code that is used as an input for tools like Fuzion compilers.
 
 ((Type)):: CAUTION: *NYI*: Text Missing
 
+[#fuzion_typeparameter]
 ((Type Parameter)):: CAUTION: *NYI*: Text Missing
 
 [appendix]

--- a/src/dev/flang/parser/Lexer.java
+++ b/src/dev/flang/parser/Lexer.java
@@ -436,7 +436,7 @@ public class Lexer extends SourceFile
   {
     var n = _asciiControlName[cp];
     return String.format("0x%04x %s", cp,
-                         n != null ? "`" + n + "`":
+                         n != null ? "`" + n.strip() + "`":
                          cp == ' ' ? "SPACE" :
                          cp < 0x7f ? "`'" + (char) cp + "'`"
                                    : "");
@@ -529,6 +529,27 @@ public class Lexer extends SourceFile
                }
              System.out.println();
            }
+         else if (x.equals("-stringLiteralEscapes"))
+           {
+             System.out.println("""
+[options=\"header\",cols=\"1,1\"]
+|====
+   | escape sequence | resulting code point
+                                """);
+             for (int i = 0; i < StringLexer.escapeChars.length; i++)
+               {
+                 var c      = StringLexer.escapeChars[i][0];
+                 var result = StringLexer.escapeChars[i][1];
+                 if (c != '\n'  && c != '\r')
+                   {
+                     System.out.println("  | `\\" + (char) c + "` | " + codePointAsString(result));
+                   }
+               }
+             System.out.println("  | `\\` + " + codePointAsString('\n') + " | _nothing_");
+             System.out.println("  | `\\` + " + codePointAsString('\r') + " + " + codePointAsString('\n') + " | _nothing_");
+             System.out.println("|====");
+           }
+
        });
   }
 
@@ -1133,7 +1154,7 @@ public class Lexer extends SourceFile
             {
     /*
     // tag::fuzion_rule_LEXR_LEGALCP[]
-Fuzion source code may not contain and
+Fuzion source code may not contain any
 xref:unsupported_code_points[unsupported code points].
     // end::fuzion_rule_LEXR_LEGALCP[]
     */
@@ -2627,7 +2648,7 @@ PIPE        : "|"
      * If this is changed, https://fuzion-lang.dev/tutorial/string_constants
      * must be changed as well.
      */
-    int[][] escapeChars = new int[][] {
+    static int[][] escapeChars = new int[][] {
         { 'b', '\b'  },  // BS 0x08
         { 't', '\t'  },  // HT 0x09
         { 'n', '\n'  },  // LF 0x0a


### PR DESCRIPTION
Also add definition of Feature and fix a typo `and` -> `any`.
