### PR TITLE
jvm/C: disable tail recursion optimization within precondition

### DIFF
--- a/src/dev/flang/be/c/C.java
+++ b/src/dev/flang/be/c/C.java
@@ -1558,7 +1558,8 @@ public class C extends ANY
                   System.out.println("Escapes, no tail call opt possible: " + _fuir.clazzAsStringNew(cl) + ", lifetime: " + _fuir.lifeTime(cl, pre).name());
                 }
 
-              if (!preCalled                                             &&  // not calling pre-condition
+              if (!pre                                                   &&  // not within precondition
+                  !preCalled                                             &&  // not calling pre-condition
                   cc == cl                                               &&  // calling myself
                   _tailCall.callIsTailCall(cl, c, i)                     &&  // as a tail call
                   _fuir.lifeTime(cl, pre).ordinal() <=

--- a/src/dev/flang/be/c/C.java
+++ b/src/dev/flang/be/c/C.java
@@ -1548,6 +1548,7 @@ public class C extends ANY
             {
 
               if (FUZION_DEBUG_TAIL_CALL                                 &&
+                  !pre                                                   &&  // not within precondition
                   !preCalled                                             &&  // not calling pre-condition
                   cc == cl                                               &&  // calling myself
                   _tailCall.callIsTailCall(cl, c, i)                     &&  // as a tail call

--- a/src/dev/flang/be/jvm/CodeGen.java
+++ b/src/dev/flang/be/jvm/CodeGen.java
@@ -719,7 +719,8 @@ class CodeGen
         {
           if (_types.clazzNeedsCode(cc))
             {
-              if (!preCalled                                                             // not calling pre-condition
+              if (!pre                                                                   // not within precondition
+                  && !preCalled                                                          // not calling pre-condition
                   && cc == cl                                                            // calling myself
                   && c != -1 && i != -1 && _jvm._tailCall.callIsTailCall(cl, c, i)       // as a tail call
                   && _fuir.lifeTime(cl, pre).ordinal() <= FUIR.LifeTime.Call.ordinal())


### PR DESCRIPTION
Before this, it could happen that a call to a feature `f` that is performed within a precondition of `f` would be treated as a tail call, which is clearly wrong.
