### PR TITLE
tools: show time in ms for building module

### DIFF
--- a/src/dev/flang/tools/Fuzion.java
+++ b/src/dev/flang/tools/Fuzion.java
@@ -78,6 +78,12 @@ public class Fuzion extends Tool
   /*----------------------------  constants  ----------------------------*/
 
 
+  /**
+   * Time at application start in System.currentTimeMillis();
+   */
+  protected static final long _timerStart = System.currentTimeMillis();
+
+
   static String  _binaryName_ = null;
   static boolean _useBoehmGC_ = true;
   static boolean _xdfa_ = true;
@@ -335,10 +341,10 @@ public class Fuzion extends Tool
             var data = fe.module().data(n);
             if (data != null)
               {
-                say(" + " + p);
                 try (var os = Files.newOutputStream(p))
                   {
                     Channels.newChannel(os).write(data);
+                    say(" + " + p + " in " + (System.currentTimeMillis() - _timerStart) + "ms");
                   }
                 catch (IOException io)
                   {


### PR DESCRIPTION
e.g.:
```
 + build/modules/base.fum in 3993ms
 + build/modules/terminal.fum in 443ms
 + build/modules/lock_free.fum in 590ms
 + build/modules/nom.fum in 542ms
```