### PR TITLE
analysis: Remove `valuecl` arg from `AbstractInterpreter.ProcessorStatement.tag`

### DIFF
--- a/src/dev/flang/be/c/C.java
+++ b/src/dev/flang/be/c/C.java
@@ -483,8 +483,9 @@ public class C extends ANY
     /**
      * Create a tagged value of type newcl from an untagged value for type valuecl.
      */
-    public Pair<CExpr, CStmnt> tag(int cl, int valuecl, CExpr value, int newcl, int tagNum)
+    public Pair<CExpr, CStmnt> tag(int cl, CExpr value, int newcl, int tagNum)
     {
+      var valuecl = _fuir.clazzChoice(newcl, tagNum);
       var res     = _names.newTemp();
       var tag     = res.field(CNames.TAG_NAME);
       var uniyon  = res.field(CNames.CHOICE_UNION_NAME);

--- a/src/dev/flang/be/jvm/CodeGen.java
+++ b/src/dev/flang/be/jvm/CodeGen.java
@@ -1063,8 +1063,6 @@ class CodeGen
    *
    * @param cl the clazz we are compiling
    *
-   * @param valuecl the original clazz of the value that is to be tagged. NYI: CLEANUP: remove?
-   *
    * @param value code to produce the value we are tagging
    *
    * @param newcl the choice type after tagging
@@ -1074,7 +1072,7 @@ class CodeGen
    *
    * @return code to produce the tagged value as a result.
    */
-  public Pair<Expr, Expr> tag(int cl, int valuecl, Expr value, int newcl, int tagNum)
+  public Pair<Expr, Expr> tag(int cl, Expr value, int newcl, int tagNum)
   {
     var res = _choices.tag(_jvm, cl, value, newcl, tagNum);
     return new Pair<>(res, Expr.UNIT);

--- a/src/dev/flang/fuir/analysis/AbstractInterpreter.java
+++ b/src/dev/flang/fuir/analysis/AbstractInterpreter.java
@@ -236,7 +236,7 @@ public class AbstractInterpreter<VALUE, RESULT> extends ANY
     /**
      * Create a tagged value of type newcl from an untagged value for type valuecl.
      */
-    public abstract Pair<VALUE, RESULT> tag(int cl, int valuecl, VALUE value, int newcl, int tagNum);
+    public abstract Pair<VALUE, RESULT> tag(int cl, VALUE value, int newcl, int tagNum);
 
     /**
      * Access the effect of type ecl that is installed in the environment.
@@ -719,7 +719,7 @@ public class AbstractInterpreter<VALUE, RESULT> extends ANY
           if (CHECKS) check
             (!_fuir.clazzIsVoidType(valuecl));
           int tagNum  = _fuir.clazzChoiceTag(newcl, valuecl);
-          var r = _processor.tag(cl, valuecl, value, newcl, tagNum);
+          var r = _processor.tag(cl, value, newcl, tagNum);
           push(stack, newcl, r._v0);
           return r._v1;
         }

--- a/src/dev/flang/fuir/analysis/dfa/DFA.java
+++ b/src/dev/flang/fuir/analysis/dfa/DFA.java
@@ -646,9 +646,9 @@ public class DFA extends ANY
 
 
     /**
-     * Create a tagged value of type newcl from an untagged value for type valuecl.
+     * Create a tagged value of type newcl from an untagged value.
      */
-    public Pair<Val, Unit> tag(int cl, int valuecl, Val value, int newcl, int tagNum)
+    public Pair<Val, Unit> tag(int cl, Val value, int newcl, int tagNum)
     {
       Val res = value.value().tag(_call._dfa, newcl, tagNum);
       return new Pair<>(res, _unit_);


### PR DESCRIPTION
This can be obtained via `_fuir.clazzChoice(newcl, tagNum)`.
