### PR TITLE
tests/fz_cmd: update expected error

### DIFF
--- a/tests/fz_cmd/fz_cmd.fz.expected_err
+++ b/tests/fz_cmd/fz_cmd.fz.expected_err
@@ -2,7 +2,7 @@
 error 1: missing main feature name in command line args
 Usage: ../../bin/fz [-h|--help|-version]  --or--
        ../../bin/fz [-c|-classes|-dfa|-effects|-interpreter|-jar|-java|-jvm|-llvm|-no-backend|-saveLib=<file>] [-h|--help|-version] [<backend specific options>]  --or--
-       ../../bin/fz -pretty [-noANSI] [-verbose[=<n>]]  ({<file>} | - | -e <code> | -execute <code>  --or--
+       ../../bin/fz -pretty [-noANSI] [-verbose[=<n>]]  ({<file>} | - | -e <code> | -execute <code>)  --or--
        ../../bin/fz -latex [-noANSI] [-verbose[=<n>]]   --or--
        ../../bin/fz -acemode [-noANSI] [-verbose[=<n>]]   --or--
 


### PR DESCRIPTION
The new `)` got added in #2671 but it was forgotten to update the test outputs.