### PR TITLE
be/c: move posix code from intrinsics to posix.c

### DIFF
--- a/include/fz.h
+++ b/include/fz.h
@@ -166,6 +166,11 @@ bool fzE_bitwise_compare_float(float f1, float f2);
 bool fzE_bitwise_compare_double(double d1, double d2);
 
 /**
+ * returns a monotonically increasing timestamp.
+ */
+uint64_t fzE_nanotime();
+
+/**
  * Sleep for `n` nano seconds.
  */
 void fzE_nanosleep(uint64_t n);

--- a/include/fz.h
+++ b/include/fz.h
@@ -185,4 +185,26 @@ int fzE_stat(const char *pathname, int64_t * metadata);
  */
 int fzE_lstat(const char *pathname, int64_t * metadata);
 
+/**
+ * Run plattform specific initialisation code
+ */
+void fzE_init();
+
+/**
+ * Start a new thread, returns a pointer to the thread.
+ */
+int64_t fzE_thread_create(void* code, void* args);
+
+/**
+ * Join with a running thread.
+ */
+// NYI add return value
+void fzE_thread_join(int64_t thrd);
+
+/**
+ * Global lock
+ */
+void fzE_lock();
+void fzE_unlock();
+
 #endif /* fz.h  */

--- a/include/fz.h
+++ b/include/fz.h
@@ -30,6 +30,7 @@ Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
 
 #include <stdlib.h>
 #include <stdio.h>
+#include <stdint.h>
 
 // NYI move to shared
 static inline void *fzE_malloc_safe(size_t size) {
@@ -163,5 +164,25 @@ bool fzE_bitwise_compare_float(float f1, float f2);
  * @return true iff d1 and d2 are represented in memory by the same bit patterns.
  */
 bool fzE_bitwise_compare_double(double d1, double d2);
+
+/**
+ * Sleep for `n` nano seconds.
+ */
+void fzE_nanosleep(uint64_t n);
+
+/**
+ * remove a file or path
+ */
+int fzE_rm(char * path);
+
+/**
+ * Get file status (resolves symbolic links)
+ */
+int fzE_stat(const char *pathname, int64_t * metadata);
+
+/**
+ * Get file status (does not resolve symbolic links)
+ */
+int fzE_lstat(const char *pathname, int64_t * metadata);
 
 #endif /* fz.h  */

--- a/include/posix.c
+++ b/include/posix.c
@@ -26,6 +26,10 @@ Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
 
 #define _POSIX_C_SOURCE 200809L
 
+#ifdef GC_THREADS
+#include <gc.h>
+#endif
+
 #include <stdio.h>
 #include <stdlib.h>     // setenv, unsetenv
 #include <errno.h>
@@ -43,6 +47,10 @@ Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
 #include <unistd.h>     // close
 #include <netdb.h>      // getaddrinfo
 #include <time.h>
+#include <assert.h>
+#ifdef FUZION_ENABLE_THREADS
+#include <pthread.h>
+#endif
 
 // make directory, return zero on success
 int fzE_mkdir(const char *pathname){
@@ -410,5 +418,97 @@ int fzE_lstat(const char *pathname, int64_t * metadata)
   metadata[2] = 0LL;
   metadata[3] = 0LL;
   return -1;
+}
+
+#ifdef FUZION_ENABLE_THREADS
+pthread_mutex_t fzE_global_mutex;
+#endif
+
+/**
+ * Run plattform specific initialisation code
+ */
+void fzE_init()
+{
+#ifdef FUZION_ENABLE_THREADS
+  pthread_mutexattr_t attr;
+  memset(&fzE_global_mutex, 0, sizeof(fzE_global_mutex));
+  bool res = pthread_mutexattr_init(&attr) == 0 &&
+            pthread_mutexattr_setprotocol(&attr, PTHREAD_PRIO_INHERIT) == 0 &&
+            pthread_mutex_init(&fzE_global_mutex, &attr) == 0;
+  assert(res);
+#endif
+
+#ifdef GC_THREADS
+  GC_INIT();
+#endif
+}
+
+
+/**
+ * Start a new thread, returns a pointer to the thread.
+ */
+int64_t fzE_thread_create(void* code, void* args)
+{
+#ifdef FUZION_ENABLE_THREADS
+  // NYI use fzE_malloc_safe
+  pthread_t * pt = malloc(sizeof(pthread_t));;
+#ifdef GC_THREADS
+  int res = GC_pthread_create(pt,NULL,code,args);
+#else
+  int res = pthread_create(pt,NULL,code,args);
+#endif
+  if (res!=0)
+  {
+    fprintf(stderr,"*** pthread_create failed with return code %d\012",res);
+    exit(EXIT_FAILURE);
+  }
+  // NYI free pt
+  return (int64_t)pt;
+#else
+  printf("You discovered a severe bug. (fzE_thread_join)");
+  exit(EXIT_FAILURE);
+  return -1;
+#endif
+}
+
+
+/**
+ * Join with a running thread.
+ */
+void fzE_thread_join(int64_t thrd)
+{
+#ifdef FUZION_ENABLE_THREADS
+#ifdef GC_THREADS
+  GC_pthread_join(*(pthread_t *)thrd, NULL);
+#else
+  pthread_join(*(pthread_t *)thrd, NULL);
+#endif
+#endif
+}
+
+
+/**
+ * Global lock
+ */
+void fzE_lock()
+{
+#ifdef FUZION_ENABLE_THREADS
+  assert(pthread_mutex_lock(&fzE_global_mutex)==0);
+#else
+  printf("You discovered a severe bug. (fzE_lock)");
+#endif
+}
+
+
+/**
+ * Global lock
+ */
+void fzE_unlock()
+{
+#ifdef FUZION_ENABLE_THREADS
+  pthread_mutex_unlock(&fzE_global_mutex);
+#else
+  printf("You discovered a severe bug. (fzE_unlock)");
+#endif
 }
 

--- a/include/posix.c
+++ b/include/posix.c
@@ -354,6 +354,21 @@ int fzE_munmap(void * mapped_address, const int file_size){
 
 
 /**
+ * returns a monotonically increasing timestamp.
+ */
+uint64_t fzE_nanotime()
+{
+  struct timespec result;
+  if (clock_gettime(CLOCK_MONOTONIC,&result)!=0)
+  {
+    fprintf(stderr,"*** clock_gettime failed\012");
+    exit(EXIT_FAILURE);
+  }
+  return result.tv_sec*1000000000ULL+result.tv_nsec;
+}
+
+
+/**
  * Sleep for `n` nano seconds.
  */
 void fzE_nanosleep(uint64_t n)

--- a/include/win.c
+++ b/include/win.c
@@ -401,6 +401,21 @@ int fzE_munmap(void * mapped_address, const int file_size){
 
 
 /**
+ * returns a monotonically increasing timestamp.
+ */
+uint64_t fzE_nanotime()
+{
+  struct timespec result;
+  if (clock_gettime(CLOCK_MONOTONIC,&result)!=0)
+  {
+    fprintf(stderr,"*** clock_gettime failed\012");
+    exit(EXIT_FAILURE);
+  }
+  return result.tv_sec*1000000000ULL+result.tv_nsec;
+}
+
+
+/**
  * Sleep for `n` nano seconds.
  */
 void fzE_nanosleep(uint64_t n)

--- a/include/win.c
+++ b/include/win.c
@@ -381,3 +381,74 @@ int fzE_munmap(void * mapped_address, const int file_size){
     : -1;
 }
 
+
+/**
+ * Sleep for `n` nano seconds.
+ */
+void fzE_nanosleep(uint64_t n)
+{
+  // NYI replace with native windows
+  struct timespec req = (struct timespec){n/1000000000LL,n-n/1000000000LL*1000000000LL};
+  // NYI while{}
+  nanosleep(&req,&req);
+}
+
+
+/**
+ * remove a file or path
+ */
+int fzE_rm(char * path)
+{
+  // NYI replace with native windows
+  return unlink(path) == 0
+    ? 0
+    : rmdir(path) == 0
+    ? 0
+    : -1;
+}
+
+
+/**
+ * Get file status (resolves symbolic links)
+ */
+int fzE_stat(const char *pathname, int64_t * metadata)
+{
+  struct stat statbuf;
+  // NYI replace with native windows
+  if (stat(pathname,&statbuf)==((int8_t) 0))
+  {
+    metadata[0] = statbuf.st_size;
+    metadata[1] = statbuf.st_mtime;
+    metadata[2] = S_ISREG(statbuf.st_mode);
+    metadata[3] = S_ISDIR(statbuf.st_mode);
+    return 0;
+  }
+  metadata[0] = errno;
+  metadata[1] = 0LL;
+  metadata[2] = 0LL;
+  metadata[3] = 0LL;
+  return -1;
+}
+
+
+/**
+ * Get file status (does not resolve symbolic links)
+ */
+int fzE_lstat(const char *pathname, int64_t * metadata)
+{
+  struct stat statbuf;
+  // NYI replace with native windows
+  if (lstat(pathname,&statbuf)==((int8_t) 0))
+  {
+    metadata[0] = statbuf.st_size;
+    metadata[1] = statbuf.st_mtime;
+    metadata[2] = S_ISREG(statbuf.st_mode);
+    metadata[3] = S_ISDIR(statbuf.st_mode);
+    return 0;
+  }
+  metadata[0] = errno;
+  metadata[1] = 0LL;
+  metadata[2] = 0LL;
+  metadata[3] = 0LL;
+  return -1;
+}

--- a/lib/io/file/open.fz
+++ b/lib/io/file/open.fz
@@ -45,6 +45,20 @@ module:public open(public T type,
     io.file.read.read_file fd
 
 
+  # seek in file
+  #
+  public seek(
+       # the offset to seek from the beginning of the stream pointer
+       offset i64) =>
+    io.file.seek.seek fd offset
+
+
+  # get the current byte position in the file
+  #
+  public file_position =>
+    io.file.seek.file_position fd
+
+
   # install mmap effect an run code
   #
   # note: the offset must be a multiple of the pagesize which usually is 4096, windows 65536?

--- a/lib/io/file/read.fz
+++ b/lib/io/file/read.fz
@@ -37,7 +37,7 @@ public read(ro Read_Handler) : simple_effect is
   # returns outcome array u8, a byte array representing the content of the file if the operation was successful
   # returns an error in case the operation fails
   #
-  public read_file(fd i64) outcome (array u8) =>
+  module read_file(fd i64) outcome (array u8) =>
     empty array u8 := []
     content := read_file fd empty
 

--- a/lib/io/file/seek.fz
+++ b/lib/io/file/seek.fz
@@ -31,7 +31,7 @@ public seek(ps Seek_Handler) : simple_effect is
   # returns an outcome i64 that represents the new offset
   # returns an error in case of failure
   #
-  seek(
+  module seek(
        # the file descriptor
        fd i64,
        # the offset to seek from the beginning of the stream pointer
@@ -44,7 +44,7 @@ public seek(ps Seek_Handler) : simple_effect is
   # the offset is measured from the beginning of the file indicated by the file descriptor
   # returns the current offset in success and error in failure
   #
-  file_position(
+  module file_position(
                 # the file descriptor
                 fd i64) =>
     tmp := ps.file_position fd
@@ -84,13 +84,13 @@ seek(
 
 # short-hand for accessing seek effect in current environment
 #
-seek =>
+module seek =>
   seek.type.install_default
   seek.env
 
 
 # reference to the seek operations that could be provided
 #
-private:public Seek_Handler ref is
-  seek(fd i64, offset i64) outcome i64 => abstract
-  file_position(fd i64) outcome i64 => abstract
+public Seek_Handler ref is
+  public seek(fd i64, offset i64) outcome i64 => abstract
+  public file_position(fd i64) outcome i64 => abstract

--- a/lib/io/file/write.fz
+++ b/lib/io/file/write.fz
@@ -31,7 +31,7 @@ public write(fwh Write_Handler) : simple_effect is
   #
   # this might overwrite parts or all of an existing file.
   #
-  public write(fd i64, content array u8) =>
+  module write(fd i64, content array u8) =>
     tmp := fwh.write fd content unit
     replace
     tmp

--- a/src/dev/flang/be/c/C.java
+++ b/src/dev/flang/be/c/C.java
@@ -928,10 +928,7 @@ public class C extends ANY
 
     // --- POSIX ---
     // NYI remove POSIX only code.
-    cf.print(
-       "#include <unistd.h>\n"+
-       "#include <sys/stat.h>\n" +
-       "#include <pthread.h>\n");
+    cf.print("#include <pthread.h>\n");
 
     var fzH = _options.pathOf("include/fz.h");
     cf.println("#include \"" + fzH + "\"\n");

--- a/src/dev/flang/be/c/C.java
+++ b/src/dev/flang/be/c/C.java
@@ -721,7 +721,11 @@ public class C extends ANY
       }
     if(_options._useBoehmGC)
       {
-        command.addAll("-lgc");
+        command.addAll("-lgc", "-DGC_THREADS");
+      }
+    if (usesThreads())
+      {
+        command.addAll("-DFUZION_ENABLE_THREADS");
       }
 
     // disable trigraphs:
@@ -739,7 +743,8 @@ public class C extends ANY
         command.add("-lm");
       }
 
-    if (linkPThread())
+      // NYI on windows link nothing
+    if (usesThreads())
       {
         command.add("-lpthread");
       }
@@ -793,9 +798,9 @@ public class C extends ANY
 
 
   /*
-   * Should POSIX threads be linked?
+   * Are threads used?
    */
-  private boolean linkPThread()
+  private boolean usesThreads()
   {
     return
       _fuir.isIntrinsicUsed("fuzion.sys.thread.spawn0") ||
@@ -907,7 +912,7 @@ public class C extends ANY
       {
                  // we need to include winsock2.h before windows.h
         cf.print("#define GC_DONT_INCLUDE_WINDOWS_H\n" +
-                 "#define GC_THREADS\n#include <gc.h>\n");
+                 "#include <gc.h>\n");
       }
 
     // --- C-11 ---
@@ -926,10 +931,6 @@ public class C extends ANY
        // defines _O_BINARY
        "#include <fcntl.h>\n");
 
-    // --- POSIX ---
-    // NYI remove POSIX only code.
-    cf.print("#include <pthread.h>\n");
-
     var fzH = _options.pathOf("include/fz.h");
     cf.println("#include \"" + fzH + "\"\n");
 
@@ -937,12 +938,6 @@ public class C extends ANY
       (CStmnt.decl("int", CNames.GLOBAL_ARGC));
     cf.print
       (CStmnt.decl("char **", CNames.GLOBAL_ARGV));
-
-    if (linkPThread())
-      {
-        cf.print
-          (CStmnt.decl("pthread_mutex_t", CNames.GLOBAL_LOCK));
-      }
 
     var o = new CIdent("of");
     var s = new CIdent("sz");
@@ -1010,34 +1005,7 @@ public class C extends ANY
 
     cf.println("int main(int argc, char **argv) { ");
 
-    // If we don't do the following stdout/err might be opened in text mode on windows.
-    // This would lead to automatic insertions of carriage returns.
-    cf.println("#if _WIN32");
-    cf.println(" _setmode( _fileno( stdout ), _O_BINARY ); // reopen stdout in binary mode");
-    cf.println(" _setmode( _fileno( stderr ), _O_BINARY ); // reopen stderr in binary mode");
-    cf.println("#endif");
-
-    if (linkPThread())
-      {
-        cf.println(" {\n" +
-                   "  pthread_mutexattr_t attr;\n" +
-                   "  memset(&" + CNames.GLOBAL_LOCK.code() + ", 0, sizeof(" + CNames.GLOBAL_LOCK.code() + "));\n" +
-                   "  bool res = pthread_mutexattr_init(&attr) == 0 &&\n" +
-                   "  #if _WIN32\n" +
-                   "  // NYI #1646 setprotocol returns EINVAL on windows. \n" +
-                   "  #else\n" +
-                   "             pthread_mutexattr_setprotocol(&attr, PTHREAD_PRIO_INHERIT) == 0 &&\n" +
-                   "  #endif\n" +
-                   "             pthread_mutex_init(&" + CNames.GLOBAL_LOCK.code() + ", &attr) == 0;\n" +
-                   "  assert(res);\n" +
-                   " }\n");
-      }
-
-
-    if (_options._useBoehmGC)
-      {
-        cf.println("GC_INIT(); /* Optional on Linux/X86 */");
-      }
+    cf.println("fzE_init();");
 
     cf.print(initializeEffectsEnvironment());
 

--- a/src/dev/flang/be/c/CNames.java
+++ b/src/dev/flang/be/c/CNames.java
@@ -196,12 +196,6 @@ public class CNames extends ANY
 
 
   /**
-   * global C variable to hold global lock
-   */
-  static final CIdent GLOBAL_LOCK = new CIdent("fzG_lock");
-
-
-  /**
    * Prefix for thread related things
    */
   private static final String THRD_PREFIX = "fzThrd_";
@@ -212,7 +206,7 @@ public class CNames extends ANY
   static final CIdent fzThreadEffectsEnvironment = new CIdent(THRD_PREFIX + "effectsEnvironment");
 
   /*
-   * the identifier of the function passed to pthread_create
+   * the identifier of the function passed to fzE_thread_create
    */
   static final CIdent fzThreadStartRoutine       = new CIdent(THRD_PREFIX + "startRoutine");
 

--- a/src/dev/flang/be/c/Intrinsics.java
+++ b/src/dev/flang/be/c/Intrinsics.java
@@ -817,23 +817,7 @@ public class Intrinsics extends ANY
     {
       return CExpr.call("fzE_thread_join", new List<>(A0));
     });
-    put("fuzion.std.nano_time", (c,cl,outer,in) ->
-        {
-          var result = new CIdent("result");
-          var onFailure = CStmnt.seq(CExpr.fprintfstderr("*** clock_gettime failed\n"),
-                                     CExpr.call("exit", new List<>(new CIdent("1")){}));
-          return CStmnt.seq(CStmnt.decl("struct timespec", result),
-                            CExpr.iff(CExpr.call("clock_gettime",
-                                                 new List<>(new CIdent("CLOCK_MONOTONIC"), result.adrOf()){}
-                                                 ).ne(new CIdent("0")),
-                                      onFailure
-                                      ),
-                            result.field(new CIdent("tv_sec"))
-                            .mul(CExpr.uint64const(1_000_000_000))
-                            .add(result.field(new CIdent("tv_nsec")))
-                            .ret()
-                            );
-        });
+    put("fuzion.std.nano_time", (c,cl,outer,in) -> CExpr.call("fzE_nanotime", new List<>()).ret());
     put("fuzion.std.nano_sleep", (c,cl,outer,in) -> CExpr.call("fzE_nanosleep", new List<>(A0)));
 
 

--- a/src/dev/flang/be/jvm/runtime/Intrinsics.java
+++ b/src/dev/flang/be/jvm/runtime/Intrinsics.java
@@ -729,7 +729,7 @@ public class Intrinsics extends ANY
     return false;
   }
 
-  public static void fuzion_sys_fileio_seek(long fd, short s, Object res)
+  public static void fuzion_sys_fileio_seek(long fd, long s, Object res)
   {
     Runtime.unsafeIntrinsic();
     if (CHECKS)

--- a/tests/fileio/fileiotests.fz
+++ b/tests/fileio/fileiotests.fz
@@ -55,7 +55,15 @@ fileiotests =>
     error =>
   say "$file exists: {exists file}"
 
-  say "$file size is {(f.stat file true).val.size}"
+  say "stat resolve=true : $file size is {(f.stat file true).val.size}"
+  say "stat resolve=false: $file size is {(f.stat file false).val.size}"
+
+  f.use unit file io.file.mode.read ()->
+    say io.file.open.file_position
+    say (io.file.open.seek 1)
+    say io.file.open.file_position
+    say (io.file.open.seek 0)
+
 
   match f.use (array u8) file io.file.mode.read ()->io.file.open.read
     bytes array u8 =>

--- a/tests/fileio/fileiotests.fz.expected_out
+++ b/tests/fileio/fileiotests.fz.expected_out
@@ -4,7 +4,12 @@ testdir exists: true
 testdir/testfile exists: false
 testdir/testfile was created
 testdir/testfile exists: true
-testdir/testfile size is 16
+stat resolve=true : testdir/testfile size is 16
+stat resolve=false: testdir/testfile size is 16
+0
+1
+1
+0
 file content bytes: [72, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100, 32, 240, 159, 140, 141]
 file content is Hello world 🌍
 testdir/testfile was deleted


### PR DESCRIPTION
With this change all POSIX-only code is removed from the compiler and moved to external *.c-files.
It believe the compiler now emits code that only follows the C99 or C11 standard. The exception to this are the uses of `__atomic*` builtins. 

<!--
Please describe your changes here, explain what effect this PR will have and how
this is achieved.  Refer to the # of the issue this PR addresses.  Make
sure the tests run successfully using `make run_tests`.
-->

- [x] I have read and accept the [Tokiwa Software Fuzion Contributor Agreement](https://github.com/tokiwa-software/fuzion/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).
