### PR TITLE
ast: make sure propagateExpectedType does not change expression

### DIFF
--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -2851,7 +2851,9 @@ public class Call extends AbstractCall
         r = propagateExpectedTypeForPartial(res, outer, t);
         if (r != this)
           {
-            r.propagateExpectedType(res, outer, t);
+            var r2 = r.propagateExpectedType(res, outer, t);
+            if (CHECKS) check
+              (r == r2);
           }
       }
     return r;

--- a/src/dev/flang/ast/InlineArray.java
+++ b/src/dev/flang/ast/InlineArray.java
@@ -176,7 +176,9 @@ public class InlineArray extends ExprWithPos
           {
             for (var e : _elements)
               {
-                e.propagateExpectedType(res, outer, elementType);
+                var e2 = e.propagateExpectedType(res, outer, elementType);
+                if (CHECKS) check
+                  (e == e2);
               }
             _type = Types.resolved.f_array.resultTypeIfPresent(res, new List<>(elementType));
           }


### PR DESCRIPTION
by adding two checks
