### PR TITLE
lib: implement `Set.add`

### DIFF
--- a/lib/container/Set.fz
+++ b/lib/container/Set.fz
@@ -52,13 +52,8 @@ public Set(public E type : property.equatable) ref : Sequence E is
 
   # add new element k to this set.
   #
-  public add (k E) Set E => abstract
-
-
-  # remove an element k from the set if it exists.
-  # return the same set if it does not exist.
-  #
-  public remove (k E) Set E => abstract
+  public add (k E) Set E =>
+    panic "*** NYI: REMOVE Set.add, we need some support for mutable Sets ***"
 
 
   public redef as_string =>

--- a/lib/container/ps_set.fz
+++ b/lib/container/ps_set.fz
@@ -73,7 +73,9 @@ is
 
   # add new element k to this set.
   #
-  public add (k K) Set K =>
+  # NYI: this should be intergrated in the mutate effect!
+  #
+  public redef add (k K) Set K =>
     add0 k
 
 

--- a/modules/lock_free/src/lock_free/map.fz
+++ b/modules/lock_free/src/lock_free/map.fz
@@ -734,7 +734,9 @@ public container.set_of_hashable(K type : property.hashable, vs (lock_free.map K
 
     # add new element k to this set.
     #
-    public add (k K) Set K =>
+    # NYI: this should be intergrated in the mutate effect!
+    #
+    public redef add (k K) Set K =>
       ss := map.snapshot false
       ss.add k unit
       set_of_hashable ss


### PR DESCRIPTION
`Set.add` being `abstract` resulted in errors for heirs of `Set` that to not have `add` when running the idioms.

Eventually, `Set.add` should be removed and we should have a proper integration of mutable Sets with the `mutate` effect or some lock-free-concurrency effect.

Also removed `Set.remove` since this seems unused but could cause similar problem.s