### PR TITLE
util: on contract failure try showing expression that led to failure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,10 +37,10 @@ endif
 
 UNICODE_SOURCE = https://www.unicode.org/Public/UCD/latest/ucd/UnicodeData.txt
 
-JAVA_FILE_TOOLS_VERSION_IN =  $(SRC)/dev/flang/tools/Version.java.in
-JAVA_FILE_TOOLS_VERSION    =  $(BUILD_DIR)/generated/src/dev/flang/tools/Version.java
+JAVA_FILE_UTIL_VERSION_IN =  $(SRC)/dev/flang/util/Version.java.in
+JAVA_FILE_UTIL_VERSION    =  $(BUILD_DIR)/generated/src/dev/flang/util/Version.java
 
-JAVA_FILES_UTIL              = $(wildcard $(SRC)/dev/flang/util/*.java          )
+JAVA_FILES_UTIL              = $(wildcard $(SRC)/dev/flang/util/*.java          ) $(JAVA_FILE_UTIL_VERSION)
 JAVA_FILES_UTIL_UNICODE      = $(wildcard $(SRC)/dev/flang/util/unicode/*.java  )
 JAVA_FILES_AST               = $(wildcard $(SRC)/dev/flang/ast/*.java           )
 JAVA_FILES_PARSER            = $(wildcard $(SRC)/dev/flang/parser/*.java        )
@@ -60,7 +60,7 @@ JAVA_FILES_BE_EFFECTS        = $(wildcard $(SRC)/dev/flang/be/effects/*.java    
 JAVA_FILES_BE_JVM            = $(wildcard $(SRC)/dev/flang/be/jvm/*.java        )
 JAVA_FILES_BE_JVM_CLASSFILE  = $(wildcard $(SRC)/dev/flang/be/jvm/classfile/*.java)
 JAVA_FILES_BE_JVM_RUNTIME    = $(wildcard $(SRC)/dev/flang/be/jvm/runtime/*.java)
-JAVA_FILES_TOOLS             = $(wildcard $(SRC)/dev/flang/tools/*.java         ) $(JAVA_FILE_TOOLS_VERSION) $(SRC)/module-info.java
+JAVA_FILES_TOOLS             = $(wildcard $(SRC)/dev/flang/tools/*.java         ) $(SRC)/module-info.java
 JAVA_FILES_TOOLS_FZJAVA      = $(wildcard $(SRC)/dev/flang/tools/fzjava/*.java  )
 JAVA_FILES_TOOLS_DOCS        = $(wildcard $(SRC)/dev/flang/tools/docs/*.java    )
 JAVA_FILES_MISC_LOGO         = $(wildcard $(SRC)/dev/flang/misc/logo/*.java     )
@@ -434,10 +434,11 @@ $(FUZION_EBNF): $(SRC)/dev/flang/parser/Parser.java
 	mkdir -p $(@D)
 	$(FZ_SRC)/bin/ebnf.sh > $@
 
-$(JAVA_FILE_TOOLS_VERSION): $(FZ_SRC)/version.txt $(JAVA_FILE_TOOLS_VERSION_IN)
+$(JAVA_FILE_UTIL_VERSION): $(FZ_SRC)/version.txt $(JAVA_FILE_UTIL_VERSION_IN)
 	mkdir -p $(@D)
-	cat $(JAVA_FILE_TOOLS_VERSION_IN) \
+	cat $(JAVA_FILE_UTIL_VERSION_IN) \
           | sed "s^@@VERSION@@^$(VERSION)^g" \
+          | sed "s^@@REPO_PATH@@^$(dir $(abspath $(lastword $(MAKEFILE_LIST))))^g" \
           | sed "s^@@GIT_HASH@@^`cd $(FZ_SRC); echo -n \`git rev-parse HEAD\` \`git diff-index --quiet HEAD -- || echo with local changes\``^g" >$@
 ifeq ($(FUZION_REPRODUCIBLE_BUILD),true)
 	sed -i "s^@@DATE@@^^g;s^@@BUILTBY@@^^g" $@

--- a/src/dev/flang/tools/Tool.java
+++ b/src/dev/flang/tools/Tool.java
@@ -37,6 +37,7 @@ import dev.flang.util.ANY;
 import dev.flang.util.Errors;
 import dev.flang.util.List;
 import dev.flang.util.Profiler;
+import dev.flang.util.Version;
 
 
 /**

--- a/src/dev/flang/util/ANY.java
+++ b/src/dev/flang/util/ANY.java
@@ -28,7 +28,6 @@ package dev.flang.util;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -74,17 +73,11 @@ public class ANY
       {
         return "Unknown origin.";
       }
-    try (Stream<String> lines = Files.lines(Path.of(System.getProperty(FuzionConstants.FUZION_HOME_PROPERTY) + "/../src/" + st[2].getClassName().replaceAll("\\.", "/") + ".java")))
+    try (Stream<String> lines = Files.lines(Path.of(Version.REPO_PATH).resolve("src").resolve(st[2].getClassName().replaceAll("\\.", "/") + ".java")))
       {
-        var previous = new AtomicReference<>("");
+        var l = lines.skip(st[2].getLineNumber()-1).map(str -> str.trim()).collect(Collectors.toList());
         return st[2].getFileName() + ":" + st[2].getLineNumber() + Terminal.BLUE + " \""
-          + lines.skip(st[2].getLineNumber()-1).map(str -> str.trim())
-            .takeWhile(str -> {
-              var result = !previous.get().endsWith(");");
-              previous.set(str);
-              return result;
-            })
-            .limit(7)
+          + l.stream().limit(Math.min(l.stream().takeWhile(s->!s.endsWith(");")).count()+1,7))
             .collect(Collectors.joining(" ")) + "\""
           + Terminal.REGULAR_COLOR;
       }

--- a/src/dev/flang/util/Version.java.in
+++ b/src/dev/flang/util/Version.java.in
@@ -24,7 +24,7 @@ Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
  *
  *---------------------------------------------------------------------*/
 
-package dev.flang.tools;
+package dev.flang.util;
 
 import dev.flang.util.ANY;
 
@@ -35,7 +35,7 @@ import dev.flang.util.ANY;
  *
  * @author Fridtjof Siebert (siebert@tokiwa.software)
  */
-class Version extends ANY
+public class Version extends ANY
 {
 
 
@@ -65,6 +65,12 @@ class Version extends ANY
    * The user and machine of the build
    */
   public static final String BUILTBY = "@@BUILTBY@@";
+
+
+  /**
+   * The repositories path
+   */
+  public static final String REPO_PATH = "@@REPO_PATH@@";
 
 }
 


### PR DESCRIPTION
example:
```
error 1: java.lang.Error: require-condition1 failed: Call.java:1453 "(Errors.any() || calledFeatureKnown() || _pendingError != null);"
        at dev.flang.util.ANY.require(ANY.java:97)
        at dev.flang.ast.Call.calledFeature(Call.java:1453)
        at dev.flang.ast.Feature.dependsOnOuterRef(Feature.java:1444)
        at dev.flang.ast.Feature.lambda$closureAccesses$7(Feature.java:1427)
        at dev.flang.ast.Expr.visitExpressions(Expr.java:258)
        at dev.flang.ast.AbstractCall.visitExpressions(AbstractCall.java:101)
```

<!--
Please describe your changes here, explain what effect this PR will have and how
this is achieved.  Refer to the # of the issue this PR addresses.  Make
sure the tests run successfully using `make run_tests`.
-->

- [x] I have read and accept the [Tokiwa Software Fuzion Contributor Agreement](https://github.com/tokiwa-software/fuzion/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).
