### PR TITLE
dfa: add call site to context of Instance and Call

### DIFF
--- a/bin/run_tests_parallel.sh
+++ b/bin/run_tests_parallel.sh
@@ -69,7 +69,7 @@ rm -rf "$BUILD_DIR"/run_tests.failures
 # print collected results up until interruption
 trap "echo """"; cat ""$BUILD_DIR""/run_tests.results ""$BUILD_DIR""/run_tests.failures; exit 130;" INT
 
-N=$(($(nproc --all || echo 1)>6 ? 6 : $(nproc --all || echo 1)))
+N=$(($(nproc --all || echo 1)>2 ? 2 : $(nproc --all || echo 1)))
 
 echo "$(echo "$TESTS" | wc -l) tests, running $N tests in parallel."
 

--- a/src/dev/flang/ast/Types.java
+++ b/src/dev/flang/ast/Types.java
@@ -163,6 +163,7 @@ public class Types extends ANY
     public final AbstractFeature f_array;
     public final AbstractFeature f_array_internal_array;
     public final AbstractFeature f_error;
+    public final AbstractFeature f_error_msg;
     public final AbstractFeature f_fuzion;
     public final AbstractFeature f_fuzion_java;
     public final AbstractFeature f_fuzion_java_object;
@@ -223,6 +224,7 @@ public class Types extends ANY
       f_array         = universe.get(mod, "array", 5);
       f_array_internal_array = f_array.get(mod, "internal_array");
       f_error         = universe.get(mod, "error", 1);
+      f_error_msg     = f_error.get(mod, "msg");
       f_fuzion                     = universe.get(mod, "fuzion");
       f_fuzion_java                = f_fuzion.get(mod, "java");
       f_fuzion_java_object         = f_fuzion_java.get(mod, "Java_Object");

--- a/src/dev/flang/fuir/FUIR.java
+++ b/src/dev/flang/fuir/FUIR.java
@@ -2076,6 +2076,19 @@ hw25 is
 
 
   /**
+   * For a clazz of error, lookup the inner clazz of the msg field.
+   *
+   * @param cl index of a clazz `error`
+   *
+   * @return the index of the requested `error.msg` field's clazz.
+   */
+  public int lookup_error_msg(int cl)
+  {
+    return lookup(cl, Types.resolved.f_error_msg);
+  }
+
+
+  /**
    * Internal helper for lookup_* methods.
    *
    * @param cl index of the outer clazz for the lookup
@@ -2177,6 +2190,21 @@ hw25 is
     return (e instanceof Expr expr) ? expr.pos() :
            (e instanceof Clazz z) ? z._type.declarationPos()  /* implicit assignment to argument field */
                                   : null;
+  }
+
+
+
+  /**
+   * Get the source code position of an expr at the given site if it is available.
+   *
+   * @param site the code position
+   *
+   * @return the source code position or null if not available.
+   */
+  public SourcePosition siteAsPos(int site)
+  {
+    return site != -1 ? codeAtAsPos(codeIndexFromSite(site), exprIndexFromSite(site))
+                      : null;
   }
 
 

--- a/src/dev/flang/fuir/FUIR.java
+++ b/src/dev/flang/fuir/FUIR.java
@@ -2197,14 +2197,14 @@ hw25 is
   /**
    * Get the source code position of an expr at the given site if it is available.
    *
-   * @param site the code position
+   * @param site the code position, IR.NO_SITE if unkown.
    *
    * @return the source code position or null if not available.
    */
   public SourcePosition siteAsPos(int site)
   {
-    return site != -1 ? codeAtAsPos(codeIndexFromSite(site), exprIndexFromSite(site))
-                      : null;
+    return site != NO_SITE ? codeAtAsPos(codeIndexFromSite(site), exprIndexFromSite(site))
+                           : null;
   }
 
 

--- a/src/dev/flang/fuir/FUIR.java
+++ b/src/dev/flang/fuir/FUIR.java
@@ -1021,7 +1021,7 @@ hw25 is
           {
             addCode(cc, code, ff);
           }
-        res = _codeIds.add(code);
+        res = addCode(code);
         _clazzCode.put(cl, res);
       }
     return res;
@@ -1092,7 +1092,7 @@ hw25 is
           {
             var code = new List<Object>();
             toStack(code, cond.get(i).cond);
-            resBoxed = _codeIds.add(code);
+            resBoxed = addCode(code);
             _clazzContract.put(key, resBoxed);
           }
         res = resBoxed;
@@ -1372,7 +1372,7 @@ hw25 is
       (ix >= 0, withinCode(c, ix));
 
     ExprKind result;
-    var e = _codeIds.get(c).get(ix);
+    var e = getExpr(c , ix);
     if (e instanceof Clazz    )  /* Clazz represents the field we assign a value to */
       {
         result = ExprKind.Assign;
@@ -1399,7 +1399,7 @@ hw25 is
        codeAt(c, ix) == ExprKind.Tag);
 
     var outerClazz = clazz(cl);
-    var t = (Tag) _codeIds.get(c).get(ix);
+    var t = (Tag) getExpr(c , ix);
     var vcl = outerClazz.actualClazzes(t, null)[0];
     return vcl == null ? -1 : id(vcl);
   }
@@ -1412,7 +1412,7 @@ hw25 is
        codeAt(c, ix) == ExprKind.Tag);
 
     var outerClazz = clazz(cl);
-    var t = (Tag) _codeIds.get(c).get(ix);
+    var t = (Tag) getExpr(c , ix);
     var ncl = outerClazz.actualClazzes(t, null)[1];
     return ncl == null ? -1 : id(ncl);
   }
@@ -1429,7 +1429,7 @@ hw25 is
        codeAt(c, ix) == ExprKind.Env);
 
     var outerClazz = clazz(cl);
-    var v = (Env) _codeIds.get(c).get(ix);
+    var v = (Env) getExpr(c , ix);
     var vcl = outerClazz.actualClazzes(v, null)[0];
     return vcl == null ? -1 : id(vcl);
   }
@@ -1442,7 +1442,7 @@ hw25 is
        codeAt(c, ix) == ExprKind.Box);
 
     var outerClazz = clazz(cl);
-    var b = (Box) _codeIds.get(c).get(ix);
+    var b = (Box) getExpr(c , ix);
     Clazz vc = outerClazz.actualClazzes(b, null)[0];
     return id(vc);
   }
@@ -1455,7 +1455,7 @@ hw25 is
        codeAt(c, ix) == ExprKind.Box);
 
     var outerClazz = clazz(cl);
-    var b = (Box) _codeIds.get(c).get(ix);
+    var b = (Box) getExpr(c , ix);
     Clazz rc = outerClazz.actualClazzes(b, null)[1];
     return id(rc);
   }
@@ -1515,7 +1515,7 @@ hw25 is
        codeAt(c, ix) == ExprKind.Assign    );
 
     var outerClazz = clazz(cl);
-    var s = _codeIds.get(c).get(ix);
+    var s = getExpr(c , ix);
     Clazz innerClazz =
       (s instanceof AbstractCall   call) ? outerClazz.actualClazzes(call, null)[2] :
       (Clazz) (Object) new Object() { { if (true) throw new Error("accessedClazz found unexpected Expr."); } } /* Java is ugly... */;
@@ -1547,7 +1547,7 @@ hw25 is
        codeAt(c, ix) == ExprKind.Assign    );
 
     var outerClazz = clazz(cl);
-    var s = _codeIds.get(c).get(ix);
+    var s = getExpr(c , ix);
     Clazz innerClazz =
       (s instanceof AbstractCall   call) ? outerClazz.actualClazzes(call, null)[0] :
       (s instanceof AbstractAssign a   ) ? outerClazz.actualClazzes(a   , null)[1] :
@@ -1578,7 +1578,7 @@ hw25 is
        codeAt(c, ix) == ExprKind.Assign    );
 
     var outerClazz = clazz(cl);
-    var s = _codeIds.get(c).get(ix);
+    var s = getExpr(c , ix);
     var t =
       (s instanceof AbstractAssign a   ) ? outerClazz.actualClazzes(a, null)[2] :
       (s instanceof Clazz          fld ) ? fld.resultClazz() :
@@ -1615,7 +1615,7 @@ hw25 is
     if (res == null)
       {
         var outerClazz = clazz(cl);
-        var s = _codeIds.get(c).get(ix);
+        var s = getExpr(c , ix);
         Clazz tclazz;
         AbstractFeature f;
         var typePars = AbstractCall.NO_GENERICS;
@@ -1736,7 +1736,7 @@ hw25 is
        codeAt(c, ix) == ExprKind.Call  );
 
     var outerClazz = clazz(cl);
-    var s = _codeIds.get(c).get(ix);
+    var s = getExpr(c , ix);
     var res =
       (s instanceof AbstractAssign ass ) ? outerClazz.actualClazzes(ass, null)[0].isRef() : // NYI: This should be the same as assignedField._outer
       (s instanceof Clazz          arg ) ? outerClazz.isRef() && !arg.feature().isOuterRef() : // assignment to arg field in inherits call (dynamic if outerClazz is ref)
@@ -1773,7 +1773,7 @@ hw25 is
        withinCode(c, ix),
        codeAt(c, ix) == ExprKind.Call);
 
-    var call = (AbstractCall) _codeIds.get(c).get(ix);
+    var call = (AbstractCall) getExpr(c , ix);
     return call.isInheritanceCall();
   }
 
@@ -1798,7 +1798,7 @@ hw25 is
        codeAt(c, ix) == ExprKind.Call  );
 
     var outerClazz = clazz(cl);
-    var s = _codeIds.get(c).get(ix);
+    var s = getExpr(c , ix);
     var tclazz =
       (s instanceof AbstractAssign ass ) ? outerClazz.actualClazzes(ass, null)[0] : // NYI: This should be the same as assignedField._outer
       (s instanceof Clazz          arg ) ? outerClazz : // assignment to arg field in inherits call, so outer clazz is current instance
@@ -1835,7 +1835,7 @@ hw25 is
        codeAt(c, ix) == ExprKind.Const);
 
     var cc = clazz(cl);
-    var ac = (AbstractConstant) _codeIds.get(c).get(ix);
+    var ac = (AbstractConstant) getExpr(c , ix);
     var acl = cc.actualClazzes(ac.origin(), null);
     // origin might be AbstractConstant, AbstractCall or InlineArray.  In all
     // cases, the clazz of the result is the first actual clazz:
@@ -1855,7 +1855,7 @@ hw25 is
        withinCode(c, ix),
        codeAt(c, ix) == ExprKind.Const);
 
-    var ic = _codeIds.get(c).get(ix);
+    var ic = getExpr(c , ix);
     return ((AbstractConstant) ic).data();
   }
 
@@ -1879,7 +1879,7 @@ hw25 is
        codeAt(c, ix) == ExprKind.Match);
 
     var cc = clazz(cl);
-    var s = _codeIds.get(c).get(ix);
+    var s = getExpr(c , ix);
     Clazz ss = cc.actualClazzes((Expr) s, null)[0];
     return id(ss);
   }
@@ -1908,7 +1908,7 @@ hw25 is
        0 <= cix && cix <= matchCaseCount(c, ix));
 
     var cc = clazz(cl);
-    var s = _codeIds.get(c).get(ix);
+    var s = getExpr(c , ix);
     int result = -1; // no field for If
     if (s instanceof AbstractMatch m)
       {
@@ -1943,7 +1943,7 @@ hw25 is
        0 <= cix && cix <= matchCaseCount(c, ix));
 
     var cc = clazz(cl);
-    var s = _codeIds.get(c).get(ix);
+    var s = getExpr(c , ix);
     int[] result;
     if (s instanceof If)
       {
@@ -2001,7 +2001,7 @@ hw25 is
        codeAt(c, ix) == ExprKind.Match,
        0 <= cix && cix <= matchCaseCount(c, ix));
 
-    var s = _codeIds.get(c).get(ix+1+cix);
+    var s = getExpr(c, ix + 1 + cix);
     return ((NumLiteral)s).intValue().intValueExact();
   }
 
@@ -2173,7 +2173,7 @@ hw25 is
     if (PRECONDITIONS) require
       (ix >= 0, withinCode(c, ix));
 
-    var e = _codeIds.get(c).get(ix);
+    var e = getExpr(c , ix);
     return (e instanceof Expr expr) ? expr.pos() :
            (e instanceof Clazz z) ? z._type.declarationPos()  /* implicit assignment to argument field */
                                   : null;

--- a/src/dev/flang/fuir/analysis/dfa/Call.java
+++ b/src/dev/flang/fuir/analysis/dfa/Call.java
@@ -163,7 +163,7 @@ public class Call extends ANY implements Comparable<Call>, Context
     _args = args;
     _env = env;
     _context = context;
-    _instance = dfa.newInstance(cc, this, site);
+    _instance = dfa.newInstance(cc, site, this);
 
     if (!pre && dfa._fuir.clazzResultField(cc)==-1) /* <==> _fuir.isConstructor(cl) */
       {
@@ -243,7 +243,7 @@ public class Call extends ANY implements Comparable<Call>, Context
             if (at >= 0)
               {
                 var rc = _dfa._fuir.clazzResultClazz(_cc);
-                var t = _dfa.newInstance(rc, this, _site);
+                var t = _dfa.newInstance(rc, _site, this);
                 // NYI: DFA missing support for Type instance, need to set field t.name to tname.
                 result = t;
               }

--- a/src/dev/flang/fuir/analysis/dfa/Call.java
+++ b/src/dev/flang/fuir/analysis/dfa/Call.java
@@ -438,11 +438,9 @@ public class Call extends ANY implements Comparable<Call>, Context
     var result = getEffectCheck(ecl);
     if (result == null && _dfa._reportResults && !_dfa._fuir.clazzOriginalName(_cc).equals("effect.type.unsafe_get"))
       {
-        var why = new StringBuilder("Callchain that lead to this point:\n\n");
-        why.append(this.contextString());
         DfaErrors.usedEffectNeverInstantiated(pos,
                                               _dfa._fuir.clazzAsString(ecl),
-                                              why.toString());
+                                              this);
         _dfa._missingEffects.add(ecl);
       }
     return result;

--- a/src/dev/flang/fuir/analysis/dfa/Call.java
+++ b/src/dev/flang/fuir/analysis/dfa/Call.java
@@ -113,6 +113,8 @@ public class Call extends ANY implements Comparable<Call>, Context
   Context _context;
 
 
+  int _site;
+
   /**
    * True if this instance escapes this call.
    */
@@ -147,7 +149,7 @@ public class Call extends ANY implements Comparable<Call>, Context
    * @param context for debugging: Reason that causes this call to be part of
    * the analysis.
    */
-  public Call(DFA dfa, int cc, boolean pre, Value target, List<Val> args, Env env, Context context)
+  public Call(DFA dfa, int cc, boolean pre, Value target, List<Val> args, Env env, Context context, int site)
   {
     _dfa = dfa;
     _cc = cc;
@@ -156,7 +158,8 @@ public class Call extends ANY implements Comparable<Call>, Context
     _args = args;
     _env = env;
     _context = context;
-    _instance = dfa.newInstance(cc, this);
+    _instance = dfa.newInstance(cc, this, site);
+    _site = site;
 
     if (!pre && dfa._fuir.clazzResultField(cc)==-1) /* <==> _fuir.isConstructor(cl) */
       {
@@ -185,6 +188,8 @@ public class Call extends ANY implements Comparable<Call>, Context
     var r =
       _cc   <   other._cc  ? -1 :
       _cc   >   other._cc  ? +1 :
+      _site <   other._site? -1 :
+      _site >   other._site? +1 :
       _pre  && !other._pre ? -1 :
       !_pre &&  other._pre ? +1 : Value.compare(_target, other._target);
     for (var i = 0; r == 0 && i < _args.size(); i++)
@@ -234,7 +239,7 @@ public class Call extends ANY implements Comparable<Call>, Context
             if (at >= 0)
               {
                 var rc = _dfa._fuir.clazzResultClazz(_cc);
-                var t = _dfa.newInstance(rc, this);
+                var t = _dfa.newInstance(rc, this, _site);
                 // NYI: DFA missing support for Type instance, need to set field t.name to tname.
                 result = t;
               }

--- a/src/dev/flang/fuir/analysis/dfa/Context.java
+++ b/src/dev/flang/fuir/analysis/dfa/Context.java
@@ -52,9 +52,10 @@ public interface Context
       say("program entry point");
       return "  ";
     }
-    public String toStringForEnv()
+    public String toString(boolean forEnv)
     {
-      return "effect environment " + Errors.effe(Env.envAsString(null)) + " at program entry";
+      return forEnv ? "effect environment " + Errors.effe(Env.envAsString(null)) + " at program entry"
+                    : "program entry point";
     }
   };
 
@@ -94,7 +95,25 @@ public interface Context
    * Show the context that caused the inclusion of this instance into the
    * analysis in a way that is useful for error related to effects.
    */
-  String toStringForEnv();
+  String toString(boolean forEnv);
+
+
+  default String contextString(boolean forEnv)
+  {
+    var result = new StringBuilder();
+    Context co = this;
+    while (co != null)
+      {
+        result.append(co.toString(forEnv) + "\n");
+        co = co instanceof Call cc ? cc._context : null;
+      }
+    return result.toString();
+  }
+
+
+  default String contextStringForEnv() { return contextString(true); }
+  default String contextString()       { return contextString(false); }
+
 
 }
 

--- a/src/dev/flang/fuir/analysis/dfa/Context.java
+++ b/src/dev/flang/fuir/analysis/dfa/Context.java
@@ -98,6 +98,17 @@ public interface Context
   String toString(boolean forEnv);
 
 
+  /**
+   * Create a multi-line String describing this context to be used in error
+   * messages.
+   *
+   * @param forEnv true if effect environments should be included in the
+   * resulting string.
+   *
+   * @return A LF-terminated String of the call context starting with the
+   * innermost context going towards older and older contexts until we reach the
+   * program entry point.
+   */
   default String contextString(boolean forEnv)
   {
     var result = new StringBuilder();
@@ -111,7 +122,15 @@ public interface Context
   }
 
 
+  /**
+   * Convenience function for `conextString(true)`
+   */
   default String contextStringForEnv() { return contextString(true); }
+
+
+  /**
+   * Convenience function for `conextString(false)`
+   */
   default String contextString()       { return contextString(false); }
 
 

--- a/src/dev/flang/fuir/analysis/dfa/DFA.java
+++ b/src/dev/flang/fuir/analysis/dfa/DFA.java
@@ -539,7 +539,7 @@ public class DFA extends ANY
      */
     private Value newValueConst(int constCl, Context context, ByteBuffer b)
     {
-      var result = newInstance(constCl, context, NO_SITE);
+      var result = newInstance(constCl, NO_SITE, context);
       var args = new List<Val>();
       for (int index = 0; index < _fuir.clazzArgCount(constCl); index++)
         {
@@ -577,9 +577,9 @@ public class DFA extends ANY
      */
     private Value newArrayConst(int constCl, Call context, ByteBuffer d)
     {
-      var result = newInstance(constCl, context, NO_SITE);
+      var result = newInstance(constCl, NO_SITE, context);
       var sa = _fuir.clazzField(constCl, 0);
-      var sa0 = newInstance(_fuir.clazzResultClazz(sa), context, NO_SITE);
+      var sa0 = newInstance(_fuir.clazzResultClazz(sa), NO_SITE, context);
 
       var elementClazz = _fuir.inlineArrayElementClazz(constCl);
       var data = _fuir.clazzField(_fuir.clazzResultClazz(sa), 0);
@@ -950,7 +950,7 @@ public class DFA extends ANY
     _true  = new TaggedValue(this, bool, Value.UNIT, 1);
     _false = new TaggedValue(this, bool, Value.UNIT, 0);
     _bool  = _true.join(_false);
-    _universe = newInstance(_fuir.clazzUniverse(), null, NO_SITE);
+    _universe = newInstance(_fuir.clazzUniverse(), NO_SITE, null);
     Errors.showAndExit();
   }
 
@@ -1903,7 +1903,7 @@ public class DFA extends ANY
         {
           var jref = cl._dfa._fuir.lookupJavaRef(cl._dfa._fuir.clazzArgClazz(cl._cc, 0));
           cl._dfa._readFields.add(jref);
-          return cl._dfa.newInstance(cl._dfa._fuir.clazzResultClazz(cl._cc), cl._context, NO_SITE);
+          return cl._dfa.newInstance(cl._dfa._fuir.clazzResultClazz(cl._cc), NO_SITE, cl._context);
         });
     put("fuzion.java.array_length"          , cl -> new NumericValue(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc)) );
     put("fuzion.java.array_to_java_object0" , cl ->
@@ -1912,18 +1912,18 @@ public class DFA extends ANY
           var jref = cl._dfa._fuir.lookupJavaRef(rc);
           var data = cl._dfa._fuir.lookup_fuzion_sys_internal_array_data(cl._dfa._fuir.clazzArgClazz(cl._cc,0));
           cl._dfa._readFields.add(data);
-          var result = cl._dfa.newInstance(cl._dfa._fuir.clazzResultClazz(cl._cc), cl._context, NO_SITE);
+          var result = cl._dfa.newInstance(cl._dfa._fuir.clazzResultClazz(cl._cc), NO_SITE, cl._context);
           result.setField(cl._dfa, jref, Value.UNKNOWN_JAVA_REF); // NYI: record putfield of result.jref := args.get(0).data
           return result;
         });
-    put("fuzion.java.bool_to_java_object"   , cl -> cl._dfa.newInstance(cl._dfa._fuir.clazzResultClazz(cl._cc), cl._context, NO_SITE) );
-    put("fuzion.java.f32_to_java_object"    , cl -> cl._dfa.newInstance(cl._dfa._fuir.clazzResultClazz(cl._cc), cl._context, NO_SITE) );
-    put("fuzion.java.f64_to_java_object"    , cl -> cl._dfa.newInstance(cl._dfa._fuir.clazzResultClazz(cl._cc), cl._context, NO_SITE) );
-    put("fuzion.java.get_field0"            , cl -> cl._dfa.newInstance(cl._dfa._fuir.clazzResultClazz(cl._cc), cl._context, NO_SITE) );
-    put("fuzion.java.i16_to_java_object"    , cl -> cl._dfa.newInstance(cl._dfa._fuir.clazzResultClazz(cl._cc), cl._context, NO_SITE) );
-    put("fuzion.java.i32_to_java_object"    , cl -> cl._dfa.newInstance(cl._dfa._fuir.clazzResultClazz(cl._cc), cl._context, NO_SITE) );
-    put("fuzion.java.i64_to_java_object"    , cl -> cl._dfa.newInstance(cl._dfa._fuir.clazzResultClazz(cl._cc), cl._context, NO_SITE) );
-    put("fuzion.java.i8_to_java_object"     , cl -> cl._dfa.newInstance(cl._dfa._fuir.clazzResultClazz(cl._cc), cl._context, NO_SITE) );
+    put("fuzion.java.bool_to_java_object"   , cl -> cl._dfa.newInstance(cl._dfa._fuir.clazzResultClazz(cl._cc), NO_SITE, cl._context) );
+    put("fuzion.java.f32_to_java_object"    , cl -> cl._dfa.newInstance(cl._dfa._fuir.clazzResultClazz(cl._cc), NO_SITE, cl._context) );
+    put("fuzion.java.f64_to_java_object"    , cl -> cl._dfa.newInstance(cl._dfa._fuir.clazzResultClazz(cl._cc), NO_SITE, cl._context) );
+    put("fuzion.java.get_field0"            , cl -> cl._dfa.newInstance(cl._dfa._fuir.clazzResultClazz(cl._cc), NO_SITE, cl._context) );
+    put("fuzion.java.i16_to_java_object"    , cl -> cl._dfa.newInstance(cl._dfa._fuir.clazzResultClazz(cl._cc), NO_SITE, cl._context) );
+    put("fuzion.java.i32_to_java_object"    , cl -> cl._dfa.newInstance(cl._dfa._fuir.clazzResultClazz(cl._cc), NO_SITE, cl._context) );
+    put("fuzion.java.i64_to_java_object"    , cl -> cl._dfa.newInstance(cl._dfa._fuir.clazzResultClazz(cl._cc), NO_SITE, cl._context) );
+    put("fuzion.java.i8_to_java_object"     , cl -> cl._dfa.newInstance(cl._dfa._fuir.clazzResultClazz(cl._cc), NO_SITE, cl._context) );
     put("fuzion.java.java_string_to_string" , cl ->
         {
           var jref = cl._dfa._fuir.lookupJavaRef(cl._dfa._fuir.clazzArgClazz(cl._cc, 0));
@@ -1934,7 +1934,7 @@ public class DFA extends ANY
       {
         var rc = cl._dfa._fuir.clazzResultClazz(cl._cc);
         var jref = cl._dfa._fuir.lookupJavaRef(rc);
-        var jobj = cl._dfa.newInstance(rc, null, NO_SITE);
+        var jobj = cl._dfa.newInstance(rc, NO_SITE, null);
         jobj.setField(cl._dfa, jref, Value.UNKNOWN_JAVA_REF);
         return jobj;
       });
@@ -1961,14 +1961,14 @@ public class DFA extends ANY
             }
             default -> {
               var jref = cl._dfa._fuir.lookupJavaRef(oc);
-              var jobj = cl._dfa.newInstance(oc, null, NO_SITE);
+              var jobj = cl._dfa.newInstance(oc, NO_SITE, null);
               jobj.setField(cl._dfa, jref, Value.UNKNOWN_JAVA_REF);
               yield jobj;
             }
           };
         var okay = new TaggedValue(cl._dfa, rc, res, 0);
         var error_cl = cl._dfa._fuir.clazzChoice(rc, 1);
-        var error = cl._dfa.newInstance(error_cl, null, NO_SITE);
+        var error = cl._dfa.newInstance(error_cl, NO_SITE, null);
         var msg = cl._dfa._fuir.lookup_error_msg(error_cl);
         error.setField(cl._dfa, msg, cl._dfa.newConstString(null, cl));
         var err = new TaggedValue(cl._dfa, rc, error, 1);
@@ -1982,7 +1982,7 @@ public class DFA extends ANY
         case c_unit -> Value.UNIT;
         default -> {
           var jref = cl._dfa._fuir.lookupJavaRef(rc);
-          var jobj = cl._dfa.newInstance(rc, null, NO_SITE);
+          var jobj = cl._dfa.newInstance(rc, NO_SITE, null);
           jobj.setField(cl._dfa, jref, Value.UNKNOWN_JAVA_REF);
           yield jobj;
         }
@@ -2034,11 +2034,11 @@ public class DFA extends ANY
       {
         var rc = cl._dfa._fuir.clazzResultClazz(cl._cc);
         var jref = cl._dfa._fuir.lookupJavaRef(rc);
-        var jobj = cl._dfa.newInstance(rc, null, NO_SITE);
+        var jobj = cl._dfa.newInstance(rc, NO_SITE, null);
         jobj.setField(cl._dfa, jref, Value.UNKNOWN_JAVA_REF);
         return jobj;
       });
-    put("fuzion.java.u16_to_java_object"    , cl -> cl._dfa.newInstance(cl._dfa._fuir.clazzResultClazz(cl._cc), null, NO_SITE) );
+    put("fuzion.java.u16_to_java_object"    , cl -> cl._dfa.newInstance(cl._dfa._fuir.clazzResultClazz(cl._cc), NO_SITE, null) );
   }
 
 
@@ -2089,10 +2089,13 @@ public class DFA extends ANY
    *
    * @param cl the clazz
    *
+   * @param site the site index where the new instances is creates, NO_SITE
+   * if not within code (instrinsics etc.)
+   *
    * @param context for debugging: Reason that causes this instance to be part
    * of the analysis.
    */
-  Value newInstance(int cl, Context context, int site)
+  Value newInstance(int cl, int site, Context context)
   {
     if (PRECONDITIONS) require
       (!_fuir.clazzIsChoice(cl) || _fuir.clazzIs(cl, SpecialClazzes.c_bool));
@@ -2111,7 +2114,7 @@ public class DFA extends ANY
         if (_fuir.clazzIsRef(cl))
           {
             var vc = _fuir.clazzAsValue(cl);
-            r = newInstance(vc, context, site).box(this, vc, cl, context);
+            r = newInstance(vc, site, context).box(this, vc, cl, context);
           }
         else
           {
@@ -2157,8 +2160,8 @@ public class DFA extends ANY
     var sysArray      = _fuir.clazzResultClazz(internalArray);
     var adata = utf8Bytes != null ? new SysArray(this, utf8Bytes, _fuir.clazz(FUIR.SpecialClazzes.c_u8))
                                   : new SysArray(this, new NumericValue(this, _fuir.clazz(FUIR.SpecialClazzes.c_u8)));
-    var r = newInstance(cs, context, NO_SITE);
-    var a = newInstance(sysArray, context, NO_SITE);
+    var r = newInstance(cs, NO_SITE, context);
+    var a = newInstance(sysArray, NO_SITE, context);
     a.setField(this,
                length,
                 utf8Bytes != null ? new NumericValue(this, _fuir.clazzResultClazz(length), utf8Bytes.length)

--- a/src/dev/flang/fuir/analysis/dfa/DFA.java
+++ b/src/dev/flang/fuir/analysis/dfa/DFA.java
@@ -426,7 +426,7 @@ public class DFA extends ANY
           }
         case Field:
           {
-            res = tvalue.value().callField(DFA.this, cc);
+            res = tvalue.value().callField(DFA.this, cc, _fuir.siteFromCI(c,i), _call);
             if (_reportResults && _options.verbose(9))
               {
                 say("DFA for "+_fuir.clazzAsString(cl)+"("+_fuir.clazzArgCount(cl)+" args) at "+c+"."+i+": "+_fuir.codeAtAsString(cl,c,i)+": " +
@@ -1404,7 +1404,7 @@ public class DFA extends ANY
           var atomic    = cl._target;
           var expected  = cl._args.get(0);
           var new_value = cl._args.get(1).value();
-          var res = atomic.callField(cl._dfa, v);
+          var res = atomic.callField(cl._dfa, v, cl.site(), cl);
 
           // NYI: we could make compare_and_swap more accurate and call setField only if res contains expected, need bit-wise comparison
           atomic.setField(cl._dfa, v, new_value);
@@ -1421,7 +1421,7 @@ public class DFA extends ANY
           var atomic    = cl._target;
           var expected  = cl._args.get(0);
           var new_value = cl._args.get(1).value();
-          var res = atomic.callField(cl._dfa, v);
+          var res = atomic.callField(cl._dfa, v, cl.site(), cl);
 
           // NYI: we could make compare_and_set more accurate and call setField only if res contains expected, need bit-wise comparison
           atomic.setField(cl._dfa, v, new_value);
@@ -1442,7 +1442,7 @@ public class DFA extends ANY
             (cl._dfa._fuir.clazzNeedsCode(v));
 
           var atomic = cl._target;
-          return atomic.callField(cl._dfa, v);
+          return atomic.callField(cl._dfa, v, cl.site(), cl);
         });
 
     put("concur.atomic.write0", cl ->
@@ -1968,7 +1968,11 @@ public class DFA extends ANY
             }
           };
         var okay = new TaggedValue(cl._dfa, rc, res, 0);
-        var err = new TaggedValue(cl._dfa, rc, cl._dfa.newInstance(cl._dfa._fuir.clazzChoice(rc, 1), null, NO_SITE), 1);
+        var error_cl = cl._dfa._fuir.clazzChoice(rc, 1);
+        var error = cl._dfa.newInstance(error_cl, null, NO_SITE);
+        var msg = cl._dfa._fuir.lookup_error_msg(error_cl);
+        error.setField(cl._dfa, msg, cl._dfa.newConstString(null, cl));
+        var err = new TaggedValue(cl._dfa, rc, error, 1);
         return okay.join(err);
       }
     return switch (cl._dfa._fuir.getSpecialClazz(rc))

--- a/src/dev/flang/fuir/analysis/dfa/DfaErrors.java
+++ b/src/dev/flang/fuir/analysis/dfa/DfaErrors.java
@@ -52,6 +52,13 @@ public class DfaErrors extends ANY
   }
 
 
+  public static void readingUninitializedField(HasSourcePosition pos, String field, String clazz, String why)
+  {
+    Errors.error(pos.pos(),
+                 "reading uninitialized field " + sqn(field) + " from instance of " + code(clazz),
+                 why);
+  }
+
 }
 
 /* end of file */

--- a/src/dev/flang/fuir/analysis/dfa/DfaErrors.java
+++ b/src/dev/flang/fuir/analysis/dfa/DfaErrors.java
@@ -44,19 +44,19 @@ public class DfaErrors extends ANY
   /*-----------------------------  methods  -----------------------------*/
 
 
-  public static void usedEffectNeverInstantiated(HasSourcePosition pos, String e, String why)
+  public static void usedEffectNeverInstantiated(HasSourcePosition pos, String e, Context why)
   {
     Errors.error(pos.pos(),
                  "Failed to verify that effect " + st(e) + " is installed in current environment.",
-                 why);
+                 "Callchain that lead to this point:\n\n" + why.contextStringForEnv());
   }
 
 
-  public static void readingUninitializedField(HasSourcePosition pos, String field, String clazz, String why)
+  public static void readingUninitializedField(HasSourcePosition pos, String field, String clazz, Context why)
   {
     Errors.error(pos.pos(),
                  "reading uninitialized field " + sqn(field) + " from instance of " + code(clazz),
-                 why);
+                 "Callchain that lead to this point:\n\n" + why.contextString());
   }
 
 }

--- a/src/dev/flang/fuir/analysis/dfa/Instance.java
+++ b/src/dev/flang/fuir/analysis/dfa/Instance.java
@@ -161,7 +161,7 @@ public class Instance extends Value implements Comparable<Instance>
   /**
    * Get set of values of given field within this instance.
    */
-  Val readFieldFromInstance(DFA dfa, int field)
+  Val readFieldFromInstance(DFA dfa, int field, int site, Context why)
   {
     if (PRECONDITIONS) require
       (_clazz == dfa._fuir.clazzAsValue(dfa._fuir.clazzOuterClazz(field)));
@@ -173,18 +173,10 @@ public class Instance extends Value implements Comparable<Instance>
       {
         if (dfa._reportResults)
           {
-            Errors.error("reading uninitialized field " + dfa._fuir.clazzAsString(field) + " from instance of " + dfa._fuir.clazzAsString(_clazz) +
-                         (_isBoxed ? " Boxed!" : "") +
-                         "\n" +
-                         "fields available:\n  " + _fields.keySet().stream().map(x -> ""+x+":"+dfa._fuir.clazzAsString(x)).collect(Collectors.joining(",\n  ")));
-
-            for (var f : _fields.keySet())
-              {
-                if (dfa._fuir.clazzAsString(f).equals(dfa._fuir.clazzAsString(field).replace("ref ","")))
-                  {
-                    say("NYI: HACK: Using value version instead: "+v);
-                  }
-              }
+            DfaErrors.readingUninitializedField(dfa._fuir.siteAsPos(site),
+                                                dfa._fuir.clazzAsString(field),
+                                                dfa._fuir.clazzAsString(_clazz) + (_isBoxed ? " Boxed!" : ""),
+                                                why.contextString());
           }
       }
     else if (!dfa._fuir.clazzIsRef(dfa._fuir.clazzResultClazz(field)))

--- a/src/dev/flang/fuir/analysis/dfa/Instance.java
+++ b/src/dev/flang/fuir/analysis/dfa/Instance.java
@@ -176,7 +176,7 @@ public class Instance extends Value implements Comparable<Instance>
             DfaErrors.readingUninitializedField(dfa._fuir.siteAsPos(site),
                                                 dfa._fuir.clazzAsString(field),
                                                 dfa._fuir.clazzAsString(_clazz) + (_isBoxed ? " Boxed!" : ""),
-                                                why.contextString());
+                                                why);
           }
       }
     else if (!dfa._fuir.clazzIsRef(dfa._fuir.clazzResultClazz(field)))

--- a/src/dev/flang/fuir/analysis/dfa/Instance.java
+++ b/src/dev/flang/fuir/analysis/dfa/Instance.java
@@ -77,6 +77,8 @@ public class Instance extends Value implements Comparable<Instance>
   final boolean _isBoxed;
 
 
+  final int _site;
+
   /*---------------------------  constructors  ---------------------------*/
 
 
@@ -90,7 +92,7 @@ public class Instance extends Value implements Comparable<Instance>
    * @param context for debugging: Reason that causes this instance to be part
    * of the analysis.
    */
-  public Instance(DFA dfa, int clazz, Context context)
+  public Instance(DFA dfa, int clazz, Context context, int site)
   {
     super(clazz);
 
@@ -101,6 +103,7 @@ public class Instance extends Value implements Comparable<Instance>
     _context = context;
     _fields = new TreeMap<>();
     _isBoxed = false;
+    _site = site;
   }
 
 
@@ -116,11 +119,15 @@ public class Instance extends Value implements Comparable<Instance>
     var i2 = other;
     var c1 = i1._clazz;
     var c2 = i2._clazz;
+    var s1 = i1._site;
+    var s2 = i2._site;
     var e1 = i1._context instanceof Call ca1 ? ca1._env : null;
     var e2 = i2._context instanceof Call ca2 ? ca2._env : null;
     return
       c1 < c2    ? -1 :
       c1 > c2    ? +1 :
+      s1 < s2    ? -1 :
+      s1 > s2    ? +1 :
       e1 == e2   ?  0 :
       e1 == null ? -1 :
       e2 == null ? +1

--- a/src/dev/flang/fuir/analysis/dfa/Instance.java
+++ b/src/dev/flang/fuir/analysis/dfa/Instance.java
@@ -77,7 +77,16 @@ public class Instance extends Value implements Comparable<Instance>
   final boolean _isBoxed;
 
 
+  /**
+   * Site of the call that created this instance, -1 if the call site is not
+   * known, i.e., the call is coming from intrinsic call or the main entry
+   * point.
+   *
+   * Instances created at different sites will be considered as different
+   * instances.
+   */
   final int _site;
+
 
   /*---------------------------  constructors  ---------------------------*/
 
@@ -92,7 +101,7 @@ public class Instance extends Value implements Comparable<Instance>
    * @param context for debugging: Reason that causes this instance to be part
    * of the analysis.
    */
-  public Instance(DFA dfa, int clazz, Context context, int site)
+  public Instance(DFA dfa, int clazz, int site, Context context)
   {
     super(clazz);
 
@@ -100,10 +109,10 @@ public class Instance extends Value implements Comparable<Instance>
       (!dfa._fuir.clazzIsRef(clazz));
 
     _dfa = dfa;
+    _site = site;
     _context = context;
     _fields = new TreeMap<>();
     _isBoxed = false;
-    _site = site;
   }
 
 

--- a/src/dev/flang/fuir/analysis/dfa/NumericValue.java
+++ b/src/dev/flang/fuir/analysis/dfa/NumericValue.java
@@ -165,7 +165,7 @@ public class NumericValue extends Value implements Comparable<NumericValue>
   /**
    * Get set of values of given field within this instance.
    */
-  Value readFieldFromInstance(DFA dfa, int field)
+  Value readFieldFromInstance(DFA dfa, int field, int site, Context why)
   {
     /* for a numeric value, this can only read the 'val' field, e.g., 'i32.val',
      * which (recursively) contains the numeric value, so we can just return

--- a/src/dev/flang/fuir/analysis/dfa/RefValue.java
+++ b/src/dev/flang/fuir/analysis/dfa/RefValue.java
@@ -111,9 +111,9 @@ public class RefValue extends Value
   /**
    * Get set of values of given field within this instance.
    */
-  Val readFieldFromInstance(DFA dfa, int field)
+  Val readFieldFromInstance(DFA dfa, int field, int site, Context why)
   {
-    return _original.readFieldFromInstance(dfa, field);
+    return _original.readFieldFromInstance(dfa, field, site, why);
   }
 
 

--- a/src/dev/flang/fuir/analysis/dfa/Value.java
+++ b/src/dev/flang/fuir/analysis/dfa/Value.java
@@ -112,15 +112,15 @@ public class Value extends Val
        * Get set of values of given field within this value.  This works for unit
        * type results even if this is not an instance (but a unit type itself).
        */
-      public Val readField(DFA dfa, int field)
+      public Val readField(DFA dfa, int field, int site, Context why)
       {
         if (dfa._fuir.clazzUniverse() == dfa._fuir.clazzOuterClazz(field))
           {
-            return dfa._universe.readField(dfa, field);
+            return dfa._universe.readField(dfa, field, site, why);
           }
         else
           {
-            return super.readField(dfa, field);
+            return super.readField(dfa, field, site, why);
           }
       }
 
@@ -231,11 +231,11 @@ public class Value extends Val
    * Get set of values of given field within this value.  This works for unit
    * type results even if this is not an instance (but a unit type itself).
    */
-  public Val readField(DFA dfa, int field)
+  public Val readField(DFA dfa, int field, int site, Context why)
   {
     var rt = dfa._fuir.clazzResultClazz(field);
     var res = dfa._fuir.clazzIsUnitType(rt) ? Value.UNIT
-                                         : readFieldFromInstance(dfa, field);
+                                            : readFieldFromInstance(dfa, field, site, why);
     return res;
   }
 
@@ -245,12 +245,12 @@ public class Value extends Val
    *
    * @param cc the inner value of the field that is called.
    */
-  Val callField(DFA dfa, int cc)
+  Val callField(DFA dfa, int cc, int site, Context why)
   {
     var resa = new Val[] { null };
     forAll(t ->
            {
-             var r = t.readField(dfa, cc);
+             var r = t.readField(dfa, cc, site, why);
              if (resa[0] == null)
                {
                  resa[0] = r;
@@ -267,7 +267,7 @@ public class Value extends Val
   /**
    * Get set of values of given field within this instance.
    */
-  Val readFieldFromInstance(DFA dfa, int field)
+  Val readFieldFromInstance(DFA dfa, int field, int site, Context why)
   {
     throw new Error("Value.readField '"+dfa._fuir.clazzAsString(field)+"' called on class " + this + " (" + getClass() + "), expected " + Instance.class);
   }

--- a/src/dev/flang/fuir/analysis/dfa/Value.java
+++ b/src/dev/flang/fuir/analysis/dfa/Value.java
@@ -26,6 +26,8 @@ Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
 
 package dev.flang.fuir.analysis.dfa;
 
+import static dev.flang.ir.IR.NO_SITE;
+
 import java.util.Comparator;
 
 import java.util.function.Consumer;
@@ -314,7 +316,7 @@ public class Value extends Val
     Value result;
     if (this == UNIT)
       {
-        result = dfa.newInstance(rc, context);
+        result = dfa.newInstance(rc, context, NO_SITE);
       }
     else
       {

--- a/src/dev/flang/fuir/analysis/dfa/Value.java
+++ b/src/dev/flang/fuir/analysis/dfa/Value.java
@@ -316,7 +316,7 @@ public class Value extends Val
     Value result;
     if (this == UNIT)
       {
-        result = dfa.newInstance(rc, context, NO_SITE);
+        result = dfa.newInstance(rc, NO_SITE, context);
       }
     else
       {

--- a/src/dev/flang/ir/IR.java
+++ b/src/dev/flang/ir/IR.java
@@ -85,7 +85,13 @@ public class IR extends ANY
    */
   protected static final int SITE_BASE = 0x70000000;
 
+
+  /**
+   * Special site index value for unknown site location (i.e, a site coming from
+   * an intrinsic or the program entry point).
+   */
   public static final int NO_SITE = SITE_BASE-1;
+
 
   /**
    * The basic types of features in Fuzion:

--- a/src/dev/flang/mir/MIR.java
+++ b/src/dev/flang/mir/MIR.java
@@ -228,7 +228,7 @@ hw25 is
     var ff = _featureIds.get(f);
     var code = prolog(ff);
     addCode(ff, code, ff);
-    return _codeIds.add(code);
+    return addCode(code);
   }
 
 
@@ -292,7 +292,7 @@ hw25 is
        codeAt(c, ix) == ExprKind.Assign    );
 
     var ff = _featureIds.get(f);
-    var s = _codeIds.get(c).get(ix);
+    var s = getExpr(c, ix);
     var af =
       (s instanceof AbstractCall   call) ? call.calledFeature() :
       (s instanceof AbstractAssign a   ) ? a._assignedField :

--- a/src/dev/flang/util/Map2Int.java
+++ b/src/dev/flang/util/Map2Int.java
@@ -35,7 +35,8 @@ import java.util.stream.IntStream;
 
 
 /**
- * Map2Int gives an efficient mapping from a comparable instance to int
+ * Map2Int gives an efficient mapping from an (possibly comparable) instance to
+ * int.
  *
  * @author Fridtjof Siebert (siebert@tokiwa.software)
  */

--- a/tests/local_mutate_negative/test_local_mutate_neg.fz.expected_err
+++ b/tests/local_mutate_negative/test_local_mutate_neg.fz.expected_err
@@ -4,16 +4,16 @@
 -------------^^^^^
 Callchain that lead to this point:
 
-effect environment '--empty--' for call to test_local_mutate_neg.test_sum.sum.count at --CURDIR--/test_local_mutate_neg.fz:80:11:
+effect environment '--empty--' for call to 'test_local_mutate_neg.test_sum.sum.count' at --CURDIR--/test_local_mutate_neg.fz:80:11:
       say count    # *** will cause compile-time an error, requires m to be installed
 ----------^^^^^
-effect environment '--empty--' for call to test_local_mutate_neg.test_sum.sum at --CURDIR--/test_local_mutate_neg.fz:115:5:
+effect environment '--empty--' for call to 'test_local_mutate_neg.test_sum.sum' at --CURDIR--/test_local_mutate_neg.fz:115:5:
     sum l
 ----^^^
-effect environment '--empty--' for call to test_local_mutate_neg.test_sum at --CURDIR--/test_local_mutate_neg.fz:117:3:
+effect environment '--empty--' for call to 'test_local_mutate_neg.test_sum' at --CURDIR--/test_local_mutate_neg.fz:117:3:
   test_sum
 --^^^^^^^^
-effect environment '--empty--' for call to test_local_mutate_neg
+effect environment '--empty--' for call to 'test_local_mutate_neg'
 effect environment '--empty--' at program entry
 
 one error.

--- a/tests/reg_issue2273/reg_issue2273.fz.expected_err
+++ b/tests/reg_issue2273/reg_issue2273.fz.expected_err
@@ -4,10 +4,10 @@ $MODULE/mutate.fz:302:7: error 1: Failed to verify that effect 'mutate' is insta
 ------^
 Callchain that lead to this point:
 
-effect environment '--empty--' for call to ((mutate.#type mutate).array.#type (mutate.array door) door).new mutate at --CURDIR--/reg_issue2273.fz:33:26:
+effect environment '--empty--' for call to '((mutate.#type mutate).array.#type (mutate.array door) door).new mutate' at --CURDIR--/reg_issue2273.fz:33:26:
 d := (mutate.array door).new mutate 100 closed
 -------------------------^^^
-effect environment '--empty--' for call to universe#0
+effect environment '--empty--' for call to 'universe#0'
 effect environment '--empty--' at program entry
 
 one error.


### PR DESCRIPTION
DFA: Take call site into account when tracing instances and calls

This increase the DFA accuracy such that tests like flang.dev's `content/design/examples/monadiclifting_helloabort.fz` no longer produce errors.

The general pattern of code that is improved by are calls that differ by their location, i.e., in the code

```
(io.out p1).go (() -> do_something)
(io.out p2).go (() -> do_something_else)
```

we can now distinguish the two instances of `io.out` such that their print handlers `p1` and `p2` will not be mixed up.

For this, support for site indices was added to IR.java. A site index is a single integer that combines a code block index and an expr index in that code block into a single value.  Eventually, code block indices and expr indices should be removed completely from IR and FUIR and replaced by site indices where site..site+n corresponds to (c,i=0)..(c,i=n).

This patch adds helper a methods `IR.addCode`/`IR.getExpr` that are used in `IR.java` and `MIR.java`.

Since the more accurate analysis results in `error` instances produced by the interface to Java code to be treated separately, this patch adds code to properly initialize the `msg` field in those `error` instances.
