### PR TITLE
be/interpreter fix output on failed postcondition

### DIFF
--- a/src/dev/flang/be/interpreter/Excecutor.java
+++ b/src/dev/flang/be/interpreter/Excecutor.java
@@ -548,8 +548,8 @@ public class Excecutor extends ProcessStatement<Value, Object>
     if (!cc.boolValue())
       {
         Errors.runTime(pos(),
-                       "Precondition does not hold",
-                       "For call to " + _fuir.clazzAsStringNew(cl) + "\n" + callStack(fuir()));
+                       (ck == ContractKind.Pre ? "Precondition" : "Postcondition") + " does not hold",
+                       (ck == ContractKind.Pre ? "For" : "After") + " call to " + _fuir.clazzAsStringNew(cl) + "\n" + callStack(fuir()));
       }
     return null;
   }


### PR DESCRIPTION
the output was always "Precondition does not hold" no matter the contract failure.

