### PR TITLE
dfa: improve error produced for uninitialized field

### DIFF
--- a/src/dev/flang/ast/Types.java
+++ b/src/dev/flang/ast/Types.java
@@ -163,6 +163,7 @@ public class Types extends ANY
     public final AbstractFeature f_array;
     public final AbstractFeature f_array_internal_array;
     public final AbstractFeature f_error;
+    public final AbstractFeature f_error_msg;
     public final AbstractFeature f_fuzion;
     public final AbstractFeature f_fuzion_java;
     public final AbstractFeature f_fuzion_java_object;
@@ -223,6 +224,7 @@ public class Types extends ANY
       f_array         = universe.get(mod, "array", 5);
       f_array_internal_array = f_array.get(mod, "internal_array");
       f_error         = universe.get(mod, "error", 1);
+      f_error_msg     = f_error.get(mod, "msg");
       f_fuzion                     = universe.get(mod, "fuzion");
       f_fuzion_java                = f_fuzion.get(mod, "java");
       f_fuzion_java_object         = f_fuzion_java.get(mod, "Java_Object");

--- a/src/dev/flang/fuir/FUIR.java
+++ b/src/dev/flang/fuir/FUIR.java
@@ -2076,6 +2076,19 @@ hw25 is
 
 
   /**
+   * For a clazz of error, lookup the inner clazz of the msg field.
+   *
+   * @param cl index of a clazz `error`
+   *
+   * @return the index of the requested `error.msg` field's clazz.
+   */
+  public int lookup_error_msg(int cl)
+  {
+    return lookup(cl, Types.resolved.f_error_msg);
+  }
+
+
+  /**
    * Internal helper for lookup_* methods.
    *
    * @param cl index of the outer clazz for the lookup

--- a/src/dev/flang/fuir/FUIR.java
+++ b/src/dev/flang/fuir/FUIR.java
@@ -1021,7 +1021,7 @@ hw25 is
           {
             addCode(cc, code, ff);
           }
-        res = _codeIds.add(code);
+        res = addCode(code);
         _clazzCode.put(cl, res);
       }
     return res;
@@ -1092,7 +1092,7 @@ hw25 is
           {
             var code = new List<Object>();
             toStack(code, cond.get(i).cond);
-            resBoxed = _codeIds.add(code);
+            resBoxed = addCode(code);
             _clazzContract.put(key, resBoxed);
           }
         res = resBoxed;
@@ -1372,7 +1372,7 @@ hw25 is
       (ix >= 0, withinCode(c, ix));
 
     ExprKind result;
-    var e = _codeIds.get(c).get(ix);
+    var e = getExpr(c , ix);
     if (e instanceof Clazz    )  /* Clazz represents the field we assign a value to */
       {
         result = ExprKind.Assign;
@@ -1399,7 +1399,7 @@ hw25 is
        codeAt(c, ix) == ExprKind.Tag);
 
     var outerClazz = clazz(cl);
-    var t = (Tag) _codeIds.get(c).get(ix);
+    var t = (Tag) getExpr(c , ix);
     var vcl = outerClazz.actualClazzes(t, null)[0];
     return vcl == null ? -1 : id(vcl);
   }
@@ -1412,7 +1412,7 @@ hw25 is
        codeAt(c, ix) == ExprKind.Tag);
 
     var outerClazz = clazz(cl);
-    var t = (Tag) _codeIds.get(c).get(ix);
+    var t = (Tag) getExpr(c , ix);
     var ncl = outerClazz.actualClazzes(t, null)[1];
     return ncl == null ? -1 : id(ncl);
   }
@@ -1429,7 +1429,7 @@ hw25 is
        codeAt(c, ix) == ExprKind.Env);
 
     var outerClazz = clazz(cl);
-    var v = (Env) _codeIds.get(c).get(ix);
+    var v = (Env) getExpr(c , ix);
     var vcl = outerClazz.actualClazzes(v, null)[0];
     return vcl == null ? -1 : id(vcl);
   }
@@ -1442,7 +1442,7 @@ hw25 is
        codeAt(c, ix) == ExprKind.Box);
 
     var outerClazz = clazz(cl);
-    var b = (Box) _codeIds.get(c).get(ix);
+    var b = (Box) getExpr(c , ix);
     Clazz vc = outerClazz.actualClazzes(b, null)[0];
     return id(vc);
   }
@@ -1455,7 +1455,7 @@ hw25 is
        codeAt(c, ix) == ExprKind.Box);
 
     var outerClazz = clazz(cl);
-    var b = (Box) _codeIds.get(c).get(ix);
+    var b = (Box) getExpr(c , ix);
     Clazz rc = outerClazz.actualClazzes(b, null)[1];
     return id(rc);
   }
@@ -1515,7 +1515,7 @@ hw25 is
        codeAt(c, ix) == ExprKind.Assign    );
 
     var outerClazz = clazz(cl);
-    var s = _codeIds.get(c).get(ix);
+    var s = getExpr(c , ix);
     Clazz innerClazz =
       (s instanceof AbstractCall   call) ? outerClazz.actualClazzes(call, null)[2] :
       (Clazz) (Object) new Object() { { if (true) throw new Error("accessedClazz found unexpected Expr."); } } /* Java is ugly... */;
@@ -1547,7 +1547,7 @@ hw25 is
        codeAt(c, ix) == ExprKind.Assign    );
 
     var outerClazz = clazz(cl);
-    var s = _codeIds.get(c).get(ix);
+    var s = getExpr(c , ix);
     Clazz innerClazz =
       (s instanceof AbstractCall   call) ? outerClazz.actualClazzes(call, null)[0] :
       (s instanceof AbstractAssign a   ) ? outerClazz.actualClazzes(a   , null)[1] :
@@ -1578,7 +1578,7 @@ hw25 is
        codeAt(c, ix) == ExprKind.Assign    );
 
     var outerClazz = clazz(cl);
-    var s = _codeIds.get(c).get(ix);
+    var s = getExpr(c , ix);
     var t =
       (s instanceof AbstractAssign a   ) ? outerClazz.actualClazzes(a, null)[2] :
       (s instanceof Clazz          fld ) ? fld.resultClazz() :
@@ -1615,7 +1615,7 @@ hw25 is
     if (res == null)
       {
         var outerClazz = clazz(cl);
-        var s = _codeIds.get(c).get(ix);
+        var s = getExpr(c , ix);
         Clazz tclazz;
         AbstractFeature f;
         var typePars = AbstractCall.NO_GENERICS;
@@ -1736,7 +1736,7 @@ hw25 is
        codeAt(c, ix) == ExprKind.Call  );
 
     var outerClazz = clazz(cl);
-    var s = _codeIds.get(c).get(ix);
+    var s = getExpr(c , ix);
     var res =
       (s instanceof AbstractAssign ass ) ? outerClazz.actualClazzes(ass, null)[0].isRef() : // NYI: This should be the same as assignedField._outer
       (s instanceof Clazz          arg ) ? outerClazz.isRef() && !arg.feature().isOuterRef() : // assignment to arg field in inherits call (dynamic if outerClazz is ref)
@@ -1773,7 +1773,7 @@ hw25 is
        withinCode(c, ix),
        codeAt(c, ix) == ExprKind.Call);
 
-    var call = (AbstractCall) _codeIds.get(c).get(ix);
+    var call = (AbstractCall) getExpr(c , ix);
     return call.isInheritanceCall();
   }
 
@@ -1798,7 +1798,7 @@ hw25 is
        codeAt(c, ix) == ExprKind.Call  );
 
     var outerClazz = clazz(cl);
-    var s = _codeIds.get(c).get(ix);
+    var s = getExpr(c , ix);
     var tclazz =
       (s instanceof AbstractAssign ass ) ? outerClazz.actualClazzes(ass, null)[0] : // NYI: This should be the same as assignedField._outer
       (s instanceof Clazz          arg ) ? outerClazz : // assignment to arg field in inherits call, so outer clazz is current instance
@@ -1835,7 +1835,7 @@ hw25 is
        codeAt(c, ix) == ExprKind.Const);
 
     var cc = clazz(cl);
-    var ac = (AbstractConstant) _codeIds.get(c).get(ix);
+    var ac = (AbstractConstant) getExpr(c , ix);
     var acl = cc.actualClazzes(ac.origin(), null);
     // origin might be AbstractConstant, AbstractCall or InlineArray.  In all
     // cases, the clazz of the result is the first actual clazz:
@@ -1855,7 +1855,7 @@ hw25 is
        withinCode(c, ix),
        codeAt(c, ix) == ExprKind.Const);
 
-    var ic = _codeIds.get(c).get(ix);
+    var ic = getExpr(c , ix);
     return ((AbstractConstant) ic).data();
   }
 
@@ -1879,7 +1879,7 @@ hw25 is
        codeAt(c, ix) == ExprKind.Match);
 
     var cc = clazz(cl);
-    var s = _codeIds.get(c).get(ix);
+    var s = getExpr(c , ix);
     Clazz ss = cc.actualClazzes((Expr) s, null)[0];
     return id(ss);
   }
@@ -1908,7 +1908,7 @@ hw25 is
        0 <= cix && cix <= matchCaseCount(c, ix));
 
     var cc = clazz(cl);
-    var s = _codeIds.get(c).get(ix);
+    var s = getExpr(c , ix);
     int result = -1; // no field for If
     if (s instanceof AbstractMatch m)
       {
@@ -1943,7 +1943,7 @@ hw25 is
        0 <= cix && cix <= matchCaseCount(c, ix));
 
     var cc = clazz(cl);
-    var s = _codeIds.get(c).get(ix);
+    var s = getExpr(c , ix);
     int[] result;
     if (s instanceof If)
       {
@@ -2001,7 +2001,7 @@ hw25 is
        codeAt(c, ix) == ExprKind.Match,
        0 <= cix && cix <= matchCaseCount(c, ix));
 
-    var s = _codeIds.get(c).get(ix+1+cix);
+    var s = getExpr(c, ix + 1 + cix);
     return ((NumLiteral)s).intValue().intValueExact();
   }
 
@@ -2186,10 +2186,25 @@ hw25 is
     if (PRECONDITIONS) require
       (ix >= 0, withinCode(c, ix));
 
-    var e = _codeIds.get(c).get(ix);
+    var e = getExpr(c , ix);
     return (e instanceof Expr expr) ? expr.pos() :
            (e instanceof Clazz z) ? z._type.declarationPos()  /* implicit assignment to argument field */
                                   : null;
+  }
+
+
+
+  /**
+   * Get the source code position of an expr at the given site if it is available.
+   *
+   * @param site the code position, IR.NO_SITE if unkown.
+   *
+   * @return the source code position or null if not available.
+   */
+  public SourcePosition siteAsPos(int site)
+  {
+    return site != NO_SITE ? codeAtAsPos(codeIndexFromSite(site), exprIndexFromSite(site))
+                           : null;
   }
 
 

--- a/src/dev/flang/fuir/analysis/dfa/Call.java
+++ b/src/dev/flang/fuir/analysis/dfa/Call.java
@@ -338,16 +338,19 @@ public class Call extends ANY implements Comparable<Call>, Context
   /**
    * Create human-readable string from this call with effect environment information
    */
-  public String toStringForEnv()
+  public String toString(boolean forEnv)
   {
     var on = _dfa._fuir.clazzOriginalName(_cc);
     var pos = callSitePos();
     return
-      (on.equals(EFFECT_ABORTABLE_NAME)
-       ? "install effect " + Errors.effe(_dfa._fuir.clazzAsString(_dfa._fuir.effectType(_cc))) + ", old envionment was "
-       : "effect environment ") +
-      Errors.effe(Env.envAsString(_env)) +
-      " for call to " + (_pre ? "precondition of " : "") +_dfa._fuir.clazzAsString(_cc)+
+      (forEnv
+       ? (on.equals(EFFECT_ABORTABLE_NAME)
+          ? "install effect " + Errors.effe(_dfa._fuir.clazzAsString(_dfa._fuir.effectType(_cc))) + ", old envionment was "
+          : "effect environment ") +
+         Errors.effe(Env.envAsString(_env)) +
+         " for call to "
+       : "call ")+
+      Errors.sqn((_pre ? "precondition of " : "") + _dfa._fuir.clazzAsString(_cc)) +
       (pos != null ? " at " + pos.pos().show() : "");
   }
 
@@ -423,16 +426,9 @@ public class Call extends ANY implements Comparable<Call>, Context
     var result = getEffectCheck(ecl);
     if (result == null && _dfa._reportResults && !_dfa._fuir.clazzOriginalName(_cc).equals("effect.type.unsafe_get"))
       {
-        var why = new StringBuilder("Callchain that lead to this point:\n\n");
-        Context co = this;
-        while (co != null)
-          {
-            why.append(co.toStringForEnv() + "\n");
-            co = co instanceof Call cc ? cc._context : null;
-          }
         DfaErrors.usedEffectNeverInstantiated(pos,
                                               _dfa._fuir.clazzAsString(ecl),
-                                              why.toString());
+                                              this);
         _dfa._missingEffects.add(ecl);
       }
     return result;

--- a/src/dev/flang/fuir/analysis/dfa/Context.java
+++ b/src/dev/flang/fuir/analysis/dfa/Context.java
@@ -52,9 +52,10 @@ public interface Context
       say("program entry point");
       return "  ";
     }
-    public String toStringForEnv()
+    public String toString(boolean forEnv)
     {
-      return "effect environment " + Errors.effe(Env.envAsString(null)) + " at program entry";
+      return forEnv ? "effect environment " + Errors.effe(Env.envAsString(null)) + " at program entry"
+                    : "program entry point";
     }
   };
 
@@ -94,7 +95,44 @@ public interface Context
    * Show the context that caused the inclusion of this instance into the
    * analysis in a way that is useful for error related to effects.
    */
-  String toStringForEnv();
+  String toString(boolean forEnv);
+
+
+  /**
+   * Create a multi-line String describing this context to be used in error
+   * messages.
+   *
+   * @param forEnv true if effect environments should be included in the
+   * resulting string.
+   *
+   * @return A LF-terminated String of the call context starting with the
+   * innermost context going towards older and older contexts until we reach the
+   * program entry point.
+   */
+  default String contextString(boolean forEnv)
+  {
+    var result = new StringBuilder();
+    Context co = this;
+    while (co != null)
+      {
+        result.append(co.toString(forEnv) + "\n");
+        co = co instanceof Call cc ? cc._context : null;
+      }
+    return result.toString();
+  }
+
+
+  /**
+   * Convenience function for `conextString(true)`
+   */
+  default String contextStringForEnv() { return contextString(true); }
+
+
+  /**
+   * Convenience function for `conextString(false)`
+   */
+  default String contextString()       { return contextString(false); }
+
 
 }
 

--- a/src/dev/flang/fuir/analysis/dfa/DFA.java
+++ b/src/dev/flang/fuir/analysis/dfa/DFA.java
@@ -36,6 +36,8 @@ import java.util.TreeSet;
 
 import java.util.function.Supplier;
 
+import static dev.flang.ir.IR.NO_SITE;
+
 import dev.flang.fuir.FUIR;
 import dev.flang.fuir.FUIR.SpecialClazzes;
 import dev.flang.fuir.analysis.AbstractInterpreter;
@@ -396,8 +398,7 @@ public class DFA extends ANY
           {
             if (_fuir.clazzNeedsCode(cc))
               {
-                var ca = newCall(cc, preCalled, tvalue.value(), args, _call._env, _call);
-                ca.addCallSiteLocation(c,i);
+                var ca = newCall(cc, preCalled, _fuir.siteFromCI(c,i), tvalue.value(), args, _call._env, _call);
                 res = ca.result();
                 if (res != null && res != Value.UNIT && !_fuir.clazzIsRef(_fuir.clazzResultClazz(cc)))
                   {
@@ -424,7 +425,7 @@ public class DFA extends ANY
           }
         case Field:
           {
-            res = tvalue.value().callField(DFA.this, cc);
+            res = tvalue.value().callField(DFA.this, cc, _fuir.siteFromCI(c,i), _call);
             if (_reportResults && _options.verbose(9))
               {
                 say("DFA for "+_fuir.clazzAsString(cl)+"("+_fuir.clazzArgCount(cl)+" args) at "+c+"."+i+": "+_fuir.codeAtAsString(cl,c,i)+": " +
@@ -538,7 +539,7 @@ public class DFA extends ANY
      */
     private Value newValueConst(int constCl, Context context, ByteBuffer b)
     {
-      var result = newInstance(constCl, context);
+      var result = newInstance(constCl, NO_SITE, context);
       var args = new List<Val>();
       for (int index = 0; index < _fuir.clazzArgCount(constCl); index++)
         {
@@ -554,9 +555,9 @@ public class DFA extends ANY
       // not every backend actually performs these calls.
       if (_fuir.hasPrecondition(constCl))
         {
-          newCall(constCl, true, _universe, args, null /* new environment */, context);
+          newCall(constCl, true, NO_SITE, _universe, args, null /* new environment */, context);
         }
-      newCall(constCl, false, _universe, args, null /* new environment */, context);
+      newCall(constCl, false, NO_SITE, _universe, args, null /* new environment */, context);
 
       return result;
     }
@@ -576,9 +577,9 @@ public class DFA extends ANY
      */
     private Value newArrayConst(int constCl, Call context, ByteBuffer d)
     {
-      var result = newInstance(constCl, context);
+      var result = newInstance(constCl, NO_SITE, context);
       var sa = _fuir.clazzField(constCl, 0);
-      var sa0 = newInstance(_fuir.clazzResultClazz(sa), context);
+      var sa0 = newInstance(_fuir.clazzResultClazz(sa), NO_SITE, context);
 
       var elementClazz = _fuir.inlineArrayElementClazz(constCl);
       var data = _fuir.clazzField(_fuir.clazzResultClazz(sa), 0);
@@ -949,7 +950,7 @@ public class DFA extends ANY
     _true  = new TaggedValue(this, bool, Value.UNIT, 1);
     _false = new TaggedValue(this, bool, Value.UNIT, 0);
     _bool  = _true.join(_false);
-    _universe = newInstance(_fuir.clazzUniverse(), null);
+    _universe = newInstance(_fuir.clazzUniverse(), NO_SITE, null);
     Errors.showAndExit();
   }
 
@@ -1103,6 +1104,7 @@ public class DFA extends ANY
       {
         newCall(cl,
                 true,
+                NO_SITE,
                 Value.UNIT,
                 new List<>(),
                 null /* env */,
@@ -1111,6 +1113,7 @@ public class DFA extends ANY
 
     newCall(cl,
             false,
+            NO_SITE,
             Value.UNIT,
             new List<>(),
             null /* env */,
@@ -1400,7 +1403,7 @@ public class DFA extends ANY
           var atomic    = cl._target;
           var expected  = cl._args.get(0);
           var new_value = cl._args.get(1).value();
-          var res = atomic.callField(cl._dfa, v);
+          var res = atomic.callField(cl._dfa, v, cl.site(), cl);
 
           // NYI: we could make compare_and_swap more accurate and call setField only if res contains expected, need bit-wise comparison
           atomic.setField(cl._dfa, v, new_value);
@@ -1417,7 +1420,7 @@ public class DFA extends ANY
           var atomic    = cl._target;
           var expected  = cl._args.get(0);
           var new_value = cl._args.get(1).value();
-          var res = atomic.callField(cl._dfa, v);
+          var res = atomic.callField(cl._dfa, v, cl.site(), cl);
 
           // NYI: we could make compare_and_set more accurate and call setField only if res contains expected, need bit-wise comparison
           atomic.setField(cl._dfa, v, new_value);
@@ -1438,7 +1441,7 @@ public class DFA extends ANY
             (cl._dfa._fuir.clazzNeedsCode(v));
 
           var atomic = cl._target;
-          return atomic.callField(cl._dfa, v);
+          return atomic.callField(cl._dfa, v, cl.site(), cl);
         });
 
     put("concur.atomic.write0", cl ->
@@ -1785,7 +1788,7 @@ public class DFA extends ANY
 
           // NYI: spawn0 needs to set up an environment representing the new
           // thread and perform thread-related checks (race-detection. etc.)!
-          var ncl = cl._dfa.newCall(call, false, cl._args.get(0).value(), new List<>(), null /* new environment */, cl);
+          var ncl = cl._dfa.newCall(call, false, NO_SITE, cl._args.get(0).value(), new List<>(), null /* new environment */, cl);
           return new NumericValue(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc));
         });
     put("fuzion.sys.thread.join0"        , cl -> Value.UNIT);
@@ -1874,7 +1877,7 @@ public class DFA extends ANY
 
           var env = cl._env;
           var newEnv = cl._dfa.newEnv(cl, env, ecl, cl._target);
-          var ncl = cl._dfa.newCall(call, false, cl._args.get(0).value(), new List<>(), newEnv, cl);
+          var ncl = cl._dfa.newCall(call, false, NO_SITE, cl._args.get(0).value(), new List<>(), newEnv, cl);
           // NYI: result must be null if result of ncl is null (ncl does not return) and effect.abort is not called
           return Value.UNIT;
         });
@@ -1900,7 +1903,7 @@ public class DFA extends ANY
         {
           var jref = cl._dfa._fuir.lookupJavaRef(cl._dfa._fuir.clazzArgClazz(cl._cc, 0));
           cl._dfa._readFields.add(jref);
-          return cl._dfa.newInstance(cl._dfa._fuir.clazzResultClazz(cl._cc), cl._context);
+          return cl._dfa.newInstance(cl._dfa._fuir.clazzResultClazz(cl._cc), NO_SITE, cl._context);
         });
     put("fuzion.java.array_length"          , cl -> new NumericValue(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc)) );
     put("fuzion.java.array_to_java_object0" , cl ->
@@ -1909,18 +1912,18 @@ public class DFA extends ANY
           var jref = cl._dfa._fuir.lookupJavaRef(rc);
           var data = cl._dfa._fuir.lookup_fuzion_sys_internal_array_data(cl._dfa._fuir.clazzArgClazz(cl._cc,0));
           cl._dfa._readFields.add(data);
-          var result = cl._dfa.newInstance(cl._dfa._fuir.clazzResultClazz(cl._cc), cl._context);
+          var result = cl._dfa.newInstance(cl._dfa._fuir.clazzResultClazz(cl._cc), NO_SITE, cl._context);
           result.setField(cl._dfa, jref, Value.UNKNOWN_JAVA_REF); // NYI: record putfield of result.jref := args.get(0).data
           return result;
         });
-    put("fuzion.java.bool_to_java_object"   , cl -> cl._dfa.newInstance(cl._dfa._fuir.clazzResultClazz(cl._cc), cl._context) );
-    put("fuzion.java.f32_to_java_object"    , cl -> cl._dfa.newInstance(cl._dfa._fuir.clazzResultClazz(cl._cc), cl._context) );
-    put("fuzion.java.f64_to_java_object"    , cl -> cl._dfa.newInstance(cl._dfa._fuir.clazzResultClazz(cl._cc), cl._context) );
-    put("fuzion.java.get_field0"            , cl -> cl._dfa.newInstance(cl._dfa._fuir.clazzResultClazz(cl._cc), cl._context) );
-    put("fuzion.java.i16_to_java_object"    , cl -> cl._dfa.newInstance(cl._dfa._fuir.clazzResultClazz(cl._cc), cl._context) );
-    put("fuzion.java.i32_to_java_object"    , cl -> cl._dfa.newInstance(cl._dfa._fuir.clazzResultClazz(cl._cc), cl._context) );
-    put("fuzion.java.i64_to_java_object"    , cl -> cl._dfa.newInstance(cl._dfa._fuir.clazzResultClazz(cl._cc), cl._context) );
-    put("fuzion.java.i8_to_java_object"     , cl -> cl._dfa.newInstance(cl._dfa._fuir.clazzResultClazz(cl._cc), cl._context) );
+    put("fuzion.java.bool_to_java_object"   , cl -> cl._dfa.newInstance(cl._dfa._fuir.clazzResultClazz(cl._cc), NO_SITE, cl._context) );
+    put("fuzion.java.f32_to_java_object"    , cl -> cl._dfa.newInstance(cl._dfa._fuir.clazzResultClazz(cl._cc), NO_SITE, cl._context) );
+    put("fuzion.java.f64_to_java_object"    , cl -> cl._dfa.newInstance(cl._dfa._fuir.clazzResultClazz(cl._cc), NO_SITE, cl._context) );
+    put("fuzion.java.get_field0"            , cl -> cl._dfa.newInstance(cl._dfa._fuir.clazzResultClazz(cl._cc), NO_SITE, cl._context) );
+    put("fuzion.java.i16_to_java_object"    , cl -> cl._dfa.newInstance(cl._dfa._fuir.clazzResultClazz(cl._cc), NO_SITE, cl._context) );
+    put("fuzion.java.i32_to_java_object"    , cl -> cl._dfa.newInstance(cl._dfa._fuir.clazzResultClazz(cl._cc), NO_SITE, cl._context) );
+    put("fuzion.java.i64_to_java_object"    , cl -> cl._dfa.newInstance(cl._dfa._fuir.clazzResultClazz(cl._cc), NO_SITE, cl._context) );
+    put("fuzion.java.i8_to_java_object"     , cl -> cl._dfa.newInstance(cl._dfa._fuir.clazzResultClazz(cl._cc), NO_SITE, cl._context) );
     put("fuzion.java.java_string_to_string" , cl ->
         {
           var jref = cl._dfa._fuir.lookupJavaRef(cl._dfa._fuir.clazzArgClazz(cl._cc, 0));
@@ -1931,7 +1934,7 @@ public class DFA extends ANY
       {
         var rc = cl._dfa._fuir.clazzResultClazz(cl._cc);
         var jref = cl._dfa._fuir.lookupJavaRef(rc);
-        var jobj = cl._dfa.newInstance(rc, null);
+        var jobj = cl._dfa.newInstance(rc, NO_SITE, null);
         jobj.setField(cl._dfa, jref, Value.UNKNOWN_JAVA_REF);
         return jobj;
       });
@@ -1958,14 +1961,14 @@ public class DFA extends ANY
             }
             default -> {
               var jref = cl._dfa._fuir.lookupJavaRef(oc);
-              var jobj = cl._dfa.newInstance(oc, null);
+              var jobj = cl._dfa.newInstance(oc, NO_SITE, null);
               jobj.setField(cl._dfa, jref, Value.UNKNOWN_JAVA_REF);
               yield jobj;
             }
           };
         var okay = new TaggedValue(cl._dfa, rc, res, 0);
         var error_cl = cl._dfa._fuir.clazzChoice(rc, 1);
-        var error = cl._dfa.newInstance(error_cl, null);
+        var error = cl._dfa.newInstance(error_cl, NO_SITE, null);
         var msg = cl._dfa._fuir.lookup_error_msg(error_cl);
         error.setField(cl._dfa, msg, cl._dfa.newConstString(null, cl));
         var err = new TaggedValue(cl._dfa, rc, error, 1);
@@ -1979,7 +1982,7 @@ public class DFA extends ANY
         case c_unit -> Value.UNIT;
         default -> {
           var jref = cl._dfa._fuir.lookupJavaRef(rc);
-          var jobj = cl._dfa.newInstance(rc, null);
+          var jobj = cl._dfa.newInstance(rc, NO_SITE, null);
           jobj.setField(cl._dfa, jref, Value.UNKNOWN_JAVA_REF);
           yield jobj;
         }
@@ -2031,11 +2034,11 @@ public class DFA extends ANY
       {
         var rc = cl._dfa._fuir.clazzResultClazz(cl._cc);
         var jref = cl._dfa._fuir.lookupJavaRef(rc);
-        var jobj = cl._dfa.newInstance(rc, null);
+        var jobj = cl._dfa.newInstance(rc, NO_SITE, null);
         jobj.setField(cl._dfa, jref, Value.UNKNOWN_JAVA_REF);
         return jobj;
       });
-    put("fuzion.java.u16_to_java_object"    , cl -> cl._dfa.newInstance(cl._dfa._fuir.clazzResultClazz(cl._cc), null) );
+    put("fuzion.java.u16_to_java_object"    , cl -> cl._dfa.newInstance(cl._dfa._fuir.clazzResultClazz(cl._cc), NO_SITE, null) );
   }
 
 
@@ -2086,10 +2089,13 @@ public class DFA extends ANY
    *
    * @param cl the clazz
    *
+   * @param site the site index where the new instances is creates, NO_SITE
+   * if not within code (instrinsics etc.)
+   *
    * @param context for debugging: Reason that causes this instance to be part
    * of the analysis.
    */
-  Value newInstance(int cl, Context context)
+  Value newInstance(int cl, int site, Context context)
   {
     if (PRECONDITIONS) require
       (!_fuir.clazzIsChoice(cl) || _fuir.clazzIs(cl, SpecialClazzes.c_bool));
@@ -2108,11 +2114,11 @@ public class DFA extends ANY
         if (_fuir.clazzIsRef(cl))
           {
             var vc = _fuir.clazzAsValue(cl);
-            r = newInstance(vc, context).box(this, vc, cl, context);
+            r = newInstance(vc, site, context).box(this, vc, cl, context);
           }
         else
           {
-            r = new Instance(this, cl, context);
+            r = new Instance(this, cl, site, context);
           }
       }
     return cache(r);
@@ -2154,8 +2160,8 @@ public class DFA extends ANY
     var sysArray      = _fuir.clazzResultClazz(internalArray);
     var adata = utf8Bytes != null ? new SysArray(this, utf8Bytes, _fuir.clazz(FUIR.SpecialClazzes.c_u8))
                                   : new SysArray(this, new NumericValue(this, _fuir.clazz(FUIR.SpecialClazzes.c_u8)));
-    var r = newInstance(cs, context);
-    var a = newInstance(sysArray, context);
+    var r = newInstance(cs, NO_SITE, context);
+    var a = newInstance(sysArray, NO_SITE, context);
     a.setField(this,
                length,
                 utf8Bytes != null ? new NumericValue(this, _fuir.clazzResultClazz(length), utf8Bytes.length)
@@ -2173,6 +2179,9 @@ public class DFA extends ANY
    *
    * @param pre true iff precondition is called
    *
+   * @param site the call site, -1 if unknown (from intrinsic or program entry
+   * point)
+   *
    * @param tvalue the target value on which cl is called
    *
    * @param args the arguments passed to the call
@@ -2185,9 +2194,9 @@ public class DFA extends ANY
    * @return cl a new or existing call to cl (or its precondition) with the
    * given target, args and environment.
    */
-  Call newCall(int cl, boolean pre, Value tvalue, List<Val> args, Env env, Context context)
+  Call newCall(int cl, boolean pre, int site, Value tvalue, List<Val> args, Env env, Context context)
   {
-    var r = new Call(this, cl, pre, tvalue, args, env, context);
+    var r = new Call(this, cl, pre, site, tvalue, args, env, context);
     var e = _calls.get(r);
     if (e == null)
       {

--- a/src/dev/flang/fuir/analysis/dfa/DFA.java
+++ b/src/dev/flang/fuir/analysis/dfa/DFA.java
@@ -1964,7 +1964,11 @@ public class DFA extends ANY
             }
           };
         var okay = new TaggedValue(cl._dfa, rc, res, 0);
-        var err = new TaggedValue(cl._dfa, rc, cl._dfa.newInstance(cl._dfa._fuir.clazzChoice(rc, 1), null), 1);
+        var error_cl = cl._dfa._fuir.clazzChoice(rc, 1);
+        var error = cl._dfa.newInstance(error_cl, null);
+        var msg = cl._dfa._fuir.lookup_error_msg(error_cl);
+        error.setField(cl._dfa, msg, cl._dfa.newConstString(null, cl));
+        var err = new TaggedValue(cl._dfa, rc, error, 1);
         return okay.join(err);
       }
     return switch (cl._dfa._fuir.getSpecialClazz(rc))

--- a/src/dev/flang/fuir/analysis/dfa/DfaErrors.java
+++ b/src/dev/flang/fuir/analysis/dfa/DfaErrors.java
@@ -44,13 +44,20 @@ public class DfaErrors extends ANY
   /*-----------------------------  methods  -----------------------------*/
 
 
-  public static void usedEffectNeverInstantiated(HasSourcePosition pos, String e, String why)
+  public static void usedEffectNeverInstantiated(HasSourcePosition pos, String e, Context why)
   {
     Errors.error(pos.pos(),
                  "Failed to verify that effect " + st(e) + " is installed in current environment.",
-                 why);
+                 "Callchain that lead to this point:\n\n" + why.contextStringForEnv());
   }
 
+
+  public static void readingUninitializedField(HasSourcePosition pos, String field, String clazz, Context why)
+  {
+    Errors.error(pos.pos(),
+                 "reading uninitialized field " + sqn(field) + " from instance of " + code(clazz),
+                 "Callchain that lead to this point:\n\n" + why.contextString());
+  }
 
 }
 

--- a/src/dev/flang/fuir/analysis/dfa/Instance.java
+++ b/src/dev/flang/fuir/analysis/dfa/Instance.java
@@ -178,18 +178,10 @@ public class Instance extends Value implements Comparable<Instance>
       {
         if (dfa._reportResults)
           {
-            Errors.error("reading uninitialized field " + dfa._fuir.clazzAsString(field) + " from instance of " + dfa._fuir.clazzAsString(_clazz) +
-                         (_isBoxed ? " Boxed!" : "") +
-                         "\n" +
-                         "fields available:\n  " + _fields.keySet().stream().map(x -> ""+x+":"+dfa._fuir.clazzAsString(x)).collect(Collectors.joining(",\n  ")));
-
-            for (var f : _fields.keySet())
-              {
-                if (dfa._fuir.clazzAsString(f).equals(dfa._fuir.clazzAsString(field).replace("ref ","")))
-                  {
-                    say("NYI: HACK: Using value version instead: "+v);
-                  }
-              }
+            DfaErrors.readingUninitializedField(dfa._fuir.siteAsPos(site),
+                                                dfa._fuir.clazzAsString(field),
+                                                dfa._fuir.clazzAsString(_clazz) + (_isBoxed ? " Boxed!" : ""),
+                                                why);
           }
       }
     else if (!dfa._fuir.clazzIsRef(dfa._fuir.clazzResultClazz(field)))

--- a/src/dev/flang/fuir/analysis/dfa/Instance.java
+++ b/src/dev/flang/fuir/analysis/dfa/Instance.java
@@ -77,6 +77,17 @@ public class Instance extends Value implements Comparable<Instance>
   final boolean _isBoxed;
 
 
+  /**
+   * Site of the call that created this instance, -1 if the call site is not
+   * known, i.e., the call is coming from intrinsic call or the main entry
+   * point.
+   *
+   * Instances created at different sites will be considered as different
+   * instances.
+   */
+  final int _site;
+
+
   /*---------------------------  constructors  ---------------------------*/
 
 
@@ -90,7 +101,7 @@ public class Instance extends Value implements Comparable<Instance>
    * @param context for debugging: Reason that causes this instance to be part
    * of the analysis.
    */
-  public Instance(DFA dfa, int clazz, Context context)
+  public Instance(DFA dfa, int clazz, int site, Context context)
   {
     super(clazz);
 
@@ -98,6 +109,7 @@ public class Instance extends Value implements Comparable<Instance>
       (!dfa._fuir.clazzIsRef(clazz));
 
     _dfa = dfa;
+    _site = site;
     _context = context;
     _fields = new TreeMap<>();
     _isBoxed = false;
@@ -154,7 +166,7 @@ public class Instance extends Value implements Comparable<Instance>
   /**
    * Get set of values of given field within this instance.
    */
-  Val readFieldFromInstance(DFA dfa, int field)
+  Val readFieldFromInstance(DFA dfa, int field, int site, Context why)
   {
     if (PRECONDITIONS) require
       (_clazz == dfa._fuir.clazzAsValue(dfa._fuir.clazzOuterClazz(field)));

--- a/src/dev/flang/fuir/analysis/dfa/NumericValue.java
+++ b/src/dev/flang/fuir/analysis/dfa/NumericValue.java
@@ -165,7 +165,7 @@ public class NumericValue extends Value implements Comparable<NumericValue>
   /**
    * Get set of values of given field within this instance.
    */
-  Value readFieldFromInstance(DFA dfa, int field)
+  Value readFieldFromInstance(DFA dfa, int field, int site, Context why)
   {
     /* for a numeric value, this can only read the 'val' field, e.g., 'i32.val',
      * which (recursively) contains the numeric value, so we can just return

--- a/src/dev/flang/fuir/analysis/dfa/RefValue.java
+++ b/src/dev/flang/fuir/analysis/dfa/RefValue.java
@@ -111,9 +111,9 @@ public class RefValue extends Value
   /**
    * Get set of values of given field within this instance.
    */
-  Val readFieldFromInstance(DFA dfa, int field)
+  Val readFieldFromInstance(DFA dfa, int field, int site, Context why)
   {
-    return _original.readFieldFromInstance(dfa, field);
+    return _original.readFieldFromInstance(dfa, field, site, why);
   }
 
 

--- a/src/dev/flang/fuir/analysis/dfa/Value.java
+++ b/src/dev/flang/fuir/analysis/dfa/Value.java
@@ -26,6 +26,8 @@ Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
 
 package dev.flang.fuir.analysis.dfa;
 
+import static dev.flang.ir.IR.NO_SITE;
+
 import java.util.Comparator;
 
 import java.util.function.Consumer;
@@ -110,15 +112,15 @@ public class Value extends Val
        * Get set of values of given field within this value.  This works for unit
        * type results even if this is not an instance (but a unit type itself).
        */
-      public Val readField(DFA dfa, int field)
+      public Val readField(DFA dfa, int field, int site, Context why)
       {
         if (dfa._fuir.clazzUniverse() == dfa._fuir.clazzOuterClazz(field))
           {
-            return dfa._universe.readField(dfa, field);
+            return dfa._universe.readField(dfa, field, site, why);
           }
         else
           {
-            return super.readField(dfa, field);
+            return super.readField(dfa, field, site, why);
           }
       }
 
@@ -229,11 +231,11 @@ public class Value extends Val
    * Get set of values of given field within this value.  This works for unit
    * type results even if this is not an instance (but a unit type itself).
    */
-  public Val readField(DFA dfa, int field)
+  public Val readField(DFA dfa, int field, int site, Context why)
   {
     var rt = dfa._fuir.clazzResultClazz(field);
     var res = dfa._fuir.clazzIsUnitType(rt) ? Value.UNIT
-                                         : readFieldFromInstance(dfa, field);
+                                            : readFieldFromInstance(dfa, field, site, why);
     return res;
   }
 
@@ -243,12 +245,12 @@ public class Value extends Val
    *
    * @param cc the inner value of the field that is called.
    */
-  Val callField(DFA dfa, int cc)
+  Val callField(DFA dfa, int cc, int site, Context why)
   {
     var resa = new Val[] { null };
     forAll(t ->
            {
-             var r = t.readField(dfa, cc);
+             var r = t.readField(dfa, cc, site, why);
              if (resa[0] == null)
                {
                  resa[0] = r;
@@ -265,7 +267,7 @@ public class Value extends Val
   /**
    * Get set of values of given field within this instance.
    */
-  Val readFieldFromInstance(DFA dfa, int field)
+  Val readFieldFromInstance(DFA dfa, int field, int site, Context why)
   {
     throw new Error("Value.readField '"+dfa._fuir.clazzAsString(field)+"' called on class " + this + " (" + getClass() + "), expected " + Instance.class);
   }
@@ -314,7 +316,7 @@ public class Value extends Val
     Value result;
     if (this == UNIT)
       {
-        result = dfa.newInstance(rc, context);
+        result = dfa.newInstance(rc, NO_SITE, context);
       }
     else
       {

--- a/src/dev/flang/ir/IR.java
+++ b/src/dev/flang/ir/IR.java
@@ -79,6 +79,19 @@ public class IR extends ANY
    */
   protected static final int FEATURE_BASE = 0x50000000;
 
+  /**
+   * For sites represented by integers, this gives the base added to the
+   * integers to detect wrong values quickly.
+   */
+  protected static final int SITE_BASE = 0x70000000;
+
+
+  /**
+   * Special site index value for unknown site location (i.e, a site coming from
+   * an intrinsic or the program entry point).
+   */
+  public static final int NO_SITE = SITE_BASE-1;
+
 
   /**
    * The basic types of features in Fuzion:
@@ -125,7 +138,17 @@ public class IR extends ANY
   }
 
 
-  protected final Map2Int<List<Object>> _codeIds;
+  /**
+   * All the code blocks in this IR. They are added via `addCode`.
+   */
+  private final Map2Int<List<Object>> _codeIds;
+
+
+  /**
+   * For every raw code block index in _codeIds, this gives the index of the
+   * first site for the corresponding code block.
+   */
+  private final List<Integer> _siteStart = new List<>(0);
 
 
   /*--------------------------  constructors  ---------------------------*/
@@ -146,6 +169,132 @@ public class IR extends ANY
   protected IR(IR original)
   {
     _codeIds = original._codeIds;
+  }
+
+  /*-----------------------  code block handling  -----------------------*/
+
+
+  /**
+   * Add given code block and abtain a unique id for it.
+   *
+   * This also sets _siteStart in case `b` was not already added.
+   *
+   * NYI: UNDER DEVELOPMENT: The returned index should be replaced by a site
+   * index, i.e., siteFromCI(result, 0).
+   *
+   * @param b a list of Expr statements to be added.
+   *
+   * @return the index of b
+   */
+  protected int addCode(List<Object> b)
+  {
+    b.freeze();
+    var res = _codeIds.add(b);
+    var index = res - CODE_BASE;
+    if (index >= _siteStart.size()-1)
+      {
+        var nextSiteStart = _siteStart.getLast() + b.size() + 1; // b.size() might be 0 so we add 1 to have disjoint site indices
+        _siteStart.add(nextSiteStart);
+      }
+    return res;
+  }
+
+
+  /**
+   * Get the Expr #i in code block c
+   *
+   * NYI: UNDER DEVELOPMENT: This should be replaced by `getExpr(int site)`.
+   *
+   * @param c the code block index returned by `addCode`
+   *
+   * @param i an index in c
+   */
+  protected Object getExpr(int c, int i)
+  {
+    return _codeIds.get(c).get(i);
+  }
+
+
+
+  /**
+   * Convert a code block index c and an Expr index in that code block to a site
+   * index.
+   *
+   * NYI: UNDER DEVELOPMENT: This should be removed once `site` is used throughout.
+   *
+   * @param c the code block index returned by `addCode`
+   *
+   * @param i an index in c
+   *
+   * @return a site index corresponding to `c`/`i`.
+   */
+  public int siteFromCI(int c, int i)
+  {
+    if (PRECONDITIONS) require
+      (0 <= i && i < _codeIds.get(c).size());
+
+    var index = c - CODE_BASE;
+    var result = _siteStart.get(index).intValue() + i + SITE_BASE;
+
+    if (POSTCONDITIONS) ensure
+      (c == codeIndexFromSite(result),
+       i == exprIndexFromSite(result));
+
+    return result;
+  }
+
+
+  /**
+   * Extract code block index from a site.
+   *
+   * NYI: UNDER DEVELOPMENT: This should be removed once `site` is used throughout.
+   *
+   * @param site a code site
+   *
+   * @return the index of the code block containing the given site.
+   */
+  protected int codeIndexFromSite(int site)
+  {
+    var rawSite = site - SITE_BASE;
+    // perform binary search in _siteStart
+    int l = 0;
+    int r = _siteStart.size()-1;
+    int result_raw_c;
+    do
+      {
+        int m = (l + r) / 2;
+        var s = _siteStart.get(m).intValue();
+        int cmp = Integer.compare(rawSite, s);
+        result_raw_c = cmp < 0 ? m-1 : m;
+        if (cmp <= 0) { r = m - 1; }
+        if (cmp >= 0) { l = m + 1; }
+      }
+    while (l <= r);
+    int result_c = result_raw_c + CODE_BASE;
+
+    if (POSTCONDITIONS) ensure
+      (site >= result_raw_c,
+       _siteStart.get(result_raw_c) <= rawSite,
+       result_raw_c == _siteStart.size()-1 || _siteStart.get(result_raw_c+1) > rawSite);
+
+    return result_c;
+  }
+
+
+  /**
+   * Extract expr index from a site.
+   *
+   * NYI: UNDER DEVELOPMENT: This should be removed once `site` is used throughout.
+   *
+   * @param site a code site
+   *
+   * @return the index of the Expr withing the code block containing the given site.
+   */
+  protected int exprIndexFromSite(int site)
+  {
+    var rawSite = site - SITE_BASE;
+    var index = codeIndexFromSite(site) - CODE_BASE;
+    return rawSite - _siteStart.get(index).intValue();
   }
 
 
@@ -249,8 +398,8 @@ public class IR extends ANY
         // if is converted to If, blockId, elseBlockId
         toStack(l, i.cond);
         l.add(i);
-        l.add(new NumLiteral(_codeIds.add(toStack(i.block      ))));
-        l.add(new NumLiteral(_codeIds.add(toStack(i.elseBlock()))));
+        l.add(new NumLiteral(addCode(toStack(i.block      ))));
+        l.add(new NumLiteral(addCode(toStack(i.elseBlock()))));
       }
     else if (e instanceof AbstractCall c)
       {
@@ -272,7 +421,7 @@ public class IR extends ANY
         for (var c : m.cases())
           {
             var caseCode = toStack(c.code());
-            l.add(new NumLiteral(_codeIds.add(caseCode)));
+            l.add(new NumLiteral(addCode(caseCode)));
           }
       }
     else if (e instanceof Tag t)

--- a/src/dev/flang/mir/MIR.java
+++ b/src/dev/flang/mir/MIR.java
@@ -228,7 +228,7 @@ hw25 is
     var ff = _featureIds.get(f);
     var code = prolog(ff);
     addCode(ff, code, ff);
-    return _codeIds.add(code);
+    return addCode(code);
   }
 
 
@@ -292,7 +292,7 @@ hw25 is
        codeAt(c, ix) == ExprKind.Assign    );
 
     var ff = _featureIds.get(f);
-    var s = _codeIds.get(c).get(ix);
+    var s = getExpr(c, ix);
     var af =
       (s instanceof AbstractCall   call) ? call.calledFeature() :
       (s instanceof AbstractAssign a   ) ? a._assignedField :

--- a/tests/local_mutate_negative/test_local_mutate_neg.fz.expected_err
+++ b/tests/local_mutate_negative/test_local_mutate_neg.fz.expected_err
@@ -4,16 +4,16 @@
 -------------^^^^^
 Callchain that lead to this point:
 
-effect environment '--empty--' for call to test_local_mutate_neg.test_sum.sum.count at --CURDIR--/test_local_mutate_neg.fz:80:11:
+effect environment '--empty--' for call to 'test_local_mutate_neg.test_sum.sum.count' at --CURDIR--/test_local_mutate_neg.fz:80:11:
       say count    # *** will cause compile-time an error, requires m to be installed
 ----------^^^^^
-effect environment '--empty--' for call to test_local_mutate_neg.test_sum.sum at --CURDIR--/test_local_mutate_neg.fz:115:5:
+effect environment '--empty--' for call to 'test_local_mutate_neg.test_sum.sum' at --CURDIR--/test_local_mutate_neg.fz:115:5:
     sum l
 ----^^^
-effect environment '--empty--' for call to test_local_mutate_neg.test_sum at --CURDIR--/test_local_mutate_neg.fz:117:3:
+effect environment '--empty--' for call to 'test_local_mutate_neg.test_sum' at --CURDIR--/test_local_mutate_neg.fz:117:3:
   test_sum
 --^^^^^^^^
-effect environment '--empty--' for call to test_local_mutate_neg
+effect environment '--empty--' for call to 'test_local_mutate_neg'
 effect environment '--empty--' at program entry
 
 one error.

--- a/tests/reg_issue2273/reg_issue2273.fz.expected_err
+++ b/tests/reg_issue2273/reg_issue2273.fz.expected_err
@@ -4,10 +4,10 @@ $MODULE/mutate.fz:302:7: error 1: Failed to verify that effect 'mutate' is insta
 ------^
 Callchain that lead to this point:
 
-effect environment '--empty--' for call to ((mutate.#type mutate).array.#type (mutate.array door) door).new mutate at --CURDIR--/reg_issue2273.fz:33:26:
+effect environment '--empty--' for call to '((mutate.#type mutate).array.#type (mutate.array door) door).new mutate' at --CURDIR--/reg_issue2273.fz:33:26:
 d := (mutate.array door).new mutate 100 closed
 -------------------------^^^
-effect environment '--empty--' for call to universe#0
+effect environment '--empty--' for call to 'universe#0'
 effect environment '--empty--' at program entry
 
 one error.


### PR DESCRIPTION
Got this error before intrinsics for Java interface during DFA initialized the `msg` field of an `error` result properly and it would have helped to get more detail, which this patch provides.

Also slightly changed the output for missing effect errors and restructured the handling of Contexts.

Removed code related to a HACK that no longer exists.

This should be reviewed against #2753, this is part four of my attempt to split up https://github.com/tokiwa-software/fuzion/pull/2743 into several PRs.
