### PR TITLE
ast: change loop scoping semantics

### DIFF
--- a/src/dev/flang/ast/Loop.java
+++ b/src/dev/flang/ast/Loop.java
@@ -291,6 +291,7 @@ public class Loop extends ANY
 
     _prologSuccessBlock = new List<>();
     _prolog             = new Block(_prologSuccessBlock, hasImplicitResult);
+    _prolog._newScope = true;
     if (!_indexVars.isEmpty())
       {
         _nextItSuccessBlock = new List<>();

--- a/tests/loop_scoping/Makefile
+++ b/tests/loop_scoping/Makefile
@@ -1,0 +1,25 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test Makefile
+#
+# -----------------------------------------------------------------------
+
+override NAME = loop_scoping
+include ../simple.mk

--- a/tests/loop_scoping/loop_scoping.fz
+++ b/tests/loop_scoping/loop_scoping.fz
@@ -1,0 +1,27 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test
+#
+# -----------------------------------------------------------------------
+
+loop_scoping is
+
+  for i := 10 do
+  say i

--- a/tests/loop_scoping/loop_scoping.fz.expected_err
+++ b/tests/loop_scoping/loop_scoping.fz.expected_err
@@ -1,0 +1,9 @@
+
+--CURDIR--/loop_scoping.fz:27:7: error 1: Could not find called feature
+  say i
+------^
+Feature not found: 'i' (no arguments)
+Target feature: 'loop_scoping'
+In call: 'i'
+
+one error.


### PR DESCRIPTION
previously this worked:
```
  for i := 10 do
  say i
```
but this does not work:
```
  for x in 1..10
        i := 10
  do
  say i
```

This patch changes the semantics of the loop in a way that the first example also results in a feature not found error.

I think this makes loop scoping more intuitive.

We loose the ability to access any non-iterating index variables until the first iterating index variable.


@tokiwa-software/developers Not sure if this change of semantics is desirable but created this PR to get your opinions.