### PR TITLE
fe: remove some unecessary/duplicate code

### DIFF
--- a/src/dev/flang/ast/UnresolvedType.java
+++ b/src/dev/flang/ast/UnresolvedType.java
@@ -535,16 +535,6 @@ public abstract class UnresolvedType extends AbstractType implements HasSourcePo
 
     res.resolveDeclarations(outerfeat);
 
-    if (CHECKS) check
-      (outerfeat.state().atLeast(State.RESOLVING_DECLARATIONS));
-
-    if (_resolved == null)
-      {
-        if (!outerfeat.state().atLeast(State.RESOLVING_DECLARATIONS))
-          {
-            res.resolveDeclarations(outerfeat);
-          }
-      }
     if (_resolved == null)
       {
         _resolved = resolveThisType(res, outerfeat);


### PR DESCRIPTION
`res.resolveDeclarations(outerfeat);` was called twice.

<!--
Please describe your changes here, explain what effect this PR will have and how
this is achieved.  Refer to the # of the issue this PR addresses.  Make
sure the tests run successfully using `make run_tests`.
-->

- [x] I have read and accept the [Tokiwa Software Fuzion Contributor Agreement](https://github.com/tokiwa-software/fuzion/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).
