### PR TITLE
fuir: Remove ExprKind.AdrOf

### DIFF
--- a/src/dev/flang/be/c/C.java
+++ b/src/dev/flang/be/c/C.java
@@ -116,16 +116,6 @@ public class C extends ANY
 
 
     /**
-     * Determine the address of a given value.  This is used on a call to an
-     * inner feature to pass a reference to the outer value type instance.
-     */
-    public Pair<CExpr, CStmnt> adrOf(CExpr v)
-    {
-      return new Pair<>(v.adrOf(), CStmnt.EMPTY);
-    }
-
-
-    /**
      * Create code to assign value to a given field w/o dynamic binding.
      *
      * @param cl the clazz we are compiling
@@ -228,7 +218,12 @@ public class C extends ANY
      */
     public Pair<CExpr, CStmnt> outer(int cl)
     {
-      return new Pair<>(CNames.OUTER, CStmnt.EMPTY);
+      CExpr result = CNames.OUTER;
+      if (_fuir.clazzFieldIsAdrOfValue(_fuir.clazzOuterRef(cl)))
+        {
+          result = result.deref();
+        }
+      return new Pair<>(result, CStmnt.EMPTY);
     }
 
 
@@ -1478,6 +1473,10 @@ public class C extends ANY
    */
   CStmnt assignField(CExpr tvalue, int tc, int tt, int f, CExpr value, int rt)
   {
+    if (_fuir.clazzFieldIsAdrOfValue(f))
+      {
+        value = value.adrOf();
+      }
     if (_fuir.clazzIsRef(tt) && tc != tt)
       {
         tvalue = tvalue.castTo(_types.clazz(tt));

--- a/src/dev/flang/be/interpreter/Excecutor.java
+++ b/src/dev/flang/be/interpreter/Excecutor.java
@@ -192,12 +192,6 @@ public class Excecutor extends ProcessStatement<Value, Object>
   }
 
   @Override
-  public Pair<Value, Object> adrOf(Value v)
-  {
-    return pair(v);
-  }
-
-  @Override
   public Object assignStatic(int cl, boolean pre, int tc, int f, int rt, Value tvalue, Value val)
   {
     if (!(_fuir.clazzIsOuterRef(f) && _fuir.clazzIsUnitType(rt)))

--- a/src/dev/flang/be/jvm/CodeGen.java
+++ b/src/dev/flang/be/jvm/CodeGen.java
@@ -201,16 +201,6 @@ class CodeGen
 
 
   /**
-   * Determine the address of a given value.  This is used on a call to an
-   * inner feature to pass a reference to the outer value type instance.
-   */
-  public Pair<Expr, Expr> adrOf(Expr v)
-  {
-    return new Pair<>(v, Expr.UNIT);
-  }
-
-
-  /**
    * Create code to assign value to a given field w/o dynamic binding.
    *
    * @param cl id of clazz we are interpreting

--- a/src/dev/flang/fuir/FUIR.java
+++ b/src/dev/flang/fuir/FUIR.java
@@ -976,10 +976,6 @@ hw25 is
         toStack(code, p.target(), !needsOuterRef /* dump result if not needed */);
         if (needsOuterRef)
           {
-            if (clazzFieldIsAdrOfValue(or))
-              {
-                code.add(ExprKind.AdrOf);
-              }
             code.add(ExprKind.Current);
             code.add(or);  // field clazz means assignment to field
           }
@@ -2163,7 +2159,6 @@ hw25 is
   {
     return switch (codeAt(c,ix))
       {
-      case AdrOf   -> "AdrOf";
       case Assign  -> "Assign to " + clazzAsString(accessedClazz     (cl, c, ix));
       case Box     -> "Box "       + clazzAsString(boxValueClazz     (cl, c, ix)) + " => " + clazzAsString(boxResultClazz  (cl, c, ix));
       case Call    -> {
@@ -2411,7 +2406,6 @@ hw25 is
   {
     return switch (codeAt(c, ix))
       {
-      case AdrOf   -> skipBack(cl, c, codeIndex(c, ix, -1));
       case Assign  ->
         {
           var tc = accessTargetClazz(cl, c, ix);

--- a/src/dev/flang/fuir/analysis/AbstractInterpreter.java
+++ b/src/dev/flang/fuir/analysis/AbstractInterpreter.java
@@ -170,12 +170,6 @@ public class AbstractInterpreter<VALUE, RESULT> extends ANY
     }
 
     /**
-     * Determine the address of a given value.  This is used on a call to an
-     * inner feature to pass a reference to the outer value type instance.
-     */
-    public abstract Pair<VALUE, RESULT> adrOf(VALUE v);
-
-    /**
      * Perform an assignment val to field f in instance rt
      *
      * @param cl id of clazz we are interpreting
@@ -673,13 +667,6 @@ public class AbstractInterpreter<VALUE, RESULT> extends ANY
     _processor._i = i;
     switch (s)
       {
-      case AdrOf:
-        {
-          var v = stack.pop();
-          var r = _processor.adrOf(v);
-          stack.push(r.v0());
-          return r.v1();
-        }
       case Assign:
         {
           // NYI: pop the stack values even in case field is unused.

--- a/src/dev/flang/fuir/analysis/dfa/DFA.java
+++ b/src/dev/flang/fuir/analysis/dfa/DFA.java
@@ -162,16 +162,6 @@ public class DFA extends ANY
 
 
     /**
-     * Determine the address of a given value.  This is used on a call to an
-     * inner feature to pass a reference to the outer value type instance.
-     */
-    public Pair<Val, Unit> adrOf(Val v)
-    {
-      return new Pair<>(v.rewrap(DFA.this, x -> x.adrOf()), _unit_);
-    }
-
-
-    /**
      * Perform an assignment val to field f in instance rt
      *
      * @param cl id of clazz we are interpreting

--- a/src/dev/flang/fuir/analysis/dfa/Value.java
+++ b/src/dev/flang/fuir/analysis/dfa/Value.java
@@ -203,12 +203,6 @@ public class Value extends Val
   Value _boxed;
 
 
-  /**
-   * Cached result of a call to adrOf().
-   */
-  Value _adrOf;
-
-
   /*---------------------------  constructors  ---------------------------*/
 
 
@@ -243,19 +237,6 @@ public class Value extends Val
 
 
   /*-----------------------------  methods  -----------------------------*/
-
-
-  /**
-   * Get the address of a value.
-   */
-  public Value adrOf()
-  {
-    if (_adrOf == null)
-      {
-        _adrOf = this; // NYI: this is a little lazy, but seems to work for simple cases
-      }
-    return _adrOf;
-  }
 
 
   /**

--- a/src/dev/flang/fuir/cfg/CFG.java
+++ b/src/dev/flang/fuir/cfg/CFG.java
@@ -574,7 +574,6 @@ public class CFG extends ANY
   {
     switch (s)
       {
-      case AdrOf : break;
       case Assign: break;
       case Box   : break;
       case Call:

--- a/src/dev/flang/ir/IR.java
+++ b/src/dev/flang/ir/IR.java
@@ -109,7 +109,6 @@ public class IR extends ANY
 
   public enum ExprKind
   {
-    AdrOf,
     Assign,
     Box,
     Call,


### PR DESCRIPTION
This was only used when setting outer references in the C backend. The implementation of outer references is a backend decision, so this patch removes it from FUIR.
