### PR TITLE
fe/me: always use .fum file as input for middle end

### DIFF
--- a/src/dev/flang/air/Clazz.java
+++ b/src/dev/flang/air/Clazz.java
@@ -49,11 +49,12 @@ import dev.flang.ast.HasGlobalIndex; // NYI: remove dependency!
 import dev.flang.ast.If; // NYI: remove dependency!
 import dev.flang.ast.InlineArray; // NYI: remove dependency!
 import dev.flang.ast.ResolvedNormalType; // NYI: remove dependency!
-import dev.flang.ast.SrcModule; // NYI: remove dependency!
 import dev.flang.ast.State; // NYI: remove dependency!
 import dev.flang.ast.ExpressionVisitor; // NYI: remove dependency!
 import dev.flang.ast.Tag; // NYI: remove dependency!
 import dev.flang.ast.Types; // NYI: remove dependency!
+
+import dev.flang.fe.Module;
 
 import dev.flang.util.ANY;
 import dev.flang.util.Errors;
@@ -87,7 +88,7 @@ public class Clazz extends ANY implements Comparable<Clazz>
 
 
   // NYI: CLEANUP #2411 remove this dependency, clazzes should be build from module files only
-  public static SrcModule _module;
+  public static Module _module;
 
 
   /*-----------------------------  classes  -----------------------------*/

--- a/src/dev/flang/air/Clazz.java
+++ b/src/dev/flang/air/Clazz.java
@@ -54,7 +54,7 @@ import dev.flang.ast.ExpressionVisitor; // NYI: remove dependency!
 import dev.flang.ast.Tag; // NYI: remove dependency!
 import dev.flang.ast.Types; // NYI: remove dependency!
 
-import dev.flang.fe.Module;
+import dev.flang.fe.FeatureLookup;
 
 import dev.flang.util.ANY;
 import dev.flang.util.Errors;
@@ -87,8 +87,7 @@ public class Clazz extends ANY implements Comparable<Clazz>
   static final Clazz[] NO_CLAZZES = new Clazz[0];
 
 
-  // NYI: CLEANUP #2411 remove this dependency, clazzes should be build from module files only
-  public static Module _module;
+  public static FeatureLookup _flu;
 
 
   /*-----------------------------  classes  -----------------------------*/
@@ -933,7 +932,7 @@ public class Clazz extends ANY implements Comparable<Clazz>
         (isUsedAsDynamicOuterRef() || isRef()))
       {
         // NYI: This should be removed, but this still finds some clazzes that findAllClasses() missed. Need to check why.
-        for (AbstractFeature f: _module.allInnerAndInheritedFeatures(feature()))
+        for (AbstractFeature f: _flu.allInnerAndInheritedFeatures(feature()))
           {
             lookupIfInstantiated(f);
           }
@@ -991,7 +990,7 @@ public class Clazz extends ANY implements Comparable<Clazz>
               }
           }
       }
-    return _module.lookupFeature(feature(), fn, f);
+    return _flu.lookupFeature(feature(), fn, f);
   }
 
 
@@ -1549,7 +1548,7 @@ public class Clazz extends ANY implements Comparable<Clazz>
         var f = feature();
         inspectCode(new List<>(), f);
 
-        for (AbstractFeature ff: _module.allInnerAndInheritedFeatures(f))
+        for (AbstractFeature ff: _flu.allInnerAndInheritedFeatures(f))
           {
             Clazzes.whenCalledDynamically(ff, () -> lookupIfInstantiated(ff));
           }
@@ -2657,7 +2656,7 @@ public class Clazz extends ANY implements Comparable<Clazz>
           // note that intrinsics may have fields that are used in the intrinsic's pre-condition!
           false && isRef() /* NYI: would be good to add isRef() here and create _fields only for value types, does not work with C backend yet */
           ? NO_CLAZZES
-          : actualFields(_module.allInnerAndInheritedFeatures(feature()));
+          : actualFields(_flu.allInnerAndInheritedFeatures(feature()));
       }
     return isRef() ? NO_CLAZZES : _fields;
   }

--- a/src/dev/flang/fe/FeatureLookup.java
+++ b/src/dev/flang/fe/FeatureLookup.java
@@ -1,0 +1,57 @@
+/*
+
+This file is part of the Fuzion language implementation.
+
+The Fuzion language implementation is free software: you can redistribute it
+and/or modify it under the terms of the GNU General Public License as published
+by the Free Software Foundation, version 3 of the License.
+
+The Fuzion language implementation is distributed in the hope that it will be
+useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+License for more details.
+
+You should have received a copy of the GNU General Public License along with The
+Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+*/
+
+/*-----------------------------------------------------------------------
+ *
+ * Tokiwa Software GmbH, Germany
+ *
+ * Source of interface FeatureLookup
+ *
+ *---------------------------------------------------------------------*/
+
+package dev.flang.fe;
+
+import java.util.Collection;
+
+import dev.flang.ast.AbstractFeature;
+import dev.flang.ast.FeatureName;
+
+
+/**
+ * Interface for looking up features that is used by middle end.
+ */
+public interface FeatureLookup {
+
+
+  /**
+   * Get all inner and inherited features of `f`.
+   */
+  public Collection<AbstractFeature> allInnerAndInheritedFeatures(AbstractFeature f);
+
+
+  /**
+   * Find feature with given name in outer.
+   *
+   * @param outer the declaring or inheriting feature
+   *
+   * @param name the feature name that we are searching for
+   */
+  public AbstractFeature lookupFeature(AbstractFeature outer, FeatureName name, AbstractFeature original);
+
+
+}

--- a/src/dev/flang/fe/Module.java
+++ b/src/dev/flang/fe/Module.java
@@ -56,7 +56,7 @@ import java.util.TreeSet;
  *
  * @author Fridtjof Siebert (siebert@tokiwa.software)
  */
-public abstract class Module extends ANY
+public abstract class Module extends ANY implements FeatureLookup
 {
 
 
@@ -392,13 +392,19 @@ public abstract class Module extends ANY
     var s = d._declaredOrInheritedFeatures;
     if (s == null)
       {
+        s = new TreeMap<>();
+
         if (outer instanceof LibraryFeature olf)
           {
             // NYI: cleanup: See #462: Remove once sub-directories are loaded
             // directly, not implicitly when outer feature is found
             loadInnerFeatures(outer);
+
+            for (var f : olf.declaredFeatures())
+              {
+                s.put(f.featureName(), f);
+              }
           }
-        s = new TreeMap<>();
 
         // first we search in additional modules
         for (Module libraryModule : modules)

--- a/src/dev/flang/fe/SourceModule.java
+++ b/src/dev/flang/fe/SourceModule.java
@@ -966,36 +966,7 @@ part of the (((inner features))) declarations of the corresponding
   }
 
 
-  /**
-   * allInnerAndInheritedFeatures returns a complete set of inner features, used
-   * by Clazz.layout and Clazz.hasState.
-   *
-   * @return
-   */
-  public Collection<AbstractFeature> allInnerAndInheritedFeatures(AbstractFeature f)
-  {
-    var d = data(f);
-    var result = d._allInnerAndInheritedFeatures;
-    if (result == null)
-      {
-        result = new TreeSet<>();
 
-        result.addAll(declaredFeatures(f).values());
-        for (var p : f.inherits())
-          {
-            var cf = p.calledFeature();
-            if (CHECKS) check
-              (Errors.any() || cf != null);
-
-            if (cf != null)
-              {
-                result.addAll(allInnerAndInheritedFeatures(cf));
-              }
-          }
-        d._allInnerAndInheritedFeatures = result;
-      }
-    return result;
-  }
 
 
   /*--------------------------  feature lookup  -------------------------*/
@@ -1005,30 +976,6 @@ part of the (((inner features))) declarations of the corresponding
   public SortedMap<FeatureName, AbstractFeature> declaredOrInheritedFeatures(AbstractFeature outer)
   {
     return this.declaredOrInheritedFeatures(outer, _dependsOn);
-  }
-
-
-  /**
-   * Find feature with given name in outer.
-   *
-   * @param outer the declaring or inheriting feature
-   */
-  public AbstractFeature lookupFeature(AbstractFeature outer, FeatureName name, AbstractFeature original)
-  {
-    if (PRECONDITIONS) require
-      (outer.state().atLeast(State.LOADING));
-
-    var result = declaredOrInheritedFeatures(outer).get(name);
-
-    /* Was feature f added to the declared features of its outer features late,
-     * i.e., after the RESOLVING_DECLARATIONS phase?  These late features are
-     * currently not added to the sets of declared or inherited features by
-     * children of their outer clazz.
-     *
-     * This is a fix for #978 but it might need to be removed when fixing #932.
-     */
-    return result == null && original instanceof Feature of && of._addedLate ? original
-                                                                             : result;
   }
 
 

--- a/src/dev/flang/me/MiddleEnd.java
+++ b/src/dev/flang/me/MiddleEnd.java
@@ -38,13 +38,14 @@ import dev.flang.ast.AbstractCall; // NYI: remove dependency!
 import dev.flang.ast.AbstractConstant; // NYI: remove dependency!
 import dev.flang.ast.AbstractFeature; // NYI: remove dependency!
 import dev.flang.ast.AbstractType; // NYI: remove dependency!
-import dev.flang.ast.Expr;
+import dev.flang.ast.Expr; // NYI: remove dependency!
+import dev.flang.ast.FeatureName; // NYI: remove dependency!
 import dev.flang.ast.FeatureVisitor; // NYI: remove dependency!
-import dev.flang.ast.InlineArray;
-import dev.flang.ast.SrcModule; // NYI: remove dependency!
+import dev.flang.ast.InlineArray; // NYI: remove dependency!
 import dev.flang.ast.State; // NYI: remove dependency!
 import dev.flang.ast.Tag; // NYI: remove dependency!
-import dev.flang.ast.Types; // NYI: remove dependency!
+
+import dev.flang.fe.Module;  // NYI: remove dependency!
 
 import dev.flang.mir.MIR;
 
@@ -96,7 +97,7 @@ public class MiddleEnd extends ANY
   /*--------------------------  constructors  ---------------------------*/
 
 
-  public MiddleEnd(FuzionOptions options, MIR mir, SrcModule mod)
+  public MiddleEnd(FuzionOptions options, MIR mir, Module mod)
   {
     _options = options;
     _mir = mir;
@@ -139,11 +140,15 @@ public class MiddleEnd extends ANY
   void markInternallyUsed() {
     var universe = _mir.universe();
     var m = Clazz._module;
-    markUsed(Types.resolved.f_fuzion_Java_Object                  , SourcePosition.builtIn);
-    markUsed(Types.resolved.f_fuzion_Java_Object_Ref              , SourcePosition.builtIn);
-    markUsed(universe.get(m, "Const_String")                      , SourcePosition.builtIn); // NYI this should be unnecessary?
-    markUsed(universe.get(m, FuzionConstants.UNIT_NAME)           , SourcePosition.builtIn);
-    markUsed(universe.get(m, "void")                              , SourcePosition.builtIn);
+    var fuzion     = m.lookupFeature(universe,   FeatureName.get("fuzion",      0), null);
+    var fuzionJava = m.lookupFeature(fuzion,     FeatureName.get("java",        0), null);
+    var JavaObject = m.lookupFeature(fuzionJava, FeatureName.get("Java_Object", 1), null);
+    var JavaRef    = m.lookupFeature(JavaObject, FeatureName.get("Java_Ref",    0), null);
+    markUsed(JavaObject                                                                     , SourcePosition.builtIn);
+    markUsed(JavaRef                                                                        , SourcePosition.builtIn);
+    markUsed(m.lookupFeature(universe, FeatureName.get("Const_String"           , 0), null) , SourcePosition.builtIn); // NYI this should be unnecessary?
+    markUsed(m.lookupFeature(universe, FeatureName.get(FuzionConstants.UNIT_NAME, 0), null) , SourcePosition.builtIn);
+    markUsed(m.lookupFeature(universe, FeatureName.get("void"                   , 0), null) , SourcePosition.builtIn);
   }
 
 

--- a/src/dev/flang/me/MiddleEnd.java
+++ b/src/dev/flang/me/MiddleEnd.java
@@ -45,7 +45,7 @@ import dev.flang.ast.InlineArray; // NYI: remove dependency!
 import dev.flang.ast.State; // NYI: remove dependency!
 import dev.flang.ast.Tag; // NYI: remove dependency!
 
-import dev.flang.fe.Module;  // NYI: remove dependency!
+import dev.flang.fe.FeatureLookup;
 
 import dev.flang.mir.MIR;
 
@@ -97,11 +97,11 @@ public class MiddleEnd extends ANY
   /*--------------------------  constructors  ---------------------------*/
 
 
-  public MiddleEnd(FuzionOptions options, MIR mir, Module mod)
+  public MiddleEnd(FuzionOptions options, MIR mir, FeatureLookup flu)
   {
     _options = options;
     _mir = mir;
-    Clazz._module = mod; // NYI: Bad hack!
+    Clazz._flu = flu; // NYI: Bad hack!
   }
 
 
@@ -139,16 +139,16 @@ public class MiddleEnd extends ANY
    */
   void markInternallyUsed() {
     var universe = _mir.universe();
-    var m = Clazz._module;
-    var fuzion     = m.lookupFeature(universe,   FeatureName.get("fuzion",      0), null);
-    var fuzionJava = m.lookupFeature(fuzion,     FeatureName.get("java",        0), null);
-    var JavaObject = m.lookupFeature(fuzionJava, FeatureName.get("Java_Object", 1), null);
-    var JavaRef    = m.lookupFeature(JavaObject, FeatureName.get("Java_Ref",    0), null);
-    markUsed(JavaObject                                                                     , SourcePosition.builtIn);
-    markUsed(JavaRef                                                                        , SourcePosition.builtIn);
-    markUsed(m.lookupFeature(universe, FeatureName.get("Const_String"           , 0), null) , SourcePosition.builtIn); // NYI this should be unnecessary?
-    markUsed(m.lookupFeature(universe, FeatureName.get(FuzionConstants.UNIT_NAME, 0), null) , SourcePosition.builtIn);
-    markUsed(m.lookupFeature(universe, FeatureName.get("void"                   , 0), null) , SourcePosition.builtIn);
+    var flu = Clazz._flu;
+    var fuzion     = flu.lookupFeature(universe,   FeatureName.get("fuzion",      0), null);
+    var fuzionJava = flu.lookupFeature(fuzion,     FeatureName.get("java",        0), null);
+    var JavaObject = flu.lookupFeature(fuzionJava, FeatureName.get("Java_Object", 1), null);
+    var JavaRef    = flu.lookupFeature(JavaObject, FeatureName.get("Java_Ref",    0), null);
+    markUsed(JavaObject                                                                       , SourcePosition.builtIn);
+    markUsed(JavaRef                                                                          , SourcePosition.builtIn);
+    markUsed(flu.lookupFeature(universe, FeatureName.get("Const_String"           , 0), null) , SourcePosition.builtIn); // NYI this should be unnecessary?
+    markUsed(flu.lookupFeature(universe, FeatureName.get(FuzionConstants.UNIT_NAME, 0), null) , SourcePosition.builtIn);
+    markUsed(flu.lookupFeature(universe, FeatureName.get("void"                   , 0), null) , SourcePosition.builtIn);
   }
 
 

--- a/src/dev/flang/tools/Fuzion.java
+++ b/src/dev/flang/tools/Fuzion.java
@@ -471,7 +471,7 @@ public class Fuzion extends Tool
     {
       var mir = fe.createMIR();                                                           f.timer("createMIR");
       var air = new MiddleEnd(fe._options, mir, fe.mainModule() /* NYI: remove */).air(); f.timer("me");
-      var fuir = new Optimizer(fe._options, air).fuir();                              f.timer("ir");
+      var fuir = new Optimizer(fe._options, air).fuir();                                  f.timer("ir");
       process(fe._options, fuir);
     }
 

--- a/src/dev/flang/tools/Fuzion.java
+++ b/src/dev/flang/tools/Fuzion.java
@@ -46,8 +46,6 @@ import dev.flang.be.effects.Effects;
 
 import dev.flang.be.interpreter.Interpreter;
 
-import dev.flang.be.interpreter.Interpreter;
-
 import dev.flang.be.jvm.JVM;
 import dev.flang.be.jvm.JVMOptions;
 
@@ -472,7 +470,7 @@ public class Fuzion extends Tool
     void processFrontEnd(Fuzion f, FrontEnd fe)
     {
       var mir = fe.createMIR();                                                       f.timer("createMIR");
-      var air = new MiddleEnd(fe._options, mir, fe.module() /* NYI: remove */).air(); f.timer("me");
+      var air = new MiddleEnd(fe._options, mir, fe.mainModule() /* NYI: remove */).air(); f.timer("me");
       var fuir = new Optimizer(fe._options, air).fuir();                              f.timer("ir");
       process(fe._options, fuir);
     }
@@ -1041,6 +1039,7 @@ public class Fuzion extends Tool
         timer("prep");
         var fe = new FrontEnd(options);
         timer("fe");
+        Errors.showAndExit();
         _backend.processFrontEnd(this, fe);
         timer("be");
         options.verbosePrintln(1, "Elapsed time for phases: " + _times);

--- a/src/dev/flang/tools/Fuzion.java
+++ b/src/dev/flang/tools/Fuzion.java
@@ -469,7 +469,7 @@ public class Fuzion extends Tool
      */
     void processFrontEnd(Fuzion f, FrontEnd fe)
     {
-      var mir = fe.createMIR();                                                       f.timer("createMIR");
+      var mir = fe.createMIR();                                                           f.timer("createMIR");
       var air = new MiddleEnd(fe._options, mir, fe.mainModule() /* NYI: remove */).air(); f.timer("me");
       var fuir = new Optimizer(fe._options, air).fuir();                              f.timer("ir");
       process(fe._options, fuir);

--- a/tests/reg_issue1109/Makefile
+++ b/tests/reg_issue1109/Makefile
@@ -1,3 +1,30 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test Makefile
+#
+# -----------------------------------------------------------------------
+
+#
+# The example caused an Error during DFA, when using module file and C backend.
+#
+
 FUZION_OPTIONS ?=
 FUZION = ../../bin/fz $(FUZION_OPTIONS)
 FUZION_HOME = $(dir $(FUZION))..


### PR DESCRIPTION
Since errors can not be written to fum file, I needed to add a `Errors.showAndExit()` after `new FrontEnd()`

