### PR TITLE
ast/Loop: replace streams with a list-based approach

### DIFF
--- a/src/dev/flang/ast/Feature.java
+++ b/src/dev/flang/ast/Feature.java
@@ -276,7 +276,10 @@ public class Feature extends AbstractFeature
   public boolean isIndexVarUpdatedByLoop() { return _isIndexVarUpdatedByLoop; }
 
 
-  boolean _newValueWhatever = false;
+  /**
+   * Is this a loop's variable that is being iterated over using the `in` keyword?
+   */
+  boolean _isLoopIterator = false;
 
 
   /**

--- a/src/dev/flang/ast/Feature.java
+++ b/src/dev/flang/ast/Feature.java
@@ -276,6 +276,9 @@ public class Feature extends AbstractFeature
   public boolean isIndexVarUpdatedByLoop() { return _isIndexVarUpdatedByLoop; }
 
 
+  boolean _newValueWhatever = false;
+
+
   /**
    * All features that have been found to be directly redefined by this feature.
    * This does not include redefinitions of redefinitions.  Four Features loaded

--- a/src/dev/flang/ast/Feature.java
+++ b/src/dev/flang/ast/Feature.java
@@ -278,8 +278,10 @@ public class Feature extends AbstractFeature
 
   /**
    * Is this a loop's variable that is being iterated over using the `in` keyword?
+   * If so, also store the internal list name.
    */
   boolean _isLoopIterator = false;
+  String _loopIteratorListName;
 
 
   /**

--- a/src/dev/flang/ast/Loop.java
+++ b/src/dev/flang/ast/Loop.java
@@ -43,11 +43,11 @@ import dev.flang.util.SourcePosition;
  * In general, this is
 
   for
-    x1 := init1, next1;
-    x2 in set2;
-    x3 := init3, next3;
-    x4 in set4;
-    x5 := init5, next5;
+    x1 := init1, next1
+    x2 in set2
+    x3 := init3, next3
+    x4 in set4
+    x5 := init5, next5
   while <whileCond>
     <body>
   until <untilCond>
@@ -60,47 +60,41 @@ import dev.flang.util.SourcePosition;
  * index variables
 
   // loop prolog
-  x1 := init1;
-  stream2 := set2.asStream;
+  x1 := init1
+  list2 := set2.as_list
   ### loopElse will be put here ###
-  if (stream2.hasNext)
-    {
-      x2 := stream2.next;
-      x3 := init3;
-      stream4 := set4.asStream;
-      if (stream4.hasNext)
-        {
-          x4 := stream4.next;
-          x5 := init5;
+  match list2
+    c2 Cons =>
+      x2 := c2.head
+      x2t := c2.tail
+      x3 := init3
+      list4 := set4.as_list
+      match list4
+        c4 Cons =>
+          x4 := c4.head
+          x4t := c4.tail
+          x5 := init5
 
           ### loop will be put here ###
 
-        }
-      else
-        {
-           loopElse
-        }
-    }
-  else
-    {
-      loopElse
-    }
+        _ nil => loopElse
+    _ nil => loopElse
 
  * The loop will be implemented using a tail recursive feature as follows
 
-  loop(x1, x2, x3, x4, x5, ... inferred-type) =>
+  loop(x1, x2, x2a, x3, x4, x4a, x5, ... inferred-type) =>
      if whileCond
        <body>
        if untilCond
          <success>
          ### OPTIONAL TRUE ###
        else ### nextIteration will be put here ###
-         loop(x1,x2,x3,x4,x5,...)   // tail recursion
+         loop(x1,x2,x2t,x3,x4,x4t,x5,...)   // tail recursion
        else
          <failure>
      else
        <failure>
-  loop(x1,x2,x3,x4,x5,...)
+  loop(x1,x2,x2t,x3,x4,x4t,x5,...)
 
  * The part marked
  *
@@ -110,29 +104,23 @@ import dev.flang.util.SourcePosition;
  * to the prolog
 
   // nextIteration:
-  x1 := next1;
+  x1 := next1
   ### loopElse will be put here ###
-  if (stream2.hasNext)
-    {
-      x2 := stream2.next;
-      x3 := next3;
-      if (stream4.hasNext)
-        {
-          x4 := stream4.next;
-          x5 := next5;
+  match x2a
+    c2 Cons =>
+      x2 := c2.head
+      x2t := c2.tail
+      x3 := next3
+      match x4a
+        c4 Cons =>
+          x4 := c4.head
+          x4t := c4.tail
+          x5 := next5
 
           ### loop tail recursive call will be put here ###
 
-        }
-      else
-        {
-          loopElse
-        }
-    }
-  else
-    {
-      loopElse
-    }
+        _ nil => loopElse
+    _ nil => loopElse
 
  * If needed, the code for the <failure> case will be put into a loopElse
  * feature that can be called at different locations:

--- a/src/dev/flang/ast/Loop.java
+++ b/src/dev/flang/ast/Loop.java
@@ -534,7 +534,7 @@ public class Loop extends ANY
         if (f._isLoopIterator)
           {
             var argList = new Feature(SourcePosition.notAvailable,
-                                      Visi.PUB,
+                                      Visi.PRIV,
                                       null,
                                       f._loopIteratorListName + "arg",
                                       new Impl(Impl.Kind.FieldActual));

--- a/src/dev/flang/ast/Loop.java
+++ b/src/dev/flang/ast/Loop.java
@@ -533,7 +533,7 @@ public class Loop extends ANY
         nextActuals    .add(new Actual(na));
         if (f._isLoopIterator)
           {
-            var argList = new Feature(p,
+            var argList = new Feature(SourcePosition.notAvailable,
                                       Visi.PUB,
                                       null,
                                       f._loopIteratorListName + "arg",
@@ -611,12 +611,12 @@ public class Loop extends ANY
             f._loopIteratorListName = listName;
             n._isLoopIterator = true;
             n._loopIteratorListName = listName;
-            g = new Feature(f.pos(),
+            g = new Feature(p,
                             Visi.PRIV,
                             null,
                             listName + "tail",
                             new Impl(f.impl().pos, nextTail1, Impl.Kind.FieldDef));
-            m = new Feature(n.pos(),
+            m = new Feature(p,
                             Visi.PRIV,
                             null,
                             listName + "tail",

--- a/src/dev/flang/ast/Loop.java
+++ b/src/dev/flang/ast/Loop.java
@@ -531,7 +531,7 @@ public class Loop extends ANY
         formalArguments.add(arg);
         initialActuals .add(new Actual(ia));
         nextActuals    .add(new Actual(na));
-        if (f._newValueWhatever)
+        if (f._isLoopIterator)
           {
             var argList = new Feature(p,
                                       Visi.PUB,
@@ -607,8 +607,8 @@ public class Loop extends ANY
             _nextItSuccessBlock = nextIt2;
             f.setImpl(new Impl(f.impl().pos, next1, Impl.Kind.FieldDef));
             n.setImpl(new Impl(n.impl().pos, next2, Impl.Kind.FieldDef));
-            f._newValueWhatever = true;
-            n._newValueWhatever = true;
+            f._isLoopIterator = true;
+            n._isLoopIterator = true;
             g = new Feature(f.pos(),
                             Visi.PRIV,
                             null,

--- a/src/dev/flang/ast/Loop.java
+++ b/src/dev/flang/ast/Loop.java
@@ -536,10 +536,10 @@ public class Loop extends ANY
             var argList = new Feature(p,
                                       Visi.PUB,
                                       null,
-                                      f.featureName().baseName() + "list",
+                                      f._loopIteratorListName + "arg",
                                       new Impl(Impl.Kind.FieldActual));
-            var ial = new Call(p, "#loop_" + f.featureName().baseName() + "_tail");
-            var nal = new Call(p, "#loop_" + f.featureName().baseName() + "_tail");
+            var ial = new Call(p, f._loopIteratorListName + "tail");
+            var nal = new Call(p, f._loopIteratorListName + "tail");
             formalArguments.add(argList);
             initialActuals.add(new Actual(ial));
             nextActuals.add(new Actual(nal));
@@ -600,7 +600,7 @@ public class Loop extends ANY
             Match match1 = new Match(p, new Call(p, listName), new List<AbstractCase>(match1c, match1n));
             Case match2c = new Case(p, consType, listName + "cons", new Block(nextIt2));
             Case match2n = new Case(p, nilType, listName + "nil", (_loopElse != null) ? Block.fromExpr(callLoopElse(false)) : Block.newIfNull(null));
-            Match match2 = new Match(p, new Call(p, f.featureName().baseName() + "list"), new List<AbstractCase>(match2c, match2n));
+            Match match2 = new Match(p, new Call(p, listName + "arg"), new List<AbstractCase>(match2c, match2n));
             _prologSuccessBlock.add(match1);
             _nextItSuccessBlock.add(match2);
             _prologSuccessBlock = prolog2;
@@ -608,16 +608,18 @@ public class Loop extends ANY
             f.setImpl(new Impl(f.impl().pos, next1, Impl.Kind.FieldDef));
             n.setImpl(new Impl(n.impl().pos, next2, Impl.Kind.FieldDef));
             f._isLoopIterator = true;
+            f._loopIteratorListName = listName;
             n._isLoopIterator = true;
+            n._loopIteratorListName = listName;
             g = new Feature(f.pos(),
                             Visi.PRIV,
                             null,
-                            "#loop_" + f.featureName().baseName() + "_tail",
+                            listName + "tail",
                             new Impl(f.impl().pos, nextTail1, Impl.Kind.FieldDef));
             m = new Feature(n.pos(),
                             Visi.PRIV,
                             null,
-                            "#loop_" + f.featureName().baseName() + "_tail",
+                            listName + "tail",
                             new Impl(n.impl().pos, nextTail2, Impl.Kind.FieldDef));
           }
         _prologSuccessBlock.add(f);


### PR DESCRIPTION
Replace the usage of `Stream` in `ast/Loop.java` by a list based approach. The documented logic has been updated to represent the new version. This depends on #2757. This does not remove `Stream` from the standard library yet, this will happen in a follow-up pull-request.

Marking as a draft for now because there is a single test failure related to the stack map table creation in `tests/reg_issue2376`.