### PR TITLE
be/jvm: -jar/-classes add option [-o=<outputName>]

### DIFF
--- a/src/dev/flang/be/jvm/JVM.java
+++ b/src/dev/flang/be/jvm/JVM.java
@@ -795,13 +795,25 @@ should be avoided as much as possible.
 
 
   /**
+   * Used as the name of created code
+   * (jar file, classes dir, etc.).
+   *
+   * @return the outputs name
+   */
+  String outputName()
+  {
+    return _options._outputName.orElse(mainName());
+  }
+
+
+  /**
    * For `-jar` backend: Name of the JAR file to be created.
    *
    * @return jar file path created from main feature's base name
    */
   Path jarPath()
   {
-    return Path.of(mainName() + ".jar");
+    return Path.of(outputName() + ".jar");
   }
 
 
@@ -812,7 +824,7 @@ should be avoided as much as possible.
    */
   Path classesDir()
   {
-    return Path.of(mainName() + ".classes");
+    return Path.of(outputName() + ".classes");
   }
 
 
@@ -824,7 +836,7 @@ should be avoided as much as possible.
    */
   Path executablePath()
   {
-    return Path.of(mainName());
+    return Path.of(outputName());
   }
 
 

--- a/src/dev/flang/be/jvm/JVMOptions.java
+++ b/src/dev/flang/be/jvm/JVMOptions.java
@@ -29,6 +29,7 @@ package dev.flang.be.jvm;
 import dev.flang.util.FuzionOptions;
 
 import java.util.ArrayList;
+import java.util.Optional;
 
 
 /**
@@ -110,6 +111,12 @@ public class JVMOptions extends FuzionOptions
   final ConstantCreation _constantCreationStrategy = ConstantCreation.onUniverseInitialization;
 
 
+  /**
+   * Custom output name when using option `-classes` or `-jvm`.
+   */
+  final Optional<String> _outputName;
+
+
   /*--------------------------  constructors  ---------------------------*/
 
 
@@ -120,7 +127,8 @@ public class JVMOptions extends FuzionOptions
                     boolean Xdfa,
                     boolean run,
                     boolean saveClasses,
-                    boolean saveJAR)
+                    boolean saveJAR,
+                    Optional<String> outputName)
   {
     super(fo);
 
@@ -129,6 +137,7 @@ public class JVMOptions extends FuzionOptions
     this._saveClasses = saveClasses;
     this._saveJAR     = saveJAR;
     this._applicationArgs = fo.getBackendArgs();
+    this._outputName = outputName;
   }
 
 

--- a/src/dev/flang/tools/Fuzion.java
+++ b/src/dev/flang/tools/Fuzion.java
@@ -34,6 +34,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 
 import java.util.ArrayList;
+import java.util.Optional;
 import java.util.TreeMap;
 
 import dev.flang.be.c.C;
@@ -79,6 +80,7 @@ public class Fuzion extends Tool
   static boolean _xdfa_ = true;
   static String _cCompiler_ = null;
   static String _cFlags_ = null;
+  static String  _jvmOutName_ = null;
 
 
   /**
@@ -160,7 +162,7 @@ public class Fuzion extends Tool
       }
       void process(FuzionOptions options, FUIR fuir)
       {
-        new JVM(new JVMOptions(options, _xdfa_, /* run */ true, /* save classes */ false, /* save JAR */ false), fuir).compile();
+        new JVM(new JVMOptions(options, _xdfa_, /* run */ true, /* save classes */ false, /* save JAR */ false, Optional.empty()), fuir).compile();
       }
       boolean takesApplicationArgs()
       {
@@ -172,7 +174,7 @@ public class Fuzion extends Tool
     {
       String usage()
       {
-        return "[-Xdfa=(on|off)] ";
+        return "[-o=<outputName>] [-Xdfa=(on|off)] ";
       }
       boolean handleOption(Fuzion f, String o)
       {
@@ -182,11 +184,16 @@ public class Fuzion extends Tool
             _xdfa_ = parseOnOffArg(o);
             result = true;
           }
+        if (o.startsWith("-o="))
+          {
+            _jvmOutName_ = o.substring(3);
+            result = true;
+          }
         return result;
       }
       void process(FuzionOptions options, FUIR fuir)
       {
-        new JVM(new JVMOptions(options, _xdfa_, /* run */ false, /* save classes */ true, /* save JAR */ false), fuir).compile();
+        new JVM(new JVMOptions(options, _xdfa_, /* run */ false, /* save classes */ true, /* save JAR */ false, Optional.ofNullable(_jvmOutName_)), fuir).compile();
       }
     },
 
@@ -194,7 +201,7 @@ public class Fuzion extends Tool
     {
       String usage()
       {
-        return "[-Xdfa=(on|off)] ";
+        return "[-o=<outputName>] [-Xdfa=(on|off)] ";
       }
       boolean handleOption(Fuzion f, String o)
       {
@@ -204,11 +211,16 @@ public class Fuzion extends Tool
             _xdfa_ = parseOnOffArg(o);
             result = true;
           }
+        if (o.startsWith("-o="))
+          {
+            _jvmOutName_ = o.substring(3);
+            result = true;
+          }
         return result;
       }
       void process(FuzionOptions options, FUIR fuir)
       {
-        new JVM(new JVMOptions(options, _xdfa_, /* run */ false, /* save classes */ false, /* save JAR */ true), fuir).compile();
+        new JVM(new JVMOptions(options, _xdfa_, /* run */ false, /* save classes */ false, /* save JAR */ true, Optional.ofNullable(_jvmOutName_)), fuir).compile();
       }
     },
 


### PR DESCRIPTION
This is useful when using -jar/-classes in scripts. E.g. for benchmarking
<!--
Please describe your changes here, explain what effect this PR will have and how
this is achieved.  Refer to the # of the issue this PR addresses.  Make
sure the tests run successfully using `make run_tests`.
-->

- [x] I have read and accept the [Tokiwa Software Fuzion Contributor Agreement](https://github.com/tokiwa-software/fuzion/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).
