### PR TITLE
be/jvm: Show written class files at `-verbose` level 2, not 1

### DIFF
--- a/src/dev/flang/be/jvm/classfile/ClassFile.java
+++ b/src/dev/flang/be/jvm/classfile/ClassFile.java
@@ -1440,7 +1440,7 @@ public class ClassFile extends ANY implements ClassFileConstants
   public void write(Path dir) throws IOException
   {
     var fp = dir.resolve(classFile());
-    _opt.verbosePrintln(" + " + fp);
+    _opt.verbosePrintln(2, " + " + fp);
     Files.write(fp, bytes());
   }
 


### PR DESCRIPTION
Avoid too much output on `fz -classes -verbose ...`.
