### PR TITLE
fe: inference, lambda return type containing tp to infer

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ ex_gcd is
   common_divisors_of(a, b i32) list i32 =>
     x := max a.abs b.abs
     y := 1..x
-    y.flat_map i32 (i->
+    y.flat_map (i->
       if (a % i = 0) && (b % i = 0)
         [-i, i]
       else

--- a/examples/readme/example_2.fz
+++ b/examples/readme/example_2.fz
@@ -5,7 +5,7 @@ ex_gcd is
   common_divisors_of(a, b i32) list i32 =>
     x := max a.abs b.abs
     y := 1..x
-    y.flat_map i32 (i->
+    y.flat_map (i->
       if (a % i = 0) && (b % i = 0)
         [-i, i]
       else

--- a/examples/webserver/webserver2.fz
+++ b/examples/webserver/webserver2.fz
@@ -49,7 +49,7 @@ webserver2 is
       read := (net.channel net.server)
         .read 1
         .or (error "read error")
-        .bind String (d -> String.type.from_bytes d)
+        .bind (d -> String.type.from_bytes d)
       s := read.val, s + read.val
     while read.ok && read.val != "\n"
     else

--- a/lib/Sequence.fz
+++ b/lib/Sequence.fz
@@ -504,7 +504,7 @@ public Sequence(public T type) ref is
   #   Sequence.this.last, b.last
   #
   public combine(U, V type, b Sequence U, f (T,U)->V) Sequence V =>
-    flat_map V x->(b.map y->(f x y))
+    flat_map x->(b.map y->(f x y))
 
 
   # create a new Sequence from tuples of all combinations of elements

--- a/lib/String.fz
+++ b/lib/String.fz
@@ -223,7 +223,7 @@ public String ref : property.equatable, property.hashable, property.orderable is
       else if (String.type.cap_a_char ≤ c ≤ String.type.cap_z_char) c - String.type.cap_a_char + 10
       else parse_error "non-digit found"
 
-    d.bind T b->
+    d.bind T b-> /* NYI can not drop arg T because if else returns error and T which only later will become outcome T */
       t := parse_integer.this.T.from_u32 b.as_u32  # i converted to T
       if t ≥ base
         parse_error "invalid integer digit for base $base"
@@ -714,7 +714,7 @@ public String ref : property.equatable, property.hashable, property.orderable is
   public type.from_mutable_array(a Mutable_Array Any) ref : String is  // NYI: Remove?
 
     redef utf8 Sequence u8 =>
-      a.flat_map u8 ai->ai.as_string.utf8
+      a.flat_map ai->ai.as_string.utf8
 
 
     redef infix + (other Any) String =>
@@ -736,7 +736,7 @@ public String ref : property.equatable, property.hashable, property.orderable is
     ref : String
       utf8 Sequence u8 =>
         codepoints
-          .flat_map u8 x->x.utf8
+          .flat_map x->x.utf8
           .as_array_backed
 
 

--- a/lib/array2.fz
+++ b/lib/array2.fz
@@ -77,7 +77,7 @@ is
   # all pairs of indices: (0,0), (0,1), (0,2), .. (length0-1, length1-1)
   #
   public index_pairs =>
-    indices0.flat_map (tuple i32 i32) (i ->
+    indices0.flat_map (i ->
       indices1.map j->(i,j))
 
 

--- a/lib/container/mutable_tree_map/Entry.fz
+++ b/lib/container/mutable_tree_map/Entry.fz
@@ -47,9 +47,9 @@ module Entry(module key KEY, module val VAL) ref is
   #
   module get(k KEY) option VAL =>
     if k < key
-      left.get.bind VAL (e -> e.get k)
+      left.get.bind (e -> e.get k)
     else if key < k
-      right.get.bind VAL (e -> e.get k)
+      right.get.bind (e -> e.get k)
     else
       val
 

--- a/lib/io/file/read.fz
+++ b/lib/io/file/read.fz
@@ -61,11 +61,11 @@ public read(ro Read_Handler) : simple_effect is
   private read_file(fd i64, tmp array u8) outcome (array u8) =>
     t := read_proxy fd bufsize
 
-    t.bind (array u8) (a->
+    t.bind a->
       if a.length > 0
         read_file fd (tmp ++ a).as_array
       else
-        tmp)
+        tmp
 
 
   # the default file reading operation reading bytes from files via fuzion.sys.fileio.read

--- a/lib/list.fz
+++ b/lib/list.fz
@@ -200,12 +200,12 @@ public list(public A type) : choice nil (Cons A (list A)), Sequence A is
       _ nil  => nil
       c Cons =>
         match (f c.head).as_list
-          _ nil => c.tail.flat_map_to_list B f
+          _ nil => c.tail.flat_map_to_list f
           c2 Cons =>
             ref : Cons B (list B)
             // Cons B (list B) with    # NYI: better syntax for anonymous feature
               head => c2.head
-              tail => c2.tail ++ c.tail.flat_map_to_list B f
+              tail => c2.tail ++ c.tail.flat_map_to_list f
 
 
   # fold the elements of this list using the given monoid.
@@ -502,7 +502,7 @@ public list(public A type) : choice nil (Cons A (list A)), Sequence A is
   #   list.this.last, b.last
   #
   public combine_list(U, V type, b Sequence U, f (A,U)->V) =>
-    flat_map V x->(b.map y->(f x y))
+    flat_map x->(b.map y->(f x y))
 
 
   # create an empty list

--- a/lib/net/channel.fz
+++ b/lib/net/channel.fz
@@ -39,7 +39,7 @@ module:public channel(T type, desc outcome i64, auto_close bool, m effect_mode.v
 is
 
   # get the last error that occurred
-  last_error => desc.bind unit (_ -> unit)
+  last_error => desc.bind _->unit
 
 
   # is this channel still active?

--- a/lib/net/server.fz
+++ b/lib/net/server.fz
@@ -43,7 +43,7 @@ module:public server(
 is
 
   # get the last error that occurred
-  public last_error => state.bind unit (_ -> unit)
+  public last_error => state.bind _->unit
 
   # is the server running?
   public is_active =>
@@ -75,7 +75,7 @@ is
           protocol.tcp =>
             ar := fuzion.sys.net.accept d
             channel server ar true
-            ar.bind unit d->unit
+            ar.bind d->unit
           * =>
             channel server state false
             unit

--- a/lib/num_option.fz
+++ b/lib/num_option.fz
@@ -76,7 +76,7 @@ is
 
 
   # monadic operator
-  public redef infix >>= (f T -> num_option T) => num_option.this.bind T f
+  public redef infix >>= (f T -> num_option T) => num_option.this.bind f
 
 
   # monadic operator

--- a/lib/outcome.fz
+++ b/lib/outcome.fz
@@ -168,7 +168,7 @@ is
   #
   # The monadic operator turns this into:
   #
-  #     (open "example.txt").bind (array u8) (fd->read fd 42)
+  #     (open "example.txt").bind (fd->read fd 42)
   #
   public bind(B type, f T -> outcome B) outcome B =>
     outcome.this ? v T => f v

--- a/lib/state.fz
+++ b/lib/state.fz
@@ -46,7 +46,7 @@ is
 
   # monadic operator
   #
-  public redef infix >>= (f T -> state T S) => state.this.bind T f
+  public redef infix >>= (f T -> state T S) => state.this.bind f
 
 
   # monadic operator

--- a/lib/uint.fz
+++ b/lib/uint.fz
@@ -202,7 +202,7 @@ is
             uint ([(tmp>>32).low32bits , tmp.low32bits] ++ zeros i+oi) unit
           )
         )
-      .flat_map uint (x -> x)
+      .flat_map x->x
       .fold uint.type.sum
 
 

--- a/modules/lock_free/src/lock_free/map.fz
+++ b/modules/lock_free/src/lock_free/map.fz
@@ -458,13 +458,12 @@ is
   # clean an indirection node:
   # compress contained container node
   private clean(nd option (Indirection_Node CTK CTV), lev u32) =>
-    nd.bind unit (i ->
+    nd.bind i->
       m := gcas_read i
       match m.data
         c container_node => gcas i m (compress c lev i.gen)
         * =>
       unit
-    )
     restart
 
 

--- a/src/dev/flang/ast/AbstractType.java
+++ b/src/dev/flang/ast/AbstractType.java
@@ -1922,6 +1922,52 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
   }
 
 
+  /**
+   * Get the index of the first found generic argument
+   * e.g. `Sequence Sequence.flat_map.B` returns 0
+   */
+  public Integer indexOfGenericArgument()
+  {
+    return isGenericArgument()
+    ? genericArgument().index()
+    : generics().stream()
+      .filter(x -> x.indexOfGenericArgument() != null)
+      .map(x -> x.indexOfGenericArgument())
+      .findFirst()
+      .orElse(null);
+  }
+
+
+  /**
+   * this the type in which to find the replacement for tp     e.g: Sequence (array i32)
+   * @param frmlT the formal type containing a tp               e.g: Sequence Sequence.flat_map.B
+   * @return the extracted type                                 e.g: array i32
+   */
+  public AbstractType extractType(AbstractType frmlT)
+  {
+    if (frmlT.isGenericArgument())
+      {
+        return this;
+      }
+    else
+      {
+        for (int i = 0; i < frmlT.generics().size(); i++)
+          {
+            if (generics().size() <= i)
+              {
+                return null;
+              }
+            var et = generics().get(i).extractType(frmlT.generics().get(i));
+            if (et != null)
+              {
+                return et;
+              }
+          }
+        return null;
+      }
+  }
+
+
 }
 
 /* end of file */

--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -2499,7 +2499,7 @@ public class Call extends AbstractCall
                   }
               }
           }
-        else if (at.containsUndefined(false))
+        else if (at.containsUndefined(false) && frmLmdRt.dependsOnGenerics())
           {
             var rt = al.propagateTypeAndInferResult(res, outer, at, false);
             // NYI What if there is more than one type parameter to infer?

--- a/src/dev/flang/ast/Impl.java
+++ b/src/dev/flang/ast/Impl.java
@@ -344,7 +344,8 @@ public class Impl extends ANY
     return
       (this._code != null) &&
       outer.hasResultField() &&
-      outer instanceof Feature fouter && !fouter.hasAssignmentsToResult();
+      outer instanceof Feature fouter && !fouter.hasAssignmentsToResult()
+      && outer.resultType() != Types.t_ERROR;
   }
 
 

--- a/tests/reg_issue1352/issue_1352.fz.expected_err
+++ b/tests/reg_issue1352/issue_1352.fz.expected_err
@@ -19,4 +19,13 @@ with argument count of the lambda expression equal to the number of type paramet
 assigned field must be given explicitly.
 To solve this, declare an explicit type for the target field, e.g., 'f (i32, i32) -> bool := x, y -> x > y'.
 
-3 errors.
+
+--CURDIR--/issue_1352.fz:27:10: error 4: No type information can be inferred from a lambda expression
+  d => b ->
+---------^
+A lambda expression can only be used if assigned to a field or argument of type 'Function'
+with argument count of the lambda expression equal to the number of type parameters of the type.  The type of the
+assigned field must be given explicitly.
+To solve this, declare an explicit type for the target field, e.g., 'f (i32, i32) -> bool := x, y -> x > y'.
+
+4 errors.

--- a/tests/reg_issue1355/Makefile
+++ b/tests/reg_issue1355/Makefile
@@ -17,42 +17,9 @@
 #
 #  Tokiwa Software GmbH, Germany
 #
-#  Source code of Fuzion test mmap_test
+#  Source code of Fuzion test Makefile
 #
 # -----------------------------------------------------------------------
 
-
-mmap_test is
-
-  testfile := "testfile"
-
-  f =>
-    io.file.open
-
-  # NYI get actual page size
-  page_size := 65536
-
-  say (io.file.use unit testfile io.file.mode.append ()->
-
-    f.write (array u8 page_size i->0)
-    f.write "hello!".utf8
-
-    offset := page_size.as_i64
-
-    # map 6 bytes of file starting from the end of the '+'s.
-    say (f.mmap offset (i64 6) buf->
-          # change the 'e' in hello to an 'a'.
-          buf[1] := buf[1] - 4)
-
-    # mmap should fail, since offset+size exceeds file size.
-    say (f.mmap offset (i64 7) _->)
-  )
-
-
-  say (io.file.use String testfile io.file.mode.read ()->
-    f
-      .read
-      .bind (x -> String.type.from_bytes (x.drop page_size))
-  )
-
-  _ := io.file.delete testfile
+override NAME = reg_issue1355
+include ../simple.mk

--- a/tests/reg_issue1355/reg_issue1355.fz
+++ b/tests/reg_issue1355/reg_issue1355.fz
@@ -17,42 +17,36 @@
 #
 #  Tokiwa Software GmbH, Germany
 #
-#  Source code of Fuzion test mmap_test
+#  Source code of Fuzion test
 #
 # -----------------------------------------------------------------------
 
+reg_issue1355 is
 
-mmap_test is
+  a := [1,2,3]
+    .flat_map (x -> [x])
 
-  testfile := "testfile"
+  say (type_of a)
+  say a
 
-  f =>
-    io.file.open
+  a := [1,2,3]
+    .flat_map (x -> [[x]])
 
-  # NYI get actual page size
-  page_size := 65536
+  say (type_of a)
+  say a
 
-  say (io.file.use unit testfile io.file.mode.append ()->
+  a := [1,2,3]
+    .flat_map (x -> [codepoint 65])
 
-    f.write (array u8 page_size i->0)
-    f.write "hello!".utf8
+  say (type_of a)
+  say a
 
-    offset := page_size.as_i64
+  b := [1,2,3]
+    .flat_map (x -> [option unit nil])
 
-    # map 6 bytes of file starting from the end of the '+'s.
-    say (f.mmap offset (i64 6) buf->
-          # change the 'e' in hello to an 'a'.
-          buf[1] := buf[1] - 4)
+  say (type_of b)
+  say b
 
-    # mmap should fail, since offset+size exceeds file size.
-    say (f.mmap offset (i64 7) _->)
-  )
+  c option unit := nil
+  say (c.bind x->"hello")
 
-
-  say (io.file.use String testfile io.file.mode.read ()->
-    f
-      .read
-      .bind (x -> String.type.from_bytes (x.drop page_size))
-  )
-
-  _ := io.file.delete testfile

--- a/tests/reg_issue1355/reg_issue1355.fz.expected_out
+++ b/tests/reg_issue1355/reg_issue1355.fz.expected_out
@@ -1,0 +1,9 @@
+Type of 'Sequence i32'
+[1, 2, 3]
+Type of 'Sequence (array i32)'
+[[1], [2], [3]]
+Type of 'Sequence codepoint'
+[A, A, A]
+Type of 'Sequence (option unit)'
+[--nil--, --nil--, --nil--]
+--nil--

--- a/tests/sockets/sockets_test_client.fz
+++ b/tests/sockets/sockets_test_client.fz
@@ -42,14 +42,14 @@ sockets_test_client is
               # read less than available bytes
               .read 12
               .or(error "error")
-              .bind String (d -> String.type.from_bytes  d)
+              .bind (d -> String.type.from_bytes  d)
             say ("$protocol/$family-client {sockets_test_client.client.this.num}, read  12 bytes from  $host:$port: >{rr}<")
 
             rr := (net.channel sockets_test_client)
               # read more than available bytes
               .read 100
               .or(error "error")
-              .bind String (d -> String.type.from_bytes  d)
+              .bind (d -> String.type.from_bytes  d)
             say ("$protocol/$family-client {sockets_test_client.client.this.num}, read 100 bytes from  $host:$port: >{rr}<")
           net.protocol.udp =>
             # rest of udp datagram was discarded

--- a/tests/sockets/sockets_test_server.fz
+++ b/tests/sockets/sockets_test_server.fz
@@ -39,7 +39,7 @@ sockets_test_server =>
         # read less than available bytes
         .read 11
         .or(error "error")
-        .bind String (d -> String.type.from_bytes  d)
+        .bind (d -> String.type.from_bytes d)
 
       say "$protocol/$family-server, read  11 bytes: >{rr1}<"
 
@@ -49,7 +49,7 @@ sockets_test_server =>
             # read more than available bytes
             .read 100
             .or (error "error")
-            .bind String (d -> String.type.from_bytes  d)
+            .bind (d -> String.type.from_bytes d)
 
           say "$protocol/$family-server, read 100 bytes: >{rr2}<"
 


### PR DESCRIPTION
fixes #1355

This patch adds type inference for e.g. 
`flat_map(B type, f T -> Sequence B) Sequence B =>...`
where the type parameter to infer is part of the lambdas result type.

<!--
Please describe your changes here, explain what effect this PR will have and how
this is achieved.  Refer to the # of the issue this PR addresses.  Make
sure the tests run successfully using `make run_tests`.
-->

- [x] I have read and accept the [Tokiwa Software Fuzion Contributor Agreement](https://github.com/tokiwa-software/fuzion/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).
