### PR TITLE
Jvm fix tailrec optimization

### DIFF
--- a/src/dev/flang/be/jvm/CodeGen.java
+++ b/src/dev/flang/be/jvm/CodeGen.java
@@ -710,7 +710,7 @@ class CodeGen
         {
           if (_types.clazzNeedsCode(cc))
             {
-              if (!preCalled                                                             // not calling pre-condition
+              if (!pre && !preCalled                                                     // not calling pre-condition
                   && cc == cl                                                            // calling myself
                   && c != -1 && i != -1 && _jvm._tailCall.callIsTailCall(cl, c, i)       // as a tail call
                   && _fuir.lifeTime(cl, pre).ordinal() <= FUIR.LifeTime.Call.ordinal())

--- a/src/dev/flang/be/jvm/CodeGen.java
+++ b/src/dev/flang/be/jvm/CodeGen.java
@@ -713,7 +713,8 @@ class CodeGen
               if (!pre && !preCalled                                                     // not calling pre-condition
                   && cc == cl                                                            // calling myself
                   && c != -1 && i != -1 && _jvm._tailCall.callIsTailCall(cl, c, i)       // as a tail call
-                  && _fuir.lifeTime(cl, pre).ordinal() <= FUIR.LifeTime.Call.ordinal())
+                  && !_fuir.lifeTime(cl, pre).maySurviveCall()
+                  )
                 { // then we can do tail recursion optimization!
 
                   // if present, store target to local #0

--- a/src/dev/flang/fuir/FUIR.java
+++ b/src/dev/flang/fuir/FUIR.java
@@ -1115,7 +1115,19 @@ hw25 is
     /* The called clazz does not have an instance value, so there is no lifetime
      * associated to it
      */
-    Undefined
+    Undefined;
+
+    /**
+     * May an instance with this LifeTime be accessible after the call to its
+     * routine?
+     */
+    public boolean maySurviveCall()
+    {
+      require
+        (this != Undefined);
+
+      return this.ordinal() > Call.ordinal();
+    }
   }
 
   static

--- a/src/dev/flang/fuir/FUIR.java
+++ b/src/dev/flang/fuir/FUIR.java
@@ -1153,12 +1153,12 @@ hw25 is
     var result =
       pre ? (switch (clazzKind(cl))
                {
-               case Abstract  -> LifeTime.Unknown;
+               case Abstract  -> LifeTime.Call;
                case Choice    -> LifeTime.Undefined;
-               case Intrinsic -> LifeTime.Unknown;
-               case Field     -> LifeTime.Unknown;
-               case Routine   -> LifeTime.Unknown;
-               case Native    -> LifeTime.Unknown;
+               case Intrinsic -> LifeTime.Call;
+               case Field     -> LifeTime.Call;
+               case Routine   -> LifeTime.Call;
+               case Native    -> LifeTime.Call;
                })
           : (switch (clazzKind(cl))
                {

--- a/src/dev/flang/fuir/analysis/dfa/DFA.java
+++ b/src/dev/flang/fuir/analysis/dfa/DFA.java
@@ -408,6 +408,8 @@ public class DFA extends ANY
                      ev._instance == _call._instance        // target is embedded in current instance, so it is kept alive by a reference (at least in the C backend)
                      ) &&
                     !_tailCall.callIsTailCall(cl,c,i)       // a tail call does not cause the target to escape
+                                                            // NYI: CLEANUP: It should be sufficient to check that tvalue
+                                                            // is not an outer ref embedded in call._instance.
                     )
                   {
                     _call.escapes();
@@ -989,7 +991,7 @@ public class DFA extends ANY
         public LifeTime lifeTime(int cl, boolean pre)
         {
           return
-            pre || (clazzKind != FeatureKind.Routine)
+            pre || (clazzKind(cl) != FeatureKind.Routine)
                 ? super.lifeTime(cl, pre)
                 : currentEscapes(cl, pre) ? LifeTime.Unknown :
                                             LifeTime.Call;

--- a/src/dev/flang/fuir/analysis/dfa/DFA.java
+++ b/src/dev/flang/fuir/analysis/dfa/DFA.java
@@ -371,16 +371,16 @@ public class DFA extends ANY
      *
      * @param cc clazz that is called
      *
-     * @param pre true to call the precondition of cl instead of cl.
+     * @param preCalled true to call the precondition of cl instead of cl.
      *
      * @return result values of the call
      */
-    Val call0(int cl, Val tvalue, List<Val> args, int c, int i, int cc, boolean pre, Val original_tvalue)
+    Val call0(int cl, Val tvalue, List<Val> args, int c, int i, int cc, boolean preCalled, Val original_tvalue)
     {
       // in case we access the value in a boxed target, unbox it first:
       tvalue = unboxTarget(tvalue, _fuir.accessTargetClazz(cl, c, i), cc);
       Val res = null;
-      switch (pre ? FUIR.FeatureKind.Routine : _fuir.clazzKind(cc))
+      switch (preCalled ? FUIR.FeatureKind.Routine : _fuir.clazzKind(cc))
         {
         case Abstract :
           Errors.error("Call to abstract feature encountered.",
@@ -391,7 +391,7 @@ public class DFA extends ANY
           {
             if (_fuir.clazzNeedsCode(cc))
               {
-                var ca = newCall(cc, pre, tvalue.value(), args, _call._env, _call);
+                var ca = newCall(cc, preCalled, tvalue.value(), args, _call._env, _call);
                 ca.addCallSiteLocation(c,i);
                 res = ca.result();
                 if (res != null && res != Value.UNIT && !_fuir.clazzIsRef(_fuir.clazzResultClazz(cc)))
@@ -407,6 +407,8 @@ public class DFA extends ANY
                      original_tvalue instanceof EmbeddedValue ev &&
                      ev._instance == _call._instance        // target is embedded in current instance, so it is kept alive by a reference (at least in the C backend)
                      ) &&
+                    _fuir.clazzKind(cl) == FUIR.FeatureKind.Routine &&  // NYI: CLEANUP: Better check that we are not analysing cl's precondition,
+                                                                        // but we currently do not have this information here.
                     !_tailCall.callIsTailCall(cl,c,i)       // a tail call does not cause the target to escape
                                                             // NYI: CLEANUP: It should be sufficient to check that tvalue
                                                             // is not an outer ref embedded in call._instance.

--- a/src/dev/flang/fuir/analysis/dfa/DFA.java
+++ b/src/dev/flang/fuir/analysis/dfa/DFA.java
@@ -968,29 +968,11 @@ public class DFA extends ANY
          */
         public LifeTime lifeTime(int cl, boolean pre)
         {
-          var result =
-            pre ? (switch (clazzKind(cl))
-                     {
-                     case Choice    -> LifeTime.Undefined;
-                     case Abstract  ,
-                          Intrinsic ,
-                          Field     ,
-                          Routine   ,
-                          Native    -> currentEscapes(cl, pre) ? LifeTime.Unknown :
-                                                                 LifeTime.Call;
-                     })
-                : (switch (clazzKind(cl))
-                     {
-                     case Abstract  -> LifeTime.Undefined;
-                     case Choice    -> LifeTime.Undefined;
-                     case Intrinsic -> LifeTime.Undefined;
-                     case Field     -> LifeTime.Call;
-                     case Routine   -> currentEscapes(cl, pre) ? LifeTime.Unknown :
-                                                                 LifeTime.Call;
-                     case Native    -> LifeTime.Undefined;
-                     });
-
-          return result;
+          return
+            pre || (clazzKind != FeatureKind.Routine)
+                ? super.lifeTime(cl, pre)
+                : currentEscapes(cl, pre) ? LifeTime.Unknown :
+                                            LifeTime.Call;
         }
 
 


### PR DESCRIPTION
For tests like `fib32.fz`, tail recursion optimization was not performed by the JVM backend resulting in jenkins test failures due to different stack trace outputs. 

The main problems were 
- that primitive types stored in local fields prevented tail call optimization since an operation like `a + 3` on a local field `a` of type `u32` does not create a reference to `a`, and
- the tail recursive call itself does not keep the current instance alife