### PR TITLE
be/c: use __thread instead of C11 _Thread_local

### DIFF
--- a/include/shared.c
+++ b/include/shared.c
@@ -33,7 +33,6 @@ Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
 #include <stdbool.h>
 #include <string.h>
 #include <assert.h>
-#include <threads.h>
 
 
 /**
@@ -101,9 +100,9 @@ void * fzE_malloc_safe(size_t size) {
 #include <jni.h>
 
 // global instance of the jvm
-JavaVM *fzE_jvm              = NULL;
+JavaVM *fzE_jvm                = NULL;
 // global instance of the jvm environment
-_Thread_local JNIEnv *fzE_jni_env          = NULL;
+__thread JNIEnv *fzE_jni_env   = NULL;
 
 // cached jclasses and jmethods which are frequently used
 


### PR DESCRIPTION
this is to work around missing support in windows clang
```
C:\Users\sam\fuzion\build\include\shared.c:36:10: fatal error: 'threads.h' file not found
   36 | #include <threads.h>
      |          ^~~~~~~~~~~
1 error generated.

error 1: C backend: C compiler failed
C compiler call 'clang -Wall -Werror -Wno-trigraphs -Wno-gnu-empty-struct -Wno-unused-variable -Wno-unused-label -Wno-unused-function -Wno-pointer-to-int-cast -Wno-infinite-recursion -Wno-unused-but-set-variable -O3 -lgc -DGC_THREADS -DGC_PTHREADS -DPTW
32_STATIC_LIB -DGC_WIN32_PTHREADS -fno-trigraphs -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -std=c11 -o HelloWorld C:\Users\sam\fuzion\build\include\shared.c C:\Users\sam\fuzion\build\include\win.c C:\tools\msys64\tmp\fuzion_HelloWorld_3587196
018116927889.c -matomics -lMswsock -lAdvApi32 -lWs2_32 C:\tools\msys64\ucrt64\bin\libgc-1.dll' failed with exit code '1'
```
