### PR TITLE
be/jvm: determine max_stack/max_locals programmatically

### DIFF
--- a/src/dev/flang/be/jvm/Choices.java
+++ b/src/dev/flang/be/jvm/Choices.java
@@ -28,11 +28,11 @@ package dev.flang.be.jvm;
 
 import dev.flang.fuir.FUIR;
 
-import dev.flang.be.jvm.classfile.ClassFile.Attribute;
 import dev.flang.be.jvm.classfile.ClassFile;
 import dev.flang.be.jvm.classfile.ClassFileConstants;
 import dev.flang.be.jvm.classfile.Expr;
 import dev.flang.be.jvm.classfile.Label;
+import dev.flang.be.jvm.classfile.VerificationType;
 
 import dev.flang.fuir.analysis.AbstractInterpreter;
 
@@ -289,7 +289,7 @@ public class Choices extends ANY implements ClassFileConstants
                           var bc_tag = Expr.iconst(tagNum)
                             .andThen(Expr.IRETURN);
                           var code_tag = hcf.codeAttribute(gtn + "in interface for "+_fuir.clazzAsString(cl),
-                                                           bc_tag, new List<>(), new List<>(), ClassFile.StackMapTable.empty(hcf));
+                                                           bc_tag, new List<>(), new List<>(), ClassFile.StackMapTable.empty(hcf, new List<>(VerificationType.UninitializedThis), bc_tag));
                           hcf.method(ACC_PUBLIC, gtn, "()I", new List<>(code_tag));
                         }
                     }
@@ -329,8 +329,10 @@ public class Choices extends ANY implements ClassFileConstants
                                        Names.TAG_NAME,
                                        PrimitiveType.type_int))
                 .andThen(Expr.RETURN);
+              var initLocals = Types.addToLocals(new List<>(), ut);
+              initLocals.add(VerificationType.Integer);
               var code_init = cf.codeAttribute("<init> in class for " + _fuir.clazzAsString(cl),
-                                               bc_init, new List<>(), new List<>(), ClassFile.StackMapTable.empty(cf));
+                                               bc_init, new List<>(), new List<>(), ClassFile.StackMapTable.empty(cf, initLocals, bc_init));
               cf.method(ACC_PUBLIC, "<init>", "(I)V", new List<>(code_init));
 
               var bc_tag = Expr.aload(0, ut)
@@ -339,7 +341,7 @@ public class Choices extends ANY implements ClassFileConstants
                                        PrimitiveType.type_int))
                 .andThen(Expr.IRETURN);
               var code_tag = cf.codeAttribute(gtn + "in class for " + _fuir.clazzAsString(cl),
-                                              bc_tag, new List<>(), new List<>(), ClassFile.StackMapTable.empty(cf));
+                                              bc_tag, new List<>(), new List<>(), ClassFile.StackMapTable.empty(cf, Types.addToLocals(new List<>(), ut), bc_tag));
               cf.method(ACC_PUBLIC, gtn, "()I", new List<>(code_tag));
 
               cf.addToClInit(bc_clinit);

--- a/src/dev/flang/be/jvm/Choices.java
+++ b/src/dev/flang/be/jvm/Choices.java
@@ -289,7 +289,7 @@ public class Choices extends ANY implements ClassFileConstants
                           var bc_tag = Expr.iconst(tagNum)
                             .andThen(Expr.IRETURN);
                           var code_tag = hcf.codeAttribute(gtn + "in interface for "+_fuir.clazzAsString(cl),
-                                                           bc_tag, new List<>(), new List<Attribute>(ClassFile.StackMapTable.empty(hcf)));
+                                                           bc_tag, new List<>(), new List<>(), ClassFile.StackMapTable.empty(hcf));
                           hcf.method(ACC_PUBLIC, gtn, "()I", new List<>(code_tag));
                         }
                     }
@@ -330,7 +330,7 @@ public class Choices extends ANY implements ClassFileConstants
                                        PrimitiveType.type_int))
                 .andThen(Expr.RETURN);
               var code_init = cf.codeAttribute("<init> in class for " + _fuir.clazzAsString(cl),
-                                               bc_init, new List<>(), new List<Attribute>(ClassFile.StackMapTable.empty(cf)));
+                                               bc_init, new List<>(), new List<>(), ClassFile.StackMapTable.empty(cf));
               cf.method(ACC_PUBLIC, "<init>", "(I)V", new List<>(code_init));
 
               var bc_tag = Expr.aload(0, ut)
@@ -339,7 +339,7 @@ public class Choices extends ANY implements ClassFileConstants
                                        PrimitiveType.type_int))
                 .andThen(Expr.IRETURN);
               var code_tag = cf.codeAttribute(gtn + "in class for " + _fuir.clazzAsString(cl),
-                                              bc_tag, new List<>(), new List<Attribute>(ClassFile.StackMapTable.empty(cf)));
+                                              bc_tag, new List<>(), new List<>(), ClassFile.StackMapTable.empty(cf));
               cf.method(ACC_PUBLIC, gtn, "()I", new List<>(code_tag));
 
               cf.addToClInit(bc_clinit);

--- a/src/dev/flang/be/jvm/CodeGen.java
+++ b/src/dev/flang/be/jvm/CodeGen.java
@@ -613,7 +613,7 @@ class CodeGen
           .andThen(p._v0 == null ? Expr.UNIT : p._v0)
           .andThen(retoern);
         var ca = cf.codeAttribute(dn + "in class for " + _fuir.clazzAsString(tt),
-                                  code, new List<>(), new List<Attribute>(ClassFile.StackMapTable.empty(cf)));
+                                  code, new List<>(), new List<>(), ClassFile.StackMapTable.empty(cf));
         cf.method(ACC_PUBLIC, dn, ds, new List<>(ca));
       }
   }

--- a/src/dev/flang/be/jvm/JVM.java
+++ b/src/dev/flang/be/jvm/JVM.java
@@ -1249,9 +1249,8 @@ should be avoided as much as possible.
         var locals = initialLocals(cl);
 
         var code_cl = cf.codeAttribute((pre ? "precondition of " : "") + _fuir.clazzAsString(cl),
-                                       numLocals(cl, pre),
                                        bc_cl,
-                                       new List<>(), new List<>(ClassFile.StackMapTable.fromCode(cf, locals, bc_cl)));
+                                       new List<>(), new List<>(), ClassFile.StackMapTable.fromCode(cf, locals, bc_cl));
 
         cf.method(ClassFileConstants.ACC_STATIC | ClassFileConstants.ACC_PUBLIC, name, _types.descriptor(cl, pre), new List<>(code_cl));
 
@@ -1288,9 +1287,8 @@ should be avoided as much as possible.
               .andThen(jt.return0());
 
             var code_comb = cf.codeAttribute("combined precondition and code of " + _fuir.clazzAsString(cl),
-                                             numLocals(cl, pre) /* NYI: UNDER DEVELOPMENT: num locals! */,
                                              bc_combined,
-                                             new List<>(), new List<>(ClassFile.StackMapTable.fromCode(cf, locals, bc_combined)));
+                                             new List<>(), new List<>(), ClassFile.StackMapTable.fromCode(cf, locals, bc_combined));
             cf.method(ClassFileConstants.ACC_STATIC | ClassFileConstants.ACC_PUBLIC, Names.COMBINED_NAME, _types.descriptor(cl, false), new List<>(code_comb));
           }
       }
@@ -1300,7 +1298,7 @@ should be avoided as much as possible.
   /**
    * Get the state of the locals at the start of execution of cl.
    */
-  private List<VerificationType> initialLocals(int cl)
+  public List<VerificationType> initialLocals(int cl)
   {
     var cf = _types.classFile(cl);
     var result = new List<VerificationType>();

--- a/src/dev/flang/be/jvm/JVM.java
+++ b/src/dev/flang/be/jvm/JVM.java
@@ -1300,42 +1300,19 @@ should be avoided as much as possible.
    */
   public List<VerificationType> initialLocals(int cl)
   {
-    var cf = _types.classFile(cl);
     var result = new List<VerificationType>();
     if (_types.hasOuterRef(cl))
       {
         var or = _fuir.clazzOuterRef(cl);
         var ot = _fuir.clazzResultClazz(or);
         var at = _types.resultType(ot);
-        if (at != PrimitiveType.type_void)
-          {
-            var vti = _types.resultType(_fuir.clazzResultClazz(_fuir.clazzOuterRef(cl))).vti();
-            if (vti.needsTwoSlots())
-              {
-                result.addAll(vti, vti);
-              }
-            else
-              {
-                result.add(vti);
-              }
-          }
+        result = Types.addToLocals(result, at);
       }
     for (var i = 0; i < _fuir.clazzArgCount(cl); i++)
       {
         var at = _fuir.clazzArgClazz(cl, i);
         var ft = _types.resultType(at);
-        if (ft != PrimitiveType.type_void)
-          {
-            var vti = _types.resultType(_fuir.clazzArgClazz(cl, i)).vti();
-            if (vti.needsTwoSlots())
-              {
-                result.addAll(vti, vti);
-              }
-            else
-              {
-                result.add(vti);
-              }
-          }
+        result = Types.addToLocals(result, ft);
       }
     result.freeze();
     return result;

--- a/src/dev/flang/be/jvm/Types.java
+++ b/src/dev/flang/be/jvm/Types.java
@@ -158,7 +158,7 @@ public class Types extends ANY implements ClassFileConstants
               .andThen(vt.load(0))
               .andThen(Expr.invokeSpecial(cn, "<init>", sig))
               .andThen(rt.return0());
-            var code_box = cf.codeAttribute(Names.BOX_METHOD_NAME + " in " + _fuir.clazzAsString(cl), bc_box, new List<>(), new List<Attribute>(ClassFile.StackMapTable.empty(cf)));
+            var code_box = cf.codeAttribute(Names.BOX_METHOD_NAME + " in " + _fuir.clazzAsString(cl), bc_box, new List<>(), new List<>(), ClassFile.StackMapTable.empty(cf));
             cf.method(ACC_PUBLIC | ACC_STATIC,
                       Names.BOX_METHOD_NAME,
                       boxSignature(cl),
@@ -168,7 +168,7 @@ public class Types extends ANY implements ClassFileConstants
           .andThen(Expr.invokeSpecial(cf._super,"<init>","()V"))
           .andThen(cod)
           .andThen(Expr.RETURN);
-        var code_init = cf.codeAttribute("<init> in " + _fuir.clazzAsString(cl), bc_init, new List<>(), new List<Attribute>(ClassFile.StackMapTable.empty(cf)));
+        var code_init = cf.codeAttribute("<init> in " + _fuir.clazzAsString(cl), bc_init, new List<>(), new List<>(), ClassFile.StackMapTable.empty(cf));
 
         cf.method(ACC_PUBLIC, "<init>", sig, new List<>(code_init));
 
@@ -181,7 +181,7 @@ public class Types extends ANY implements ClassFileConstants
               .andThen(_fuir.hasPrecondition(maincl) ? invokeStatic(maincl, true) : Expr.UNIT)
               .andThen(invokeStatic(maincl, false)).drop()
               .andThen(Expr.RETURN);
-            var code_run = cf.codeAttribute(Names.MAIN_RUN + " in " + _fuir.clazzAsString(cl), bc_run, new List<>(), new List<Attribute>(ClassFile.StackMapTable.empty(cf)));
+            var code_run = cf.codeAttribute(Names.MAIN_RUN + " in " + _fuir.clazzAsString(cl), bc_run, new List<>(), new List<>(), ClassFile.StackMapTable.empty(cf));
             cf.method(ACC_PUBLIC, Names.MAIN_RUN, "()V", new List<>(code_run));
 
             var bc_main =
@@ -192,7 +192,7 @@ public class Types extends ANY implements ClassFileConstants
               .andThen(Expr.invokeSpecial(cn, "<init>", "()V"))
               .andThen(Expr.invokeStatic(Names.RUNTIME_CLASS, Names.RUNTIME_RUN, "(" + new ClassType(Names.MAIN_INTERFACE).argDescriptor() + ")V", PrimitiveType.type_void))
               .andThen(Expr.RETURN);
-            var code_main = cf.codeAttribute("main in " + _fuir.clazzAsString(cl), bc_main, new List<>(), new List<Attribute>(ClassFile.StackMapTable.empty(cf)));
+            var code_main = cf.codeAttribute("main in " + _fuir.clazzAsString(cl), bc_main, new List<>(), new List<>(), ClassFile.StackMapTable.empty(cf));
             cf.method(ACC_STATIC | ACC_PUBLIC, "main", "([Ljava/lang/String;)V", new List<>(code_main));
           }
       }

--- a/src/dev/flang/be/jvm/classfile/ByteCode.java
+++ b/src/dev/flang/be/jvm/classfile/ByteCode.java
@@ -467,24 +467,6 @@ abstract class ByteCode extends ANY implements ClassFileConstants
   public abstract void code(ClassFile.ByteCodeWriter bw, ClassFile cf);
 
 
-  /**
-   * NYI: HACK: determine the max stack use of the bytecodes.
-   */
-  public int max_stack()
-  {
-    // NYI: ByteCode.max_stack/max_locals not implemented yet, just using 10
-    return 20;
-  }
-
-  /**
-   * NYI: HACK: determine the max local index used by the bytecodes.
-   */
-  public int max_locals()
-  {
-    // NYI: ByteCode.max_stack/max_locals not implemented yet, just using 10
-    return 10;
-  }
-
 }
 
 /* end of file */

--- a/src/dev/flang/be/jvm/classfile/ClassFile.java
+++ b/src/dev/flang/be/jvm/classfile/ClassFile.java
@@ -1119,12 +1119,14 @@ public class ClassFile extends ANY implements ClassFileConstants
 
     /**
      * The state of the stack at bytecode position. Saved during buildStackMapTable.
+     * Note: long and double occupy only one stack slot.
      */
     final Map<Integer, Stack<VerificationType>> stacks = new TreeMap<>();
 
 
     /**
      * The state of locals at bytecode positions that are found during buildStackMapTable.
+     * Note: long and double always occupy two list entries.
      */
     final List<Pair<Integer, List<VerificationType>>> locals = new List<>();
 
@@ -1255,9 +1257,9 @@ public class ClassFile extends ANY implements ClassFileConstants
     /**
      * static initializer for an empty table.
      */
-    public static StackMapTable empty(ClassFile cf)
+    public static StackMapTable empty(ClassFile cf, List<VerificationType> argsLocals, Expr code)
     {
-      return cf.new StackMapTable(new List<>(), Expr.UNIT)
+      return cf.new StackMapTable(argsLocals, code)
         {
           @Override
           byte[] data()
@@ -1265,22 +1267,6 @@ public class ClassFile extends ANY implements ClassFileConstants
             var o = new Kaku();
             o.writeU2(0);
             return o._b.toByteArray();
-          }
-
-          /**
-           * NYI: HACK: determine the max stack use of the bytecodes.
-           */
-          public int max_stack()
-          {
-            return 20;
-          }
-
-          /**
-           * NYI: HACK: determine the max local index used by the bytecodes.
-           */
-          public int max_locals()
-          {
-            return 10;
           }
         };
     }
@@ -1658,7 +1644,7 @@ public class ClassFile extends ANY implements ClassFileConstants
         bc_clinit = bc_clinit
           .andThen(Expr.RETURN);
         var code_clinit = codeAttribute("<clinit> in class for " + _name,
-                                        bc_clinit, new List<>(), new List<>(), StackMapTable.empty(this));
+                                        bc_clinit, new List<>(), new List<>(), StackMapTable.empty(this, new List<>(), bc_clinit));
         method(ACC_PUBLIC | ACC_STATIC, "<clinit>", "()V", new List<>(code_clinit));
       }
 

--- a/src/dev/flang/be/jvm/classfile/Expr.java
+++ b/src/dev/flang/be/jvm/classfile/Expr.java
@@ -374,6 +374,8 @@ public abstract class Expr extends ByteCode
         {
           locals.set(local()._v0+1, local()._v1);
         }
+
+      smt.updateMaxLocal(local()._v0 + (local()._v1.needsTwoSlots() ? 2 : 1));
     }
 
   }


### PR DESCRIPTION
For now this is only implemented for non-empty StackMapTables

Bytecode that uses `StackMapTable.empty` still has a fixed number of stack/locals.

fixes #2176

<!--
Please describe your changes here, explain what effect this PR will have and how
this is achieved.  Refer to the # of the issue this PR addresses.  Make
sure the tests run successfully using `make run_tests`.
-->

- [x] I have read and accept the [Tokiwa Software Fuzion Contributor Agreement](https://github.com/tokiwa-software/fuzion/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).
