### PR TITLE
be/int: add skip file for test sockets

### DIFF
--- a/tests/sockets/skip_int
+++ b/tests/sockets/skip_int
@@ -1,0 +1,1 @@
+NYI: BUG: interpreter not thread safe, see #2813


### PR DESCRIPTION
tests frequently fails, see #2813

[ci skip]