### PR TITLE
Parser simplify block

### DIFF
--- a/src/dev/flang/ast/Block.java
+++ b/src/dev/flang/ast/Block.java
@@ -194,7 +194,9 @@ public class Block extends AbstractBlock
    */
   public SourcePosition pos()
   {
-    return _expressions.isEmpty()
+    return _range != null
+      ? _range
+      : _expressions.isEmpty()
       || _expressions.getFirst().pos().isBuiltIn()
       || _expressions.getLast().pos().isBuiltIn()
       ? SourcePosition.notAvailable

--- a/src/dev/flang/ast/Block.java
+++ b/src/dev/flang/ast/Block.java
@@ -45,8 +45,6 @@ public class Block extends AbstractBlock
   /*----------------------------  variables  ----------------------------*/
 
 
-  SourcePosition _closingBracePos;
-
   boolean _newScope;
 
 
@@ -73,30 +71,11 @@ public class Block extends AbstractBlock
    * in this block should remain visible after the block (which is usually the
    * case for artificially generated blocks)
    */
-  private Block(SourcePosition closingBracePos,
-                List<Expr> s,
-                boolean newScope)
-  {
-    super(s);
-    this._closingBracePos = closingBracePos;
-    this._newScope = newScope;
-  }
-
-
-  /**
-   * Generate a block of expressions that define a new scope. This is generally
-   * called from the Parser when the source contains a block.
-   *
-   * @param closingBracePos the sourcecode position of this block's closing
-   * brace. In case this block does not originate in source code, but was added
-   * by AST manipulations, this might as well be equal to pos.
-   *
-   * @param s the list of expressions
-   */
-  public Block(SourcePosition closingBracePos,
+  public Block(boolean newScope,
                List<Expr> s)
   {
-    this(closingBracePos, s, true);
+    super(s);
+    this._newScope = newScope;
   }
 
 
@@ -106,7 +85,7 @@ public class Block extends AbstractBlock
    */
   public Block()
   {
-    this(SourcePosition.notAvailable, new List<>());
+    this(true, new List<>());
   }
 
 
@@ -118,7 +97,7 @@ public class Block extends AbstractBlock
    */
   public Block(List<Expr> s)
   {
-    this(SourcePosition.notAvailable, s, false);
+    this(false, s);
   }
 
 

--- a/src/dev/flang/ast/Block.java
+++ b/src/dev/flang/ast/Block.java
@@ -71,7 +71,7 @@ public class Block extends AbstractBlock
    * in this block should remain visible after the block (which is usually the
    * case for artificially generated blocks)
    */
-  public Block(boolean newScope,
+  private Block(boolean newScope,
                List<Expr> s)
   {
     super(s);

--- a/src/dev/flang/ast/Block.java
+++ b/src/dev/flang/ast/Block.java
@@ -266,13 +266,9 @@ public class Block extends AbstractBlock
    */
   SourcePosition posOfLast()
   {
-    SourcePosition result = _closingBracePos;
     Expr resExpr = resultExpression();
-    if (resExpr != null)
-      {
-        result = resExpr.pos();
-      }
-    return result;
+    return resExpr != null ? resExpr.pos()
+                           : pos();
   }
 
 
@@ -351,7 +347,7 @@ public class Block extends AbstractBlock
       }
     else if (r.resultType().compareTo(Types.resolved.t_unit) != 0)
       {
-        AstErrors.blockMustEndWithExpression(_closingBracePos, r.resultType());
+        AstErrors.blockMustEndWithExpression(pos(), r.resultType());
       }
     return this;
   }

--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -706,7 +706,7 @@ public class Call extends AbstractCall
         isInfixOperator() &&
         _target instanceof Call tc &&
         tc.isInfixOperator() &&
-        tc.isOperatorCall())
+        tc.isOperatorCall(false))
       {
         result = (tc._actuals.get(0) instanceof Call acc && acc.isChainedBoolRHS())
           ? acc
@@ -1070,8 +1070,11 @@ public class Call extends AbstractCall
   /**
    * Is this an operator call like `a+b` or `-x` in contrast to a named call `f`
    * or `t.g`?
+   *
+   * @param parenthesesAllowed true if an operator call in parentheses is still
+   * ok.  (+x)`.
    */
-  boolean isOperatorCall()
+  boolean isOperatorCall(boolean parenthesesAllowed)
   {
     return false;
   }
@@ -1088,7 +1091,7 @@ public class Call extends AbstractCall
   String newNameForPartial(AbstractType expectedType)
   {
     String result = null;
-    if (expectedType.arity() == 1 && isOperatorCall())
+    if (expectedType.arity() == 1 && isOperatorCall(true))
       {
         var name = _name;
         if (name.startsWith(FuzionConstants.PREFIX_OPERATOR_PREFIX))

--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -705,7 +705,8 @@ public class Call extends AbstractCall
         targetFeature(res, thiz) == Types.resolved.f_bool &&
         isInfixOperator() &&
         _target instanceof Call tc &&
-        tc.isInfixOperator())
+        tc.isInfixOperator() &&
+        tc.isOperatorCall())
       {
         result = (tc._actuals.get(0) instanceof Call acc && acc.isChainedBoolRHS())
           ? acc

--- a/src/dev/flang/ast/Cond.java
+++ b/src/dev/flang/ast/Cond.java
@@ -73,9 +73,9 @@ public class Cond
    *
    * @return a new list with each `Expr` form `l` wrapped into a `Cond`.
    */
-  public static List<Cond> from(List<Expr> l)
+  public static List<Cond> from(Block b)
   {
-    return l.map2(e->new Cond(e));
+    return b._expressions.map2(e->new Cond(e));
   }
 
 

--- a/src/dev/flang/ast/Expr.java
+++ b/src/dev/flang/ast/Expr.java
@@ -103,7 +103,7 @@ public abstract class Expr extends HasGlobalIndex implements HasSourcePosition
   /**
    * Source code position range of this Expression. null if not known.
    */
-  private SourceRange _range;
+  protected SourceRange _range;
 
   /*--------------------------  constructors  ---------------------------*/
 

--- a/src/dev/flang/ast/Expr.java
+++ b/src/dev/flang/ast/Expr.java
@@ -556,8 +556,8 @@ public abstract class Expr extends HasGlobalIndex implements HasSourcePosition
                                 outer);
         r.scheduleForResolution(res);
         res.resolveTypes();
-        result = new Block(pos, new List<>(assignToField(res, outer, r),
-                                                    new Call(pos, new Current(pos, outer), r).resolveTypes(res, outer)));
+        result = new Block(new List<>(assignToField(res, outer, r),
+                                      new Call(pos, new Current(pos, outer), r).resolveTypes(res, outer)));
       }
     return result;
   }

--- a/src/dev/flang/ast/Impl.java
+++ b/src/dev/flang/ast/Impl.java
@@ -431,14 +431,13 @@ public class Impl extends ANY
     if (needsImplicitAssignmentToResult(outer))
       {
         var resultField = outer.resultField();
-        var endPos = (this._expr instanceof Block) ? ((Block) this._expr)._closingBracePos : this._expr.pos();
         Assign ass = new Assign(res,
-                                endPos,
+                                this._expr.pos(),
                                 resultField,
                                 this._expr,
                                 outer);
         ass._value = this._expr.box(ass._assignedField.resultType());  // NYI: move to constructor of Assign?
-        this._expr = new Block (new List<Expr>(ass));
+        this._expr = ass;
       }
   }
 

--- a/src/dev/flang/ast/ParsedOperatorCall.java
+++ b/src/dev/flang/ast/ParsedOperatorCall.java
@@ -53,10 +53,11 @@ public class ParsedOperatorCall extends ParsedCall
 
 
   /**
-   * Is this really an operator call? This in invalidated if placed inside
-   * parentheses `(-a)` or `(a+b)`.
+   * Has this been put into parentheses? If so, it may no longer be used as
+   * chained boolean `(a < b) < c`, but it may still used as partial call `l.map
+   * (+x)`.
    */
-  private boolean _isOperatorCall = true;
+  private boolean _inParentheses = false;
 
 
   /*--------------------------  constructors  ---------------------------*/
@@ -98,10 +99,13 @@ public class ParsedOperatorCall extends ParsedCall
   /**
    * Is this an operator call like `a+b` or `-x` in contrast to a named call `f`
    * or `t.g`?
+   *
+   * @param parenthesesAllowed true if an operator call in parentheses is still
+   * ok.  (+x)`.
    */
-  boolean isOperatorCall()
+  boolean isOperatorCall(boolean parenthesesAllowed)
   {
-    return _isOperatorCall;
+    return parenthesesAllowed || !_inParentheses;
   }
 
 
@@ -112,7 +116,7 @@ public class ParsedOperatorCall extends ParsedCall
    */
   public void putInParentheses()
   {
-    _isOperatorCall = false;
+    _inParentheses = true;
   }
 
 }

--- a/src/dev/flang/ast/ParsedOperatorCall.java
+++ b/src/dev/flang/ast/ParsedOperatorCall.java
@@ -49,6 +49,19 @@ import dev.flang.util.List;
 public class ParsedOperatorCall extends ParsedCall
 {
 
+  /*-----------------------------  fields  ------------------------------*/
+
+
+  /**
+   * Is this really an operator call? This in invalidated if placed inside
+   * parentheses `(-a)` or `(a+b)`.
+   */
+  private boolean _isOperatorCall = true;
+
+
+  /*--------------------------  constructors  ---------------------------*/
+
+
   /**
    * Constructor for a prefix or postfix operator on target.
    *
@@ -88,7 +101,18 @@ public class ParsedOperatorCall extends ParsedCall
    */
   boolean isOperatorCall()
   {
-    return true;
+    return _isOperatorCall;
+  }
+
+
+  /**
+   * Is this Expr put into parentheses `(`/`)`. If so, we no longer want to do
+   * certain transformations like chained booleans `a < b < c` to `a < b && b <
+   * c`.
+   */
+  public void putInParentheses()
+  {
+    _isOperatorCall = false;
   }
 
 }

--- a/src/dev/flang/parser/Lexer.java
+++ b/src/dev/flang/parser/Lexer.java
@@ -1152,24 +1152,24 @@ public class Lexer extends SourceFile
    *
    * The non-empty case
    *
-   *    x is block
-   *        ^^    ^
-   *        ||    +------ lastPos
+   *    x is something
+   *        ^^        ^
+   *        ||        +-- endPos
    *        |+----------- pos
    *        |
    *        +------------ prevPos
    *    y is block
    *
-   * results in pos..lastPos:
+   * results in pos..endPos:
    *
-   *    x is block
-   *    -----^^^^^
+   *    x is something
+   *    -----^^^^^^^^^
    *
-   * while empty case
+   * while the empty case
    *
    *    x is
    *        ^
-   *        +------------ lastPos
+   *        +------------ endPos
    *        +------------ prevPos
    *    y is block
    *    ^

--- a/src/dev/flang/parser/Lexer.java
+++ b/src/dev/flang/parser/Lexer.java
@@ -1136,9 +1136,10 @@ public class Lexer extends SourceFile
   {
     if (PRECONDITIONS) require
       (0 <= pos,
-       pos < lastTokenEndPos());
+       Errors.any() || pos < lastTokenEndPos());
 
-    return sourceRange(pos, lastTokenEndPos());
+    var endPos = Math.max(pos+1, lastTokenEndPos());
+    return sourceRange(pos, endPos);
   }
 
 

--- a/src/dev/flang/parser/Lexer.java
+++ b/src/dev/flang/parser/Lexer.java
@@ -878,7 +878,17 @@ public class Lexer extends SourceFile
 
 
   /**
-   * short-hand for bracketTermWithNLs with atMinIndent==false and c==def.
+   * short-hand for bracketTermWithNLs with c==def.
+   */
+  <V> V optionalBrackets(Parens brackets, String rule, Callable<V> c)
+  {
+    return currentMatches(true, brackets._left)
+      ? bracketTermWithNLs(brackets, rule, c, c)
+      : c.call();
+  }
+
+  /**
+   * short-hand for bracketTermWithNLs with c==def.
    */
   <V> V bracketTermWithNLs(Parens brackets, String rule, Callable<V> c)
   {

--- a/src/dev/flang/parser/Lexer.java
+++ b/src/dev/flang/parser/Lexer.java
@@ -1127,6 +1127,81 @@ public class Lexer extends SourceFile
 
 
   /**
+   * Obtain the given range pos..lastTokenEndPos() as a SourceRange object.
+   *
+   * @param pos a byte position within this file, must be smaller than
+   * lastTokenEndPos().
+   */
+  public SourceRange sourceRange(int pos)
+  {
+    if (PRECONDITIONS) require
+      (0 <= pos,
+       pos < lastTokenEndPos());
+
+    return sourceRange(pos, lastTokenEndPos());
+  }
+
+
+  /**
+   * Obtain the given range pos..endPos as a SourceRange object.  In case this
+   * range is empty, get the range prevPos..prevPos+1
+   *
+   * This is useful in case the range could be empty as for a code block as
+   * follows:
+   *
+   * The non-empty case
+   *
+   *    x is block
+   *        ^^    ^
+   *        ||    +------ lastPos
+   *        |+----------- pos
+   *        |
+   *        +------------ prevPos
+   *    y is block
+   *
+   * results in pos..lastPos:
+   *
+   *    x is block
+   *    -----^^^^^
+   *
+   * while empty case
+   *
+   *    x is
+   *        ^
+   *        +------------ lastPos
+   *        +------------ prevPos
+   *    y is block
+   *    ^
+   *    |
+   *    +---------------- pos
+   *
+   * results in
+   *
+   *    x is
+   *    ----^
+   *    y is block
+   *
+   * @param prevPos the last position of the previous token
+   *
+   * @param pos a byte position within this file.
+   *
+   * @param endPos a byte position, usually after pos within this file.
+   */
+  public SourceRange sourceRange(int prevPos, int pos, int endPos)
+  {
+    if (PRECONDITIONS) require
+      (0 <= prevPos,
+       0 <= pos,
+       prevPos <= byteLength(),
+       pos     <= byteLength(),
+       endPos  <= byteLength());
+
+    return pos < endPos ? sourceRange(pos, endPos)
+                        : sourceRange(prevPos, prevPos+1);
+  }
+
+
+  /**
    * The line number of the current token.
    */
   int line()

--- a/src/dev/flang/parser/Parser.java
+++ b/src/dev/flang/parser/Parser.java
@@ -2464,7 +2464,6 @@ caseBlock   : ARROW          // if followed by '|'
    */
   Block caseBlock()
   {
-    Block result;
     matchOperator("=>", "caseBlock");
     var oldLine = sameLine(-1);
     var bar = current() == Token.t_barLimit;

--- a/src/dev/flang/parser/Parser.java
+++ b/src/dev/flang/parser/Parser.java
@@ -201,17 +201,17 @@ public class Parser extends Lexer
   /**
    * Parse a unit, i.e., exprs followed by Token.t_eof.
    *
-unit        : exprs EOF
+unit        : block EOF
             ;
    */
   public List<Expr> unit()
   {
-    var result = exprs();
+    var result = block();
     if (!Errors.any())
       {
         match(Token.t_eof, "Unit");
       }
-    return result;
+    return result._expressions;
   }
 
 
@@ -2557,9 +2557,14 @@ brblock     : BRACEL exprs BRACER
    */
   Block block()
   {
-    var start = lastTokenEndPos();
+    var s0 = lastTokenEndPos();
+    var s = tokenPos();
     var b = optionalBrackets(BRACES, "block", () -> new Block(exprs()));
-    b.setSourceRange(sourceRange(start, Math.max(start+1,lastTokenEndPos())));
+    var e = lastTokenEndPos();
+    var r = s0 == e
+      ? sourceRange(s0-1, s0)
+      : sourceRange(s, e);
+    b.setSourceRange(r);
     return b;
   }
 
@@ -3481,7 +3486,7 @@ contract    : require
   /**
    * Parse require
    *
-require     : "pre" exprs
+require     : "pre" block
             |
             ;
    */
@@ -3490,7 +3495,7 @@ require     : "pre" exprs
     List<Cond> result = null;
     if (skip(atMinIndent, Token.t_pre))
       {
-        result = Cond.from(exprs());
+        result = Cond.from(block());
       }
     return result;
   }
@@ -3499,7 +3504,7 @@ require     : "pre" exprs
   /**
    * Parse ensure
    *
-ensure      : "post" exprs
+ensure      : "post" block
             |
             ;
    */
@@ -3508,7 +3513,7 @@ ensure      : "post" exprs
     List<Cond> result = null;
     if (skip(atMinIndent, Token.t_post))
       {
-        result = Cond.from(exprs());
+        result = Cond.from(block());
       }
     return result;
   }
@@ -3517,7 +3522,7 @@ ensure      : "post" exprs
   /**
    * Parse invariant
    *
-invariant   : "inv" exprs
+invariant   : "inv" block
             |
             ;
    */
@@ -3526,7 +3531,7 @@ invariant   : "inv" exprs
     List<Cond> result = null;
     if (skip(atMinIndent, Token.t_inv))
       {
-        result = Cond.from(exprs());
+        result = Cond.from(block());
       }
     return result;
   }

--- a/src/dev/flang/parser/Parser.java
+++ b/src/dev/flang/parser/Parser.java
@@ -1995,26 +1995,20 @@ klammerLambd: LPAREN argNamesOpt RPAREN lambda
                        () -> Void.TYPE);
 
 
-    // a lambda expression
-    if (isLambdaPrefix())
+    if (isLambdaPrefix())                  // a lambda expression
       {
         return lambda(f.bracketTermWithNLs(PARENS, "argNamesOpt", () -> f.argNamesOpt()));
       }
-    // an expr wrapped in parentheses, not a tuple
-    else if (tupleElements.size() == 1)
+    else if (tupleElements.size() == 1)    // an expr wrapped in parentheses, not a tuple
       {
-        var actual = tupleElements.get(0).expr(null);
-
-        // special handling for cases like:
-        // s9a i16 := -(32768)
-        // s9c i16 := -(-(-32768))
-        // s9a := i16 -(32768)
-        return (actual instanceof NumLiteral)
-          ? actual
-          : new Block(true, new List<>(actual));  // NYI: why?
+        var e = tupleElements.get(0).expr(null);
+        if (e instanceof ParsedOperatorCall oc)
+          { // disable chained boolean optimization or partial application:
+            oc.putInParentheses();
+          }
+        return e;
       }
-    // a tuple
-    else
+    else                                   // a tuple
       {
         return new Call(pos, null, "tuple", tupleElements);
       }

--- a/src/dev/flang/parser/Parser.java
+++ b/src/dev/flang/parser/Parser.java
@@ -2011,7 +2011,7 @@ klammerLambd: LPAREN argNamesOpt RPAREN lambda
         // s9a := i16 -(32768)
         return (actual instanceof NumLiteral)
           ? actual
-          : new Block(tokenSourcePos(), new List<>(actual));  // NYI: why?
+          : new Block(true, new List<>(actual));  // NYI: why?
       }
     // a tuple
     else
@@ -2561,7 +2561,10 @@ brblock     : BRACEL exprs BRACER
     if (PRECONDITIONS) require
       (lastTokenEndPos() >= 0);
 
-    return new Block(sourcePos(lastTokenEndPos()), new List<>());
+    var b = new Block();
+    var p0 = lastTokenEndPos();
+    b.setSourceRange(sourceRange(p0, p0+1));
+    return b;
   }
 
   /**

--- a/src/dev/flang/util/SourcePosition.java
+++ b/src/dev/flang/util/SourcePosition.java
@@ -200,7 +200,7 @@ public class SourcePosition extends ANY implements Comparable<SourcePosition>, H
                 sb.append('-');
               }
           }
-        if (p < _sourceFile.lineEndPos(l) || p == byteEndPos()) // suppress '^' at LFs except for LF at end position
+        if (p < _sourceFile.lineEndPos(l) || p == byteEndPos()-1) // suppress '^' at LFs except for LF at end position
           {
             sb.append('^');
             if (p+1 < byteEndPos() && p+1 == _sourceFile.lineEndPos(l))

--- a/tests/reg_issue1739_this_type_in_type_feature_choice/issue1739.fz
+++ b/tests/reg_issue1739_this_type_in_type_feature_choice/issue1739.fz
@@ -24,7 +24,7 @@
 issue1739 is
 
   a : choice nil unit is
-    public fixed type.empty a.this is
+    public fixed type.empty a.this =>
       nil  // should flag an error: Incompatible types in assignment
 
   match a.empty

--- a/tests/reg_issue1945_ambiguity_for_lambda_result_neg/issue1945neg.fz.expected_err
+++ b/tests/reg_issue1945_ambiguity_for_lambda_result_neg/issue1945neg.fz.expected_err
@@ -2,7 +2,7 @@
 --CURDIR--/issue1945neg.fz:52:9: error 1: Syntax error: expected semicolon ';', found keyword 'is'
     i32 is () -> 4718   # illegal, no LF allowed after -> in function result
 --------^
-While parsing: semicolon or flat line break, parse stack: semiOrFlatLF, exprs, block, implRout, implFldOrRout, routOrField, feature, expr, exprs, unit
+While parsing: semicolon or flat line break, parse stack: semiOrFlatLF, exprs, block, implRout, implFldOrRout, routOrField, feature, expr, exprs, block, unit
 
 
 --CURDIR--/issue1945neg.fz:39:3: error 2: Could not find called feature

--- a/tests/reg_issue2492/reg_issue2492.fz.expected_err
+++ b/tests/reg_issue2492/reg_issue2492.fz.expected_err
@@ -1,7 +1,10 @@
 
---CURDIR--/reg_issue2492.fz:24:7: error 1: Failed to infer type of expression.
+--CURDIR--/reg_issue2492.fz:24:7: error 1: No type information can be inferred from a lambda expression
 _ := (x->3).call
 ------^^^^
-Expression with unknown type: 'x->3'
+A lambda expression can only be used if assigned to a field or argument of type 'Function'
+with argument count of the lambda expression equal to the number of type parameters of the type.  The type of the
+assigned field must be given explicitly.
+To solve this, declare an explicit type for the target field, e.g., 'f (i32, i32) -> bool := x, y -> x > y'.
 
 one error.


### PR DESCRIPTION
A number of changes to simplify handing of parsing a `block` and creation of instances of `dev.flang.ast.Block`:

Removed unused field `Block. _closingBracePos` and changed or removed constructors that set this field.

Improved code that associated a `SourceRange` to a `Block`.

Replaced the special handling of `Numeric` in parentheses by a special handling of operator expressions, which is really what was needed here.

Pre- and Postconditions are now parsed as `block`, no longer as `exprs`.

Added new helper `Lexer.optionalBrackets` that is used for parsing `block` and `match` that both have optional `{`/`}`.

Added helpers `Lexer.sourceRange(pos)` to get the source range of the code parsed from `pos` up to the current location and `Lexer.sourceRange(prevPos, pos, endPos)` that results in `pos..endPos` unless that range is empty, when it results in `prevPov..prevPos+1`. The latter is convenient for optional blocks. 

A compilation unit is now a `block`.

Added helper `Parser.emptyBlock()` to create an empty block at the current location. 

Updated some tests and test expected error outputs.