### PR TITLE
lib: file read, increase bufsize to 4KB

### DIFF
--- a/lib/io/file/read.fz
+++ b/lib/io/file/read.fz
@@ -30,7 +30,7 @@ public read(ro Read_Handler) : simple_effect is
 
   # how much of a file do we read at a time, in bytes
   #
-  private bufsize u64 => 512
+  private bufsize u64 => 4096
 
 
   # reads all bytes from the file in the path


### PR DESCRIPTION
In the future we will probably have an effect providing a buffer array and then this can be removed.
