### PR TITLE
be/c, windows: fix sockets tests

### DIFF
--- a/include/fz.h
+++ b/include/fz.h
@@ -181,7 +181,6 @@ int fzE_close(int sockfd)
 {
 #ifdef _WIN32
   closesocket(sockfd);
-  WSACleanup();
   return fzE_net_error();
 #else
   return ( close(sockfd) == - 1 )


### PR DESCRIPTION
When closing a socket `WSACleanup` was called on windows. `WSACleanup` terminates use of the Winsock 2 DLL according to https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-wsacleanup So it was/is wrong to call this function.

This also made the socket-test fail. What I don't understand is why the test seemed to have work e.g. a month ago since the mentioned code has not been changed recently.
