### PR TITLE
lib: add effect to reuse internal_arrays used for intrinsics results

### DIFF
--- a/lib/fuzion/sys/fileio.fz
+++ b/lib/fuzion/sys/fileio.fz
@@ -68,10 +68,11 @@ module fileio is
   private get_file_size(
                         # the (relative or absolute) file name, using platform specific path separators
                         path String) outcome i64 =>
-    md := fuzion.sys.internal_array_init i64 4
-    match stats (fuzion.sys.c_string path) md.data
-      TRUE  => md.as_array[0]
-      FALSE => error "error getting file size"
+    res := fuzion.sys.heap i64
+    if stats (fuzion.sys.c_string path) res.data
+      res[0]
+    else
+      error "error getting file size"
 
 
   # writes the content of an array of bytes to a file opened as fd
@@ -201,13 +202,13 @@ module fileio is
               path String,
               # a flag to speicify the open method (Read: 0, Write: 1, Append: 2)
               flag i8) outcome i64 =>
-    or := fuzion.sys.internal_array_init i64 2  # [file descriptor, error number]
-    open (fuzion.sys.c_string path) or.data flag
-    open_results := or.as_array
-    if open_results[1] = i64 0
-      open_results[0]
+    # [file descriptor, error number]
+    res := fuzion.sys.heap i64
+    open (fuzion.sys.c_string path) res.data flag
+    if res[1] = 0
+      res[0]
     else
-      error "error number: {open_results[1]}"
+      error "error number: {res[1]}"
 
   # intrinsic that fills a Fuzion object with the file descriptor and the error number from C back-end/ -1 in the interpreter
   # after opening the source represented by the path parameter
@@ -253,13 +254,12 @@ module fileio is
               fd i64,
               # the offset to seek from the beginning of this file
               offset i64) outcome i64 =>
-    iarr := fuzion.sys.internal_array_init i64 2
-    seek fd offset iarr.data
-    arr := iarr.as_array
-    if arr[1] = i64 0
-      arr[0]
+    res := fuzion.sys.heap i64
+    seek fd offset res.data
+    if res[1] = 0
+      res[0]
     else
-      error "error number: {arr[1]}"
+      error "error number: {res[1]}"
 
   # intrinsic to set the file-pointer offset at which the next read or write occurs
   # the offset is measured from the beginning of the file indicated by the file descriptor
@@ -282,13 +282,12 @@ module fileio is
   module file_position(
                        # file descriptor
                        fd i64) outcome i64 =>
-    iarr := fuzion.sys.internal_array_init i64 2
-    file_position fd iarr.data
-    arr := iarr.as_array
-    if arr[1] = i64 0
-      arr[0]
+    res := fuzion.sys.heap i64
+    file_position fd res.data
+    if res[1] = 0
+      res[0]
     else
-      error "error number: {arr[1]}"
+      error "error number: {res[1]}"
 
   # intrinsic that fills a Fuzion object with the current file stream position
   # and the error number from C back-end/ -1 in the interpreter
@@ -369,13 +368,13 @@ module fileio is
   # to the opened directory, or an error if one was encountered.
   #
   module open_dir(path String) outcome i64 =>
-    or := fuzion.sys.internal_array_init i64 2  # [file descriptor, error number]
-    open_dir (fuzion.sys.c_string path) or.data
-    open_results := or.as_array
-    if open_results[1] = i64 0
-      open_results[0]
+    # [file descriptor, error number]
+    res := fuzion.sys.heap i64
+    open_dir (fuzion.sys.c_string path) res.data
+    if res[1] = 0
+      res[0]
     else
-      error "error number: {open_results[1]}"
+      error "error number: {res[1]}"
 
 
   # reads the next entry of the directory given by opaque integer reference

--- a/lib/fuzion/sys/internal_array.fz
+++ b/lib/fuzion/sys/internal_array.fz
@@ -73,3 +73,19 @@ module internal_array(T type, module data fuzion.sys.Pointer, module length i32)
     #array.this[i] == o
   =>
     setel T data i o
+
+
+
+# effect containing a preallocated internal_array for usage
+# with intrinsics.
+#
+heap(T type, a fuzion.sys.internal_array T) : simple_effect is
+
+
+# returns a preallocated internal_array of - currently - length 16 for usage
+# with intrinsics. The internal_array may contain random data.
+#
+module heap(T type) =>
+  if !(effect.type.is_installed (fuzion.sys.heap T))
+    (heap T (fuzion.sys.internal_array_init T 16)).default
+  (heap T).env.a

--- a/lib/fuzion/sys/net.fz
+++ b/lib/fuzion/sys/net.fz
@@ -53,13 +53,12 @@ module net is
   # bind a name to a newly created socket, wrapper for bind0 intrinsic
   #
   module bind    (family, socket_type, protocol i32, host String, port u16) outcome i64 =>
-    iarr := fuzion.sys.internal_array_init i64 1
-    r := bind0 family socket_type protocol (fuzion.sys.c_string host) (fuzion.sys.c_string port.as_string) iarr.data = 0
-    arr := iarr.as_array
+    res := fuzion.sys.heap i64
+    r := bind0 family socket_type protocol (fuzion.sys.c_string host) (fuzion.sys.c_string port.as_string) res.data = 0
     if r
-      arr[0]
+      res[0]
     else
-      error "error: {arr[0]}"
+      error "error: {res[0]}"
 
 
 
@@ -86,11 +85,11 @@ module net is
   # accept a new connection for given socket descriptor, wrapper for accept intrinsic.
   # returns an error or a new descriptor.
   module accept(sd i64) outcome i64 =>
-    iarr := fuzion.sys.internal_array_init i64 1
-    if accept sd iarr.data then
-      iarr[0]
+    res := fuzion.sys.heap i64
+    if accept sd res.data then
+      res[0]
     else
-      error "accept failed, error number: {iarr[0]}"
+      error "accept failed, error number: {res[0]}"
 
 
   # open and connect a client socket
@@ -104,13 +103,11 @@ module net is
   # open and connect a client socket
   #
   module connect(family, socket_type, protocol i32, host String, port u16) outcome i64 =>
-    iarr := fuzion.sys.internal_array_init i64 1
-    res := connect0 family socket_type protocol (fuzion.sys.c_string host) (fuzion.sys.c_string port.as_string) iarr.data = 0
-    arr := iarr.as_array
-    if res
-      arr[0]
+    res := fuzion.sys.heap i64
+    if connect0 family socket_type protocol (fuzion.sys.c_string host) (fuzion.sys.c_string port.as_string) res.data = 0
+      res[0]
     else
-      error "error: {arr[0]}"
+      error "error: {res[0]}"
 
 
 
@@ -127,17 +124,15 @@ module net is
   #
   module read(descriptor i64, max_bytes i32) outcome (array u8) =>
     buff := fuzion.sys.internal_array_init u8 max_bytes
-    iarr := fuzion.sys.internal_array_init i64 1
-    res := read descriptor buff.data max_bytes iarr.data
-    arr := iarr.as_array
-    if res
-      if arr[0].as_i32 = max_bytes
+    res := fuzion.sys.heap i64
+    if read descriptor buff.data max_bytes res.data
+      if res[0].as_i32 = max_bytes
         buff.as_array
       else
         # NYI there should be a way to use a slice of internal_array to init array
-        array u8 arr[0].as_i32 (idx -> buff[idx])
+        array u8 res[0].as_i32 (idx -> buff[idx])
     else
-      error "error: {arr[0]}"
+      error "error: {res[0]}"
 
 
   # write buffer bytes on socket

--- a/lib/io/buffered/reader.fz
+++ b/lib/io/buffered/reader.fz
@@ -244,8 +244,7 @@ public read_fully array u8 ! reader =>
 # any trailing carriage returns (ASCII 13) from the resulting strings.
 #
 public read_lines array String ! reader =>
-  (String.from_bytes read_fully).split "\n"
-                                     .map s->
-                                       s.ends_with "\r" ? TRUE  => s.substring 0 s.byte_length-1
-                                                        | FALSE => s
-                                     .as_array
+  (String.from_bytes read_fully)
+    .split "\n"
+    .map (s -> if s.ends_with "\r" then s.substring 0 s.byte_length-1 else s)
+    .as_array

--- a/lib/io/file/open.fz
+++ b/lib/io/file/open.fz
@@ -73,9 +73,8 @@ module:public open(public T type,
   pre offset % 4096 = 0 # NYI get real page size instead of 4096.
   =>
 
-    arr := fuzion.sys.internal_array_init i32 1
-    mapped_memory := fuzion.sys.fileio.mmap fd offset size arr.data
-    res := arr.as_array
+    res := fuzion.sys.heap i32
+    mapped_memory := fuzion.sys.fileio.mmap fd offset size res.data
 
     if res[0] = -1
       error "mmap failed"

--- a/lib/io/file/stat.fz
+++ b/lib/io/file/stat.fz
@@ -47,15 +47,13 @@ public stat(ps Stat_Handler) : simple_effect is
   public stats(
         # the (relative or absolute) file name, using platform specific path separators
         path String) outcome meta_data =>
-    arr := fuzion.sys.internal_array_init i64 4  # will contain: [size, time of last modification in seconds, regular file? 1 : 0, dir? 1 : 0]
-    res := ps.stats (fuzion.sys.c_string path) arr.data
-    data := arr.as_array
-    if res
-      replace
-      meta_data data[0] data[1] (data[2] = i64 1) (data[3] = i64 1)
+    # will contain: [size, time of last modification in seconds, regular file? 1 : 0, dir? 1 : 0]
+    replace
+    res := fuzion.sys.heap i64
+    if ps.stats (fuzion.sys.c_string path) res.data
+      meta_data res[0] res[1] (res[2] = 1) (res[3] = 1)
     else
-      replace
-      error "stat error {data[0]} for {path}"
+      error "stat error {res[0]} for {path}"
 
   # returns stats of the file/dir passed in the pathname
   # in success it will return a meta_data outcome storing stats regarding the file/dir
@@ -65,15 +63,13 @@ public stat(ps Stat_Handler) : simple_effect is
   public lstats(
          # the (relative or absolute) file name, using platform specific path separators
          path String) outcome meta_data => # NYI : not sure whether to use meta_data or introduce a new feature for lstats metadata
-    arr := fuzion.sys.internal_array_init i64 4  # will contain: [size, time of last modification in seconds, regular file? 1 : 0, dir? 1 : 0]
-    res := ps.stats (fuzion.sys.c_string path) arr.data
-    data := arr.as_array
-    if res
-      replace
-      meta_data data[0] data[1] (data[2] = i64 1) (data[3] = i64 1)
+    # will contain: [size, time of last modification in seconds, regular file? 1 : 0, dir? 1 : 0]
+    replace
+    res := fuzion.sys.heap i64
+    if ps.stats (fuzion.sys.c_string path) res.data
+      meta_data res[0] res[1] (res[2] = 1) (res[3] = 1)
     else
-      replace
-      error "lstat error {data[0]} for {path}"
+      error "lstat error {res[0]} for {path}"
 
 
   # the default file stat provided

--- a/lib/time/now.fz
+++ b/lib/time/now.fz
@@ -39,9 +39,8 @@ public now (p () -> time.date_time) : simple_effect is
   # the system is giving us.
   #
   private type.default_now ()->time.date_time => () ->
-    arr := fuzion.sys.internal_array_init i32 6
-    fuzion.std.date_time arr.data
-    a := arr.as_array
+    a := (fuzion.sys.heap i32)
+    fuzion.std.date_time a.data
     time.date_time a[0] a[1] a[2] a[3] a[4] a[5]
 
 

--- a/src/dev/flang/be/interpreter/Intrinsics.java
+++ b/src/dev/flang/be/interpreter/Intrinsics.java
@@ -478,6 +478,7 @@ public class Intrinsics extends ANY
     putUnsafe("fuzion.sys.fileio.open", (interpreter, innerClazz) -> args ->
         {
           var open_results = (long[])args.get(2).arrayData()._array;
+          open_results[1] = 0;
           try
             {
               switch (args.get(3).i8Value()) {

--- a/src/dev/flang/be/jvm/runtime/Intrinsics.java
+++ b/src/dev/flang/be/jvm/runtime/Intrinsics.java
@@ -651,6 +651,7 @@ public class Intrinsics extends ANY
 
     var path = Runtime.utf8ByteArrayDataToString((byte[]) s);
     long[] open_results = (long[]) res;
+    open_results[1] = 0;
     try
       {
         switch (mode)


### PR DESCRIPTION
also removed some duplicate `replace`s
and made `read_lines` implementation a bit more readable.

