### PR TITLE
dfa: simplify `DFA.lifeTime()` using `super.lifeTime()`

### DIFF
--- a/src/dev/flang/fuir/FUIR.java
+++ b/src/dev/flang/fuir/FUIR.java
@@ -1155,7 +1155,7 @@ hw25 is
                case Intrinsic -> LifeTime.Undefined;
                case Field     -> LifeTime.Call;
                case Routine   -> LifeTime.Unknown;
-               case Native    -> LifeTime.Unknown;
+               case Native    -> LifeTime.Undefined;
                });
 
       return result;

--- a/src/dev/flang/fuir/analysis/dfa/DFA.java
+++ b/src/dev/flang/fuir/analysis/dfa/DFA.java
@@ -977,29 +977,11 @@ public class DFA extends ANY
          */
         public LifeTime lifeTime(int cl, boolean pre)
         {
-          var result =
-            pre ? (switch (clazzKind(cl))
-                     {
-                     case Choice    -> LifeTime.Undefined;
-                     case Abstract  ,
-                          Intrinsic ,
-                          Field     ,
-                          Routine   ,
-                          Native    -> currentEscapes(cl, pre) ? LifeTime.Unknown :
-                                                                 LifeTime.Call;
-                     })
-                : (switch (clazzKind(cl))
-                     {
-                     case Abstract  -> LifeTime.Undefined;
-                     case Choice    -> LifeTime.Undefined;
-                     case Intrinsic -> LifeTime.Undefined;
-                     case Field     -> LifeTime.Call;
-                     case Routine   -> currentEscapes(cl, pre) ? LifeTime.Unknown :
-                                                                 LifeTime.Call;
-                     case Native    -> LifeTime.Undefined;
-                     });
-
-          return result;
+          return
+            pre || (clazzKind != FeatureKind.Routine)
+                ? super.lifeTime(cl, pre)
+                : currentEscapes(cl, pre) ? LifeTime.Unknown :
+                                            LifeTime.Call;
         }
 
 

--- a/src/dev/flang/fuir/analysis/dfa/DFA.java
+++ b/src/dev/flang/fuir/analysis/dfa/DFA.java
@@ -978,7 +978,7 @@ public class DFA extends ANY
         public LifeTime lifeTime(int cl, boolean pre)
         {
           return
-            pre || (clazzKind != FeatureKind.Routine)
+            pre || (clazzKind(cl) != FeatureKind.Routine)
                 ? super.lifeTime(cl, pre)
                 : currentEscapes(cl, pre) ? LifeTime.Unknown :
                                             LifeTime.Call;


### PR DESCRIPTION
Futile to attempt escape analysis on abstract, intrinsic, field and native, so don't do that.  Also set the default lifetime for native feature to Undefined since there is no instance. 
