### PR TITLE
makefile: add `rerecord_simple_tests`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1247,3 +1247,8 @@ syntaxcheck: min-java
 .PHONY: add_simple_test
 add_simple_test: no-java
 	$(BUILD_DIR)/bin/fz bin/add_simple_test.fz
+
+.PHONY: rerecord_simple_tests
+rerecord_simple_tests:
+	echo "ATTENTION: This rerecording is naive. You will have to manually revert any inappropriate changes after recording session."
+	for file in tests/*/ ; do if [ "$$(find "$$file" -maxdepth 1 -type f -name "*.expected_out" -print -quit)" ]; then make record -C build/"$$file"/ && cp build/"$$file"/*.expected_* "$$file"; fi done


### PR DESCRIPTION
I sometimes find this to be helpful even though you will likely have to do some manual reverts after rerecording.

- [x] I have read and accept the [Tokiwa Software Fuzion Contributor Agreement](https://github.com/tokiwa-software/fuzion/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).
