### PR TITLE
be/interpreter, fuir: remove synchronized hack from FUIR

### DIFF
--- a/src/dev/flang/be/interpreter/Interpreter.java
+++ b/src/dev/flang/be/interpreter/Interpreter.java
@@ -52,9 +52,15 @@ public class Interpreter extends ANY
   public Interpreter(FuzionOptions options, FUIR fuir)
   {
     this._options_ = options;
-    this._fuir = fuir;
-    var processor = new Excecutor(fuir, _options_);
-    _ai = new AbstractInterpreter<Value, Object>(fuir, processor);
+    this._fuir = new FUIR(fuir)
+      {
+        // NYI: BUG: fuir should be thread safe #2760
+        public synchronized int[] matchCaseTags(int cl, int c, int ix, int cix) {
+          return super.matchCaseTags(cl, c, ix, cix);
+        };
+      };
+    var processor = new Excecutor(_fuir, _options_);
+    _ai = new AbstractInterpreter<Value, Object>(_fuir, processor);
     Intrinsics.ENABLE_UNSAFE_INTRINSICS = options.enableUnsafeIntrinsics();  // NYI: Add to Fuzion IR or BE Config
   }
 

--- a/src/dev/flang/fuir/FUIR.java
+++ b/src/dev/flang/fuir/FUIR.java
@@ -1928,7 +1928,13 @@ hw25 is
   }
 
 
-  // NYI replace by more intelligent code
+  /**
+   * For a given tag return the index of the corresponding case.
+   *
+   * @param tag e.g. 0,1,2,...
+   *
+   * @return the index of the case for tag `tag`
+   */
   public int matchCaseIndex(int cl, int c, int i, int tag)
   {
     var result = -1;
@@ -1959,8 +1965,7 @@ hw25 is
    *
    * @return array of tag numbers this case matches
    */
-  // NYI: UNDER DEVELOPMENT thread safety, #2760
-  public synchronized int[] matchCaseTags(int cl, int c, int ix, int cix)
+  public int[] matchCaseTags(int cl, int c, int ix, int cix)
   {
     if (PRECONDITIONS) require
       (ix >= 0,


### PR DESCRIPTION
now only FUIR for interpreter uses _synchronized_ on `matchCaseTags`

also added a previously missing comment to `matchCaseIndex`


