### PR TITLE
remove now unecessary `-unsafeIntrinsics=on`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1245,8 +1245,8 @@ spellcheck:
 # currently only examples/ are checked.
 .PHONY: syntaxcheck
 syntaxcheck: min-java
-	find ./examples/ -name '*.fz' -print0 | xargs -0L1 $(BUILD_DIR)/bin/fz -unsafeIntrinsics=on -modules=java.base,java.datatransfer,java.xml,java.desktop -no-backend
-	find ./bin/ -name '*.fz' -print0 | xargs -0L1 $(BUILD_DIR)/bin/fz -unsafeIntrinsics=on -modules=java.base,java.datatransfer,java.xml,java.desktop -no-backend
+	find ./examples/ -name '*.fz' -print0 | xargs -0L1 $(BUILD_DIR)/bin/fz -modules=java.base,java.datatransfer,java.xml,java.desktop -no-backend
+	find ./bin/ -name '*.fz' -print0 | xargs -0L1 $(BUILD_DIR)/bin/fz -modules=java.base,java.datatransfer,java.xml,java.desktop -no-backend
 
 .PHONY: add_simple_test
 add_simple_test: no-java

--- a/examples/callingJava/Makefile
+++ b/examples/callingJava/Makefile
@@ -27,7 +27,5 @@ all:
         # we need to provide two additional options:
         #
         #   -modules=java.base    to add Fuzion interface to java.base module
-        #   -unsafeIntrinsics=on  to allow the Fuzion interface to look up Java
-        #                         code through reflection.
         #
-	../../bin/fz -unsafeIntrinsics=on -modules=java.base javaHello
+	../../bin/fz -modules=java.base javaHello

--- a/examples/javaGraphics/Makefile
+++ b/examples/javaGraphics/Makefile
@@ -27,7 +27,5 @@ all:
         # we need to provide two additional options:
         #
         #   -modules=java.base,...  to add Fuzion interface to Java modules
-        #   -unsafeIntrinsics=on    to allow the Fuzion interface to look up Java
-        #                           code through reflection.
         #
-	../../bin/fz -unsafeIntrinsics=on -modules=java.base,java.datatransfer,java.xml,java.desktop gfx
+	../../bin/fz -modules=java.base,java.datatransfer,java.xml,java.desktop gfx

--- a/examples/webserver/Makefile
+++ b/examples/webserver/Makefile
@@ -27,7 +27,5 @@ all:
         # we need to provide two additional options:
         #
         #   -modules=java.base    to add Fuzion interface to java.base module
-        #   -unsafeIntrinsics=on  to allow the Fuzion interface to look up Java
-        #                         code through reflection.
         #
-	../../bin/fz -unsafeIntrinsics=on -modules=java.base webserver
+	../../bin/fz -modules=java.base webserver

--- a/examples/webserver/webserver2.fz
+++ b/examples/webserver/webserver2.fz
@@ -26,7 +26,7 @@
 #
 # To start this webserver in the interpreter, use:
 #
-#   fz -unsafeIntrinsics=on webserver2.fz
+#   fz webserver2.fz
 #
 # Alternatively, compile it using the C backend and run the resulting
 # executable:

--- a/tests/fileio/Makefile
+++ b/tests/fileio/Makefile
@@ -24,6 +24,5 @@
 # -----------------------------------------------------------------------
 
 override NAME = fileiotests
-FUZION_OPTIONS = -unsafeIntrinsics=on
 FUZION_JAVA_STACK_SIZE = 10m
 include ../simple.mk

--- a/tests/fz_cmd/Makefile
+++ b/tests/fz_cmd/Makefile
@@ -22,5 +22,5 @@
 # -----------------------------------------------------------------------
 
 override NAME = fz_cmd
-FUZION_OPTIONS = -unsafeIntrinsics=on -modules=java.base,fz_cmd
+FUZION_OPTIONS = -modules=java.base,fz_cmd
 include ../simple.mk

--- a/tests/javaBase/Makefile
+++ b/tests/javaBase/Makefile
@@ -24,5 +24,5 @@
 # -----------------------------------------------------------------------
 
 override NAME = javaHello
-FUZION_OPTIONS = -unsafeIntrinsics=on -modules=java.base
+FUZION_OPTIONS = -modules=java.base
 include ../simple.mk

--- a/tests/sockets/Makefile
+++ b/tests/sockets/Makefile
@@ -30,7 +30,6 @@
 #  FUZION -- the fz command
 #  FUZION_OPTIONS -- options to be passed to $(FUZION)
 override NAME = sockets_test_client
-FUZION_OPTIONS = -unsafeIntrinsics=on
 FUZION = ../../bin/fz
 FUZION_RUN = $(FUZION) $(FUZION_OPTIONS)
 FILE = $(NAME).fz


### PR DESCRIPTION
default was changed to _on_ some time ago

<!--
Please describe your changes here, explain what effect this PR will have and how
this is achieved.  Refer to the # of the issue this PR addresses.  Make
sure the tests run successfully using `make run_tests`.
-->

- [x] I have read and accept the [Tokiwa Software Fuzion Contributor Agreement](https://github.com/tokiwa-software/fuzion/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).
