### PR TITLE
parser: Allow `then` to be placed at min indentation

### DIFF
--- a/src/dev/flang/parser/Parser.java
+++ b/src/dev/flang/parser/Parser.java
@@ -3004,7 +3004,7 @@ thenPart    : "then" block
   Block thenPart(boolean emptyBlockIfNoBlockPresent)
   {
     var p = tokenPos();
-    skip(Token.t_then);
+    skip(true, Token.t_then);
     var result = block();
     return emptyBlockIfNoBlockPresent && p == tokenPos() ? null : result;
   }


### PR DESCRIPTION
This permits code like
```
  if a=b
  then
    say "equal"
  else
    say "not equal"
```
which is also permitted for `do`, `while`, `until` and seems more uniform.
