### PR TITLE
jvm: make `fuzion.std.exit` safe for use in fuzion-lang.dev

### DIFF
--- a/src/dev/flang/be/jvm/runtime/Intrinsics.java
+++ b/src/dev/flang/be/jvm/runtime/Intrinsics.java
@@ -271,7 +271,6 @@ public class Intrinsics extends ANY
 
   public static void fuzion_std_exit (int code)
   {
-    Runtime.unsafeIntrinsic();
     System.exit(code);
   }
 


### PR DESCRIPTION
This can't do much harm and it is used in examples in `tutorial/void_type`.
