### PR TITLE
fe: improve type inference for mixed numeric types

### DIFF
--- a/src/dev/flang/ast/AbstractBlock.java
+++ b/src/dev/flang/ast/AbstractBlock.java
@@ -191,6 +191,40 @@ public abstract class AbstractBlock extends Expr
 
 
   /**
+   * During type inference: Inform this expression that it is
+   * expected to result in the given type.
+   *
+   * @param t the expected type.
+   */
+  @Override
+  protected void propagateExpectedType(AbstractType t)
+  {
+    var resExpr = resultExpression();
+    if (resExpr != null)
+      {
+        resExpr.propagateExpectedType(t);
+      }
+  }
+
+
+  /**
+   * typeForUnion returns the type of this expression or null if the type is
+   * still unknown, i.e., before or during type resolution.  This is redefined
+   * by sub-classes of Expr to provide type information.
+   *
+   * @return this Expr's type or null if not known.
+   */
+  @Override
+  AbstractType typeForUnion()
+  {
+    Expr resExpr = resultExpression();
+    return resExpr == null
+      ? Types.resolved.t_unit
+      : resExpr.typeForUnion();
+  }
+
+
+  /**
    * toString
    *
    * @return

--- a/src/dev/flang/ast/AbstractMatch.java
+++ b/src/dev/flang/ast/AbstractMatch.java
@@ -128,7 +128,7 @@ public abstract class AbstractMatch extends Expr
    */
   private AbstractType typeFromCases()
   {
-    var result = Expr.union(cases().map2(x -> x.code()), false);
+    var result = Expr.union(cases().map2(x -> x.code()));
     if (result == Types.t_ERROR)
       {
         new IncompatibleResultsOnBranches(pos(),

--- a/src/dev/flang/ast/AbstractMatch.java
+++ b/src/dev/flang/ast/AbstractMatch.java
@@ -128,12 +128,7 @@ public abstract class AbstractMatch extends Expr
    */
   private AbstractType typeFromCases()
   {
-    AbstractType result = Types.resolved.t_void;
-    for (var c: cases())
-      {
-        var t = c.code().typeForInferencing();
-        result = result == null || t == null ? null : result.union(t);
-      }
+    var result = Expr.union(cases().map2(x -> x.code()), false);
     if (result == Types.t_ERROR)
       {
         new IncompatibleResultsOnBranches(pos(),

--- a/src/dev/flang/ast/Expr.java
+++ b/src/dev/flang/ast/Expr.java
@@ -252,12 +252,11 @@ public abstract class Expr extends HasGlobalIndex implements HasSourcePosition
     for (var e : exprs)
       {
         var et = e.typeForInferencing();
-        if (et == null && ignoreUnknow)
+        if (et != null || !ignoreUnknow)
           {
-            continue;
+            result = result == null || et == null
+              ? null : result.union(et);
           }
-        result = result == null || et == null
-          ? null : result.union(et);
       }
 
     return result;

--- a/src/dev/flang/ast/Expr.java
+++ b/src/dev/flang/ast/Expr.java
@@ -220,11 +220,10 @@ public abstract class Expr extends HasGlobalIndex implements HasSourcePosition
    *
    * @param exprs the expression to unionize
    *
-   * @param ignoreUnknow ignore any expressions whose type is not yet known.
-   *
-   * @return the union of exprs result type or null if not yet known.
+   * @return the union of exprs result type, defaulting to Types.resolved.t_void if
+   * no expression can be inferred yet.
    */
-  public static AbstractType union(List<Expr> exprs, boolean ignoreUnknow)
+  public static AbstractType union(List<Expr> exprs)
   {
     AbstractType t = Types.resolved.t_void;
 
@@ -252,10 +251,9 @@ public abstract class Expr extends HasGlobalIndex implements HasSourcePosition
     for (var e : exprs)
       {
         var et = e.typeForInferencing();
-        if (et != null || !ignoreUnknow)
+        if (et != null)
           {
-            result = result == null || et == null
-              ? null : result.union(et);
+            result = result.union(et);
           }
       }
 

--- a/src/dev/flang/ast/If.java
+++ b/src/dev/flang/ast/If.java
@@ -166,17 +166,7 @@ public class If extends ExprWithPos
    */
   private AbstractType typeFromIfOrElse()
   {
-    AbstractType result = Types.resolved.t_void;
-
-    Iterator<Expr> it = branches();
-    while (it.hasNext())
-      {
-        var t = it.next().typeForInferencing();
-        t = t == null
-          ? Types.resolved.t_void
-          : t;
-        result = result.union(t);
-      }
+    var result = Expr.union(new List<>(branches()), true);
     if (result==Types.t_ERROR)
       {
         new IncompatibleResultsOnBranches(pos(),

--- a/src/dev/flang/ast/If.java
+++ b/src/dev/flang/ast/If.java
@@ -166,7 +166,7 @@ public class If extends ExprWithPos
    */
   private AbstractType typeFromIfOrElse()
   {
-    var result = Expr.union(new List<>(branches()), true);
+    var result = Expr.union(new List<>(branches()));
     if (result==Types.t_ERROR)
       {
         new IncompatibleResultsOnBranches(pos(),

--- a/src/dev/flang/ast/Impl.java
+++ b/src/dev/flang/ast/Impl.java
@@ -490,7 +490,7 @@ public class Impl extends ANY
         var iv = initialValueFromCall(i, res);
         exprs.add(iv);
       }
-    var result = Expr.union(exprs, true);
+    var result = Expr.union(exprs);
     if (reportError)
       {
         if (_initialCalls.size() == 0)

--- a/src/dev/flang/ast/Impl.java
+++ b/src/dev/flang/ast/Impl.java
@@ -484,17 +484,13 @@ public class Impl extends ANY
    */
   AbstractType typeFromInitialValues(Resolution res, AbstractFeature formalArg, boolean reportError)
   {
-    AbstractType result = Types.resolved.t_void;
+    var exprs = new List<Expr>();
     for (var i = 0; i < _initialCalls.size(); i++)
       {
-        var io = _outerOfInitialCalls.get(i);
         var iv = initialValueFromCall(i, res);
-        AbstractType t = iv.typeForInferencing();
-        if (t != null)
-          {
-            result = result.union(t);
-          }
+        exprs.add(iv);
       }
+    var result = Expr.union(exprs, true);
     if (reportError)
       {
         if (_initialCalls.size() == 0)

--- a/src/dev/flang/ast/InlineArray.java
+++ b/src/dev/flang/ast/InlineArray.java
@@ -124,7 +124,7 @@ public class InlineArray extends ExprWithPos
   {
     if (_type == null && !_elements.isEmpty())
       {
-        var t = Expr.union(_elements, true);
+        var t = Expr.union(_elements);
         if (t == Types.t_ERROR)
           {
             new IncompatibleResultsOnBranches(pos(),

--- a/src/dev/flang/ast/InlineArray.java
+++ b/src/dev/flang/ast/InlineArray.java
@@ -124,14 +124,7 @@ public class InlineArray extends ExprWithPos
   {
     if (_type == null && !_elements.isEmpty())
       {
-        AbstractType t = Types.resolved.t_void;
-        for (var e : _elements)
-          {
-            var et = e.typeForInferencing();
-            t =
-              t  == null ? null :
-              et == null ? null : t.union(et);
-          }
+        var t = Expr.union(_elements, false);
         if (t == Types.t_ERROR)
           {
             new IncompatibleResultsOnBranches(pos(),

--- a/src/dev/flang/ast/InlineArray.java
+++ b/src/dev/flang/ast/InlineArray.java
@@ -124,7 +124,7 @@ public class InlineArray extends ExprWithPos
   {
     if (_type == null && !_elements.isEmpty())
       {
-        var t = Expr.union(_elements, false);
+        var t = Expr.union(_elements, true);
         if (t == Types.t_ERROR)
           {
             new IncompatibleResultsOnBranches(pos(),

--- a/src/dev/flang/ast/NumLiteral.java
+++ b/src/dev/flang/ast/NumLiteral.java
@@ -458,23 +458,9 @@ public class NumLiteral extends Constant
 
   private AbstractType extractNumericType(AbstractType t)
   {
-    var numericTypes = new TreeSet<AbstractType>(
-      new List<>(
-        Types.resolved.t_i8,
-        Types.resolved.t_i16,
-        Types.resolved.t_i32,
-        Types.resolved.t_i64,
-        Types.resolved.t_u8,
-        Types.resolved.t_u16,
-        Types.resolved.t_u32,
-        Types.resolved.t_u64,
-        Types.resolved.t_f32,
-        Types.resolved.t_f64)
-    );
-
     var result = t
       .choices()
-      .filter(x -> numericTypes.contains(x))
+      .filter(x -> Types.resolved.numericTypes.contains(x))
       .collect(Collectors.toList());
 
     return result.size() == 1
@@ -791,7 +777,7 @@ public class NumLiteral extends Constant
 
 
   /**
-   * Check if type t is one of the known integer types i8, i16, i32, i64, u8,
+   * Check if type t is one of the known numeric types i8, i16, i32, i64, u8,
    * u16, u32, u64, f32, f64 and return the corresponding ConstantType constant.
    *
    * @param t an interned type

--- a/src/dev/flang/ast/Types.java
+++ b/src/dev/flang/ast/Types.java
@@ -37,6 +37,7 @@ import dev.flang.util.ANY;
 import dev.flang.util.Errors;
 import dev.flang.util.FuzionConstants;
 import dev.flang.util.FuzionOptions;
+import dev.flang.util.List;
 
 /*---------------------------------------------------------------------*/
 
@@ -177,6 +178,7 @@ public class Types extends ANY
     public final AbstractFeature f_Types_get;
     public final AbstractFeature f_Lazy;
     public final AbstractFeature f_Unary;
+    public final Set<AbstractType> numericTypes;
     public static interface CreateType
     {
       AbstractType type(String name);
@@ -234,6 +236,17 @@ public class Types extends ANY
       f_Types_get                  = f_Types.get(mod, "get");
       f_Lazy                       = universe.get(mod, LAZY_NAME);
       f_Unary                      = universe.get(mod, UNARY_NAME);
+      numericTypes = new TreeSet<AbstractType>(new List<>(
+        t_i8,
+        t_i16,
+        t_i32,
+        t_i64,
+        t_u8,
+        t_u16,
+        t_u32,
+        t_u64,
+        t_f32,
+        t_f64));
       resolved = this;
       ((ArtificialBuiltInType) t_ADDRESS  ).resolveArtificialType(universe.get(mod, FuzionConstants.ANY_NAME));
       ((ArtificialBuiltInType) t_UNDEFINED).resolveArtificialType(universe);

--- a/tests/reg_issue1069/Makefile
+++ b/tests/reg_issue1069/Makefile
@@ -1,0 +1,25 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test Makefile
+#
+# -----------------------------------------------------------------------
+
+override NAME = reg_issue1069
+include ../simple.mk

--- a/tests/reg_issue1069/reg_issue1069.fz
+++ b/tests/reg_issue1069/reg_issue1069.fz
@@ -1,0 +1,36 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test
+#
+# -----------------------------------------------------------------------
+
+reg_issue1069 is
+
+  a := [0.3, option 3.142, nil, 42]
+  for v in a do say "$v {type_of v}"
+
+  f(b bool) =>
+    if b
+      42
+    else
+      option 3.14
+
+  say (f true)
+  say (f false)

--- a/tests/reg_issue1069/reg_issue1069.fz
+++ b/tests/reg_issue1069/reg_issue1069.fz
@@ -34,3 +34,5 @@ reg_issue1069 is
 
   say (f true)
   say (f false)
+  say (type_of (f true))
+  say (type_of (f false))

--- a/tests/reg_issue1069/reg_issue1069.fz.expected_out
+++ b/tests/reg_issue1069/reg_issue1069.fz.expected_out
@@ -1,0 +1,6 @@
+0.3 Type of 'option f64'
+3.142 Type of 'option f64'
+--nil-- Type of 'option f64'
+42.0 Type of 'option f64'
+42.0
+3.14

--- a/tests/reg_issue1069/reg_issue1069.fz.expected_out
+++ b/tests/reg_issue1069/reg_issue1069.fz.expected_out
@@ -4,3 +4,5 @@
 42.0 Type of 'option f64'
 42.0
 3.14
+Type of 'option f64'
+Type of 'option f64'


### PR DESCRIPTION
fixes #1069
fixes #2282 

This patch enhances type inference for numbers if they are unified with results from other branches like in arrays, if-else or match-cases.

Examples:
- `a := [0.3, option 3.142, nil, 42]`   # infers that all the numbers to be of type `option f64`
- `if b then 42  else option 3.14`     # infers that all the numbers to be of type `option f64`

<!--
Please describe your changes here, explain what effect this PR will have and how
this is achieved.  Refer to the # of the issue this PR addresses.  Make
sure the tests run successfully using `make run_tests`.
-->

- [x] I have read and accept the [Tokiwa Software Fuzion Contributor Agreement](https://github.com/tokiwa-software/fuzion/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).
