### PR TITLE
tests: record time

### DIFF
--- a/bin/run_tests.sh
+++ b/bin/run_tests.sh
@@ -52,17 +52,15 @@ for test in $TESTS; do
     echo "$test: skipped" >>"$BUILD_DIR"/run_tests.results
   else
     START_TIME=$(date +%s%N | cut -b1-13)
-    if make "$TARGET" -e -C "$test" >"$test"/out.txt 2>"$test"/stderr.txt; then
-        echo -n "."
-        echo "$test: ok"     >>"$BUILD_DIR"/run_tests.results
-    else
-        echo -n "#"
-        echo "$test: failed" >>"$BUILD_DIR"/run_tests.results
-        cat "$test"/out.txt "$test"/stderr.txt >>"$BUILD_DIR"/run_tests.failures
-    fi
+    TEST_RESULT=$(make "$TARGET" -e -C "$test" >"$test"/out.txt 2>"$test"/stderr.txt)
     END_TIME=$(date +%s%N | cut -b1-13)
-    if test -n "$VERBOSE"; then
-      echo -en " time: $((END_TIME-START_TIME))ms"
+    if $TEST_RESULT; then
+      echo -n "."
+      echo "$test in $((END_TIME-START_TIME))ms: ok"     >>"$BUILD_DIR"/run_tests.results
+    else
+      echo -n "#"
+      echo "$test in $((END_TIME-START_TIME))ms: failed" >>"$BUILD_DIR"/run_tests.results
+      cat "$test"/out.txt "$test"/stderr.txt >>"$BUILD_DIR"/run_tests.failures
     fi
   fi
 done

--- a/bin/run_tests_parallel.sh
+++ b/bin/run_tests_parallel.sh
@@ -60,7 +60,7 @@ renice -n 19 $$ > /dev/null
 
 BUILD_DIR=$1
 TARGET=$2
-TESTS=$(find "$BUILD_DIR"/tests -name Makefile -print0 | xargs -0 -n1 dirname)
+TESTS=$(find "$BUILD_DIR"/tests -name Makefile -print0 | xargs -0 -n1 dirname | sort)
 VERBOSE="${VERBOSE:-""}"
 
 rm -rf "$BUILD_DIR"/run_tests.results
@@ -84,12 +84,15 @@ for test in $TESTS; do
       echo -n "_"
       echo "$test: skipped" >>"$BUILD_DIR"/run_tests.results
     else
-      if make "$TARGET" -e -C "$test" >"$test"/out.txt 2>"$test"/stderr.txt; then
+      START_TIME=$(date +%s%N | cut -b1-13)
+      TEST_RESULT=$(make "$TARGET" -e -C "$test" >"$test"/out.txt 2>"$test"/stderr.txt)
+      END_TIME=$(date +%s%N | cut -b1-13)
+      if $TEST_RESULT; then
         echo -n "."
-        echo "$test: ok"     >>"$BUILD_DIR"/run_tests.results
+        echo "$test in $((END_TIME-START_TIME))ms: ok"     >>"$BUILD_DIR"/run_tests.results
       else
         echo -n "#"
-        echo "$test: failed" >>"$BUILD_DIR"/run_tests.results
+        echo "$test in $((END_TIME-START_TIME))ms: failed" >>"$BUILD_DIR"/run_tests.results
         cat "$test"/out.txt "$test"/stderr.txt >>"$BUILD_DIR"/run_tests.failures
       fi
     fi


### PR DESCRIPTION
e.g.:
```
/home/not_synced/fuzion (2024-04-10T14-44-08+02-00)130$ make run_tests_parallel
testing JVM backend: 221 tests, running 6 tests in parallel.
.....^C
./build/tests/argumentcount_negative in 539ms: ok
./build/tests/assignment_negative in 648ms: ok
./build/tests/abstractfeatures_negative in 1201ms: ok
./build/tests/basicIntegers_negative in 1035ms: ok
./build/tests/call_with_ambiguous_result_type_negative in 1196ms: ok
```

