### PR TITLE
lib: change `bench` to use `time.nano` effect

### DIFF
--- a/lib/bench.fz
+++ b/lib/bench.fz
@@ -30,13 +30,13 @@
 #
 # returns: iterations per second
 #
-public bench(f ()->unit, nano_seconds u64, warm_up_nano_seconds u64) f64 =>
-  start := fuzion.std.nano_time
+public bench(f ()->unit, nano_seconds u64, warm_up_nano_seconds u64) f64 ! time.nano =>
+  start := time.nano.read
 
-  is_warmup => fuzion.std.nano_time - start < warm_up_nano_seconds
+  is_warmup => time.nano.read - start < warm_up_nano_seconds
 
   for iter := (u64 0), if (is_warmup) iter else iter + 1
-  while fuzion.std.nano_time - start < warm_up_nano_seconds + nano_seconds
+  while time.nano.read - start < warm_up_nano_seconds + nano_seconds
   do
     f.call
   else

--- a/lib/time/nano.fz
+++ b/lib/time/nano.fz
@@ -66,7 +66,8 @@ public nano (p Nano_Time_Handler) : simple_effect is
 # short-hand for accessing time.nano effect in current environment
 #
 public nano =>
-  nano.type.install_default
+  if !effect.type.is_installed nano
+    nano.type.install_default
   nano.env
 
 


### PR DESCRIPTION
before it was using fuzion.std.nano_time directly

<!--
Please describe your changes here, explain what effect this PR will have and how
this is achieved.  Refer to the # of the issue this PR addresses.  Make
sure the tests run successfully using `make run_tests`.
-->

- [x] I have read and accept the [Tokiwa Software Fuzion Contributor Agreement](https://github.com/tokiwa-software/fuzion/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).
