### PR TITLE
be/interpreter: fix _callStackFrames initialization

### DIFF
--- a/src/dev/flang/be/interpreter/Interpreter.java
+++ b/src/dev/flang/be/interpreter/Interpreter.java
@@ -78,6 +78,7 @@ public class Interpreter extends ANY
   {
     try
       {
+        FuzionThread.current()._callStackFrames.push(_fuir.mainClazzId());
         _ai.process(_fuir.mainClazzId(), true);
         _ai.process(_fuir.mainClazzId(), false);
       }


### PR DESCRIPTION
In callOnInstance `cc` is pushed to `callStackFrames` but at start of application we also need to push to `callStackFrames`.
```
   FuzionThread.current()._callStackFrames.push(cc);
   FuzionThread.current()._callStack.push(site());

   new AbstractInterpreter<>(_fuir, new Excecutor(cur, outer, args))
      .process(cc, pre);
```
