### PR TITLE
be/jvm/interpreter: increase robustness of intrinsics on runtime exce…

### DIFF
--- a/src/dev/flang/be/interpreter/Intrinsics.java
+++ b/src/dev/flang/be/interpreter/Intrinsics.java
@@ -129,7 +129,7 @@ public class Intrinsics extends ANY
         f.close();
         return true;
       }
-      catch(Exception e)
+      catch(Throwable e)
       {
         return false;
       }
@@ -404,7 +404,7 @@ public class Intrinsics extends ANY
 
               return new i32Value(bytesRead);
             }
-          catch (Exception e)
+          catch (Throwable e)
             {
               return new i32Value(-2);
             }
@@ -429,7 +429,7 @@ public class Intrinsics extends ANY
                 }
               return new i32Value(0);
             }
-          catch (Exception e)
+          catch (Throwable e)
             {
               return new i32Value(-1);
             }
@@ -442,7 +442,7 @@ public class Intrinsics extends ANY
               boolean b = Files.deleteIfExists(path);
               return new boolValue(b);
             }
-          catch (Exception e)
+          catch (Throwable e)
             {
               return new boolValue(false);
             }
@@ -456,7 +456,7 @@ public class Intrinsics extends ANY
               Files.move(oldPath, newPath);
               return new boolValue(true);
             }
-          catch (Exception e)
+          catch (Throwable e)
             {
               return new boolValue(false);
             }
@@ -469,7 +469,7 @@ public class Intrinsics extends ANY
               Files.createDirectory(path);
               return new boolValue(true);
             }
-          catch (Exception e)
+          catch (Throwable e)
             {
               return new boolValue(false);
             }
@@ -500,7 +500,7 @@ public class Intrinsics extends ANY
                   System.exit(1);
               }
             }
-          catch (Exception e)
+          catch (Throwable e)
             {
               open_results[1] = -1;
             }
@@ -541,6 +541,10 @@ public class Intrinsics extends ANY
             {
               err = SystemErrNo.EACCES;
             }
+          catch (Throwable e)
+            {
+              err = SystemErrNo.UNSPECIFIED;
+            }
 
           stats[0] = err.errno;
           stats[1] = 0;
@@ -559,7 +563,7 @@ public class Intrinsics extends ANY
               seekResults[0] = raf.getFilePointer();
               return Value.EMPTY_VALUE;
             }
-          catch (Exception e)
+          catch (Throwable e)
             {
               seekResults[1] = -1;
               return Value.EMPTY_VALUE;
@@ -574,7 +578,7 @@ public class Intrinsics extends ANY
               arr[0] = ((RandomAccessFile)_openStreams_.get(fd)).getFilePointer();
               return Value.EMPTY_VALUE;
             }
-          catch (Exception e)
+          catch (Throwable e)
             {
               arr[1] = -1;
               return Value.EMPTY_VALUE;
@@ -625,7 +629,7 @@ public class Intrinsics extends ANY
                   }
                 };
             }
-          catch (IOException e)
+          catch (Throwable e)
             {
               ((int[])args.get(4).arrayData()._array)[0] = -1;
               return new ArrayData(new byte[0]);
@@ -661,7 +665,7 @@ public class Intrinsics extends ANY
                 }
               });
             }
-          catch (IOException e)
+          catch (Throwable e)
             {
               open_results[1] = -1;
             }
@@ -972,7 +976,7 @@ public class Intrinsics extends ANY
           result[0] = SystemErrNo.EADDRINUSE.errno;
           return new i32Value(-1);
         }
-      catch(IOException e)
+      catch(Throwable e)
         {
           result[0] = -1;
           return new i32Value(-1);
@@ -1000,7 +1004,7 @@ public class Intrinsics extends ANY
             }
           throw new Error("NYI");
         }
-      catch(IOException e)
+      catch(Throwable e)
         {
           return new boolValue(false);
         }
@@ -1043,6 +1047,11 @@ public class Intrinsics extends ANY
           result[0] = SystemErrNo.ECONNREFUSED.errno;
           return new i32Value(-1);
         }
+      catch(Throwable e)
+        {
+          result[0] = SystemErrNo.UNSPECIFIED.errno;
+          return new i32Value(-1);
+        }
     });
 
     putUnsafe("fuzion.sys.net.get_peer_address", (excecutor, innerClazz) -> args -> {
@@ -1056,7 +1065,7 @@ public class Intrinsics extends ANY
             }
           return new i32Value(-1);
         }
-      catch (IOException e)
+      catch (Throwable e)
         {
           return new i32Value(-1);
         }
@@ -1071,7 +1080,7 @@ public class Intrinsics extends ANY
             }
           return new u16Value(0);
         }
-      catch (IOException e)
+      catch (Throwable e)
         {
           return new u16Value(0);
         }
@@ -1102,7 +1111,7 @@ public class Intrinsics extends ANY
           ((long[])args.get(4).arrayData()._array)[0] = bytesRead;
           return new boolValue(bytesRead != -1);
         }
-      catch(IOException e) //SocketTimeoutException and others
+      catch(Throwable e) //SocketTimeoutException and others
         {
           // unspecified error
           ((long[])args.get(4).arrayData()._array)[0] = -1;
@@ -1118,7 +1127,7 @@ public class Intrinsics extends ANY
           sc.write(ByteBuffer.wrap(fileContent));
           return new i32Value(0);
         }
-      catch(IOException e)
+      catch(Throwable e)
         {
           return new i32Value(-1);
         }
@@ -1139,7 +1148,7 @@ public class Intrinsics extends ANY
           asc.configureBlocking(blocking == 1);
           return new i32Value(0);
         }
-      catch(IOException e)
+      catch(Throwable e)
         {
           return new i32Value(-1);
         }
@@ -1411,7 +1420,7 @@ public class Intrinsics extends ANY
           result[3] = _openStreams_.add(process.getErrorStream());
           return new i32Value(0);
         }
-      catch (IOException e)
+      catch (Throwable e)
         {
           return new i32Value(-1);
         }
@@ -1426,7 +1435,7 @@ public class Intrinsics extends ANY
           _openProcesses_.remove(desc);
           return new i32Value(result);
         }
-      catch(InterruptedException e)
+      catch(Throwable e)
         {
           return new i32Value(-1);
         }
@@ -1444,7 +1453,7 @@ public class Intrinsics extends ANY
             ? new i32Value(0)
             : new i32Value(readBytes);
         }
-      catch (IOException e)
+      catch (Throwable e)
         {
           return new i32Value(-1);
         }
@@ -1459,7 +1468,7 @@ public class Intrinsics extends ANY
           os.write(buff);
           return new i32Value(buff.length);
         }
-      catch (IOException e)
+      catch (Throwable e)
         {
           return new i32Value(-1);
         }

--- a/src/dev/flang/be/jvm/runtime/Intrinsics.java
+++ b/src/dev/flang/be/jvm/runtime/Intrinsics.java
@@ -332,7 +332,7 @@ public class Intrinsics extends ANY
         result[0] = SystemErrNo.EADDRINUSE.errno;
         return -1;
       }
-    catch(IOException e)
+    catch(Throwable e)
       {
         result[0] = -1;
         return -1;
@@ -369,6 +369,10 @@ public class Intrinsics extends ANY
         throw new RuntimeException("NYI: UNDER DEVELOPMENT: accept for asc instanceof " + asc.getClass());
       }
     catch(IOException e)
+      {
+        return false;
+      }
+    catch(Throwable e)
       {
         return false;
       }
@@ -413,6 +417,11 @@ public class Intrinsics extends ANY
         result[0] = SystemErrNo.ECONNREFUSED.errno;
         return -1;
       }
+    catch(Throwable e)
+      {
+        result[0] = SystemErrNo.UNSPECIFIED.errno;
+        return -1;
+      }
   }
 
   public static int fuzion_sys_net_get_peer_address(long sockfd, Object res)
@@ -432,7 +441,7 @@ public class Intrinsics extends ANY
           }
         return -1;
       }
-    catch (IOException e)
+    catch(Throwable e)
       {
         return -1;
       }
@@ -449,7 +458,7 @@ public class Intrinsics extends ANY
           }
         return 0;
       }
-    catch (IOException e)
+    catch (Throwable e)
       {
         return 0;
       }
@@ -490,7 +499,7 @@ public class Intrinsics extends ANY
         result[0] = bytesRead;
         return bytesRead != -1;
       }
-    catch(IOException e) //SocketTimeoutException and others
+    catch(Throwable e) //SocketTimeoutException and others
       {
         // unspecified error
         result[0] = -1;
@@ -507,7 +516,7 @@ public class Intrinsics extends ANY
         sc.write(ByteBuffer.wrap((byte[]) fileContent));
         return 0;
       }
-    catch(IOException e)
+    catch(Throwable e)
       {
         return -1;
       }
@@ -530,7 +539,8 @@ public class Intrinsics extends ANY
         asc.configureBlocking(blocking == 1);
         return 0;
       }
-    catch(IOException e)
+    // ClosedChannelException, IOException etc.
+    catch(Throwable e)
       {
         return -1;
       }
@@ -606,7 +616,7 @@ public class Intrinsics extends ANY
       {
         return Files.deleteIfExists(path);
       }
-    catch (Exception e)
+    catch (Throwable e)
       {
         return false;
       }
@@ -622,7 +632,7 @@ public class Intrinsics extends ANY
         Files.move(oldPath, newPath);
         return true;
       }
-    catch (Exception e)
+    catch (Throwable e)
       {
         return false;
       }
@@ -637,7 +647,7 @@ public class Intrinsics extends ANY
         Files.createDirectory(path);
         return true;
       }
-    catch (Exception e)
+    catch (Throwable e)
       {
         return false;
       }
@@ -675,7 +685,7 @@ public class Intrinsics extends ANY
             System.exit(1);
           }
       }
-    catch (Exception e)
+    catch (Throwable e)
       {
         open_results[1] = -1;
       }
@@ -726,6 +736,10 @@ public class Intrinsics extends ANY
       {
         err = SystemErrNo.EACCES;
       }
+    catch (Throwable e)
+      {
+        err = SystemErrNo.UNSPECIFIED;
+      }
 
     stats[0] = err.errno;
     stats[1] = 0;
@@ -748,7 +762,7 @@ public class Intrinsics extends ANY
         seekResults[0] = raf.getFilePointer();
         return;
       }
-    catch (Exception e)
+    catch (Throwable e)
       {
         seekResults[1] = -1;
         return;
@@ -767,7 +781,7 @@ public class Intrinsics extends ANY
         arr[0] = ((RandomAccessFile) Runtime._openStreams_.get(fd)).getFilePointer();
         return;
       }
-    catch (Exception e)
+    catch (Throwable e)
       {
         arr[1] = -1;
         return;
@@ -799,7 +813,7 @@ public class Intrinsics extends ANY
         result[0] = 0;
         return mmap;
       }
-    catch (IOException e)
+    catch (Throwable e)
       {
         result[0] = -1;
         return new byte[0];
@@ -854,7 +868,7 @@ public class Intrinsics extends ANY
           }
         });
       }
-    catch (IOException e)
+    catch (Throwable e)
       {
         open_results[1] = -1;
       }
@@ -951,7 +965,7 @@ public class Intrinsics extends ANY
         result[3] = Runtime._openStreams_.add(process.getErrorStream());
         return 0;
       }
-    catch (IOException e)
+    catch (Throwable e)
       {
         return -1;
       }
@@ -966,7 +980,7 @@ public class Intrinsics extends ANY
         Runtime._openProcesses_.remove(desc);
         return result;
       }
-    catch(InterruptedException e)
+    catch(Throwable e)
       {
         return -1;
       }


### PR DESCRIPTION
before:
```
/home/not_synced/fuzion (2024-03-26T15-41-12+01-00)130$ cat ~/playground/test.fz
ex is
  say (net.client ex net.family.ipv4 net.protocol.tcp "i_dont_exist" 99)
/home/not_synced/fuzion (2024-03-26T15-41-12+01-00)$ fz ~/playground/test.fz 

error 1: java.nio.channels.UnresolvedAddressException
        at java.base/sun.nio.ch.Net.checkAddress(Net.java:137)
        at java.base/sun.nio.ch.Net.checkAddress(Net.java:145)
        at java.base/sun.nio.ch.SocketChannelImpl.checkRemote(SocketChannelImpl.java:842)
        at java.base/sun.nio.ch.SocketChannelImpl.connect(SocketChannelImpl.java:865)
        at dev.flang.be.jvm.runtime.Intrinsics.fuzion_sys_net_connect0(Intrinsics.java:397)
        at fzC_fuzion__sys__net__5connect.fzRoutine($MODULE/fuzion/sys/net.fz)
        at fzC_net__4client_ex.fzRoutine($MODULE/net/client.fz)
        at fzC_ex.fzRoutine(/home/sam/playground/test.fz)
        at fzC_universe.fz_run(--builtin--)
        at dev.flang.be.jvm.runtime.FuzionThread.lambda$new$1(FuzionThread.java:97)
        at dev.flang.util.Errors.runAndExit(Errors.java:935)
        at dev.flang.be.jvm.runtime.FuzionThread.lambda$new$2(FuzionThread.java:106)
        at java.base/java.lang.Thread.run(Thread.java:1583)


*** fatal errors encountered, stopping.
```
now:
```
/home/not_synced/fuzion (be/jvm/interpreter--increase-robustness-of-intrinsics-on-runtime-exceptions)$ cat ~/playground/test.fz
ex is
  say (net.client ex net.family.ipv4 net.protocol.tcp "i_dont_exist" 99)
/home/not_synced/fuzion (be/jvm/interpreter--increase-robustness-of-intrinsics-on-runtime-exceptions)$ fz ~/playground/test.fz 
--error: error: 0--
```