### PR TITLE
fe: raise error if effect is stored in field

### DIFF
--- a/lib/panic.fz
+++ b/lib/panic.fz
@@ -87,5 +87,5 @@ public Panic_Handler ref is
   # removed and the result of do_panic should be returned instead).
   #
   public use(R type, code, def ()->R) =>
-    p := panic Panic_Handler.this unit
-    p.run code def
+    panic Panic_Handler.this unit
+      .run code def

--- a/src/dev/flang/ast/AbstractAssign.java
+++ b/src/dev/flang/ast/AbstractAssign.java
@@ -27,6 +27,7 @@ Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
 package dev.flang.ast;
 
 import dev.flang.util.Errors;
+import dev.flang.util.FuzionConstants;
 
 
 /**
@@ -270,6 +271,10 @@ public abstract class AbstractAssign extends Expr
 
         if (CHECKS) check
           (res._module.lookupFeature(this._target.type().featureOfType(), f.featureName(), f) == f || Errors.any());
+      }
+    if (_value.type().isEffect() && !f.featureName().isInternal() && !(f.outer().hasResultField() && f.outer().resultField().equals(f)))
+      {
+        AstErrors.mustNotStoreEffectInField(pos(), f, _value);
       }
   }
 

--- a/src/dev/flang/ast/AbstractType.java
+++ b/src/dev/flang/ast/AbstractType.java
@@ -1922,6 +1922,14 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
   }
 
 
+  public boolean isEffect()
+  {
+    return isGenericArgument()
+      ? genericArgument().constraint().featureOfType().inheritsFrom(Types.resolved.f_effect)
+      : featureOfType().inheritsFrom(Types.resolved.f_effect);
+  }
+
+
 }
 
 /* end of file */

--- a/src/dev/flang/ast/AstErrors.java
+++ b/src/dev/flang/ast/AstErrors.java
@@ -2097,6 +2097,12 @@ public class AstErrors extends ANY
       "To solve this, increase the visibility of " + s(f) + " to at least " + s(f.outer().visibility().featureVisibility()));
   }
 
+  public static void mustNotStoreEffectInField(SourcePosition pos, AbstractFeature f, Expr _value)
+  {
+    error(pos, "Effect must not be stored in a field.",
+      "To solve this, install the effect once then call <effect>." + skw("env") + " whereever you want to use the effect.");
+  }
+
 }
 
 /* end of file */

--- a/src/dev/flang/ast/Types.java
+++ b/src/dev/flang/ast/Types.java
@@ -177,6 +177,7 @@ public class Types extends ANY
     public final AbstractFeature f_Types_get;
     public final AbstractFeature f_Lazy;
     public final AbstractFeature f_Unary;
+    public final AbstractFeature f_effect;
     public static interface CreateType
     {
       AbstractType type(String name);
@@ -234,6 +235,7 @@ public class Types extends ANY
       f_Types_get                  = f_Types.get(mod, "get");
       f_Lazy                       = universe.get(mod, LAZY_NAME);
       f_Unary                      = universe.get(mod, UNARY_NAME);
+      f_effect                     = universe.get(mod, "effect", 1);
       resolved = this;
       ((ArtificialBuiltInType) t_ADDRESS  ).resolveArtificialType(universe.get(mod, FuzionConstants.ANY_NAME));
       ((ArtificialBuiltInType) t_UNDEFINED).resolveArtificialType(universe);

--- a/tests/fileio/fileiotests.fz
+++ b/tests/fileio/fileiotests.fz
@@ -33,8 +33,8 @@ fileiotests =>
 
   f := io.file
 
-  writer := f.write
-  reader := f.read
+  writer => f.write
+  reader => f.read
 
   exists(path String) bool =>
     match f.stat path true


### PR DESCRIPTION
Effects instances must always be obtained from env. With this patch an error is raised if it is attempted to store an effect in field.

<!--
Please describe your changes here, explain what effect this PR will have and how
this is achieved.  Refer to the # of the issue this PR addresses.  Make
sure the tests run successfully using `make run_tests`.
-->

- [x] I have read and accept the [Tokiwa Software Fuzion Contributor Agreement](https://github.com/tokiwa-software/fuzion/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).
