### PR TITLE
ast: improve error message "feature not found"

### DIFF
--- a/src/dev/flang/ast/AstErrors.java
+++ b/src/dev/flang/ast/AstErrors.java
@@ -1170,13 +1170,17 @@ public class AstErrors extends ANY
   {
     if (!any() || !errorInOuterFeatures(targetFeature))
       {
+        var msg = !candidatesHidden.isEmpty()
+          ? plural(candidatesHidden.size(), "Feature") + " not visible at call site"
+          : !candidatesArgCountMismatch.isEmpty()
+          ? "Different count of arguments needed when calling feature"
+          : "Could not find called feature";
         var solution1 = solutionDeclareReturnTypeIfResult(calledName.baseName(),
                                                           calledName.argCount());
         var solution2 = solutionWrongArgumentNumber(candidatesArgCountMismatch);
         var solution3 = solutionAccidentalFreeType(target);
         var solution4 = solutionHidden(candidatesHidden);
-        error(call.pos(),
-              "Could not find called feature",
+        error(call.pos(), msg,
               "Feature not found: " + sbn(calledName) + "\n" +
               "Target feature: " + s(targetFeature) + "\n" +
               "In call: " + s(call) + "\n" +

--- a/tests/partial_application_negative/partial_application_negative.fz.expected_err
+++ b/tests/partial_application_negative/partial_application_negative.fz.expected_err
@@ -75,7 +75,7 @@ Target feature: 'i32'
 In call: '3.postfix*'
 
 
---CURDIR--/partial_application_negative.fz:77:38: error 9: Could not find called feature
+--CURDIR--/partial_application_negative.fz:77:38: error 9: Different count of arguments needed when calling feature
   test "data.map  .as_string " (data.map  .as_string ) "[1,2,3,4,5,6,7,8,9,10]"  // 11. should flag an error: dot-call partials require parentheses
 -------------------------------------^^^
 Feature not found: 'map' (no arguments)

--- a/tests/visibility_modules_negative/main.fz.expected_err
+++ b/tests/visibility_modules_negative/main.fz.expected_err
@@ -8,7 +8,7 @@ in feature: 'a'
 To solve this, check the spelling of the type you have used.
 
 
---CURDIR--/main.fz:67:5: error 2: Could not find called feature
+--CURDIR--/main.fz:67:5: error 2: Feature not visible at call site
   b.mod_pub // should flag an error should not be callable
 ----^^^^^^^
 Feature not found: 'mod_pub' (no arguments)


### PR DESCRIPTION
This was sometimes confusing sometimes to both @maxteufel and me.

So I changed the main message from "Could not find called feature" to: 1) "Feature not visible at call site" when feature is not visible 2) "Different count of arguments needed when calling feature" when feature needs different amount of args.

<!--
Please describe your changes here, explain what effect this PR will have and how
this is achieved.  Refer to the # of the issue this PR addresses.  Make
sure the tests run successfully using `make run_tests`.
-->

- [x] I have read and accept the [Tokiwa Software Fuzion Contributor Agreement](https://github.com/tokiwa-software/fuzion/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).
