### PR TITLE
fe: change `typeForInferencing` usage of `type` to `typeForInferencing`

### DIFF
--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -1462,8 +1462,8 @@ public class Call extends AbstractCall
   AbstractType typeForInferencing()
   {
     reportPendingError();
-    return (_calledFeature instanceof Feature f) && f.isAnonymousInnerFeature() && f.inherits().getFirst().type().isRef()
-      ? f.inherits().getFirst().type()
+    return (_calledFeature instanceof Feature f) && f.isAnonymousInnerFeature() && f.inherits().getFirst().typeForInferencing() != null && f.inherits().getFirst().typeForInferencing().isRef()
+      ? f.inherits().getFirst().typeForInferencing()
       : _type;
   }
 

--- a/src/dev/flang/ast/Partial.java
+++ b/src/dev/flang/ast/Partial.java
@@ -259,7 +259,7 @@ public class Partial extends AbstractLambda
     // unlike type(), we do not produce an error but just return null here since
     // everything might eventually turn out fine in this case.
     return _function == null ? null
-                             : _function.type();
+                             : _function.typeForInferencing();
   }
 
 


### PR DESCRIPTION
<!--
Please describe your changes here, explain what effect this PR will have and how
this is achieved.  Refer to the # of the issue this PR addresses.  Make
sure the tests run successfully using `make run_tests`.
-->

- [x] I have read and accept the [Tokiwa Software Fuzion Contributor Agreement](https://github.com/tokiwa-software/fuzion/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).
