### PR TITLE
air: relax precondition for for `Clazz.clazzForFieldX` in case of earlier errors

### DIFF
--- a/src/dev/flang/air/Clazz.java
+++ b/src/dev/flang/air/Clazz.java
@@ -1342,7 +1342,7 @@ public class Clazz extends ANY implements Comparable<Clazz>
     if (CHECKS) check
       (Errors.any() || field.isField(),
        Errors.any() || feature().inheritsFrom(field.outer()),
-       field.isOpenGenericField() == (select != -1));
+       Errors.any() || field.isOpenGenericField() == (select != -1));
 
     var result = _clazzForField.get(field);
     if (result == null)


### PR DESCRIPTION
This fails for flang.dev's tutorial/examples/tuple_example3.fz.
