### PR TITLE
parser: Require `is` or `=>` even if feature uses `{`..`}`

### DIFF
--- a/src/dev/flang/parser/Parser.java
+++ b/src/dev/flang/parser/Parser.java
@@ -3588,8 +3588,7 @@ invariant   : "inv" exprs
   /**
    * Parse implRout
    *
-implRout    : block
-            | "is" "abstract"
+implRout    : "is" "abstract"
             | "is" "intrinsic"
             | "is" "intrinsic_constructor"
             | "is" "native"
@@ -3603,24 +3602,21 @@ implRout    : block
   {
     SourcePosition pos = tokenSourcePos();
     Impl result;
-
-    if (hasType && currentAtMinIndent() == Token.t_is)
+    var has_is    = skip(true, Token.t_is);
+    var has_arrow = !has_is && skip(true, "=>");
+    if (hasType && has_is)
       {
         AstErrors.constructorWithReturnType(pos);
       }
-
-    var routine =
-      currentAtMinIndent() == Token.t_lbrace ||
-      skip(true, Token.t_is)                 ||
-      hasType && skip(true, "=>");
-    if      (routine               ) { result = skip(Token.t_abstract             ) ? Impl.ABSTRACT              :
+    if      (has_is || has_arrow   ) { result = skip(Token.t_abstract             ) ? Impl.ABSTRACT              :
                                                 skip(Token.t_intrinsic            ) ? Impl.INTRINSIC             :
                                                 skip(Token.t_intrinsic_constructor) ? Impl.INTRINSIC_CONSTRUCTOR :
                                                 skip(Token.t_native               ) ? Impl.NATIVE                :
-                                                new Impl(pos, block()       , Impl.Kind.Routine   ); }
-    else if (skip(true, "=>"      )) { result = new Impl(pos, block()       , Impl.Kind.RoutineDef); }
-    else if (skip(true, Token.t_of)) { result = new Impl(pos, block()       , Impl.Kind.Of        ); }
-    else if (skipFullStop()        ) { result = new Impl(pos, new Block()   , Impl.Kind.Routine   ); }
+                                                new Impl(pos, block()    , has_is  ? Impl.Kind.Routine :
+                                                                           hasType ? Impl.Kind.Routine
+                                                                                   : Impl.Kind.RoutineDef); }
+    else if (skip(true, Token.t_of)) { result = new Impl(pos, block()    , Impl.Kind.Of        ); }
+    else if (skipFullStop()        ) { result = new Impl(pos, new Block(), Impl.Kind.Routine   ); }
     else
       {
         syntaxError(tokenPos(), "'is', '{' or '=>' in routine declaration", "implRout");

--- a/tests/assignment_negative/illegal_assignment.fz
+++ b/tests/assignment_negative/illegal_assignment.fz
@@ -26,11 +26,11 @@
 illegal_assignment is
 
   Q ref is
-    A ref { x { say "*** should never be here ***" } }
-    B ref { x { say "*** should never be here ***" } }
-    C ref { x { say "*** should never be here ***" }; xc {} }
-    D ref { x { say "*** should never be here ***" }; xb {}; xc {} }
-    E ref { x { say "*** should never be here ***" }; xb {}; xc {} }
+    A ref is { x is { say "*** should never be here ***" } }
+    B ref is { x is { say "*** should never be here ***" } }
+    C ref is { x is { say "*** should never be here ***" }; xc {} }
+    D ref is { x is { say "*** should never be here ***" }; xb {}; xc {} }
+    E ref is { x is { say "*** should never be here ***" }; xb {}; xc {} }
 
   curid i32 := 0
   id i32 is

--- a/tests/functions/functions.fz
+++ b/tests/functions/functions.fz
@@ -33,7 +33,7 @@ functions is
       else
         r
 
-    y(f ()->i32){}
+    y(f ()->i32) is {}
     x0(f0 Function i32 Any i32) is
       say "here 1x0---------------"
       r1 i32 := f0.call "hallo" 3


### PR DESCRIPTION
This time including required changes to tests. 
    
I prefer not to have any special handling for the braces-variant of a feature, so making is or => compulsory even for a feature body using {..}.
    
 Will have to update fuzion-lang.dev tutorial examples in the version that uses braces.
