### PR TITLE
lib/tests: fix code of potentially unitialized access

### DIFF
--- a/lib/num/ryu.fz
+++ b/lib/num/ryu.fz
@@ -970,25 +970,28 @@ public ryū(public T type : float) is
 
 
   # step 5: construct the string
-  step_5(output, output_length, exponent i64, is_negative, scientific_notation bool) String =>
+  step_5(output, output_length, exponent i64, is_negative, scientific_notation bool) String
+  pre debug: output_length > 0
+  =>
 
 
     # convert output to string
     output_as_string(output i64, output_length i64) String =>
-      for _ in (i64 1)..(output_length)
-          o := output, o / 10
+      for o := output, o / 10
           s := "{o % 10}", "{o % 10}$s"
+          _ in (i64 1)..(output_length-1 )
       do
       else
         s
 
     # this float as a scientific string e.g. 3.2E2
     scientific =>
-      for idx in i64 1 .. output_length
+      for str0 := "** internal error **", str
+          idx in i64 1 .. output_length
           output := output, output / 10
           str := "{output % 10}", "{output % 10}" + (if idx = output_length then "." else "") + str
       else
-        "{str}E{exponent}"
+        "{str0}E{exponent}"
 
     # the float as a decimal string
     full =>
@@ -997,12 +1000,13 @@ public ryū(public T type : float) is
       else if exponent + 1 >= output_length
         "{output_as_string output output_length}{"0" * (exponent+1-output_length).as_i32}.0"
       else
-        for idx in i64 0 .. output_length
+        for str0 := "** internal error **", str
+            idx in i64 0 .. output_length
             is_dot_pos := false, output_length - idx - 1 = exponent
             output := output, if is_dot_pos then output else output / 10
             str := "{output % 10}", (if is_dot_pos then "." else "{output % 10}") + str
         else
-          str
+          str0
 
     if is_negative then "-" else ""
       + (if scientific_notation then scientific else full)

--- a/tests/atomic/test_atomic.fz
+++ b/tests/atomic/test_atomic.fz
@@ -157,81 +157,33 @@ test_atomic is
   c2 := concur.atomic i64 0
   s2 := concur.atomic i64 -1
 
-  if false  # NYI: The tail recursion is not properly recognized in this case yet,
-            #      resulting in stack overflow for the C and interpreter backends:
-    concur.thread.spawn (()->
-      end := time.nano.read + (time.durations.seconds 5).nanos
-      for
-        s := i64 0, o=v ? s+1 : s
-        c in (i64 0)..
-      while time.nano.read < end do
-        v := a.read
-        n := v + 1
-        o := a.compare_and_swap v n
-      else
-        c1.write c
-        s1.write s
-      )
+  concur.thread.spawn (()->
+    end := time.nano.read + (time.durations.seconds 5).nanos
+    for
+      s := i64 0, o=v ? s+1 : s
+      c := i64 0, c+1
+    while time.nano.read < end do
+      v := a.read
+      n := v + 1
+      o := a.compare_and_swap v n
+    else
+      c1.write c
+      s1.write s
+    )
 
-    concur.thread.spawn (()->
-      end := time.nano.read + (time.durations.seconds 5).nanos
-      for
-        s := i64 0, o=v ? s+1 : s
-        c in (i64 0)..
-      while time.nano.read < end do
-        v := a.read
-        n := v + 0x1_0000_0000
-        o := a.compare_and_swap v n
-      else
-        c2.write c
-        s2.write s
-      )
-
-  else
-    # alternative avoiding loops/tail recursion
-    end := time.nano.read + (time.durations.ms 100).nanos
-    concur.thread.spawn (()->
-      rec(d i32) (i32, i32) =>
-        if time.nano.read < end
-          if d > 0
-            (succ0,count0) := (rec d-1)
-            (succ1,count1) := (rec d-1)
-            (succ0 + succ1, count0 + count1)
-          else
-            v := a.read
-            n := v + 0x1
-            o := a.compare_and_swap v n
-            if o = v
-              (1,1)
-            else
-              (0,1)
-        else
-          (0, 0)
-      (s, c) := rec 32
-      c1.write c.as_i64
-      s1.write s.as_i64
-      )
-    concur.thread.spawn (()->
-      rec(d i32) (i32, i32) =>
-        if time.nano.read < end
-          if d > 0
-            (succ0,count0) := (rec d-1)
-            (succ1,count1) := (rec d-1)
-            (succ0 + succ1, count0 + count1)
-          else
-            v := a.read
-            n := v + 0x1_0000_0000
-            o := a.compare_and_swap v n
-            if o = v
-              (1,1)
-            else
-              (0,1)
-        else
-          (0, 0)
-      (s, c) := rec 32
-      c2.write c.as_i64
-      s2.write s.as_i64
-      )
+  concur.thread.spawn (()->
+    end := time.nano.read + (time.durations.seconds 5).nanos
+    for
+      s := i64 0, o=v ? s+1 : s
+      c := i64 0, c+1
+    while time.nano.read < end do
+      v := a.read
+      n := v + 0x1_0000_0000
+      o := a.compare_and_swap v n
+    else
+      c2.write c
+      s2.write s
+    )
 
   while s1.read < 0 || s2.read < 0 do
     time.nano.sleep (time.durations.ms 20)

--- a/tests/reg_issue2376/reg_issue2376.fz
+++ b/tests/reg_issue2376/reg_issue2376.fz
@@ -21,12 +21,13 @@
 #
 # -----------------------------------------------------------------------
 
-for e in [ 3, 1, 4 ]
+for b0 Sequence i32 := [], b
+    e in [ 3, 1, 4 ]
     b Sequence i32 := [], c
 do
   c Sequence i32 :=  if      e = 4         then b.filter _->false
                      else if (b ∃ x->true) then b.map    _->e
                      else                       [e]
 else
-  say b.first
+  say b0.first
 


### PR DESCRIPTION
In the else-clause of a loop only variables before any `in` will be accessible (not yet enforced by the compiler). This PR changes the loops in lib/tests that violate this rule.