### PR TITLE
parser: conditions are now syntactically the same as `exprs`, fix #149

### DIFF
--- a/lib/Sequence.fz
+++ b/lib/Sequence.fz
@@ -570,8 +570,8 @@ public Sequence(public T type) ref is
   #
   public index [] (i i32) T
     pre
-      debug: 0 ≤ i,
-      debug: finite: i < count,
+      debug: 0 ≤ i
+      debug: finite: i < count
       debug: !finite: !(drop i-1).is_empty
   =>
     (nth i).get

--- a/lib/String.fz
+++ b/lib/String.fz
@@ -513,8 +513,8 @@ public String ref : property.equatable, property.hashable, property.orderable is
   #
   public split_n(s String, n u32) list String
     pre
-      !s.is_empty,
-      n > (u32 0)
+      debug: !s.is_empty
+      debug: n > (u32 0)
     =>
       split0 s n false
 
@@ -526,7 +526,7 @@ public String ref : property.equatable, property.hashable, property.orderable is
   #
   public split_after_n(s String, n u32) list String
     pre
-      !s.is_empty,
+      !s.is_empty
       n > (u32 0)
     =>
       split0 s n true
@@ -542,10 +542,10 @@ public String ref : property.equatable, property.hashable, property.orderable is
   #
   private split0(s String, limit option u32, split_after bool) list String
     pre
-      !s.is_empty,
-      match limit
-        nil => true
-        n u32 => n > (u32 0)
+      debug: !s.is_empty
+      debug: match limit
+               nil => true
+               n u32 => n > (u32 0)
     =>
       (container.searchable_sequence utf8).split0 s.utf8 limit split_after
           .map_to_list x->(String.type.from_bytes x)

--- a/lib/array.fz
+++ b/lib/array.fz
@@ -83,7 +83,7 @@ module:public array(
   #
   public redef index [ ] (i i32) T
     pre
-      safety: 0 ≤ i,
+      safety: 0 ≤ i
       safety: i < length
   =>
     internal_array[i]
@@ -262,7 +262,7 @@ module:public array(
   #
   enumerate_cons (i i32) : Cons (i32, T) (list (tuple i32 T))
     pre
-      debug: 0 ≤ i,
+      debug: 0 ≤ i
       debug: i < length
   is
     head => (i, index[] i)

--- a/lib/array2.fz
+++ b/lib/array2.fz
@@ -33,8 +33,8 @@ public array2(T type,
               length0, length1 i32,
               init2 (i32, i32) -> T)
   pre
-    safety: length0 ≥ 0,
-    safety: length1 ≥ 0,
+    safety: length0 ≥ 0
+    safety: length1 ≥ 0
     safety: length0 *? length1 >=? 0
 =>
 
@@ -60,8 +60,8 @@ private:public array2(
        _ unit)
  : array T internal_array unit unit unit
   pre
-    safety: length0 ≥ 0,
-    safety: length1 ≥ 0,
+    safety: length0 ≥ 0
+    safety: length1 ≥ 0
     safety: length0 *? length1 >=? 0
 is
 
@@ -83,7 +83,7 @@ is
 
   public index [ ] (i1, i2 i32) T
     pre
-      safety: 0 ≤ i1 < length0,
+      safety: 0 ≤ i1 < length0
       safety: 0 ≤ i2 < length1
   =>
     array2.this[i1 * length1 + i2]
@@ -116,7 +116,7 @@ is
   #
   enumerate_cons (i, j i32) : Cons (i32, i32, T) (list (tuple i32 i32 T))
     pre
-      debug: 0 ≤ i < length0,
+      debug: 0 ≤ i < length0
       debug: 0 ≤ j < length1
   is
     head => (i, j, index[] i j)

--- a/lib/array3.fz
+++ b/lib/array3.fz
@@ -33,9 +33,9 @@ public array3(T type,
        length0, length1, length2 i32,
        init3 (i32, i32, i32) -> T)
   pre
-    safety: length0 ≥ 0,
-    safety: length1 ≥ 0,
-    safety: length2 ≥ 0,
+    safety: length0 ≥ 0
+    safety: length1 ≥ 0
+    safety: length2 ≥ 0
     safety: length0 *? length1 *? length2 >=? 0
 =>
 
@@ -64,9 +64,9 @@ private:public array3(
        _ unit)
  : array T internal_array unit unit unit
   pre
-    safety: length0 ≥ 0,
-    safety: length1 ≥ 0,
-    safety: length2 ≥ 0,
+    safety: length0 ≥ 0
+    safety: length1 ≥ 0
+    safety: length2 ≥ 0
     safety: length0 *? length1 *? length2 >=? 0
 is
 
@@ -88,8 +88,8 @@ is
 
   public index [ ] (i0, i1, i2 i32) T
     pre
-      safety: 0 ≤ i0 < length0,
-      safety: 0 ≤ i1 < length1,
+      safety: 0 ≤ i0 < length0
+      safety: 0 ≤ i1 < length1
       safety: 0 ≤ i2 < length2
   =>
     array3.this[(i0 * length1 + i1) * length2 + i2]
@@ -133,8 +133,8 @@ is
   #
   enumerate_cons (i, j, k i32) : Cons (tuple i32 i32 i32 T) (list (tuple i32 i32 i32 T))
     pre
-      debug: 0 ≤ i < length0,
-      debug: 0 ≤ j < length1,
+      debug: 0 ≤ i < length0
+      debug: 0 ≤ j < length1
       debug: 0 ≤ k < length2
   is
     head => (i, j, k, index[] i j k)

--- a/lib/codepoint.fz
+++ b/lib/codepoint.fz
@@ -27,7 +27,7 @@
 #
 public codepoint(public val u32) : String
   pre
-    debug: codepoint.type.range.contains val,
+    debug: (codepoint.type.range.contains val)
     debug: !codepoint.type.utf16_surrogate.contains val
 is
 

--- a/lib/container/searchable_sequence.fz
+++ b/lib/container/searchable_sequence.fz
@@ -134,10 +134,10 @@ is
   #
   module split0(s Sequence A, limit option u32, split_after bool) list (Sequence A)
     pre
-      !s.is_empty,
-      match limit
-        nil => true
-        n u32 => n > (u32 0)
+      debug: !s.is_empty
+      debug: match limit
+              nil => true
+              n u32 => n > (u32 0)
     =>
       match (find s)
         nil     => from : nil

--- a/lib/container/sorted_array.fz
+++ b/lib/container/sorted_array.fz
@@ -74,8 +74,8 @@ is
     ) array T
 
     pre
-      debug: heap_size ≥ 0,
-      debug: (heap_size & (heap_size-1)) = 0
+      debug: (heap_size ≥ 0)
+      debug: ((heap_size & (heap_size-1)) = 0)
       # NYI: analysis: for all i=0..a.length/heap_size: a[heap_size*i .. heap_size*(i+1)-1] is sorted
   =>
     # check if the array is fully sorted

--- a/lib/i16.fz
+++ b/lib/i16.fz
@@ -78,7 +78,7 @@ public i16(public val i16) : num.wrap_around, has_interval is
   # conversion to u32, i64 and u64, with range check
   public as_i8 i8
     pre
-      thiz ≥ i8.type.min.as_i16,
+      thiz ≥ i8.type.min.as_i16
       thiz ≤ i8.type.max.as_i16
     =>
       low8bits.cast_to_i8

--- a/lib/i32.fz
+++ b/lib/i32.fz
@@ -78,13 +78,13 @@ public i32(public val i32) : num.wrap_around, has_interval is
   # conversion to u32, i64 and u64, with range check
   public as_i8 i8
     pre
-      thiz ≥ i8.type.min.as_i32,
+      thiz ≥ i8.type.min.as_i32
       thiz ≤ i8.type.max.as_i32
     =>
       low8bits.cast_to_i8
   public as_i16 i16
     pre
-      thiz ≥ i16.type.min.as_i32,
+      thiz ≥ i16.type.min.as_i32
       thiz ≤ i16.type.max.as_i32
     =>
       low16bits.cast_to_i16
@@ -92,13 +92,13 @@ public i32(public val i32) : num.wrap_around, has_interval is
 # as_i128 NYI
   public as_u8 u8
     pre
-      thiz ≥ u8.type.min.as_i32,
+      thiz ≥ u8.type.min.as_i32
       thiz ≤ u8.type.max.as_i32
     =>
       low8bits
   public as_u16 u16
     pre
-      thiz ≥ u16.type.min.as_i32,
+      thiz ≥ u16.type.min.as_i32
       thiz ≤ u16.type.max.as_i32
     =>
       low16bits

--- a/lib/i64.fz
+++ b/lib/i64.fz
@@ -78,7 +78,7 @@ public i64(public val i64) : num.wrap_around, has_interval is
   # this i64 as an i8
   public as_i8 i8
     pre
-      thiz ≥ i8.type.min.as_i64,
+      thiz ≥ i8.type.min.as_i64
       thiz ≤ i8.type.max.as_i64
     =>
       low8bits.as_i8
@@ -87,7 +87,7 @@ public i64(public val i64) : num.wrap_around, has_interval is
   # this i64 as an i16
   public as_i16 i16
     pre
-      thiz ≥ i16.type.min.as_i64,
+      thiz ≥ i16.type.min.as_i64
       thiz ≤ i16.type.max.as_i64
     =>
       low16bits.as_i16
@@ -96,7 +96,7 @@ public i64(public val i64) : num.wrap_around, has_interval is
   # this i64 as an i32
   public as_i32 i32
     pre
-      thiz ≥ i32.type.min.as_i64,
+      thiz ≥ i32.type.min.as_i64
       thiz ≤ i32.type.max.as_i64
     =>
       low32bits.cast_to_i32

--- a/lib/integer.fz
+++ b/lib/integer.fz
@@ -80,7 +80,7 @@ module:public integer : numeric is
   # note that this assumes zero to be divisible by any positive integer.
   public gcd(b integer.this) integer.this
     pre
-      safety: sign ≥ 0,
+      safety: sign ≥ 0
       safety: b.sign ≥ 0
   =>
     if b = integer.this.type.zero

--- a/lib/num/ryu.fz
+++ b/lib/num/ryu.fz
@@ -105,8 +105,8 @@ public ryū(public T type : float) is
 
     # calculates: ⌈log₂ 5ᵉ⌉
     private pow5bits(e i64)
-    pre e >= 0,
-        e <= 3528
+    pre debug: (e >= 0)
+        debug: (e <= 3528)
     post
       pow5bits.this.result = (T.log T.two (five ** T.from_i64 e)).as_i64
     =>
@@ -801,15 +801,15 @@ public ryū(public T type : float) is
 
 
     private mul_pow5_div_pow2(m, i, j i64)
-    pre (actual_shift j) >= 0,
-        exponent < 0
+    pre debug: (actual_shift j >= 0)
+        debug: (exponent < 0)
     =>
       mul_pow5_div_pow2 m i j pow5_split
 
 
     private mul_pow5_inv_div_pow2(m, i, j i64) i64
-    pre (actual_shift j) >= 0,
-        exponent >= 0
+    pre debug: (actual_shift j >= 0)
+        debug: (exponent >= 0)
     =>
       mul_pow5_div_pow2 m i j pow5_inv_split
 
@@ -826,8 +826,8 @@ public ryū(public T type : float) is
 
       # computes ⌊log₁₀ 2ᵉ⌋
       floor_log₁₀_pow_2(e i64) i64
-      pre e >= 0,
-          e <= 1650
+      pre debug: (e >= 0)
+          debug: (e <= 1650)
       post
         floor_log₁₀_pow_2.this.result = (T.log T.ten (T.two ** T.from_i64 e)).floor.as_i64
       =>
@@ -858,8 +858,8 @@ public ryū(public T type : float) is
 
       # computes ⌊log₁₀ 5ᵉ⌋
       floor_log₁₀_pow_5 (e i64) i64
-      pre e >= 0,
-          e <= 2620
+      pre debug: (e >= 0)
+          debug: (e <= 2620)
       post
         ( T.log T.ten (five ** T.from_i64 e) = T.infinity
           || floor_log₁₀_pow_5.this.result = (T.log T.ten (five ** T.from_i64 e)).floor.as_i64)

--- a/lib/num/wrap_around.fz
+++ b/lib/num/wrap_around.fz
@@ -86,21 +86,21 @@ module:public wrap_around : integer is
   # addition, with check for overflow
   public redef infix +  (other wrap_around.this) wrap_around.this
     pre
-      debug: !(overflow_on_add other),
+      debug: !(overflow_on_add other)
       debug: !(underflow_on_add other)
   => wrap_around.this +° other
 
   # subtraction, with check for overflow
   public redef infix -  (other wrap_around.this) wrap_around.this
     pre
-      debug: !(overflow_on_sub other),
+      debug: !(overflow_on_sub other)
       debug: !(underflow_on_sub other)
   => wrap_around.this -° other
 
   # multiplication, with check for overflow
   public redef infix *  (other wrap_around.this) wrap_around.this
     pre
-      debug: !(overflow_on_mul other),
+      debug: !(overflow_on_mul other)
       debug: !(underflow_on_mul other)
   => wrap_around.this *° other
 
@@ -124,8 +124,8 @@ module:public wrap_around : integer is
   #
   public infix ** (other wrap_around.this) wrap_around.this
     pre
-      safety: other ≥ wrap_around.this.type.zero,
-      debug: !overflow_on_exp other
+      safety: (other ≥ wrap_around.this.type.zero)
+      debug: (!overflow_on_exp other)
   =>
     wrap_around.this **° other
 
@@ -136,7 +136,7 @@ module:public wrap_around : integer is
   #
   public infix **° (other wrap_around.this) wrap_around.this
     pre
-      safety: other ≥ wrap_around.this.type.zero
+      safety: (other ≥ wrap_around.this.type.zero)
   =>
     if      (other = wrap_around.this.type.zero) wrap_around.this.type.one
     else if (other = wrap_around.this.type.one ) wrap_around.this
@@ -154,7 +154,7 @@ module:public wrap_around : integer is
   #
   public infix **? (other wrap_around.this) num_option wrap_around.this
     pre
-      safety: other ≥ wrap_around.this.type.zero
+      safety: (other ≥ wrap_around.this.type.zero)
   =>
     if      (other = wrap_around.this.type.zero) wrap_around.this.type.one
     else if (other = wrap_around.this.type.one ) wrap_around.this
@@ -177,7 +177,7 @@ module:public wrap_around : integer is
   #
   public infix **^ (other wrap_around.this) wrap_around.this
     pre
-      safety: other ≥ wrap_around.this.type.zero
+      safety: (other ≥ wrap_around.this.type.zero)
   =>
     if overflow_on_exp other
       if (wrap_around.this ≥ wrap_around.this.type.zero) || (other %% wrap_around.this.type.two)

--- a/lib/num_option.fz
+++ b/lib/num_option.fz
@@ -62,7 +62,7 @@ is
   #
   public val T
     pre
-      safety: num_option.this??
+      safety: (num_option.this??)
   =>
     num_option.this ? v T => v
                     | nil => fuzion.std.panic "num_option.val called on nil"

--- a/lib/numeric.fz
+++ b/lib/numeric.fz
@@ -45,40 +45,40 @@ module:public numeric : property.hashable, property.orderable is
   # basic operations: 'infix +' (addition)
   public infix +  (other numeric.this) numeric.this
     pre
-      safety: numeric.this +! other
+      safety: (numeric.this +! other)
   => abstract
 
   # basic operations: 'infix -' (subtraction)
   public infix -  (other numeric.this) numeric.this
     pre
-      safety: numeric.this -! other
+      safety: (numeric.this -! other)
   => abstract
 
   # basic operations: 'infix *' (multiplication)
   public infix *  (other numeric.this) numeric.this
     pre
-      safety: numeric.this *! other
+      safety: (numeric.this *! other)
   => abstract
 
   # basic operations: 'infix /' (division)
   public infix /  (other numeric.this) numeric.this
     pre
-      safety: numeric.this /! other,
-      safety: other != numeric.this.type.zero
+      safety: (numeric.this /! other)
+      safety: (other != numeric.this.type.zero)
   => abstract
 
   # basic operations: 'infix %' (division remainder)
   public infix %  (other numeric.this) numeric.this
     pre
-      safety: numeric.this %! other,
-      safety: other != numeric.this.type.zero
+      safety: (numeric.this %! other)
+      safety: (other != numeric.this.type.zero)
   => abstract
 
   # basic operations: 'infix **' (exponentiation)
   public infix ** (other numeric.this) numeric.this
     pre
-      safety: numeric.this **! other,
-      safety: other ≥ numeric.this.type.zero
+      safety: (numeric.this **! other)
+      safety: (other ≥ numeric.this.type.zero)
   => abstract
 
 
@@ -123,7 +123,7 @@ module:public numeric : property.hashable, property.orderable is
   # NYI replace this by as_u32?
   to_u32 u32
     pre
-      debug: numeric.this ≥ numeric.this.type.zero
+      debug: (numeric.this ≥ numeric.this.type.zero)
   =>
     if (numeric.this ≥ numeric.this.type.one) ((numeric.this - numeric.this.type.one).to_u32 + 1)
     else 0
@@ -132,7 +132,7 @@ module:public numeric : property.hashable, property.orderable is
   # this numeric value as an u8
   public as_u8 u8
     pre
-      debug: numeric.this ≥ numeric.this.type.zero
+      debug: (numeric.this ≥ numeric.this.type.zero)
   => abstract
 
 
@@ -140,9 +140,9 @@ module:public numeric : property.hashable, property.orderable is
   #
   module highest(b numeric.this) numeric.this
     pre
-      debug: numeric.this.sign ≥ 0
+      debug: (numeric.this.sign ≥ 0)
     post
-      debug: (numeric.this = numeric.this.type.zero: result = numeric.this.type.one),
+      debug: (numeric.this = numeric.this.type.zero: result = numeric.this.type.one)
       debug: (numeric.this != numeric.this.type.zero: numeric.this / b < result ≤ numeric.this)
   # NYI: original postcondition code should cause a compiler error since
   # result.infix <= expects an argument of type T while integer.this =>

--- a/lib/option.fz
+++ b/lib/option.fz
@@ -104,7 +104,7 @@ is
   #
   public get
   pre
-    safety: option.this??
+    safety: (option.this??)
   =>
     option.this ? v T => v
                 | nil => fuzion.std.panic "option.get called on nil"

--- a/lib/outcome.fz
+++ b/lib/outcome.fz
@@ -82,7 +82,7 @@ is
   #
   public val T
     pre
-      safety: outcome.this??
+      safety: (outcome.this??)
   =>
     outcome.this ? v T   => v
                  | error => panic "outcome.val called on error"
@@ -103,7 +103,7 @@ is
   #
   public err error
     pre
-      safety: outcome.this!!
+      safety: (outcome.this!!)
   =>
     outcome.this ? T       => panic "outcome.err called on successful outcome"
                  | e error => e

--- a/lib/time/date_time.fz
+++ b/lib/time/date_time.fz
@@ -28,11 +28,11 @@
 #
 public date_time(public year, day_in_year, hour, minute, second, nano_second i32) : property.orderable
 pre
-  day_in_year ≥ 1  & day_in_year  ≤ days_in_year year,  # leap years have 366 days
-  hour        ≥ 0  & hour         ≤ 23,
-  minute      ≥ 0  & minute       ≤ 59,
-  second      ≥ 0  & second       ≤ 60,                 # 60 because of possible leap seconds
-  nano_second ≥ 0  & nano_second  ≤ 1E9
+  debug: (day_in_year ≥ 1  & day_in_year  ≤ days_in_year year)   # leap years have 366 days
+  debug: (hour        ≥ 0  & hour         ≤ 23               )
+  debug: (minute      ≥ 0  & minute       ≤ 59               )
+  debug: (second      ≥ 0  & second       ≤ 60               )   # 60 because of possible leap seconds
+  debug: (nano_second ≥ 0  & nano_second  ≤ 1E9              )
 is
 
   # how many days does february have in the given year?

--- a/src/dev/flang/ast/Cond.java
+++ b/src/dev/flang/ast/Cond.java
@@ -26,6 +26,8 @@ Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
 
 package dev.flang.ast;
 
+import dev.flang.util.List;
+
 
 /**
  * Cond <description>
@@ -58,6 +60,22 @@ public class Cond
   public Cond(Expr c)
   {
     this.cond = c;
+  }
+
+
+  /*-------------------------  static methods  --------------------------*/
+
+
+  /**
+   * Wrap Expr instances from given list into new `Cond` instances
+   *
+   * @param l a list of `Expr` to be used as conditions
+   *
+   * @return a new list with each `Expr` form `l` wrapped into a `Cond`.
+   */
+  public static List<Cond> from(List<Expr> l)
+  {
+    return l.map2(e->new Cond(e));
   }
 
 

--- a/src/dev/flang/parser/Parser.java
+++ b/src/dev/flang/parser/Parser.java
@@ -2943,19 +2943,6 @@ nextValue   : COMMA exprInLine
 
 
   /**
-   * Parse cond
-   *
-cond        : exprInLine
-            ;
-   */
-  Cond cond()
-  {
-    Expr e = exprInLine();
-    return new Cond(e);
-  }
-
-
-  /**
    * Parse ifexpr
    *
 ifexpr      : "if" exprInLine thenPart elseBlock
@@ -3031,13 +3018,13 @@ elseBlock   : "else" block
   /**
    * Parse checkexpr
    *
-checkexpr   : "check" cond
+checkexpr   : "check" expr
             ;
    */
   Expr checkexpr()
   {
     match(Token.t_check, "checkexpr");
-    return new Check(tokenSourcePos(), cond());
+    return new Check(tokenSourcePos(), new Cond(expr()));
   }
 
 
@@ -3515,7 +3502,7 @@ contract    : require
   /**
    * Parse require
    *
-require     : "pre" condList
+require     : "pre" exprs
             |
             ;
    */
@@ -3524,7 +3511,7 @@ require     : "pre" condList
     List<Cond> result = null;
     if (skip(atMinIndent, Token.t_pre))
       {
-        result = condList();
+        result = Cond.from(exprs());
       }
     return result;
   }
@@ -3533,7 +3520,7 @@ require     : "pre" condList
   /**
    * Parse ensure
    *
-ensure      : "post" condList
+ensure      : "post" exprs
             |
             ;
    */
@@ -3542,7 +3529,7 @@ ensure      : "post" condList
     List<Cond> result = null;
     if (skip(atMinIndent, Token.t_post))
       {
-        result = condList();
+        result = Cond.from(exprs());
       }
     return result;
   }
@@ -3551,7 +3538,7 @@ ensure      : "post" condList
   /**
    * Parse invariant
    *
-invariant   : "inv" condList
+invariant   : "inv" exprs
             |
             ;
    */
@@ -3560,29 +3547,8 @@ invariant   : "inv" condList
     List<Cond> result = null;
     if (skip(atMinIndent, Token.t_inv))
       {
-        result = condList();
+        result = Cond.from(exprs());
       }
-    return result;
-  }
-
-
-  /**
-   * Parse condList
-   *
-condList    : cond ( COMMA condList
-                   |
-                   )
-              semi
-            ;
-   */
-  List<Cond> condList()
-  {
-    List<Cond> result = new List<>(cond());
-    while (skipComma())
-      {
-        result.add(cond());
-      }
-    semi();
     return result;
   }
 

--- a/tests/choice_mix/choice_mix.fz
+++ b/tests/choice_mix/choice_mix.fz
@@ -179,7 +179,7 @@ choice_mix is
     black   : color is redef rgb => u32 0
     white   : color is redef rgb => red.rgb + blue.rgb + green.rgb
     transparent (alpha u32) : color
-      pre alpha ≥ u32 0, alpha ≤ u32 255
+      pre alpha ≥ u32 0; alpha ≤ u32 255
     is
       redef rgb => alpha * 256*256*256
 
@@ -233,7 +233,7 @@ choice_mix is
     black   : color is redef rgb => u32 0
     white   : color is redef rgb => red.rgb + blue.rgb + green.rgb
     transparent (alpha u32) : color
-      pre alpha ≥ u32 0, alpha ≤ u32 255
+      pre alpha ≥ u32 0; alpha ≤ u32 255
     is
       redef rgb => alpha * 256*256*256
 


### PR DESCRIPTION
Syntactially, the conditions in a pre/post condition or the (unused) invariant are now parsed as `exprs`, i.e. like an indented block in a feature declaration.

Conditions are no longer separated by commas, but by semicolons or non-indenting new lines.

The Fuzion grammar becomes slightly simpler with rules `cond` and `condList` removed.

Updated syntax of conditions in base lib and tests where `,` was used, added `debug:` qualifiers at some places and `(`/`)` for clarity, it is a bit unfortunate that, e.g., `debug: -a = b` is parsed as `((debug.postfix :) - a) = b`...

