### PR TITLE
be/interpreter: fix ClassCastException

### DIFF
--- a/src/dev/flang/be/interpreter/Interpreter.java
+++ b/src/dev/flang/be/interpreter/Interpreter.java
@@ -1139,11 +1139,11 @@ public class Interpreter extends ANY
                                                    : curValue;
         clazz = ((ValueWithClazz) curValue).clazz();
       }
-      if (staticClazz.isBoxed())
-        {
-          clazz = ((Boxed)curValue)._valueClazz;
-          curValue = ((Boxed)curValue)._contents;
-        }
+    if (staticClazz.isBoxed())
+      {
+        clazz = ((Boxed)curValue)._valueClazz;
+        curValue = ((Boxed)curValue)._contents;
+      }
       off = Layout.get(clazz).offset0(thiz, select);
 
     // NYI: check if this is a can be enabled or removed:

--- a/src/dev/flang/be/interpreter/Intrinsics.java
+++ b/src/dev/flang/be/interpreter/Intrinsics.java
@@ -1042,12 +1042,15 @@ public class Intrinsics extends ANY
     });
 
     putUnsafe("fuzion.sys.net.get_peer_address", (interpreter, innerClazz) -> args -> {
-      var sockfd = (SocketChannel)_openStreams_.get(args.get(1).i64Value());
       try
         {
-          byte[] address = ((InetSocketAddress)sockfd.getRemoteAddress()).getAddress().getAddress();
-          System.arraycopy(address, 0, args.get(2).arrayData()._array, 0, address.length);
-          return new i32Value(address.length);
+          if (_openStreams_.get(args.get(1).i64Value()) instanceof SocketChannel sockfd)
+            {
+              byte[] address = ((InetSocketAddress)sockfd.getRemoteAddress()).getAddress().getAddress();
+              System.arraycopy(address, 0, args.get(2).arrayData()._array, 0, address.length);
+              return new i32Value(address.length);
+            }
+          return new i32Value(-1);
         }
       catch (IOException e)
         {
@@ -1056,10 +1059,13 @@ public class Intrinsics extends ANY
     });
 
     putUnsafe("fuzion.sys.net.get_peer_port", (interpreter, innerClazz) -> args -> {
-      var sockfd = (SocketChannel)_openStreams_.get(args.get(1).i64Value());
       try
         {
-          return new u16Value(((InetSocketAddress)sockfd.getRemoteAddress()).getPort());
+          if (_openStreams_.get(args.get(1).i64Value()) instanceof SocketChannel sockfd)
+            {
+              return new u16Value(((InetSocketAddress)sockfd.getRemoteAddress()).getPort());
+            }
+          return new u16Value(0);
         }
       catch (IOException e)
         {

--- a/tests/sockets/Makefile
+++ b/tests/sockets/Makefile
@@ -48,10 +48,10 @@ compile_server_c:
 	$(FUZION_RUN) -c -o=server sockets_test_server.fz
 
 
-int: IPv4_TCP_PID = $(shell $(FUZION_RUN) sockets_test_server.fz ipv4 tcp > /dev/null & echo $$!)
-int: IPv4_UDP_PID = $(shell $(FUZION_RUN) sockets_test_server.fz ipv4 udp > /dev/null & echo $$!)
-int: IPv6_TCP_PID = $(shell $(FUZION_RUN) sockets_test_server.fz ipv6 tcp > /dev/null & echo $$!)
-int: IPv6_UDP_PID = $(shell $(FUZION_RUN) sockets_test_server.fz ipv6 udp > /dev/null & echo $$!)
+int: IPv4_TCP_PID = $(shell $(FUZION_RUN) -interpreter sockets_test_server.fz ipv4 tcp > /dev/null & echo $$!)
+int: IPv4_UDP_PID = $(shell $(FUZION_RUN) -interpreter sockets_test_server.fz ipv4 udp > /dev/null & echo $$!)
+int: IPv6_TCP_PID = $(shell $(FUZION_RUN) -interpreter sockets_test_server.fz ipv6 tcp > /dev/null & echo $$!)
+int: IPv6_UDP_PID = $(shell $(FUZION_RUN) -interpreter sockets_test_server.fz ipv6 udp > /dev/null & echo $$!)
 int:
 	sleep 10
 	$(ENV) ../check_simple_example_int.sh "$(FUZION_RUN)" $(FILE) || exit 1


### PR DESCRIPTION
Problem was that the test socket did not use interpreter for starting server. Now it does but had to fix two intrinsics.

Also some unrelated cleanups/improvements that I did not want to add yet another PR for.