### PR TITLE
lib: change visibility of `Type` to `module:public`

### DIFF
--- a/lib/Type.fz
+++ b/lib/Type.fz
@@ -31,7 +31,7 @@
 # All type features inherit directly (Any.type) or indirectly (all
 # others type features) from this feature.
 #
-public Type ref is
+module:public Type ref is
 
 
   # name of this type, including type parameters, e.g. 'option (list i32)'.


### PR DESCRIPTION
fixes #2577

Type must not be called or inherited

<!--
Please describe your changes here, explain what effect this PR will have and how
this is achieved.  Refer to the # of the issue this PR addresses.  Make
sure the tests run successfully using `make run_tests`.
-->

- [x] I have read and accept the [Tokiwa Software Fuzion Contributor Agreement](https://github.com/tokiwa-software/fuzion/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).
