### PR TITLE
ir/fuir/mir: Add support for site instead of c/i for codeblock and index

### DIFF
--- a/src/dev/flang/ast/Types.java
+++ b/src/dev/flang/ast/Types.java
@@ -163,6 +163,7 @@ public class Types extends ANY
     public final AbstractFeature f_array;
     public final AbstractFeature f_array_internal_array;
     public final AbstractFeature f_error;
+    public final AbstractFeature f_error_msg;
     public final AbstractFeature f_fuzion;
     public final AbstractFeature f_fuzion_java;
     public final AbstractFeature f_fuzion_java_object;
@@ -223,6 +224,7 @@ public class Types extends ANY
       f_array         = universe.get(mod, "array", 5);
       f_array_internal_array = f_array.get(mod, "internal_array");
       f_error         = universe.get(mod, "error", 1);
+      f_error_msg     = f_error.get(mod, "msg");
       f_fuzion                     = universe.get(mod, "fuzion");
       f_fuzion_java                = f_fuzion.get(mod, "java");
       f_fuzion_java_object         = f_fuzion_java.get(mod, "Java_Object");

--- a/src/dev/flang/fuir/FUIR.java
+++ b/src/dev/flang/fuir/FUIR.java
@@ -2076,6 +2076,19 @@ hw25 is
 
 
   /**
+   * For a clazz of error, lookup the inner clazz of the msg field.
+   *
+   * @param cl index of a clazz `error`
+   *
+   * @return the index of the requested `error.msg` field's clazz.
+   */
+  public int lookup_error_msg(int cl)
+  {
+    return lookup(cl, Types.resolved.f_error_msg);
+  }
+
+
+  /**
    * Internal helper for lookup_* methods.
    *
    * @param cl index of the outer clazz for the lookup

--- a/src/dev/flang/fuir/FUIR.java
+++ b/src/dev/flang/fuir/FUIR.java
@@ -1021,7 +1021,7 @@ hw25 is
           {
             addCode(cc, code, ff);
           }
-        res = _codeIds.add(code);
+        res = addCode(code);
         _clazzCode.put(cl, res);
       }
     return res;
@@ -1092,7 +1092,7 @@ hw25 is
           {
             var code = new List<Object>();
             toStack(code, cond.get(i).cond);
-            resBoxed = _codeIds.add(code);
+            resBoxed = addCode(code);
             _clazzContract.put(key, resBoxed);
           }
         res = resBoxed;
@@ -1372,7 +1372,7 @@ hw25 is
       (ix >= 0, withinCode(c, ix));
 
     ExprKind result;
-    var e = _codeIds.get(c).get(ix);
+    var e = getExpr(c , ix);
     if (e instanceof Clazz    )  /* Clazz represents the field we assign a value to */
       {
         result = ExprKind.Assign;
@@ -1399,7 +1399,7 @@ hw25 is
        codeAt(c, ix) == ExprKind.Tag);
 
     var outerClazz = clazz(cl);
-    var t = (Tag) _codeIds.get(c).get(ix);
+    var t = (Tag) getExpr(c , ix);
     var vcl = outerClazz.actualClazzes(t, null)[0];
     return vcl == null ? -1 : id(vcl);
   }
@@ -1412,7 +1412,7 @@ hw25 is
        codeAt(c, ix) == ExprKind.Tag);
 
     var outerClazz = clazz(cl);
-    var t = (Tag) _codeIds.get(c).get(ix);
+    var t = (Tag) getExpr(c , ix);
     var ncl = outerClazz.actualClazzes(t, null)[1];
     return ncl == null ? -1 : id(ncl);
   }
@@ -1429,7 +1429,7 @@ hw25 is
        codeAt(c, ix) == ExprKind.Env);
 
     var outerClazz = clazz(cl);
-    var v = (Env) _codeIds.get(c).get(ix);
+    var v = (Env) getExpr(c , ix);
     var vcl = outerClazz.actualClazzes(v, null)[0];
     return vcl == null ? -1 : id(vcl);
   }
@@ -1442,7 +1442,7 @@ hw25 is
        codeAt(c, ix) == ExprKind.Box);
 
     var outerClazz = clazz(cl);
-    var b = (Box) _codeIds.get(c).get(ix);
+    var b = (Box) getExpr(c , ix);
     Clazz vc = outerClazz.actualClazzes(b, null)[0];
     return id(vc);
   }
@@ -1455,7 +1455,7 @@ hw25 is
        codeAt(c, ix) == ExprKind.Box);
 
     var outerClazz = clazz(cl);
-    var b = (Box) _codeIds.get(c).get(ix);
+    var b = (Box) getExpr(c , ix);
     Clazz rc = outerClazz.actualClazzes(b, null)[1];
     return id(rc);
   }
@@ -1515,7 +1515,7 @@ hw25 is
        codeAt(c, ix) == ExprKind.Assign    );
 
     var outerClazz = clazz(cl);
-    var s = _codeIds.get(c).get(ix);
+    var s = getExpr(c , ix);
     Clazz innerClazz =
       (s instanceof AbstractCall   call) ? outerClazz.actualClazzes(call, null)[2] :
       (Clazz) (Object) new Object() { { if (true) throw new Error("accessedClazz found unexpected Expr."); } } /* Java is ugly... */;
@@ -1547,7 +1547,7 @@ hw25 is
        codeAt(c, ix) == ExprKind.Assign    );
 
     var outerClazz = clazz(cl);
-    var s = _codeIds.get(c).get(ix);
+    var s = getExpr(c , ix);
     Clazz innerClazz =
       (s instanceof AbstractCall   call) ? outerClazz.actualClazzes(call, null)[0] :
       (s instanceof AbstractAssign a   ) ? outerClazz.actualClazzes(a   , null)[1] :
@@ -1578,7 +1578,7 @@ hw25 is
        codeAt(c, ix) == ExprKind.Assign    );
 
     var outerClazz = clazz(cl);
-    var s = _codeIds.get(c).get(ix);
+    var s = getExpr(c , ix);
     var t =
       (s instanceof AbstractAssign a   ) ? outerClazz.actualClazzes(a, null)[2] :
       (s instanceof Clazz          fld ) ? fld.resultClazz() :
@@ -1615,7 +1615,7 @@ hw25 is
     if (res == null)
       {
         var outerClazz = clazz(cl);
-        var s = _codeIds.get(c).get(ix);
+        var s = getExpr(c , ix);
         Clazz tclazz;
         AbstractFeature f;
         var typePars = AbstractCall.NO_GENERICS;
@@ -1736,7 +1736,7 @@ hw25 is
        codeAt(c, ix) == ExprKind.Call  );
 
     var outerClazz = clazz(cl);
-    var s = _codeIds.get(c).get(ix);
+    var s = getExpr(c , ix);
     var res =
       (s instanceof AbstractAssign ass ) ? outerClazz.actualClazzes(ass, null)[0].isRef() : // NYI: This should be the same as assignedField._outer
       (s instanceof Clazz          arg ) ? outerClazz.isRef() && !arg.feature().isOuterRef() : // assignment to arg field in inherits call (dynamic if outerClazz is ref)
@@ -1773,7 +1773,7 @@ hw25 is
        withinCode(c, ix),
        codeAt(c, ix) == ExprKind.Call);
 
-    var call = (AbstractCall) _codeIds.get(c).get(ix);
+    var call = (AbstractCall) getExpr(c , ix);
     return call.isInheritanceCall();
   }
 
@@ -1798,7 +1798,7 @@ hw25 is
        codeAt(c, ix) == ExprKind.Call  );
 
     var outerClazz = clazz(cl);
-    var s = _codeIds.get(c).get(ix);
+    var s = getExpr(c , ix);
     var tclazz =
       (s instanceof AbstractAssign ass ) ? outerClazz.actualClazzes(ass, null)[0] : // NYI: This should be the same as assignedField._outer
       (s instanceof Clazz          arg ) ? outerClazz : // assignment to arg field in inherits call, so outer clazz is current instance
@@ -1835,7 +1835,7 @@ hw25 is
        codeAt(c, ix) == ExprKind.Const);
 
     var cc = clazz(cl);
-    var ac = (AbstractConstant) _codeIds.get(c).get(ix);
+    var ac = (AbstractConstant) getExpr(c , ix);
     var acl = cc.actualClazzes(ac.origin(), null);
     // origin might be AbstractConstant, AbstractCall or InlineArray.  In all
     // cases, the clazz of the result is the first actual clazz:
@@ -1855,7 +1855,7 @@ hw25 is
        withinCode(c, ix),
        codeAt(c, ix) == ExprKind.Const);
 
-    var ic = _codeIds.get(c).get(ix);
+    var ic = getExpr(c , ix);
     return ((AbstractConstant) ic).data();
   }
 
@@ -1879,7 +1879,7 @@ hw25 is
        codeAt(c, ix) == ExprKind.Match);
 
     var cc = clazz(cl);
-    var s = _codeIds.get(c).get(ix);
+    var s = getExpr(c , ix);
     Clazz ss = cc.actualClazzes((Expr) s, null)[0];
     return id(ss);
   }
@@ -1908,7 +1908,7 @@ hw25 is
        0 <= cix && cix <= matchCaseCount(c, ix));
 
     var cc = clazz(cl);
-    var s = _codeIds.get(c).get(ix);
+    var s = getExpr(c , ix);
     int result = -1; // no field for If
     if (s instanceof AbstractMatch m)
       {
@@ -1943,7 +1943,7 @@ hw25 is
        0 <= cix && cix <= matchCaseCount(c, ix));
 
     var cc = clazz(cl);
-    var s = _codeIds.get(c).get(ix);
+    var s = getExpr(c , ix);
     int[] result;
     if (s instanceof If)
       {
@@ -2001,7 +2001,7 @@ hw25 is
        codeAt(c, ix) == ExprKind.Match,
        0 <= cix && cix <= matchCaseCount(c, ix));
 
-    var s = _codeIds.get(c).get(ix+1+cix);
+    var s = getExpr(c, ix + 1 + cix);
     return ((NumLiteral)s).intValue().intValueExact();
   }
 
@@ -2186,10 +2186,25 @@ hw25 is
     if (PRECONDITIONS) require
       (ix >= 0, withinCode(c, ix));
 
-    var e = _codeIds.get(c).get(ix);
+    var e = getExpr(c , ix);
     return (e instanceof Expr expr) ? expr.pos() :
            (e instanceof Clazz z) ? z._type.declarationPos()  /* implicit assignment to argument field */
                                   : null;
+  }
+
+
+
+  /**
+   * Get the source code position of an expr at the given site if it is available.
+   *
+   * @param site the code position, IR.NO_SITE if unkown.
+   *
+   * @return the source code position or null if not available.
+   */
+  public SourcePosition siteAsPos(int site)
+  {
+    return site != NO_SITE ? codeAtAsPos(codeIndexFromSite(site), exprIndexFromSite(site))
+                           : null;
   }
 
 

--- a/src/dev/flang/fuir/analysis/dfa/DFA.java
+++ b/src/dev/flang/fuir/analysis/dfa/DFA.java
@@ -1964,7 +1964,11 @@ public class DFA extends ANY
             }
           };
         var okay = new TaggedValue(cl._dfa, rc, res, 0);
-        var err = new TaggedValue(cl._dfa, rc, cl._dfa.newInstance(cl._dfa._fuir.clazzChoice(rc, 1), null), 1);
+        var error_cl = cl._dfa._fuir.clazzChoice(rc, 1);
+        var error = cl._dfa.newInstance(error_cl, null);
+        var msg = cl._dfa._fuir.lookup_error_msg(error_cl);
+        error.setField(cl._dfa, msg, cl._dfa.newConstString(null, cl));
+        var err = new TaggedValue(cl._dfa, rc, error, 1);
         return okay.join(err);
       }
     return switch (cl._dfa._fuir.getSpecialClazz(rc))

--- a/src/dev/flang/ir/IR.java
+++ b/src/dev/flang/ir/IR.java
@@ -79,6 +79,19 @@ public class IR extends ANY
    */
   protected static final int FEATURE_BASE = 0x50000000;
 
+  /**
+   * For sites represented by integers, this gives the base added to the
+   * integers to detect wrong values quickly.
+   */
+  protected static final int SITE_BASE = 0x70000000;
+
+
+  /**
+   * Special site index value for unknown site location (i.e, a site coming from
+   * an intrinsic or the program entry point).
+   */
+  public static final int NO_SITE = SITE_BASE-1;
+
 
   /**
    * The basic types of features in Fuzion:
@@ -125,7 +138,17 @@ public class IR extends ANY
   }
 
 
-  protected final Map2Int<List<Object>> _codeIds;
+  /**
+   * All the code blocks in this IR. They are added via `addCode`.
+   */
+  private final Map2Int<List<Object>> _codeIds;
+
+
+  /**
+   * For every raw code block index in _codeIds, this gives the index of the
+   * first site for the corresponding code block.
+   */
+  private final List<Integer> _siteStart = new List<>(0);
 
 
   /*--------------------------  constructors  ---------------------------*/
@@ -146,6 +169,132 @@ public class IR extends ANY
   protected IR(IR original)
   {
     _codeIds = original._codeIds;
+  }
+
+  /*-----------------------  code block handling  -----------------------*/
+
+
+  /**
+   * Add given code block and abtain a unique id for it.
+   *
+   * This also sets _siteStart in case `b` was not already added.
+   *
+   * NYI: UNDER DEVELOPMENT: The returned index should be replaced by a site
+   * index, i.e., siteFromCI(result, 0).
+   *
+   * @param b a list of Expr statements to be added.
+   *
+   * @return the index of b
+   */
+  protected int addCode(List<Object> b)
+  {
+    b.freeze();
+    var res = _codeIds.add(b);
+    var index = res - CODE_BASE;
+    if (index >= _siteStart.size()-1)
+      {
+        var nextSiteStart = _siteStart.getLast() + b.size() + 1; // b.size() might be 0 so we add 1 to have disjoint site indices
+        _siteStart.add(nextSiteStart);
+      }
+    return res;
+  }
+
+
+  /**
+   * Get the Expr #i in code block c
+   *
+   * NYI: UNDER DEVELOPMENT: This should be replaced by `getExpr(int site)`.
+   *
+   * @param c the code block index returned by `addCode`
+   *
+   * @param i an index in c
+   */
+  protected Object getExpr(int c, int i)
+  {
+    return _codeIds.get(c).get(i);
+  }
+
+
+
+  /**
+   * Convert a code block index c and an Expr index in that code block to a site
+   * index.
+   *
+   * NYI: UNDER DEVELOPMENT: This should be removed once `site` is used throughout.
+   *
+   * @param c the code block index returned by `addCode`
+   *
+   * @param i an index in c
+   *
+   * @return a site index corresponding to `c`/`i`.
+   */
+  public int siteFromCI(int c, int i)
+  {
+    if (PRECONDITIONS) require
+      (0 <= i && i < _codeIds.get(c).size());
+
+    var index = c - CODE_BASE;
+    var result = _siteStart.get(index).intValue() + i + SITE_BASE;
+
+    if (POSTCONDITIONS) ensure
+      (c == codeIndexFromSite(result),
+       i == exprIndexFromSite(result));
+
+    return result;
+  }
+
+
+  /**
+   * Extract code block index from a site.
+   *
+   * NYI: UNDER DEVELOPMENT: This should be removed once `site` is used throughout.
+   *
+   * @param site a code site
+   *
+   * @return the index of the code block containing the given site.
+   */
+  protected int codeIndexFromSite(int site)
+  {
+    var rawSite = site - SITE_BASE;
+    // perform binary search in _siteStart
+    int l = 0;
+    int r = _siteStart.size()-1;
+    int result_raw_c;
+    do
+      {
+        int m = (l + r) / 2;
+        var s = _siteStart.get(m).intValue();
+        int cmp = Integer.compare(rawSite, s);
+        result_raw_c = cmp < 0 ? m-1 : m;
+        if (cmp <= 0) { r = m - 1; }
+        if (cmp >= 0) { l = m + 1; }
+      }
+    while (l <= r);
+    int result_c = result_raw_c + CODE_BASE;
+
+    if (POSTCONDITIONS) ensure
+      (site >= result_raw_c,
+       _siteStart.get(result_raw_c) <= rawSite,
+       result_raw_c == _siteStart.size()-1 || _siteStart.get(result_raw_c+1) > rawSite);
+
+    return result_c;
+  }
+
+
+  /**
+   * Extract expr index from a site.
+   *
+   * NYI: UNDER DEVELOPMENT: This should be removed once `site` is used throughout.
+   *
+   * @param site a code site
+   *
+   * @return the index of the Expr withing the code block containing the given site.
+   */
+  protected int exprIndexFromSite(int site)
+  {
+    var rawSite = site - SITE_BASE;
+    var index = codeIndexFromSite(site) - CODE_BASE;
+    return rawSite - _siteStart.get(index).intValue();
   }
 
 
@@ -249,8 +398,8 @@ public class IR extends ANY
         // if is converted to If, blockId, elseBlockId
         toStack(l, i.cond);
         l.add(i);
-        l.add(new NumLiteral(_codeIds.add(toStack(i.block      ))));
-        l.add(new NumLiteral(_codeIds.add(toStack(i.elseBlock()))));
+        l.add(new NumLiteral(addCode(toStack(i.block      ))));
+        l.add(new NumLiteral(addCode(toStack(i.elseBlock()))));
       }
     else if (e instanceof AbstractCall c)
       {
@@ -272,7 +421,7 @@ public class IR extends ANY
         for (var c : m.cases())
           {
             var caseCode = toStack(c.code());
-            l.add(new NumLiteral(_codeIds.add(caseCode)));
+            l.add(new NumLiteral(addCode(caseCode)));
           }
       }
     else if (e instanceof Tag t)

--- a/src/dev/flang/mir/MIR.java
+++ b/src/dev/flang/mir/MIR.java
@@ -228,7 +228,7 @@ hw25 is
     var ff = _featureIds.get(f);
     var code = prolog(ff);
     addCode(ff, code, ff);
-    return _codeIds.add(code);
+    return addCode(code);
   }
 
 
@@ -292,7 +292,7 @@ hw25 is
        codeAt(c, ix) == ExprKind.Assign    );
 
     var ff = _featureIds.get(f);
-    var s = _codeIds.get(c).get(ix);
+    var s = getExpr(c, ix);
     var af =
       (s instanceof AbstractCall   call) ? call.calledFeature() :
       (s instanceof AbstractAssign a   ) ? a._assignedField :


### PR DESCRIPTION
A `site` is an int the identifies an expression in a code block, so it is a more
conveninient way compared ot passing the pair `c`/`i` that is so far used in
FUIR.  Eventually, codeblock indices should be removed completely and replaced
by `site`s only.

This patch adds a convenience method `IR.addCode` that manages the calculation
of `site` and `getExpr` as a temporary convenience method to get an Expr for
given `c`/`i`.

This should be reviewed against #2750, this is part two of my attempt to split up #2743 into several PRs.