### PR TITLE
lib: Make `Sequence.infix |` an alias for `map`

### DIFF
--- a/lib/Sequence.fz
+++ b/lib/Sequence.fz
@@ -171,9 +171,14 @@ public Sequence(public T type) ref is
     as_list
 
 
-  # create a list and have it consumed by f, infix operator synonym of for_each.
+  # consume all elements of this Sequence by f. This is an infix operator alias
+  # for for_each.
   #
-  public infix | (f T -> unit) => for_each f
+  # Ex.: To print all the elements of a list, you can use
+  #
+  #  1..10 ! say
+  #
+  public infix ! (f T -> unit) => for_each f
 
 
   # apply 'f' to each element 'e' as long as 'f e'
@@ -311,13 +316,34 @@ public Sequence(public T type) ref is
   public as_strings => map c->c.as_string
 
 
-  # map the Sequence to a new list applying function f to all elements
+  # map the Sequence to a new Sequence applying function f to all elements
   #
   # This performs a lazy mapping, f is called only when the elements
   # in the resulting list are accessed.
   #
   public map(B type, f Unary B T) Sequence B =>
     as_list.map_to_list f
+
+
+  # map the Sequence to a new Sequence applying function f to all elements
+  #
+  # This is an infix operator alias of map enabling piping code like
+  #
+  #   l := 1..10 | *10 | 300-
+  #
+  # to obtain 290,280,270,...200
+  #
+  # Note that map and therefore also this operator is lazy, so
+  #
+  #   _ := (1..10 | say)
+  #
+  # will not print anything while
+  #
+  #   (1..10 | say).for_each _->unit
+  #
+  # will print the elements since `for_each` is not lazy.
+  #
+  public infix | (B type, f Unary B T) Sequence B => map f
 
 
   # map each element of this Sequence to Sequence

--- a/lib/Stream.fz
+++ b/lib/Stream.fz
@@ -95,11 +95,6 @@ public stream(public T type) ref : Sequence T is
   public redef for_each(f T -> unit) unit => while has_next do f(next)
 
 
-  # apply f to all elements in this stream, infix operator synonym of for_each.
-  #
-  public redef infix | (f T -> unit) unit => while has_next do f(next)
-
-
   # apply 'f' to each element 'e' as long as 'f e'
   #
   public redef for_while(f T -> bool) unit => while has_next && f(next)

--- a/tests/choice_mix/choice_mix.fz
+++ b/tests/choice_mix/choice_mix.fz
@@ -292,7 +292,7 @@ choice_mix is
       say ""
 
     // check that pipe also works as operator:
-    (1..10) | i -> yak i
+    (1..10) ! yak
     say ""
   alternatives1
 

--- a/tests/partial_application_negative/partial_application_negative.fz.expected_err
+++ b/tests/partial_application_negative/partial_application_negative.fz.expected_err
@@ -81,7 +81,7 @@ In call: '3.postfix*'
 Feature not found: 'map' (no arguments)
 Target feature: 'has_interval.infix ..'
 In call: 'map'
-To solve this, you might change the actual number of arguments to match the feature 'map' (2 arguments) at $FUZION/lib/Sequence.fz:319:10:
+To solve this, you might change the actual number of arguments to match the feature 'map' (2 arguments) at $FUZION/lib/Sequence.fz:324:10:
   public map(B type, f Unary B T) Sequence B =>
 ---------^
 

--- a/tests/qualified_declaration/qualified_declaration.fz
+++ b/tests/qualified_declaration/qualified_declaration.fz
@@ -35,7 +35,7 @@ qualified_declaration is
   x.y.z.f4(i i32) i32 => i*i
   x.y.z.f5(i i32) => i*i
 
-  1..10 | i -> say ("$i " +
+  1..10 ! i -> say ("$i " +
                     "{x.y.z.f1(i)} " +
                     "{x.y.z.f2(i)} " +
                     "{x.y.z.f3(i)} " +

--- a/tests/rosettacode_factors_of_an_integer/factors.fz
+++ b/tests/rosettacode_factors_of_an_integer/factors.fz
@@ -55,14 +55,14 @@ factors is
   say ((1..n).filter (x -> n %% x))
 
   yak "factors using pipes to filter and print a Sequence: "
-  (1..n) & (x -> n %% x) | (x -> print x)
+  (1..n & x -> n %% x) ! print
   say ""
 
   say "factors embedded in String: {(1..n) &  (x -> n %% x)}"
 
-  (1..n) | m ->
+  (1..n) ! m ->
     say("factors of $m: " +
-        ((1..m) & (x -> m %% x)))
+        (1..m & x -> m %% x))
 
   // NYI: better syntax
   //

--- a/tests/rosettacode_man_or_boy/man_or_boy.fz
+++ b/tests/rosettacode_man_or_boy/man_or_boy.fz
@@ -68,4 +68,4 @@ man_or_boy is
   // K(n i32) => fun => n
   K(n i32) Function i32 => ()->n
 
-  (0..8) | n -> say "manorboy a($n) = {a n K(1) K(-1) K(-1) K(1) K(0)}"
+  (0..8) ! n -> say "manorboy a($n) = {a n K(1) K(-1) K(-1) K(1) K(0)}"

--- a/tests/rosettacode_primes/primes.fz
+++ b/tests/rosettacode_primes/primes.fz
@@ -67,9 +67,9 @@ primes is
     primes4(n i32) is  // sieve using pipes
       a := (mutate.array bool).type.new mi n+1 false
 
-      (2..n) |& (i -> !a[i]) | i ->
+      ((2..n) |& (i -> !a[i])) ! i ->
         yak "$i "
-        (1..n/i) | j -> a[i*j] := true
+        (1..n/i) ! j -> a[i*j] := true
 
     say "Primes using pipes:"; primes4 1000; say ""
   )


### PR DESCRIPTION
This seems more useful than the previous `for_each` this was an alias for. New alias for `for_each` is `infix !`.

Remove redefinition of `infix |` from `Stream`.

Replaced `list` by `Sequence` in a comment.
