### PR TITLE
interpreter: fix java intrinsics, wrap result in outcome

### DIFF
--- a/src/dev/flang/be/interpreter/Intrinsics.java
+++ b/src/dev/flang/be/interpreter/Intrinsics.java
@@ -747,7 +747,7 @@ public class Intrinsics extends ANY
           String in = innerClazz.feature().qualifiedName();   // == _fuir.clazzOriginalName(cl);
           var virtual     = in.equals("fuzion.java.call_v0");
           var constructor = in.equals("fuzion.java.call_c0");
-          Clazz resultClazz = innerClazz.actualGenerics()[0];
+          Clazz resultClazz = innerClazz.resultClazz();
           return args ->
             {
               int a = 1;


### PR DESCRIPTION
It was changed recently that results of call_*0 are always wrapped in an outcome. Interpreter missed that change.

fixes #2838