### PR TITLE
be/jvm: For `-jar` and `-classes` backends, fix arguments and include cmd as `args[0]`

### DIFF
--- a/src/dev/flang/be/jvm/Intrinsix.java
+++ b/src/dev/flang/be/jvm/Intrinsix.java
@@ -569,7 +569,9 @@ public class Intrinsix extends ANY implements ClassFileConstants
           var val = Expr.getstatic(Names.RUNTIME_CLASS,
                                    Names.RUNTIME_ARGS,
                                    JAVA_LANG_STRING.array())
-            .andThen(Expr.ARRAYLENGTH);
+            .andThen(Expr.ARRAYLENGTH)
+            .andThen(Expr.iconst(1))
+            .andThen(Expr.IADD);
           return new Pair<>(val, Expr.UNIT);
         });
 

--- a/src/dev/flang/be/jvm/JVM.java
+++ b/src/dev/flang/be/jvm/JVM.java
@@ -498,9 +498,7 @@ should be avoided as much as possible.
         // of warnings, report them here.
         Errors.showAndExit(true);
 
-        var applicationArgs = new ArrayList<>(jvm._options._applicationArgs);
-        applicationArgs.add(0, jvm._fuir.clazzAsString(jvm._fuir.mainClazzId()));
-        jvm._runner.runMain(applicationArgs);
+        jvm._runner.runMain(jvm._options._applicationArgs);
 
         // We are done, the code is running in new threads and we silently
         // terminate without reporting any warning or error statistics that
@@ -848,8 +846,9 @@ should be avoided as much as possible.
                                   """
                                   #!/bin/sh
 
-                                  java %s
+                                  java -D%s="$0" %s "$@"
                                   """,
+                                  FUZION_COMMAND_PROPERTY,
                                   args));
         out.close();
         f.setExecutable(true);

--- a/src/dev/flang/be/jvm/Names.java
+++ b/src/dev/flang/be/jvm/Names.java
@@ -95,9 +95,9 @@ public class Names extends ANY implements ClassFileConstants
 
 
   /**
-   * Name and signature of Runtime.args field / Runtime.args_get method
+   * Name and signature of Runtime._args_ field and Runtime.args_get method
    */
-  static final String RUNTIME_ARGS = "args";
+  static final String RUNTIME_ARGS = "_args_";
   static final String RUNTIME_ARGS_GET = "args_get";
   static final String RUNTIME_ARGS_GET_SIG = "(I)[B";
 

--- a/src/dev/flang/be/jvm/runtime/Runtime.java
+++ b/src/dev/flang/be/jvm/runtime/Runtime.java
@@ -193,7 +193,21 @@ public class Runtime extends ANY
   public static final Object LOCK_FOR_ATOMIC = new Object();
 
 
-  public static String[] args = new String[] { "argument list not initialized", "this may indicate a severe bug" };
+  /**
+   * The result of `envir.args[0]`
+   */
+  public static String _cmd_ =
+    System.getProperties().computeIfAbsent(FUZION_COMMAND_PROPERTY,
+                                           k -> ProcessHandle.current()
+                                                             .info()
+                                                             .command()
+                                                             .orElse("")) instanceof String str ? str : "";
+
+
+  /**
+   * The results of `envir.args[1..n]`
+   */
+  public static String[] _args_ = new String[] { "argument list not initialized", "this may indicate a severe bug" };
 
 
   /*-------------------------  static methods  --------------------------*/
@@ -1056,7 +1070,8 @@ public class Runtime extends ANY
 
   public static byte[] args_get(int i)
   {
-    return stringToUtf8ByteArray(args[i]);
+    return stringToUtf8ByteArray(i == 0 ? _cmd_
+                                        : _args_[i-1]);
   }
 
 

--- a/src/dev/flang/tools/Tool.java
+++ b/src/dev/flang/tools/Tool.java
@@ -31,11 +31,6 @@ import java.nio.file.Path;
 import java.util.TreeSet;
 import java.util.Set;
 
-
-
-
-
-
 import dev.flang.parser.Parser;
 
 import dev.flang.util.ANY;
@@ -109,7 +104,7 @@ public abstract class Tool extends ANY
   protected Tool(String name, String[] args)
   {
     _rawCmd = name;
-    _cmd = System.getProperty("fuzion.command", name);
+    _cmd = System.getProperty(FUZION_COMMAND_PROPERTY, name);
     _args = args;
   }
 

--- a/src/dev/flang/util/ANY.java
+++ b/src/dev/flang/util/ANY.java
@@ -50,6 +50,12 @@ public class ANY
     System.getenv().getOrDefault("CHECKS", "false").equals("true");
 
 
+  /**
+   * Property to set the command name, i.e. the result of `envir.args[0]`.
+   */
+  public static final String FUZION_COMMAND_PROPERTY = "fuzion.command";
+
+
   /*-----------------------------  methods  -----------------------------*/
 
 


### PR DESCRIPTION
The script created for -jar and -classes did not propagate the command name as part of the arguments, so the first argument was falsely taken as the command name.

With this patch, the command name is passed explicitly via a property `fuzion.command`, which will be set to the script file in case of -jar/-classes targets and to the `fz` command in case of the `-jvm` target.
