### PR TITLE
fe/ir/fuir: Split off MirExprKind from IR.ExprKind

### DIFF
--- a/src/dev/flang/fe/LibraryModule.java
+++ b/src/dev/flang/fe/LibraryModule.java
@@ -44,11 +44,11 @@ import dev.flang.ast.Generic;
 import dev.flang.ast.UnresolvedType;
 import dev.flang.ast.Types;
 import dev.flang.ast.Visi;
-import dev.flang.ir.IR;
 
 import dev.flang.mir.MIR;
 
 import dev.flang.util.FuzionConstants;
+import static dev.flang.util.FuzionConstants.MirExprKind;
 import dev.flang.util.HexDump;
 import dev.flang.util.List;
 import dev.flang.util.SourceFile;
@@ -1474,9 +1474,9 @@ Expression
   {
     return data().get(expressionKindPos(at)) & 0xff;
   }
-  IR.ExprKind expressionKind(int at)
+  MirExprKind expressionKind(int at)
   {
-    return IR.ExprKind.from(expressionKindRaw(at) & 0x7f);
+    return MirExprKind.from(expressionKindRaw(at) & 0x7f);
   }
   boolean expressionHasPosition(int at)
   {
@@ -1510,18 +1510,18 @@ Expression
     var eAt = expressionExprPos(at);
     return switch (k)
       {
-      case Assign  -> assignNextPos(eAt);
-      case Box     -> eAt;
-      case Const   -> constNextPos(eAt);
-      case Current -> eAt;
-      case Match   -> matchNextPos(eAt);
-      case Call    -> callNextPos (eAt);
-      case Tag     -> tagNextPos  (eAt);
-      case Env     -> envNextPos  (eAt);
-      case Pop     -> eAt;
-      case Unit    -> eAt;
+      case Assign      -> assignNextPos(eAt);
+      case Box         -> eAt;
+      case Const       -> constNextPos(eAt);
+      case Current     -> eAt;
+      case Match       -> matchNextPos(eAt);
+      case Call        -> callNextPos (eAt);
+      case Tag         -> tagNextPos  (eAt);
+      case Env         -> envNextPos  (eAt);
+      case Pop         -> eAt;
+      case Unit        -> eAt;
       case InlineArray -> inlineArrayNextPos(eAt);
-      default      -> throw new Error("unexpected expression kind "+k+" at "+at+" in "+this);
+      default          -> throw new Error("unexpected expression kind "+k+" at "+at+" in "+this);
       };
   }
 
@@ -1551,24 +1551,24 @@ Assign
   int assignFieldPos(int at)
   {
     if (PRECONDITIONS) require
-      (expressionKindRaw(at-1) ==  IR.ExprKind.Assign.ordinal()         ||
-       expressionKindRaw(at-9) == (IR.ExprKind.Assign.ordinal() | 0x80)    );
+      (expressionKindRaw(at-1) ==  MirExprKind.Assign.ordinal()         ||
+       expressionKindRaw(at-9) == (MirExprKind.Assign.ordinal() | 0x80)    );
 
     return at;
   }
   int assignField(int at)
   {
     if (PRECONDITIONS) require
-     (expressionKindRaw(at-1) ==  IR.ExprKind.Assign.ordinal()         ||
-      expressionKindRaw(at-9) == (IR.ExprKind.Assign.ordinal() | 0x80)     );
+     (expressionKindRaw(at-1) ==  MirExprKind.Assign.ordinal()         ||
+      expressionKindRaw(at-9) == (MirExprKind.Assign.ordinal() | 0x80)     );
 
     return data().getInt(assignFieldPos(at));
   }
   int assignNextPos(int at)
   {
     if (PRECONDITIONS) require
-     (expressionKindRaw(at-1) ==  IR.ExprKind.Assign.ordinal()         ||
-      expressionKindRaw(at-9) == (IR.ExprKind.Assign.ordinal() | 0x80)     );
+     (expressionKindRaw(at-1) ==  MirExprKind.Assign.ordinal()         ||
+      expressionKindRaw(at-9) == (MirExprKind.Assign.ordinal() | 0x80)     );
 
     return assignFieldPos(at) + 4;
   }
@@ -1605,48 +1605,48 @@ Constant
   int constTypePos(int at)
   {
     if (PRECONDITIONS) require
-     (expressionKindRaw(at-1) ==  IR.ExprKind.Const.ordinal()         ||
-      expressionKindRaw(at-9) == (IR.ExprKind.Const.ordinal() | 0x80)     );
+     (expressionKindRaw(at-1) ==  MirExprKind.Const.ordinal()         ||
+      expressionKindRaw(at-9) == (MirExprKind.Const.ordinal() | 0x80)     );
 
     return at;
   }
   AbstractType constType(int at)
   {
     if (PRECONDITIONS) require
-     (expressionKindRaw(at-1) ==  IR.ExprKind.Const.ordinal()         ||
-      expressionKindRaw(at-9) == (IR.ExprKind.Const.ordinal() | 0x80)     );
+     (expressionKindRaw(at-1) ==  MirExprKind.Const.ordinal()         ||
+      expressionKindRaw(at-9) == (MirExprKind.Const.ordinal() | 0x80)     );
 
     return type(constTypePos(at));
   }
   int constLengthPos(int at)
   {
     if (PRECONDITIONS) require
-     (expressionKindRaw(at-1) ==  IR.ExprKind.Const.ordinal()         ||
-      expressionKindRaw(at-9) == (IR.ExprKind.Const.ordinal() | 0x80)     );
+     (expressionKindRaw(at-1) ==  MirExprKind.Const.ordinal()         ||
+      expressionKindRaw(at-9) == (MirExprKind.Const.ordinal() | 0x80)     );
 
     return typeNextPos(constTypePos(at));
   }
   int constLength(int at)
   {
     if (PRECONDITIONS) require
-     (expressionKindRaw(at-1) ==  IR.ExprKind.Const.ordinal()         ||
-      expressionKindRaw(at-9) == (IR.ExprKind.Const.ordinal() | 0x80)     );
+     (expressionKindRaw(at-1) ==  MirExprKind.Const.ordinal()         ||
+      expressionKindRaw(at-9) == (MirExprKind.Const.ordinal() | 0x80)     );
 
     return data().getInt(constLengthPos(at));
   }
   int constDataPos(int at)
   {
     if (PRECONDITIONS) require
-     (expressionKindRaw(at-1) ==  IR.ExprKind.Const.ordinal()         ||
-      expressionKindRaw(at-9) == (IR.ExprKind.Const.ordinal() | 0x80)     );
+     (expressionKindRaw(at-1) ==  MirExprKind.Const.ordinal()         ||
+      expressionKindRaw(at-9) == (MirExprKind.Const.ordinal() | 0x80)     );
 
     return constLengthPos(at) + 4;
   }
   byte[] constData(int at)
   {
     if (PRECONDITIONS) require
-     (expressionKindRaw(at-1) ==  IR.ExprKind.Const.ordinal()         ||
-      expressionKindRaw(at-9) == (IR.ExprKind.Const.ordinal() | 0x80)     );
+     (expressionKindRaw(at-1) ==  MirExprKind.Const.ordinal()         ||
+      expressionKindRaw(at-9) == (MirExprKind.Const.ordinal() | 0x80)     );
 
     var l = constLength(at);
     var result = new byte[l];
@@ -1656,8 +1656,8 @@ Constant
   int constNextPos(int at)
   {
     if (PRECONDITIONS) require
-     (expressionKindRaw(at-1) ==  IR.ExprKind.Const.ordinal()         ||
-      expressionKindRaw(at-9) == (IR.ExprKind.Const.ordinal() | 0x80)     );
+     (expressionKindRaw(at-1) ==  MirExprKind.Const.ordinal()         ||
+      expressionKindRaw(at-9) == (MirExprKind.Const.ordinal() | 0x80)     );
 
     return constDataPos(at) + constLength(at);
   }
@@ -1716,40 +1716,40 @@ Call
   int callCalledFeaturePos(int at)
   {
     if (PRECONDITIONS) require
-     (expressionKindRaw(at-1) ==  IR.ExprKind.Call.ordinal()         ||
-      expressionKindRaw(at-9) == (IR.ExprKind.Call.ordinal() | 0x80)     );
+     (expressionKindRaw(at-1) ==  MirExprKind.Call.ordinal()         ||
+      expressionKindRaw(at-9) == (MirExprKind.Call.ordinal() | 0x80)     );
 
     return at;
   }
   int callCalledFeature(int at)
   {
     if (PRECONDITIONS) require
-     (expressionKindRaw(at-1) ==  IR.ExprKind.Call.ordinal()         ||
-      expressionKindRaw(at-9) == (IR.ExprKind.Call.ordinal() | 0x80)     );
+     (expressionKindRaw(at-1) ==  MirExprKind.Call.ordinal()         ||
+      expressionKindRaw(at-9) == (MirExprKind.Call.ordinal() | 0x80)     );
 
     return data().getInt(callCalledFeaturePos(at));
   }
   int callTypePos(int at)
   {
     if (PRECONDITIONS) require
-     (expressionKindRaw(at-1) ==  IR.ExprKind.Call.ordinal()         ||
-      expressionKindRaw(at-9) == (IR.ExprKind.Call.ordinal() | 0x80)     );
+     (expressionKindRaw(at-1) ==  MirExprKind.Call.ordinal()         ||
+      expressionKindRaw(at-9) == (MirExprKind.Call.ordinal() | 0x80)     );
 
     return callCalledFeaturePos(at) + 4;
   }
   AbstractType callType(int at)
   {
     if (PRECONDITIONS) require
-     (expressionKindRaw(at-1) ==  IR.ExprKind.Call.ordinal()         ||
-      expressionKindRaw(at-9) == (IR.ExprKind.Call.ordinal() | 0x80)     );
+     (expressionKindRaw(at-1) ==  MirExprKind.Call.ordinal()         ||
+      expressionKindRaw(at-9) == (MirExprKind.Call.ordinal() | 0x80)     );
 
     return type(callTypePos(at));
   }
   int callNumArgsPos(int at)
   {
     if (PRECONDITIONS) require
-     (expressionKindRaw(at-1) ==  IR.ExprKind.Call.ordinal()         ||
-      expressionKindRaw(at-9) == (IR.ExprKind.Call.ordinal() | 0x80)     );
+     (expressionKindRaw(at-1) ==  MirExprKind.Call.ordinal()         ||
+      expressionKindRaw(at-9) == (MirExprKind.Call.ordinal() | 0x80)     );
 
     var p = callTypePos(at);
     return typeNextPos(p);
@@ -1757,8 +1757,8 @@ Call
   int callNumArgsRaw(int at)
   {
     if (PRECONDITIONS) require
-      (expressionKindRaw(at-1) ==  IR.ExprKind.Call.ordinal()         ||
-       expressionKindRaw(at-9) == (IR.ExprKind.Call.ordinal() | 0x80)       ,
+      (expressionKindRaw(at-1) ==  MirExprKind.Call.ordinal()         ||
+       expressionKindRaw(at-9) == (MirExprKind.Call.ordinal() | 0x80)       ,
        libraryFeature(callCalledFeature(at)).hasOpenGenericsArgList());
 
     return data().getInt(callNumArgsPos(at));
@@ -1766,8 +1766,8 @@ Call
   int callNumArgs(int at)
   {
     if (PRECONDITIONS) require
-     (expressionKindRaw(at-1) ==  IR.ExprKind.Call.ordinal()         ||
-      expressionKindRaw(at-9) == (IR.ExprKind.Call.ordinal() | 0x80)     );
+     (expressionKindRaw(at-1) ==  MirExprKind.Call.ordinal()         ||
+      expressionKindRaw(at-9) == (MirExprKind.Call.ordinal() | 0x80)     );
 
     var f = libraryFeature(callCalledFeature(at));
     return f.hasOpenGenericsArgList()
@@ -1777,8 +1777,8 @@ Call
   int callNumTypeParametersPos(int at)
   {
     if (PRECONDITIONS) require
-     (expressionKindRaw(at-1) ==  IR.ExprKind.Call.ordinal()         ||
-      expressionKindRaw(at-9) == (IR.ExprKind.Call.ordinal() | 0x80)     );
+     (expressionKindRaw(at-1) ==  MirExprKind.Call.ordinal()         ||
+      expressionKindRaw(at-9) == (MirExprKind.Call.ordinal() | 0x80)     );
 
     return callNumArgsPos(at) +
       (libraryFeature(callCalledFeature(at)).hasOpenGenericsArgList() ? 4 : 0);
@@ -1786,8 +1786,8 @@ Call
   int callNumTypeParametersRaw(int at)
   {
     if (PRECONDITIONS) require
-      (expressionKindRaw(at-1) ==  IR.ExprKind.Call.ordinal()         ||
-       expressionKindRaw(at-9) == (IR.ExprKind.Call.ordinal() | 0x80)    ,
+      (expressionKindRaw(at-1) ==  MirExprKind.Call.ordinal()         ||
+       expressionKindRaw(at-9) == (MirExprKind.Call.ordinal() | 0x80)    ,
        libraryFeature(callCalledFeature(at)).generics().isOpen());
 
     return data().getInt(callNumTypeParametersPos(at));
@@ -1795,8 +1795,8 @@ Call
   int callNumTypeParameters(int at)
   {
     if (PRECONDITIONS) require
-     (expressionKindRaw(at-1) ==  IR.ExprKind.Call.ordinal()         ||
-      expressionKindRaw(at-9) == (IR.ExprKind.Call.ordinal() | 0x80)     );
+     (expressionKindRaw(at-1) ==  MirExprKind.Call.ordinal()         ||
+      expressionKindRaw(at-9) == (MirExprKind.Call.ordinal() | 0x80)     );
 
     var f = libraryFeature(callCalledFeature(at));
     return f.generics().isOpen()
@@ -1806,8 +1806,8 @@ Call
   int callTypeParametersPos(int at)
   {
     if (PRECONDITIONS) require
-     (expressionKindRaw(at-1) ==  IR.ExprKind.Call.ordinal()         ||
-      expressionKindRaw(at-9) == (IR.ExprKind.Call.ordinal() | 0x80)     );
+     (expressionKindRaw(at-1) ==  MirExprKind.Call.ordinal()         ||
+      expressionKindRaw(at-9) == (MirExprKind.Call.ordinal() | 0x80)     );
 
     return callNumTypeParametersPos(at) +
       (libraryFeature(callCalledFeature(at)).generics().isOpen() ? 4 : 0);
@@ -1815,8 +1815,8 @@ Call
   int callSelectPos(int at)
   {
     if (PRECONDITIONS) require
-     (expressionKindRaw(at-1) ==  IR.ExprKind.Call.ordinal()         ||
-      expressionKindRaw(at-9) == (IR.ExprKind.Call.ordinal() | 0x80)     );
+     (expressionKindRaw(at-1) ==  MirExprKind.Call.ordinal()         ||
+      expressionKindRaw(at-9) == (MirExprKind.Call.ordinal() | 0x80)     );
 
     var n = callNumTypeParameters(at);
     var tat = callTypeParametersPos(at);
@@ -1830,8 +1830,8 @@ Call
   int callSelect(int at)
   {
     if (PRECONDITIONS) require
-      (expressionKindRaw(at-1) ==  IR.ExprKind.Call.ordinal()         ||
-       expressionKindRaw(at-9) == (IR.ExprKind.Call.ordinal() | 0x80)    ,
+      (expressionKindRaw(at-1) ==  MirExprKind.Call.ordinal()         ||
+       expressionKindRaw(at-9) == (MirExprKind.Call.ordinal() | 0x80)    ,
        libraryFeature(callCalledFeature(at)).resultType().isOpenGeneric());
 
     return data().getInt(callSelectPos(at));
@@ -1839,8 +1839,8 @@ Call
   int callNextPos(int at)
   {
     if (PRECONDITIONS) require
-     (expressionKindRaw(at-1) ==  IR.ExprKind.Call.ordinal()         ||
-      expressionKindRaw(at-9) == (IR.ExprKind.Call.ordinal() | 0x80)     );
+     (expressionKindRaw(at-1) ==  MirExprKind.Call.ordinal()         ||
+      expressionKindRaw(at-9) == (MirExprKind.Call.ordinal() | 0x80)     );
 
     var sat = callSelectPos(at);
     var nat = sat + (libraryFeature(callCalledFeature(at)).resultType().isOpenGeneric() ? 4 : 0);
@@ -1877,32 +1877,32 @@ Match
   int matchNumberOfCasesPos(int at)
   {
     if (PRECONDITIONS) require
-     (expressionKindRaw(at-1) ==  IR.ExprKind.Match.ordinal()         ||
-      expressionKindRaw(at-9) == (IR.ExprKind.Match.ordinal() | 0x80)     );
+     (expressionKindRaw(at-1) ==  MirExprKind.Match.ordinal()         ||
+      expressionKindRaw(at-9) == (MirExprKind.Match.ordinal() | 0x80)     );
 
     return at;
   }
   int matchNumberOfCases(int at)
   {
     if (PRECONDITIONS) require
-     (expressionKindRaw(at-1) ==  IR.ExprKind.Match.ordinal()         ||
-      expressionKindRaw(at-9) == (IR.ExprKind.Match.ordinal() | 0x80)     );
+     (expressionKindRaw(at-1) ==  MirExprKind.Match.ordinal()         ||
+      expressionKindRaw(at-9) == (MirExprKind.Match.ordinal() | 0x80)     );
 
     return data().getInt(matchNumberOfCasesPos(at));
   }
   int matchCasesPos(int at)
   {
     if (PRECONDITIONS) require
-     (expressionKindRaw(at-1) ==  IR.ExprKind.Match.ordinal()         ||
-      expressionKindRaw(at-9) == (IR.ExprKind.Match.ordinal() | 0x80)     );
+     (expressionKindRaw(at-1) ==  MirExprKind.Match.ordinal()         ||
+      expressionKindRaw(at-9) == (MirExprKind.Match.ordinal() | 0x80)     );
 
     return matchNumberOfCasesPos(at) + 4;
   }
   int matchNextPos(int at)
   {
     if (PRECONDITIONS) require
-     (expressionKindRaw(at-1) ==  IR.ExprKind.Match.ordinal()         ||
-      expressionKindRaw(at-9) == (IR.ExprKind.Match.ordinal() | 0x80)     );
+     (expressionKindRaw(at-1) ==  MirExprKind.Match.ordinal()         ||
+      expressionKindRaw(at-9) == (MirExprKind.Match.ordinal() | 0x80)     );
 
     var n = matchNumberOfCases(at);
     at = matchCasesPos(at);

--- a/src/dev/flang/fe/LibraryOut.java
+++ b/src/dev/flang/fe/LibraryOut.java
@@ -57,11 +57,10 @@ import dev.flang.ast.Tag;
 import dev.flang.ast.Types;
 import dev.flang.ast.Universe;
 
-import dev.flang.ir.IR;
-
 import dev.flang.util.ANY;
 import dev.flang.util.Errors;
 import dev.flang.util.FuzionConstants;
+import static dev.flang.util.FuzionConstants.MirExprKind;
 import dev.flang.util.List;
 import dev.flang.util.SourceFile;
 import dev.flang.util.SourcePosition;
@@ -639,7 +638,7 @@ class LibraryOut extends ANY
    *   +--------+--------+---------------+-----------------------------------------------+
    *   | cond.  | repeat | type          | what                                          |
    *   +--------+--------+---------------+-----------------------------------------------+
-   *   | true   | 1      | byte          | ExprKind k in bits 0..6,  hasPos in bit 7     |
+   *   | true   | 1      | byte          | MirExprKind k in bits 0..6,  hasPos in bit 7  |
    *   +--------+--------+---------------+-----------------------------------------------+
    *   | hasPos | 1      | int           | source position: index in this file's         |
    *   |        |        |               | SourceFiles section, 0 for builtIn pos        |
@@ -665,7 +664,7 @@ class LibraryOut extends ANY
       {
         lastPos = expressions(a._value, lastPos);
         lastPos = expressions(a._target, lastPos);
-        lastPos = exprKindAndPos(IR.ExprKind.Assign, lastPos, e.pos());
+        lastPos = exprKindAndPos(MirExprKind.Assign, lastPos, e.pos());
   /*
    *   +---------------------------------------------------------------------------------+
    *   | Assign                                                                          |
@@ -680,7 +679,7 @@ class LibraryOut extends ANY
     else if (e instanceof Box b)
       {
         lastPos = expressions(b._value, lastPos);
-        lastPos = exprKindAndPos(IR.ExprKind.Box, lastPos, e.pos());
+        lastPos = exprKindAndPos(MirExprKind.Box, lastPos, e.pos());
       }
     else if (e instanceof AbstractBlock b)
       {
@@ -700,12 +699,12 @@ class LibraryOut extends ANY
           }
         if (!dumpResult)
           {
-            _data.writeByte(IR.ExprKind.Unit.ordinal());
+            _data.writeByte(MirExprKind.Unit.ordinal());
           }
       }
     else if (e instanceof Constant c)
       {
-        lastPos = exprKindAndPos(IR.ExprKind.Const, lastPos, e.pos());
+        lastPos = exprKindAndPos(MirExprKind.Const, lastPos, e.pos());
   /*
    *   +---------------------------------------------------------------------------------+
    *   | Constant                                                                        |
@@ -726,12 +725,12 @@ class LibraryOut extends ANY
       }
     else if (e instanceof AbstractCurrent)
       {
-        lastPos = exprKindAndPos(IR.ExprKind.Current, lastPos, e.pos());
+        lastPos = exprKindAndPos(MirExprKind.Current, lastPos, e.pos());
       }
     else if (e instanceof If i)
       {
         lastPos = expressions(i.cond, lastPos);
-        lastPos = exprKindAndPos(IR.ExprKind.Match, lastPos, e.pos());
+        lastPos = exprKindAndPos(MirExprKind.Match, lastPos, e.pos());
         _data.writeInt(2);
         _data.writeInt(1);
         type(Types.resolved.f_TRUE.resultType());
@@ -758,7 +757,7 @@ class LibraryOut extends ANY
           {
             lastPos = expressions(a, lastPos);
           }
-        lastPos = exprKindAndPos(IR.ExprKind.Call, lastPos, e.pos());
+        lastPos = exprKindAndPos(MirExprKind.Call, lastPos, e.pos());
   /*
    *   +---------------------------------------------------------------------------------+
    *   | Call                                                                            |
@@ -817,13 +816,13 @@ class LibraryOut extends ANY
           }
         if (dumpResult)
           {
-            _data.writeByte(IR.ExprKind.Pop.ordinal());
+            _data.writeByte(MirExprKind.Pop.ordinal());
           }
       }
     else if (e instanceof AbstractMatch m)
       {
         lastPos = expressions(m.subject(), lastPos);
-        lastPos = exprKindAndPos(IR.ExprKind.Match, lastPos, e.pos());
+        lastPos = exprKindAndPos(MirExprKind.Match, lastPos, e.pos());
   /*
    *   +---------------------------------------------------------------------------------+
    *   | Match                                                                           |
@@ -877,7 +876,7 @@ class LibraryOut extends ANY
     else if (e instanceof Tag t)
       {
         lastPos = expressions(t._value, lastPos);
-        lastPos = exprKindAndPos(IR.ExprKind.Tag, lastPos, e.pos());
+        lastPos = exprKindAndPos(MirExprKind.Tag, lastPos, e.pos());
   /*
    *   +---------------------------------------------------------------------------------+
    *   | Tag                                                                             |
@@ -891,7 +890,7 @@ class LibraryOut extends ANY
       }
     else if (e instanceof Env)
       {
-        lastPos = exprKindAndPos(IR.ExprKind.Env, lastPos, e.pos());
+        lastPos = exprKindAndPos(MirExprKind.Env, lastPos, e.pos());
   /*
    *   +---------------------------------------------------------------------------------+
    *   | Env                                                                             |
@@ -911,11 +910,11 @@ class LibraryOut extends ANY
         // Universe is ignored, a call with target clazz universe will get its
         // target implicitly.
         //
-        // write(IR.ExprKind.Universe.ordinal());
+        // write(MirExprKind.Universe.ordinal());
       }
     else if (e instanceof InlineArray ia)
       {
-        lastPos = exprKindAndPos(IR.ExprKind.InlineArray, lastPos, e.pos());
+        lastPos = exprKindAndPos(MirExprKind.InlineArray, lastPos, e.pos());
   /*
    *   +---------------------------------------------------------------------------------+
    *   | InlineArray                                                                     |
@@ -988,7 +987,7 @@ class LibraryOut extends ANY
    * @param newPos the new position that is to be written if it differs from
    * lastPos
    */
-  SourcePosition exprKindAndPos(IR.ExprKind k, SourcePosition lastPos, SourcePosition newPos)
+  SourcePosition exprKindAndPos(MirExprKind k, SourcePosition lastPos, SourcePosition newPos)
   {
     if (lastPos == null || lastPos.compareTo(newPos) != 0)
       {

--- a/src/dev/flang/fuir/FUIR.java
+++ b/src/dev/flang/fuir/FUIR.java
@@ -2192,7 +2192,6 @@ hw25 is
       case Env     -> "Env";
       case Pop     -> "Pop";
       case Unit    -> "Unit";
-      case InlineArray -> "InlineArray";
       };
   }
 
@@ -2450,7 +2449,6 @@ hw25 is
       case Env     -> codeIndex(c, ix, -1);
       case Pop     -> skipBack(cl, c, codeIndex(c, ix, -1));
       case Unit    -> codeIndex(c, ix, -1);
-      case InlineArray -> { check(false); yield codeIndex(c, ix, -1); }
       };
   }
 

--- a/src/dev/flang/ir/IR.java
+++ b/src/dev/flang/ir/IR.java
@@ -119,21 +119,7 @@ public class IR extends ANY
     Tag,
     Env,
     Pop,
-    Unit,
-    // this is eliminated in FUIR
-    InlineArray;
-
-    /**
-     * get the Kind that corresponds to the given ordinal number.
-     */
-    public static ExprKind from(int ordinal)
-    {
-      if (CHECKS) check
-        (values()[ordinal].ordinal() == ordinal);
-
-      return values()[ordinal];
-    }
-
+    Unit;
   }
 
 

--- a/src/dev/flang/util/FuzionConstants.java
+++ b/src/dev/flang/util/FuzionConstants.java
@@ -322,6 +322,39 @@ public class FuzionConstants extends ANY
   public static final Path SYMBOLIC_FUZION_MODULE = Path.of("$MODULE");
 
 
+  /**
+   * Expression kind ids for use in FUM file are the ordinal numbers of these
+   * constants.
+   */
+  public enum MirExprKind
+  {
+    Assign,
+    Box,
+    Call,
+    Current,
+    Comment,
+    Const,
+    Match,
+    Tag,
+    Env,
+    Pop,
+    Unit,
+    InlineArray;
+
+    /**
+     * get the Kind that corresponds to the given ordinal number.
+     */
+    public static MirExprKind from(int ordinal)
+    {
+      if (CHECKS) check
+        (values()[ordinal].ordinal() == ordinal);
+
+      return values()[ordinal];
+    }
+
+  }
+
+
   /*-----------------  special values used in AIR file  -----------------*/
 
 


### PR DESCRIPTION
This avoids the need to handle InlineArray in FUIR.
