### PR TITLE
parser: Better source position for an `t.env` expression

### DIFF
--- a/src/dev/flang/parser/Parser.java
+++ b/src/dev/flang/parser/Parser.java
@@ -3302,10 +3302,12 @@ dotEnv      : typeInParens dot "env"
    */
   Env dotEnv()
   {
+    var p0 = tokenPos();
     var t = typeInParens();
     skipDot();
+    var pos = sourceRange(p0, tokenEndPos());
     match(Token.t_env, "env");
-    return new Env(tokenSourcePos(), t);
+    return new Env(pos, t);
   }
 
 


### PR DESCRIPTION
For code like
```
    use_a => _ := a.env
    now_to_something_completely_different
```
the position of `a.env` used to be
```
    now_to_something_completely_different
----^
```
now it is
```
    use_a => _ := a.env
------------------^^^^^
```
