### PR TITLE
dfa: add wasChanged, consider changes to escaped values for fix point

### DIFF
--- a/src/dev/flang/fuir/analysis/dfa/Call.java
+++ b/src/dev/flang/fuir/analysis/dfa/Call.java
@@ -191,11 +191,7 @@ public class Call extends ANY implements Comparable<Call>, Context
     if (!_returns)
       {
         _returns = true;
-        if (!_dfa._changed)
-          {
-            _dfa._changedSetBy = "Call.returns for " + this;
-          }
-        _dfa._changed = true;
+        _dfa.wasChanged(() -> "Call.returns for " + this);
       }
   }
 

--- a/src/dev/flang/fuir/analysis/dfa/DFA.java
+++ b/src/dev/flang/fuir/analysis/dfa/DFA.java
@@ -28,10 +28,13 @@ package dev.flang.fuir.analysis.dfa;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+
 import java.util.Arrays;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
+
+import java.util.function.Supplier;
 
 import dev.flang.fuir.FUIR;
 import dev.flang.fuir.FUIR.SpecialClazzes;
@@ -896,8 +899,13 @@ public class DFA extends ANY
    * Flag to detect changes during current iteration of the fix-point algorithm.
    * If this remains false during one iteration we have reached a fix-point.
    */
-  boolean _changed = false;
-  String _changedSetBy;
+  private boolean _changed = false;
+
+
+  /**
+   * For debugging: lazy creation of a message why _changed was set to true.
+   */
+  private Supplier<String> _changedSetBy;
 
 
   /**
@@ -1097,10 +1105,11 @@ public class DFA extends ANY
           {
             _options.verbosePrintln(2,
                                     "DFA iteration #"+cnt+": --------------------------------------------------" +
-                                    (!_options.verbose(3) ? "" : _calls.size()+","+_instances.size()+"; "+_changedSetBy));
+                                    (_options.verbose(3) ? _calls.size() + "," + _instances.size() + "; " + _changedSetBy.get()
+                                                         : ""                                                                  ));
           }
         _changed = false;
-        _changedSetBy = "*** change not set ***";
+        _changedSetBy = () -> "*** change not set ***";
         iteration();
       }
     while (_changed && (true || cnt < 100) || false && (cnt < 50));
@@ -1116,6 +1125,29 @@ public class DFA extends ANY
       }
     _reportResults = true;
     iteration();
+  }
+
+
+  /**
+   * Set flag _changed to record the fact that the current iteration has not
+   * reached a fix point yet.
+   *
+   * @param by in case _changed was not set yet, by is used to procude a message
+   * why we have not reached a fix point yet.
+   */
+  void wasChanged(Supplier<String> by)
+  {
+    if (!_changed)
+      {
+        if (SHOW_STACK_ON_CHANGE)
+          {
+            var msg = by.get();
+            System.out.println(msg);
+            Thread.dumpStack();
+          }
+        _changedSetBy = by;
+        _changed = true;
+      }
   }
 
 
@@ -1243,13 +1275,10 @@ public class DFA extends ANY
    */
   void escapes(int cc, boolean pre)
   {
-    if (pre)
+    var escapeSet = pre ? _escapesPre : _escapes;
+    if (escapeSet.add(cc))
       {
-        _escapesPre.add(cc);
-      }
-    else
-      {
-        _escapes.add(cc);
+        wasChanged(() -> "Esacpes: " + (pre ? "precondition of " : "") + _fuir.clazzAsString(cc));
       }
   }
 
@@ -1279,7 +1308,11 @@ public class DFA extends ANY
         )
       {
         var cp = new CodePos(ev._cl, ev._code, ev._index);
-        _escapesCode.add(cp);
+        if (!_escapesCode.contains(cp))
+          {
+            _escapesCode.add(cp);
+            wasChanged(() -> "code escapes: "+_fuir.codeAtAsString(cl,c,i));
+          }
       }
   }
 
@@ -1797,11 +1830,7 @@ public class DFA extends ANY
             {
               cl._dfa._defaultEffects.put(ecl, new_e);
               cl._dfa._defaultEffectContexts.put(ecl, cl);
-              if (!cl._dfa._changed)
-                {
-                  cl._dfa._changedSetBy = "effect.default called: "+cl._dfa._fuir.clazzAsString(cl._cc);
-                }
-              cl._dfa._changed = true;
+              cl._dfa.wasChanged(() -> "effect.default called: " + cl._dfa._fuir.clazzAsString(cl._cc));
             }
           return Value.UNIT;
         });
@@ -1987,11 +2016,7 @@ public class DFA extends ANY
     if (old_e == null || Value.compare(old_e, new_e) != 0)
       {
         _defaultEffects.put(ecl, new_e);
-        if (!_changed)
-          {
-            _changedSetBy = "effect.replace called: " + _fuir.clazzAsString(ecl);
-          }
-        _changed = true;
+        wasChanged(() -> "effect.replace called: " + _fuir.clazzAsString(ecl));
       }
   }
 
@@ -2073,12 +2098,7 @@ public class DFA extends ANY
       {
         _instances.put(r, r);
         e = r;
-        if (SHOW_STACK_ON_CHANGE && !_changed) Thread.dumpStack();
-        if (!_changed)
-          {
-            _changedSetBy = "DFA.newInstance for "+_fuir.clazzAsString(r._clazz);
-          }
-        _changed = true;
+        wasChanged(() -> "DFA.newInstance for " + _fuir.clazzAsString(r._clazz));
       }
     return e;
   }
@@ -2141,12 +2161,7 @@ public class DFA extends ANY
         _newCalls.add(r);
         _calls.put(r,r);
         e = r;
-        if (SHOW_STACK_ON_CHANGE && !_changed) { System.out.println("new call: "+r); Thread.dumpStack();}
-        if (!_changed)
-          {
-            _changedSetBy = "DFA.newCall to "+e;
-          }
-        _changed = true;
+        wasChanged(() -> "DFA.newCall to " + r);
         analyzeNewCall(r);
       }
     return e;
@@ -2229,12 +2244,7 @@ public class DFA extends ANY
       {
         _envs.put(newEnv, newEnv);
         e = newEnv;
-        if (SHOW_STACK_ON_CHANGE && !_changed) { System.out.println("new env: " + e); Thread.dumpStack();}
-        if (!_changed)
-          {
-            _changedSetBy = "DFA.newEnv for " + e;
-          }
-        _changed = true;
+        wasChanged(() -> "DFA.newEnv for " + newEnv);
       }
     return e;
   }

--- a/src/dev/flang/fuir/analysis/dfa/Env.java
+++ b/src/dev/flang/fuir/analysis/dfa/Env.java
@@ -241,11 +241,7 @@ public class Env extends ANY implements Comparable<Env>
         if (Value.compare(oe, ne) != 0)
           {
             _effectValue = ne;
-            if (!_dfa._changed)
-              {
-                _dfa._changedSetBy = "effect.replace called: "+_dfa._fuir.clazzAsString(ecl);
-              }
-            _dfa._changed = true;
+            _dfa.wasChanged(() -> "effect.replace called: "+_dfa._fuir.clazzAsString(ecl));
           }
       }
     else if (_outer != null)

--- a/src/dev/flang/fuir/analysis/dfa/Instance.java
+++ b/src/dev/flang/fuir/analysis/dfa/Instance.java
@@ -131,10 +131,10 @@ public class Instance extends Value implements Comparable<Instance>
       {
         v = oldv.join(v);
       }
-    if (!_dfa._changed && (oldv == null || Value.COMPARATOR.compare(oldv, v) != 0))
+    if (oldv == null || Value.COMPARATOR.compare(oldv, v) != 0)
       {
-        _dfa._changedSetBy = "setField: new values "+v+" (was "+oldv+") for " + this;
-        _dfa._changed = true;
+        var fv = v;
+        _dfa.wasChanged(() -> "setField: new values " + fv + " (was " + oldv + ") for " + this);
       }
     dfa._writtenFields.add(field);
     _fields.put(field, v);

--- a/src/dev/flang/fuir/analysis/dfa/SysArray.java
+++ b/src/dev/flang/fuir/analysis/dfa/SysArray.java
@@ -153,11 +153,7 @@ public class SysArray extends Value implements Comparable<SysArray>
       }
     if (_elements == null || Value.compare(_elements, ne) != 0)
       {
-        if (!_dfa._changed)
-          {
-            _dfa._changedSetBy = "elements of SysArray changed: " + _elements + " =>" + ne;
-          }
-        _dfa._changed = true;
+        _dfa.wasChanged(() -> "elements of SysArray changed: " + _elements + " =>" + ne);
         _elements = ne;
       }
   }


### PR DESCRIPTION
Add helper function `DFA.wasChanged` to set `_changed` flag that signals to DFA that a fix point has not been reached yet.

Added no changed to the escape analysis results to the DFA termination condition.
