### PR TITLE
be/c: fix nanosleep interruption by signal

### DIFF
--- a/include/posix.c
+++ b/include/posix.c
@@ -413,8 +413,7 @@ uint64_t fzE_nanotime()
 void fzE_nanosleep(uint64_t n)
 {
   struct timespec req = (struct timespec){n/1000000000LL,n-n/1000000000LL*1000000000LL};
-  // NYI while{}
-  nanosleep(&req,&req);
+  while (nanosleep(&req, &req));
 }
 
 

--- a/include/win.c
+++ b/include/win.c
@@ -445,8 +445,7 @@ void fzE_nanosleep(uint64_t n)
 {
   // NYI replace with native windows
   struct timespec req = (struct timespec){n/1000000000LL,n-n/1000000000LL*1000000000LL};
-  // NYI while{}
-  nanosleep(&req,&req);
+  while (nanosleep(&req, &req));
 }
 
 


### PR DESCRIPTION
fixes #2882

This likely also helps with the sockets_test failures we saw sometimes in the past.
