### PR TITLE
fe: lazily load position of `.env` expressions from `.fum` file

### DIFF
--- a/src/dev/flang/fe/LibraryFeature.java
+++ b/src/dev/flang/fe/LibraryFeature.java
@@ -689,7 +689,8 @@ public class LibraryFeature extends AbstractFeature
           case Env:
             {
               var envType = _libModule.envType(iat);
-              x = new Env(LibraryModule.DUMMY_POS, envType);
+              x = new Env(LibraryModule.DUMMY_POS, envType)
+                { public SourcePosition pos() { return LibraryFeature.this.pos(fpos); } };
               break;
             }
           case Unit:


### PR DESCRIPTION
The position used to be unknown resulting in poor error messages related to effects used in modules.
