### PR TITLE
be/jvm: fix showing elapsed time stats (`-verbose>1`)

### DIFF
--- a/src/dev/flang/tools/Fuzion.java
+++ b/src/dev/flang/tools/Fuzion.java
@@ -65,6 +65,7 @@ import dev.flang.util.Errors;
 import dev.flang.util.FuzionConstants;
 import dev.flang.util.FuzionOptions;
 import dev.flang.util.SourceFile;
+import dev.flang.util.QuietThreadTermination;
 
 
 /**
@@ -174,7 +175,13 @@ public class Fuzion extends Tool
       }
       void process(FuzionOptions options, FUIR fuir)
       {
-        new JVM(new JVMOptions(options, _xdfa_, /* run */ true, /* save classes */ false, /* save JAR */ false, Optional.empty()), fuir).compile();
+        try
+          {
+            new JVM(new JVMOptions(options, _xdfa_, /* run */ true, /* save classes */ false, /* save JAR */ false, Optional.empty()), fuir).compile();
+          }
+        catch (QuietThreadTermination e)
+          {
+          }
       }
       boolean takesApplicationArgs()
       {

--- a/src/dev/flang/util/Errors.java
+++ b/src/dev/flang/util/Errors.java
@@ -934,9 +934,6 @@ public class Errors extends ANY
             r.run();
             Errors.showAndExit(true);
           }
-        catch (QuietThreadTermination e)
-          {
-          }
         catch (Throwable e)
           {
             Errors.fatal(e);


### PR DESCRIPTION
Because of QuietThreadTermination caught for whole compilation process, elapsed time was not printed anymore.

Moved catching of exception to backend `-jvm` only.