### PR TITLE
ast: suppress subsequent error `Incompatible result on branches of ...`

### DIFF
--- a/src/dev/flang/ast/AstErrors.java
+++ b/src/dev/flang/ast/AstErrors.java
@@ -1791,11 +1791,15 @@ public class AstErrors extends ANY
 
   static void incompatibleResultsOnBranches(SourcePosition pos, String msg, List<AbstractType> types, Map<AbstractType, List<SourcePosition>> positions)
   {
-    error(pos,
-          msg,
-          "Incompatible result types in different branches:\n" +
-          typesMsg("block returns", "blocks return", types, positions));
+    if (!any() || types.stream().noneMatch(t -> t == Types.t_ERROR))
+      {
+        error(pos,
+              msg,
+              "Incompatible result types in different branches:\n" +
+              typesMsg("block returns", "blocks return", types, positions));
+      }
   }
+
 
   static void incompatibleTypesOfActualArguments(AbstractFeature formalArg,
                                                  List<AbstractType> types,


### PR DESCRIPTION
In case any of the branches in an if or a match results in `***error***` we do not want to report this unless there were no previous errors.
