### PR TITLE
dfa: increase accuracy of comparing Environments: Include effect values

### DIFF
--- a/src/dev/flang/fuir/analysis/dfa/Call.java
+++ b/src/dev/flang/fuir/analysis/dfa/Call.java
@@ -405,7 +405,7 @@ public class Call extends ANY implements Comparable<Call>, Context
   Value getEffectCheck(int ecl)
   {
     return
-      _env != null ? _env.getEffect(ecl)
+      _env != null ? _env.getActualEffectValues(ecl)
                    : _dfa._defaultEffects.get(ecl);
   }
 

--- a/src/dev/flang/fuir/analysis/dfa/DFA.java
+++ b/src/dev/flang/fuir/analysis/dfa/DFA.java
@@ -747,8 +747,13 @@ public class DFA extends ANY
   /**
    * For debugging: dump stack when _changed is set, for debugging when fix point
    * is not reached.
+   *
+   * To enable, use fz with
+   *
+   *   FUZION_JAVA_OPTIONS=-Ddev.flang.fuir.analysis.dfa.DFA.SHOW_STACK_ON_CHANGE=true
    */
-  static boolean SHOW_STACK_ON_CHANGE = false;
+  static final boolean SHOW_STACK_ON_CHANGE =
+    Boolean.getBoolean("dev.flang.fuir.analysis.dfa.DFA.SHOW_STACK_ON_CHANGE");
 
 
   /**
@@ -1137,7 +1142,7 @@ public class DFA extends ANY
           {
             _options.verbosePrintln(2,
                                     "DFA iteration #"+cnt+": --------------------------------------------------" +
-                                    (_options.verbose(3) ? _calls.size() + "," + _instances.size() + "; " + _changedSetBy.get()
+                                    (_options.verbose(3) ? "calls:"+_calls.size() + ",instances:" + _instances.size() + ",envs:" + _envs.size() + "; " + _changedSetBy.get()
                                                          : ""                                                                  ));
           }
         _changed = false;

--- a/src/dev/flang/fuir/analysis/dfa/Env.java
+++ b/src/dev/flang/fuir/analysis/dfa/Env.java
@@ -177,12 +177,9 @@ public class Env extends ANY implements Comparable<Env>
    */
   public int compareTo(Env other)
   {
-    // NYI: The code to distinguish two environments is currently poor, we just
-    // distinguish environments depending on the set types they set, so two
-    // environments that set, e.g., io.out, to different effects will be treated
-    // the same.  This must be improved in a way that gives more accuracy
-    // without state explosion!
-    var ta = _types;
+    // this is a little strict in the sense that the order of effects is
+    // relevant. Might need to relax this if this results in a state explosion.
+    var ta = this ._types;
     var oa = other._types;
     var res =
       ta.length < oa.length ? -1 :
@@ -191,9 +188,11 @@ public class Env extends ANY implements Comparable<Env>
       {
         var tt = ta[i];
         var ot = oa[i];
+        var te = this .getEffect(tt);
+        var oe = other.getEffect(ot);
         res =
           tt < ot ? -1 :
-          tt > ot ? +1 : 0;
+          tt > ot ? +1 : Value.envCompare(te, oe);
       }
     return res;
   }

--- a/src/dev/flang/fuir/analysis/dfa/Instance.java
+++ b/src/dev/flang/fuir/analysis/dfa/Instance.java
@@ -234,7 +234,7 @@ public class Instance extends Value implements Comparable<Instance>
    */
   public String toString()
   {
-    return _dfa._fuir.clazzAsString(_clazz);
+    return _dfa._fuir.clazzAsString(_clazz) + "@" + _dfa._fuir.siteAsPos(_site);
   }
 
 }

--- a/src/dev/flang/fuir/analysis/dfa/Instance.java
+++ b/src/dev/flang/fuir/analysis/dfa/Instance.java
@@ -120,6 +120,17 @@ public class Instance extends Value implements Comparable<Instance>
 
 
   /**
+   * Get the environment this instance was created in, or null if none.
+   *
+   * This environment is taken into account when comparing instances.
+   */
+  Env env()
+  {
+    return _context instanceof Call ca1 ? ca1._env : null;
+  }
+
+
+  /**
    * Compare this to another instance.
    */
   public int compareTo(Instance other)
@@ -130,8 +141,8 @@ public class Instance extends Value implements Comparable<Instance>
     var c2 = i2._clazz;
     var s1 = i1._site;
     var s2 = i2._site;
-    var e1 = i1._context instanceof Call ca1 ? ca1._env : null;
-    var e2 = i2._context instanceof Call ca2 ? ca2._env : null;
+    var e1 = i1.env();
+    var e2 = i2.env();
     return
       c1 < c2    ? -1 :
       c1 > c2    ? +1 :

--- a/src/dev/flang/fuir/analysis/dfa/Instance.java
+++ b/src/dev/flang/fuir/analysis/dfa/Instance.java
@@ -143,6 +143,28 @@ public class Instance extends Value implements Comparable<Instance>
                  : e1.compareTo(e2);
   }
 
+  /**
+   * Compare this to another instance, used to compare effect instances in
+   * Env[ironmnents].  The main different to `compareTo` is that the effect
+   * environment is ignored since that would lead to an explosion of
+   * Environments.
+   */
+  public int envCompareTo(Instance other)
+  {
+    var i1 = this;
+    var i2 = other;
+    var c1 = i1._clazz;
+    var c2 = i2._clazz;
+    var s1 = i1._site;
+    var s2 = i2._site;
+    return
+      c1 < c2    ? -1 :
+      c1 > c2    ? +1 :
+      s1 < s2    ? -1 :
+      s1 > s2    ? +1
+                 :  0;
+  }
+
 
   /**
    * Add v to the set of values of given field within this instance.

--- a/src/dev/flang/fuir/analysis/dfa/RefValue.java
+++ b/src/dev/flang/fuir/analysis/dfa/RefValue.java
@@ -96,6 +96,19 @@ public class RefValue extends Value
 
 
   /**
+   * Compare this to another RefValue, used to compare effect instances in
+   * Env[ironmnents].
+   */
+  public int envCompareTo(RefValue other)
+  {
+    return
+      _clazz < other._clazz ? -1 :
+      _clazz > other._clazz ? +1 :
+      Value.envCompare(_original, other._original);
+  }
+
+
+  /**
    * Add v to the set of values of given field within this instance.
    */
   public void setField(DFA dfa, int field, Value v)

--- a/src/dev/flang/fuir/analysis/dfa/Value.java
+++ b/src/dev/flang/fuir/analysis/dfa/Value.java
@@ -86,6 +86,38 @@ public class Value extends Val
     };
 
 
+  /**
+   * Comparator instance to compare two Values of effect instances that are used in
+   * Env[ironmnents].
+   */
+  static Comparator<Value> ENV_COMPARATOR = new Comparator<>() {
+      /**
+       * compare two values.
+       */
+      public int compare(Value a, Value b)
+      {
+        if      (a == b)                                                       { return 0;                    }
+     // else if (a == UNIT                    || b == UNIT                   ) { return a == UNIT  ? +1 : -1; }
+        else if (a instanceof Instance     ai && b instanceof Instance     bi) { return ai.envCompareTo(bi);     }
+     // else if (a instanceof NumericValue an && b instanceof NumericValue bn) { return an.envCompareTo(bn);     }
+        else if (a instanceof RefValue     ab && b instanceof RefValue     bb) { return ab.envCompareTo(bb);     }
+     // else if (a instanceof TaggedValue  at && b instanceof TaggedValue  bt) { return at.envCompareTo(bt);     }
+     // else if (a instanceof SysArray     aa && b instanceof SysArray     ba) { return aa.envCompareTo(ba);     }
+        else if (a instanceof ValueSet     as && b instanceof ValueSet     bs) { return as.envCompareTo(bs);     }
+        else if (a instanceof Instance    ) { return +1; } else if (b instanceof Instance       ) { return -1; }
+     // else if (a instanceof NumericValue) { return +1; } else if (b instanceof NumericValue   ) { return -1; }
+        else if (a instanceof RefValue    ) { return +1; } else if (b instanceof RefValue       ) { return -1; }
+     // else if (a instanceof TaggedValue ) { return +1; } else if (b instanceof TaggedValue    ) { return -1; }
+     // else if (a instanceof SysArray    ) { return +1; } else if (b instanceof SysArray       ) { return -1; }
+        else if (a instanceof ValueSet    ) { return +1; } else if (b instanceof ValueSet       ) { return -1; }
+        else
+          {
+            throw new Error(getClass().toString() + "envCompareTo requires support for " + a.getClass() + " and " + b.getClass());
+          }
+      }
+    };
+
+
 
   /**
    * The unit value 'unit', '{}'
@@ -193,11 +225,20 @@ public class Value extends Val
 
 
   /**
-   * compare two values.
+   * compare two Values.
    */
   public static int compare(Value a, Value b)
   {
     return COMPARATOR.compare(a,b);
+  }
+
+
+  /**
+   * compare two Values of effect instances that are used in Env[ironmnents].
+   */
+  public static int envCompare(Value a, Value b)
+  {
+    return ENV_COMPARATOR.compare(a,b);
   }
 
 

--- a/src/dev/flang/fuir/analysis/dfa/ValueSet.java
+++ b/src/dev/flang/fuir/analysis/dfa/ValueSet.java
@@ -121,6 +121,44 @@ public class ValueSet extends Value
 
 
   /**
+   * Compare this to another ValueSet, both sets containing effect instances
+   * that are used in Env[ironmnents].
+   *
+   * @param other the other ValueSet
+   *
+   * @return -1, 0, or +1 depending on whether this < other, this == other or
+   * this > other by some order.
+   */
+  public int envCompareTo(ValueSet other)
+  {
+    var s1 = _components.size();
+    var s2 = other._components.size();
+    if (s1 == s2)
+      {
+        for (int i = 0; i < _componentsArray.length; i++)
+          {
+            var x1 = _componentsArray[i];
+            var x2 = other._componentsArray[i];
+            var res = Value.envCompare(x1, x2);
+            if (res != 0)
+              {
+                return res;
+              }
+          }
+        return 0;
+      }
+    else if (s1 < s2)
+      {
+        return -1;
+      }
+    else
+      {
+        return +1;
+      }
+  }
+
+
+  /**
    * Create human-readable string from this value.
    */
   public String toString()


### PR DESCRIPTION
This fixes the fuzion-lang.dev example `content/tutorial/examples/effect3.fz` that requires the distinction of call environments that differ only in the actual effect values.

To avoid explosion of values, the comparison of effects for this had to be relaxed not to include the effect environment.
