### PR TITLE
lib: option/outcome, add `prefix !`

### DIFF
--- a/lib/num_option.fz
+++ b/lib/num_option.fz
@@ -55,6 +55,11 @@ is
   public postfix !! => is_nil
 
 
+  # short-hand prefix operator for 'is_nil'
+  #
+  public prefix ! => is_nil
+
+
   # value of an option that is known to contain a value
   #
   # this can only be called in cases where it is known for sure that this option

--- a/lib/option.fz
+++ b/lib/option.fz
@@ -55,6 +55,11 @@ is
   public postfix !! => is_nil
 
 
+  # short-hand prefix operator for 'is_nil'
+  #
+  public prefix ! => is_nil
+
+
   # value of an option that is known to contain a value
   #
   # this can only be called in cases where it is known for sure that this option

--- a/lib/outcome.fz
+++ b/lib/outcome.fz
@@ -76,6 +76,11 @@ is
   public postfix !! => is_error
 
 
+  # short-hand prefix operator for 'is_error'
+  #
+  public prefix ! => is_error
+
+
   # value of an outcome that is known to contain a value
   #
   # This can only be called in cases where it is known for sure that this


### PR DESCRIPTION
I think a lot of people are kind of used to this prefix operator.

Enables code like:
```
a num_option i32 := nil
if !a
  say "a is not a number"
```

