### PR TITLE
lib: limit number of entries shown by as_string for non-finite Sequences

### DIFF
--- a/lib/Sequence.fz
+++ b/lib/Sequence.fz
@@ -302,11 +302,38 @@ public Sequence(public T type) ref is
   # representations of its contents, separated by ',' and enclosed in '['
   # and ']'.
   #
-  public redef as_string => as_list.as_string
+  # In case this Sequence is known to be `finite` or has at most (Sequence T).type
+  # .AS_STRING_NON_FINITE_MAX_ELEMENTS elements, all elements will be shown in the
+  # resulting string. Otherwise, only the first elements will be shown followed by
+  # ",…" as in "[1,2,3,4,5,6,7,8,9,10,…]".
+  #
+  # To force printing of all elements of a finite `Sequence` for which `finite` is
+  # false (which may be the case since a Sequence in general might not know that it
+  # if finite), you may use `as_string_all`.
+  #
+  public redef as_string =>
+    max := (Sequence T).type.AS_STRING_NON_FINITE_MAX_ELEMENTS;
+    if finite || ((map _->unit).drop max).is_empty
+      as_string_all
+    else
+      ((map (.as_string)).take max ++ ["…"]).as_string_all
+
+
+  # create a string representation of this Sequence including all the string
+  # representations of its contents, separated by ',' and enclosed in '['
+  # and ']'.
+  #
+  # NOTE: In case this Sequence is not finite, this will attempt to create an
+  # infinitely long string resulting in failure due to resource exchaustion.
+  #
+  public as_string_all => "[{as_string ","}]"
 
 
   # create a string representation of this Sequence including all the string
   # representations of its contents, separated by 'sep'.
+  #
+  # NOTE: In case this Sequence is not finite, this will attempt to create an
+  # infinitely long string resulting in failure due to resource exchaustion.
   #
   public as_string (sep String) => as_list.as_string sep
 
@@ -577,7 +604,6 @@ public Sequence(public T type) ref is
       (take chunk_size).as_list : ((drop chunk_size).chunk chunk_size)
 
 
-
   # monoid of Sequences with infix concatentation operation.
   #
   public type.concat_monoid : Monoid (Sequence T) is
@@ -590,3 +616,9 @@ public Sequence(public T type) ref is
     #
     e Sequence T =>
       (list T).type.empty
+
+
+  # Maximum number of elements shown for on a call to `as_string` for a non-finite
+  # Sequence.
+  #
+  public type.AS_STRING_NON_FINITE_MAX_ELEMENTS => 10

--- a/lib/Sequence.fz
+++ b/lib/Sequence.fz
@@ -313,10 +313,12 @@ public Sequence(public T type) ref is
   #
   public redef as_string =>
     max := (Sequence T).type.AS_STRING_NON_FINITE_MAX_ELEMENTS;
-    if finite || ((map _->unit).drop max).is_empty
+    if finite
       as_string_all
     else
-      ((map (.as_string)).take max ++ ["…"]).as_string_all
+      indexed.map (t -> if t.values.0 < 10 then $t.values.1 else "…")
+             .take 11
+             .as_string_all
 
 
   # create a string representation of this Sequence including all the string

--- a/lib/Sequence.fz
+++ b/lib/Sequence.fz
@@ -312,12 +312,12 @@ public Sequence(public T type) ref is
   # if finite), you may use `as_string_all`.
   #
   public redef as_string =>
-    max := (Sequence T).type.AS_STRING_NON_FINITE_MAX_ELEMENTS;
     if finite
       as_string_all
     else
-      indexed.map (t -> if t.values.0 < 10 then $t.values.1 else "…")
-             .take 11
+      max := (Sequence T).type.AS_STRING_NON_FINITE_MAX_ELEMENTS
+      indexed.map (t -> if t.values.0 < max then $t.values.1 else "…")
+             .take max+1
              .as_string_all
 
 

--- a/lib/Sequence.fz
+++ b/lib/Sequence.fz
@@ -316,9 +316,8 @@ public Sequence(public T type) ref is
       as_string_all
     else
       max := (Sequence T).type.AS_STRING_NON_FINITE_MAX_ELEMENTS
-      indexed.map (t -> if t.values.0 < max then $t.values.1 else "…")
-             .take max+1
-             .as_string_all
+      (zip i32 String /* NYI: BUG #2527: type inference not powerful enough to infer `i32` here */
+           0..max (v,n -> if n < max then $v else "…")).as_string_all
 
 
   # create a string representation of this Sequence including all the string

--- a/lib/list.fz
+++ b/lib/list.fz
@@ -297,14 +297,6 @@ public list(public A type) : choice nil (Cons A (list A)), Sequence A is
 
 
   # create a string representation of this list including all the string
-  # representations of its contents, separated by ',' and enclosed in '['
-  # and ']'.
-  #
-  public redef as_string =>
-    "[{as_string ","}]"
-
-
-  # create a string representation of this list including all the string
   # representations of its contents, separated by 'sep'.
   #
   public redef as_string (sep String) =>

--- a/tests/partial_application_negative/partial_application_negative.fz.expected_err
+++ b/tests/partial_application_negative/partial_application_negative.fz.expected_err
@@ -81,7 +81,7 @@ In call: '3.postfix*'
 Feature not found: 'map' (no arguments)
 Target feature: 'has_interval.infix ..'
 In call: 'map'
-To solve this, you might change the actual number of arguments to match the feature 'map' (2 arguments) at $FUZION/lib/Sequence.fz:324:10:
+To solve this, you might change the actual number of arguments to match the feature 'map' (2 arguments) at $FUZION/lib/Sequence.fz:353:10:
   public map(B type, f Unary B T) Sequence B =>
 ---------^
 

--- a/tests/partial_application_negative/partial_application_negative.fz.expected_err
+++ b/tests/partial_application_negative/partial_application_negative.fz.expected_err
@@ -81,7 +81,7 @@ In call: '3.postfix*'
 Feature not found: 'map' (no arguments)
 Target feature: 'has_interval.infix ..'
 In call: 'map'
-To solve this, you might change the actual number of arguments to match the feature 'map' (2 arguments) at $FUZION/lib/Sequence.fz:353:10:
+To solve this, you might change the actual number of arguments to match the feature 'map' (2 arguments) at $FUZION/lib/Sequence.fz:352:10:
   public map(B type, f Unary B T) Sequence B =>
 ---------^
 


### PR DESCRIPTION
This results in useful output as in
```
  > echo "say [1,2,3].cycle" | ./build/bin/fz -
  [1,2,3,1,2,3,1,2,3,1,…]
```
Instead of crashing with an out of memory or stack overflow error.

Compared to #2520, this does not cause repeated evaluation of list elements and it also updated error output of one test.