### PR TITLE
be/jvm: add source file attribute

### DIFF
--- a/src/dev/flang/be/jvm/Types.java
+++ b/src/dev/flang/be/jvm/Types.java
@@ -120,7 +120,7 @@ public class Types extends ANY implements ClassFileConstants
     if (hasClassFile(cl))
       {
         var cn = _names.javaClass(cl);
-        var cf = new ClassFile(_opt, cn, Names.ANY_CLASS);
+        var cf = new ClassFile(_opt, cn, Names.ANY_CLASS, _fuir.clazzSrcFile(cl));
         _classFiles.put(cl, cf);
 
         if (cl == _fuir.clazzUniverse())
@@ -322,7 +322,7 @@ public class Types extends ANY implements ClassFileConstants
    */
   private void makeInterface(int cl)
   {
-    var i = new ClassFile(_opt, _names.javaInterface(cl), "java/lang/Object", true);
+    var i = new ClassFile(_opt, _names.javaInterface(cl), "java/lang/Object", true, _fuir.clazzSrcFile(cl));
     _interfaceFiles.put(cl, i);
     if (!_fuir.clazzIsChoice(cl))
       {

--- a/src/dev/flang/be/jvm/classfile/ClassFile.java
+++ b/src/dev/flang/be/jvm/classfile/ClassFile.java
@@ -1375,6 +1375,33 @@ public class ClassFile extends ANY implements ClassFileConstants
     }
   }
 
+  /*
+   * https://docs.oracle.com/javase/specs/jvms/se21/jvms21.pdf
+   * §4.7.10 "The SourceFile attribute is an optional fixed-length attribute in the attributes
+   * table of a ClassFile structure (§4.1).
+   * There may be at most one SourceFile attribute in the attributes table of a
+   * ClassFile structure."
+   */
+  public class SourceFileAttribute extends Attribute {
+
+    private CPEntry _srcFile;
+
+    SourceFileAttribute(String srcFile)
+    {
+      super("SourceFile");
+      this._srcFile = cpUtf8(srcFile);
+    }
+
+    @Override
+    byte[] data()
+    {
+      var o = new Kaku();
+      o.writeU2(_srcFile.index());
+      return o._b.toByteArray();
+    }
+
+  }
+
 
   /*----------------------------  constants  ----------------------------*/
 
@@ -1421,9 +1448,9 @@ public class ClassFile extends ANY implements ClassFileConstants
    *
    * @param name the class name
    */
-  public ClassFile(FuzionOptions opt, String name, String supr)
+  public ClassFile(FuzionOptions opt, String name, String supr, String srcFile)
   {
-    this(opt, name, supr, false);
+    this(opt, name, supr, false, srcFile);
   }
 
 
@@ -1432,7 +1459,7 @@ public class ClassFile extends ANY implements ClassFileConstants
    *
    * @param name the class name
    */
-  public ClassFile(FuzionOptions opt, String name, String supr, boolean interfce)
+  public ClassFile(FuzionOptions opt, String name, String supr, boolean interfce, String srcFile)
   {
     _opt = opt;
     _name = name;
@@ -1442,6 +1469,7 @@ public class ClassFile extends ANY implements ClassFileConstants
     _flags = ACC_PUBLIC | (interfce ? (ACC_INTERFACE|ACC_ABSTRACT) : ACC_SUPER);
     _this = cpClass(name);
     _super = cpClass(supr == null ? "java/lang/Object" : supr);
+    _attributes.add(new SourceFileAttribute(srcFile));
   }
 
 

--- a/src/dev/flang/fuir/FUIR.java
+++ b/src/dev/flang/fuir/FUIR.java
@@ -2761,6 +2761,17 @@ hw25 is
 
 
   /**
+   * Get the source file the clazz originates from.
+   *
+   * e.g. /fuzion/tests/hello/HelloWorld.fz, $FUZION/lib/panic.fz
+   */
+  public String clazzSrcFile(int cl)
+  {
+    return this.clazz(cl)._type.declarationPos()._sourceFile._fileName.toString();
+  }
+
+
+  /**
    * The java class name of a generated class. e.g. java/lang/String
    *
    * special cases: bool, i8, i16, u16, i32, i64, f32, f64


### PR DESCRIPTION
example output from javap -v
```
$ javap -v HelloWorld.classes/fzC_1panic.class
Classfile /home/not_synced/fuzion/HelloWorld.classes/fzC_1panic.class
  Last modified 26 Mar 2024; size 205 bytes
  SHA-256 checksum f9f7d552f819bbe14fc4043cd837ea1c712c68db593e503576ad81361f2182d0
  Compiled from "$FUZION/lib/panic.fz"
public class fzC_1panic extends dev.flang.be.jvm.runtime.Any
  minor version: 0
  ...

$ javap -v HelloWorld.classes/fzC_HelloWorld.class
Classfile /home/not_synced/fuzion/HelloWorld.classes/fzC_HelloWorld.class
  Last modified 26 Mar 2024; size 425 bytes
  SHA-256 checksum 61233ef733288b2f946d99a245e0d462a6cd3fc728a142c651c1a4a3b2675372
  Compiled from "/home/not_synced/fuzion/tests/hello/HelloWorld.fz"
  ...
```
