### PR TITLE
fuir: clazzNeedsCode, check if class is unit like

### DIFF
--- a/src/dev/flang/fuir/FUIR.java
+++ b/src/dev/flang/fuir/FUIR.java
@@ -1134,11 +1134,31 @@ hw25 is
             (cc.isInstantiated() || cc.feature().isOuterRef())
             && cc != Clazzes.Const_String.getIfCreated()
             && !cc.isAbsurd()
-            && !cc.isBoxed();
+            && !cc.isBoxed()
+            && clazzHasSideEffectOrIsNotUnitType(cl);
           };
         (result ? _needsCode : _doesNotNeedCode).set(cl - CLAZZ_BASE);
         return result;
       }
+  }
+
+  /**
+   * Does this class have a side effect or is not of unit type?
+   */
+  public boolean clazzHasSideEffectOrIsNotUnitType(int cl)
+  {
+    return
+      // has contract
+         clazzContract(cl, FUIR.ContractKind.Pre , 0) != -1
+      || clazzContract(cl, FUIR.ContractKind.Post, 0) != -1
+      // is not a routine
+      || clazzKind(cl) != FeatureKind.Routine
+      // has code
+      || withinCode(clazzCode(cl), 0)
+      // is universe
+      || cl == clazzUniverse()
+      // is not a unit type
+      || !clazzIsUnitType(cl);
   }
 
 

--- a/src/dev/flang/fuir/analysis/dfa/DFA.java
+++ b/src/dev/flang/fuir/analysis/dfa/DFA.java
@@ -242,7 +242,6 @@ public class DFA extends ANY
     public Pair<Val, Unit> call(int cl, boolean pre, int c, int i, Val tvalue, List<Val> args)
     {
       var ccP = _fuir.accessedPreconditionClazz(cl, c, i);
-      var cc0 = _fuir.accessedClazz            (cl, c, i);
       Val res = Value.UNIT;
       if (ccP != -1)
         {
@@ -303,7 +302,11 @@ public class DFA extends ANY
             });
         }
       var res = resf[0];
-      if (!found[0])
+      if (!found[0] && !_fuir.clazzNeedsCode(cc0))
+        {
+          res = unitValue();
+        }
+      else if (!found[0])
         { // NYI: proper error reporting
           var detail = "Considered targets: ";
           for (var ccii = 0; ccii < ccs.length; ccii += 2)


### PR DESCRIPTION
For clazzes that have no side effects and are unit like we can omit generating code.

Effect of this patch on HelloWorld (truncated because of GitHub limit):
```diff
--- HelloWorld.c	2024-04-11 14:28:12.115725510 +0200
+++ HelloWorld_new.c	2024-04-11 14:27:40.415695644 +0200
@@ -12855,10 +12855,7 @@
 };
 _Thread_local struct fzThrd_effectsEnvironment* fzThrd_effectsEnvironment;
 void fzC__L6129io_oHtype___u_handler();
-void fzC_FALSE();
-void fzC_TRUE();
 fzT__L3877fuzion__sy__rray_w_u8 fzC__L3877fuzion__sy__rray_w_u8(fzT_fuzion__sys_RPointer* arg0, fzT_1i32 arg1);
-void fzC_unit();
 fzT__RString* fzC__L722_RConst_u___s_u_string(fzT__RConst_u_String* fzouter);
 fzT__RSequence_w_u8* fzC__RConst_u_String__utf8(fzT__RConst_u_String* fzouter);
 fzT_bool fzC__L728_RConst_u___is_u_empty(fzT__RConst_u_String* fzouter);
@@ -12870,7 +12867,6 @@
 fzT_bool fzC_list_w_bool__1first(fzT_list_w_bool* fzouter, fzT_bool arg0);
 fzT_4array_w_u8 fzC_4array_w_u8(fzT__L3877fuzion__sy__rray_w_u8 arg0);
 fzT__RSequence_w_u8* fzC__L1423list_w_u8____u_backed(fzT_list_w_u8* fzouter);
-void fzC_nil();
 fzT_list_w_u8 fzC__L1492_RConst_u___sequences(fzT__RConst_u_String* fzouter, fzT__RSequence_w_u8* arg0);
 fzT__L1560_RConst_u____R_Hfun59* fzC__L1560_RConst_u____R_Hfun59(fzT__L1492_RConst_u___sequences* fzouter);
 fzT_list_w_u8 fzC__L1628_RConst_u___n59__call(fzT__L1560_RConst_u____R_Hfun59* fzouter);
@@ -12888,7 +12884,6 @@
 fzT__RString* fzC__L1909String_oHt__1infix_wp(fzT__L5717String_oHt__nonymous2* fzouter, fzT__RAny* arg0);
 fzT__RString* fzC__L1931list_oHtyp___u_string();
 fzT__RString* fzC__L1943list_oHtyp___lm__name();
-void fzC_Types();
 void fzC_Types__get_w_String();
 void fzC_Types__get_wC_array_w_u8_D();
 void fzC_Types__get_w_codepoint();
@@ -12948,15 +12943,12 @@
 fzT_list_w_u8 fzC_2infix_wU3a_w_u8(fzT_1u8 arg0, fzT__RLazy_wC_list_w_u8_D* arg1);
 fzT_bool fzC_false();
 fzT_bool fzC_true();
-void fzC_fuzion__sys__err__ascii();
 fzT_1u8 fzC_fuzion__sys__err__ascii__lf();
 fzT_1error fzC_1error(fzT__RString* arg0);
-void fzC_effect_u_mode__plain();
 fzT_list_w_u8__as_u_array__lm fzC_list_w_u8__as_u_array__lm();
 fzT_1codepoint fzC_1codepoint(fzT_1u32 arg0);
 void fzP_1codepoint(fzT_1u32 arg0);
 fzT__RSequence_w_u8* fzC_1codepoint__utf8(fzT_1codepoint* fzouter);
-void fzC_container();
 fzT_bool fzC_debug();
 void fzC_io__1out__default(fzT_io__1out* fzouter);
 void fzC_io__1out__replace(fzT_io__1out* fzouter);
@@ -12964,7 +12956,6 @@
 void fzC__L2800list_w_u8___y_w_u8_DD(fzT_list_w_u8__as_u_array__lm* fzouter, fzT__L3261list_w_u8___ay_w_u8_D* arg0);
 fzT__L3261list_w_u8___ay_w_u8_D* fzC__L3261list_w_u8___ay_w_u8_D(fzT__RFunction_wC_array_w_u8_D* arg0);
 void fzC__L3450list_w_u8___8_D__call(fzT__L3261list_w_u8___ay_w_u8_D* fzouter);
-void fzC_effect_u_mode();
 fzT_4array_w_u8 fzC__L3648list_w_u8___ay_w_u8_D(fzT_list_w_u8__as_u_array__lm* fzouter, fzT__RFunction_wC_array_w_u8_D* arg0);
 fzT__L3676list_w_u8___D_R_Hfun3* fzC__L3676list_w_u8___D_R_Hfun3(fzT__L3648list_w_u8___ay_w_u8_D* fzouter);
 fzT_4array_w_u8 fzC__L3692list_w_u8___un3__call(fzT__L3676list_w_u8___D_R_Hfun3* fzouter);
@@ -12992,11 +12983,8 @@
 fzT_bool fzC_2infix_wlw_i64(fzT_1i64 arg0, fzT_1i64 arg1);
 fzT_bool fzC_2infix_wlw_u32(fzT_1u32 arg0, fzT_1u32 arg1);
 fzT_bool fzC_2infix_wlw_u8(fzT_1u8 arg0, fzT_1u8 arg1);
-void fzC_fuzion();
-void fzC_fuzion__std();
 void fzC_fuzion__std__1exit(fzT_1i32 arg0);
 void fzC_fuzion__std__1panic(fzT__RString* arg0);
-void fzC_fuzion__sys();
 fzT_1u8 fzC__L3893fuzion__sy__U5b_wU5d_(fzT__L3877fuzion__sy__rray_w_u8* fzouter, fzT_1i32 arg0);
 void fzP__L3893fuzion__sy__U5b_wU5d_(fzT__L3877fuzion__sy__rray_w_u8* fzouter, fzT_1i32 arg0);
 fzT_1u8 fzC__L3921fuzion__sy__2get_w_u8(fzT__L3877fuzion__sy__rray_w_u8* fzouter, fzT_fuzion__sys_RPointer* arg0, fzT_1i32 arg1);
@@ -13004,18 +12992,14 @@
 void fzP__L3937fuzion__sy__d_wU3a_ew(fzT__L3877fuzion__sy__rray_w_u8* fzouter, fzT_1i32 arg0, fzT_1u8 arg1);
 void fzC__L3969fuzion__sy__8__freeze(fzT__L3877fuzion__sy__rray_w_u8* fzouter);
 void fzC__L3977fuzion__sy__etel_w_u8(fzT__L3877fuzion__sy__rray_w_u8* fzouter, fzT_fuzion__sys_RPointer* arg0, fzT_1i32 arg1, fzT_1u8 arg2);
-void fzC_fuzion__sys__err();
 void fzC_fuzion__sys__err__1println(fzT__RAny* arg0);
 fzT_1i64 fzC_fuzion__sys__err__stderr();
 void fzC_fuzion__sys__err__1write(fzT_4array_w_u8 arg0);
-void fzC_fuzion__sys__fileio();
 fzT_outcome_w_unit fzC_fuzion__sys__fileio__2write(fzT_1i64 arg0, fzT_4array_w_u8 arg1);
 fzT_1i32 fzC_fuzion__sys__fileio__3write(fzT_1i64 arg0, fzT_fuzion__sys_RPointer* arg1, fzT_1i32 arg2);
 fzT__L3877fuzion__sy__rray_w_u8 fzC__L4031fuzion__sy__init_w_u8(fzT_1i32 arg0);
 fzT_fuzion__sys_RPointer* fzC__L4047fuzion__sy__lloc_w_u8(fzT__L4031fuzion__sy__init_w_u8* fzouter, fzT_1i32 arg0);
-void fzC_fuzion__sys__misc();
 fzT_1u64 fzC__L4058fuzion__sy__ique_u_id();
-void fzC_fuzion__sys__out();
 void fzC_fuzion__sys__out__1print(fzT__RAny* arg0);
 void fzC_fuzion__sys__out__1write(fzT_4array_w_u8 arg0);
 fzT_1i64 fzC_fuzion__sys__out__stdout();
@@ -13068,7 +13052,6 @@
 fzT_bool fzC__L43043interval___n0__1call(fzT_3interval_w_u32_R_Hfun0* fzouter, fzT_1u32 arg0);
 fzT_3interval_w_i32 fzC_1i32__1infix_woo(fzT_1i32 fzouter, fzT_1i32 arg0);
 fzT_3interval_w_u32 fzC_1u32__1infix_woo(fzT_1u32 fzouter, fzT_1u32 arg0);
-void fzC_io();
 fzT_io__1out fzC_io__1out(fzT_io_RPrint_u_Handler* arg0);
 fzT_io__1out fzC_io__out();
 void fzC_io__1out__1println(fzT_io__1out* fzouter, fzT__RAny* arg0);
@@ -13165,7 +13148,6 @@
 fzT_bool fzC_option_w_u8__exists(fzT_option_w_u8* fzouter);
 fzT_bool fzC_option_w_bool__postfix_wQQ(fzT_option_w_bool* fzouter);
 fzT_bool fzC_option_w_u8__postfix_wQQ(fzT_option_w_u8* fzouter);
-void fzC_property();
 fzT_bool fzC_safety();
 void fzC_1say(fzT__RAny* arg0);
 fzT_1u32 fzC_1u32__1infix_wU26_(fzT_1u32 fzouter, fzT_1u32 arg0);
@@ -13240,32 +13222,10 @@
   start:
   {
     //    0: Call io(outer universe#0) io
-    fzC_io();
+    // access to Call io(outer universe#0) io eliminated
     //    1: Pop
   }
 }
-// code for clazz#2552 FALSE:
-void fzC_FALSE()
-{
-  // cur may escape, so use malloc
-  fzT_FALSE* fzCur;
-  fzCur = fzE_malloc_safe(sizeof(fzT_FALSE));
-
-  start:
-  {
-  }
-}
-// code for clazz#2553 TRUE:
-void fzC_TRUE()
-{
-  // cur may escape, so use malloc
-  fzT_TRUE* fzCur;
-  fzCur = fzE_malloc_safe(sizeof(fzT_TRUE));
-
-  start:
-  {
-  }
-}
 // code for clazz#3877 fuzion.sys.internal_array u8:
 fzT__L3877fuzion__sy__rray_w_u8 fzC__L3877fuzion__sy__rray_w_u8(fzT_fuzion__sys_RPointer* arg0, fzT_1i32 arg1)
 {
@@ -13280,17 +13240,6 @@
     return *fzCur;
   }
 }
-// code for clazz#5629 unit:
-void fzC_unit()
-{
-  // cur may escape, so use malloc
-  fzT_unit* fzCur;
-  fzCur = fzE_malloc_safe(sizeof(fzT_unit));
-
-  start:
-  {
-  }
-}
 // code for clazz#722 Const_String.as_string:
 fzT__RString* fzC__L722_RConst_u___s_u_string(fzT__RConst_u_String* fzouter)
 {
@@ -13447,7 +13396,7 @@
     //    0: Call debug(outer universe#0) bool
     fzT_bool fzM_0;
     fzM_0 = fzC_debug();
-    //    1: Match 0=>l441 1=>l442
+    //    1: Match 0=>l470 1=>l471
     switch (fzM_0.fzTag)
     {
       case 1/* TRUE */:
@@ -13457,7 +13406,7 @@
         //    2: Call (Sequence u8).is_empty(outer Sequence u8) bool
         fzT_bool fzM_1;
         fzM_1 = fzC__L728_RConst_u___is_u_empty((fzT__RConst_u_String*)fzCur->fzF_1__H_c_Sequence_o_first);
-        //    3: Match 0=>l439 1=>l440
+        //    3: Match 0=>l468 1=>l469
         switch (fzM_1.fzTag)
         {
           case 1/* TRUE */:
@@ -13517,7 +13466,7 @@
     //    2: Call (list bool).is_empty(outer list bool) bool
     fzT_bool fzM_0;
     fzM_0 = fzC_list_w_bool__is_u_empty((fzT_list_w_bool*)fzCur.fzF_2__H_c_Sequence_o_first);
-    //    3: Match 0=>l86 1=>l87
+    //    3: Match 0=>l109 1=>l110
     switch (fzM_0.fzTag)
     {
       case 1/* TRUE */:
@@ -13589,7 +13538,7 @@
     //    2: Call (list u8).is_array_backed(outer list u8) bool
     fzT_bool fzM_0;
     fzM_0 = fzC__L1210list_w_u8____u_backed();
-    //    3: Match 0=>l449 1=>l450
+    //    3: Match 0=>l490 1=>l491
     switch (fzM_0.fzTag)
     {
       case 1/* TRUE */:
@@ -13637,17 +13586,6 @@
     return fzCur->fzF_0_result;
   }
 }
-// code for clazz#5187 nil:
-void fzC_nil()
-{
-  // cur may escape, so use malloc
-  fzT_nil* fzCur;
-  fzCur = fzE_malloc_safe(sizeof(fzT_nil));
-
-  start:
-  {
-  }
-}
 // code for clazz#1492 Const_String.concat_sequences:
 fzT_list_w_u8 fzC__L1492_RConst_u___sequences(fzT__RConst_u_String* fzouter, fzT__RSequence_w_u8* arg0)
 {
@@ -13859,7 +13797,7 @@
     fzCur.fzF_0_a = arg0;
     fzCur.fzF_1_b = arg1;
     //    0: Call Types(outer universe#0) Types
-    fzC_Types();
+    // access to Call Types(outer universe#0) Types eliminated
     //    1: Call Types.get i32(outer Types) i32.#type i32
     fzC_Types__get_w_i32();
     //    2: Current
@@ -13890,7 +13828,7 @@
     fzCur.fzF_0_a = arg0;
     fzCur.fzF_1_b = arg1;
     //    0: Call Types(outer universe#0) Types
-    fzC_Types();
+    // access to Call Types(outer universe#0) Types eliminated
     //    1: Call Types.get i64(outer Types) i64.#type i64
     fzC_Types__get_w_i64();
     //    2: Current
@@ -13921,7 +13859,7 @@
     fzCur.fzF_0_a = arg0;
     fzCur.fzF_1_b = arg1;
     //    0: Call Types(outer universe#0) Types
-    fzC_Types();
+    // access to Call Types(outer universe#0) Types eliminated
     //    1: Call Types.get u32(outer Types) u32.#type u32
     fzC_Types__get_w_u32();
     //    2: Current
@@ -13952,7 +13890,7 @@
     fzCur.fzF_0_a = arg0;
     fzCur.fzF_1_b = arg1;
     //    0: Call Types(outer universe#0) Types
-    fzC_Types();
+    // access to Call Types(outer universe#0) Types eliminated
     //    1: Call Types.get u8(outer Types) u8.#type u8
     fzC_Types__get_w_u8();
     //    2: Current
@@ -14044,7 +13982,7 @@
     fzCur.fzF_2__H_c_String_o_infix_wp = (fzT__RConst_u_String*)fzouter;
     fzCur.fzF_0_other = (fzT__RAny*)arg0;
     //    0: Call Types(outer universe#0) Types
-    fzC_Types();
+    // access to Call Types(outer universe#0) Types eliminated
     //    1: Call Types.get String(outer Types) String.#type String
     fzC_Types__get_w_String();
     //    2: Current
@@ -14133,7 +14071,7 @@
     fzCur.fzF_2__H_c_String_o_infix_wp = (fzT__L5717String_oHt__nonymous2*)fzouter;
     fzCur.fzF_0_other = (fzT__RAny*)arg0;
     //    0: Call Types(outer universe#0) Types
-    fzC_Types();
+    // access to Call Types(outer universe#0) Types eliminated
     //    1: Call Types.get String(outer Types) String.#type String
     fzC_Types__get_w_String();
     //    2: Current
@@ -14220,17 +14158,6 @@
 {
   return (fzT__RString*)fzH_heapClone(&(fzT__RConst_u_String){.clazzId = 720, .fields = (fzT_Const_u_String){.fzF_0_internal_u_array = (fzT__L3877fuzion__sy__rray_w_u8){.fzF_0_data = (void *)"(list u8).as_array#0.lm",.fzF_1_length = 23}}},sizeof (fzT__RConst_u_String){.clazzId = 720, .fields = (fzT_Const_u_String){.fzF_0_internal_u_array = (fzT__L3877fuzion__sy__rray_w_u8){.fzF_0_data = (void *)"(list u8).as_array#0.lm",.fzF_1_length = 23}}});
 }
-// code for clazz#1948 Types:
-void fzC_Types()
-{
-  // cur may escape, so use malloc
-  fzT_Types* fzCur;
-  fzCur = fzE_malloc_safe(sizeof(fzT_Types));
-
-  start:
-  {
-  }
-}
 // code for clazz#1953 Types.get String:
 void fzC_Types__get_w_String()
 {
@@ -14462,7 +14389,7 @@
     fzCur.fzF_0_length = arg0;
     fzCur.fzF_1_init = (fzT__RUnary_w_u8_w_i32*)arg1;
     //    0: Call Types(outer universe#0) Types
-    fzC_Types();
+    // access to Call Types(outer universe#0) Types eliminated
     //    1: Call Types.get (array u8)(outer Types) array.#type (array u8) u8
     fzC_Types__get_wC_array_w_u8_D();
     //    2: Current
@@ -14571,7 +14498,7 @@
     //    0: Call debug(outer universe#0) bool
     fzT_bool fzM_0;
     fzM_0 = fzC_debug();
-    //    1: Match 0=>l157 1=>l158
+    //    1: Match 0=>l191 1=>l192
     switch (fzM_0.fzTag)
     {
       case 1/* TRUE */:
@@ -14651,7 +14578,7 @@
     //    0: Call debug(outer universe#0) bool
     fzT_bool fzM_0;
     fzM_0 = fzC_debug();
-    //    1: Match 0=>l157 1=>l158
+    //    1: Match 0=>l191 1=>l192
     switch (fzM_0.fzTag)
     {
       case 1/* TRUE */:
@@ -14744,7 +14671,7 @@
     //    0: Call safety(outer universe#0) bool
     fzT_bool fzM_0;
     fzM_0 = fzC_safety();
-    //    1: Match 0=>l187 1=>l188
+    //    1: Match 0=>l219 1=>l220
     switch (fzM_0.fzTag)
     {
       case 1/* TRUE */:
@@ -14779,7 +14706,7 @@
     //    0: Call safety(outer universe#0) bool
     fzT_bool fzM_2;
     fzM_2 = fzC_safety();
-    //    1: Match 0=>l190 1=>l191
+    //    1: Match 0=>l222 1=>l223
     switch (fzM_2.fzTag)
     {
       case 1/* TRUE */:
@@ -14894,7 +14821,7 @@
     //    0: Call safety(outer universe#0) bool
     fzT_bool fzM_0;
     fzM_0 = fzC_safety();
-    //    1: Match 0=>l187 1=>l188
+    //    1: Match 0=>l219 1=>l220
     switch (fzM_0.fzTag)
     {
       case 1/* TRUE */:
@@ -14929,7 +14856,7 @@
     //    0: Call safety(outer universe#0) bool
     fzT_bool fzM_2;
     fzM_2 = fzC_safety();
-    //    1: Match 0=>l190 1=>l191
+    //    1: Match 0=>l222 1=>l223
     switch (fzM_2.fzTag)
     {
       case 1/* TRUE */:
@@ -15004,7 +14931,7 @@
     //    0: Call debug(outer universe#0) bool
     fzT_bool fzM_0;
     fzM_0 = fzC_debug();
-    //    1: Match 0=>l163 1=>l164
+    //    1: Match 0=>l197 1=>l198
     switch (fzM_0.fzTag)
     {
       case 1/* TRUE */:
@@ -15039,7 +14966,7 @@
     //    0: Call debug(outer universe#0) bool
     fzT_bool fzM_2;
     fzM_2 = fzC_debug();
-    //    1: Match 0=>l166 1=>l167
+    //    1: Match 0=>l200 1=>l201
     switch (fzM_2.fzTag)
     {
       case 1/* TRUE */:
@@ -15114,7 +15041,7 @@
     //    0: Call debug(outer universe#0) bool
     fzT_bool fzM_0;
     fzM_0 = fzC_debug();
-    //    1: Match 0=>l163 1=>l164
+    //    1: Match 0=>l197 1=>l198
     switch (fzM_0.fzTag)
     {
       case 1/* TRUE */:
@@ -15149,7 +15076,7 @@
     //    0: Call debug(outer universe#0) bool
     fzT_bool fzM_2;
     fzM_2 = fzC_debug();
-    //    1: Match 0=>l166 1=>l167
+    //    1: Match 0=>l200 1=>l201
     switch (fzM_2.fzTag)
     {
       case 1/* TRUE */:
@@ -15220,7 +15147,7 @@
     //    0: Call debug(outer universe#0) bool
     fzT_bool fzM_0;
     fzM_0 = fzC_debug();
-    //    1: Match 0=>l163 1=>l164
+    //    1: Match 0=>l197 1=>l198
     switch (fzM_0.fzTag)
     {
       case 1/* TRUE */:
@@ -15255,7 +15182,7 @@
     //    0: Call debug(outer universe#0) bool
     fzT_bool fzM_2;
     fzM_2 = fzC_debug();
-    //    1: Match 0=>l166 1=>l167
+    //    1: Match 0=>l200 1=>l201
     switch (fzM_2.fzTag)
     {
       case 1/* TRUE */:
@@ -15341,13 +15268,13 @@
     //    8: Call infix ≤ i32(outer universe#0, a i32, b i32) bool
     fzT_bool fzM_0;
     fzM_0 = fzC_2infix_wU2264_w_i32(fzCur.fzF_1__H_c_array_o_slice_oHanonymous5_o_as_u_list->fields.fzF_0__H_c_array_o_slice_oHanonymous5->fzF_1_to,fzCur.fzF_1__H_c_array_o_slice_oHanonymous5_o_as_u_list->fields.fzF_0__H_c_array_o_slice_oHanonymous5->fzF_0_from);
-    //    9: Match 0=>l170 1=>l171
+    //    9: Match 0=>l185 1=>l186
     switch (fzM_0.fzTag)
     {
       case 1/* TRUE */:
       {
         //    0: Call nil(outer universe#0) nil
-        fzC_nil();
+        // access to Call nil(outer universe#0) nil eliminated
         //    1: Tag
         // Tag a value to be of choice type list u8 static value type Any
         fzT_list_w_u8 fzM_1;
@@ -15419,13 +15346,13 @@
     //    8: Call infix ≤ i32(outer universe#0, a i32, b i32) bool
     fzT_bool fzM_0;
     fzM_0 = fzC_2infix_wU2264_w_i32(fzCur.fzF_1__H_c_array_o_slice_oHanonymous5_o_as_u_list->fields.fzF_0__H_c_array_o_slice_oHanonymous5->fzF_1_to,fzCur.fzF_1__H_c_array_o_slice_oHanonymous5_o_as_u_list->fields.fzF_0__H_c_array_o_slice_oHanonymous5->fzF_0_from);
-    //    9: Match 0=>l170 1=>l171
+    //    9: Match 0=>l185 1=>l186
     switch (fzM_0.fzTag)
     {
       case 1/* TRUE */:
       {
         //    0: Call nil(outer universe#0) nil
-        fzC_nil();
+        // access to Call nil(outer universe#0) nil eliminated
         //    1: Tag
         // Tag a value to be of choice type list u8 static value type Any
         fzT_list_w_u8 fzM_1;
@@ -15545,7 +15472,7 @@
     //    0: Call debug(outer universe#0) bool
     fzT_bool fzM_0;
     fzM_0 = fzC_debug();
-    //    1: Match 0=>l207 1=>l178
+    //    1: Match 0=>l238 1=>l209
     switch (fzM_0.fzTag)
     {
       case 1/* TRUE */:
@@ -15561,7 +15488,7 @@
         //    7: Call infix ≤ i32(outer universe#0, a i32, b i32) bool
         fzT_bool fzM_1;
         fzM_1 = fzC_2infix_wU2264_w_i32(0,fzCur->fzF_3__HchainedBoolTemp29);
-        //    8: Match 0=>l173 1=>l174
+        //    8: Match 0=>l204 1=>l205
         switch (fzM_1.fzTag)
         {
           case 1/* TRUE */:
@@ -15594,7 +15521,7 @@
         }
         //   11: Current
         //   12: Call (array u8).array_cons.#exprResult175(outer (array u8).array_cons) bool
-        //   13: Match 0=>l175 1=>l176
+        //   13: Match 0=>l206 1=>l207
         switch (fzCur->fzF_5__HexprResult175.fzTag)
         {
           case 1/* TRUE */:
@@ -15678,7 +15605,7 @@
     //    0: Call debug(outer universe#0) bool
     fzT_bool fzM_0;
     fzM_0 = fzC_debug();
-    //    1: Match 0=>l177 1=>l178
+    //    1: Match 0=>l208 1=>l209
     switch (fzM_0.fzTag)
     {
       case 1/* TRUE */:
@@ -15694,7 +15621,7 @@
         //    7: Call infix ≤ i32(outer universe#0, a i32, b i32) bool
         fzT_bool fzM_1;
         fzM_1 = fzC_2infix_wU2264_w_i32(0,fzCur->fzF_3__HchainedBoolTemp29);
-        //    8: Match 0=>l173 1=>l174
+        //    8: Match 0=>l204 1=>l205
         switch (fzM_1.fzTag)
         {
           case 1/* TRUE */:
@@ -15727,7 +15654,7 @@
         }
         //   11: Current
         //   12: Call (ref array u8).array_cons.#exprResult175(outer (ref array u8).array_cons) bool
-        //   13: Match 0=>l175 1=>l176
+        //   13: Match 0=>l206 1=>l207
         switch (fzCur->fzF_5__HexprResult175.fzTag)
         {
           case 1/* TRUE */:
@@ -15993,7 +15920,7 @@
   start:
   {
     //    0: Call FALSE(outer universe#0) FALSE
-    fzC_FALSE();
+    // access to Call FALSE(outer universe#0) FALSE eliminated
     //    1: Tag
     // Tag a value to be of choice type bool static value type FALSE
     fzT_bool fzM_0;
@@ -16014,7 +15941,7 @@
   start:
   {
     //    0: Call TRUE(outer universe#0) TRUE
-    fzC_TRUE();
+    // access to Call TRUE(outer universe#0) TRUE eliminated
     //    1: Tag
     // Tag a value to be of choice type bool static value type TRUE
     fzT_bool fzM_0;
@@ -16026,17 +15953,6 @@
     return fzCur.fzF_0_result;
   }
 }
-// code for clazz#2559 fuzion.sys.err.ascii:
-void fzC_fuzion__sys__err__ascii()
-{
-  // cur may escape, so use malloc
-  fzT_fuzion__sys__err__ascii* fzCur;
-  fzCur = fzE_malloc_safe(sizeof(fzT_fuzion__sys__err__ascii));
-
-  start:
-  {
-  }
-}
 // code for clazz#2561 fuzion.sys.err.ascii.lf:
 fzT_1u8 fzC_fuzion__sys__err__ascii__lf()
 {
@@ -16065,17 +15981,6 @@
     return *fzCur;
   }
 }
-// code for clazz#3639 effect_mode.plain:
-void fzC_effect_u_mode__plain()
-{
-  // cur may escape, so use malloc
-  fzT_effect_u_mode__plain* fzCur;
-  fzCur = fzE_malloc_safe(sizeof(fzT_effect_u_mode__plain));
-
-  start:
-  {
-  }
-}
 // code for clazz#4550 (list u8).as_array.lm:
 fzT_list_w_u8__as_u_array__lm fzC_list_w_u8__as_u_array__lm()
 {
@@ -16086,9 +15991,9 @@
   start:
   {
     //    0: Call effect_mode(outer universe#0) effect_mode
-    fzC_effect_u_mode();
+    // access to Call effect_mode(outer universe#0) effect_mode eliminated
     //    1: Call effect_mode.plain(outer effect_mode) effect_mode.plain
-    fzC_effect_u_mode__plain();
+    // access to Call effect_mode.plain(outer effect_mode) effect_mode.plain eliminated
     //    2: Tag
     // Tag a value to be of choice type effect_mode.val static value type effect_mode.plain
     fzT_effect_u_mode__val fzM_0;
@@ -16115,11 +16020,11 @@
       }
     }
     //   13: Call fuzion(outer universe#0) fuzion
-    fzC_fuzion();
+    // access to Call fuzion(outer universe#0) fuzion eliminated
     //   14: Call fuzion.sys(outer fuzion) fuzion.sys
-    fzC_fuzion__sys();
+    // access to Call fuzion.sys(outer fuzion) fuzion.sys eliminated
     //   15: Call fuzion.sys.misc(outer fuzion.sys) fuzion.sys.misc
-    fzC_fuzion__sys__misc();
+    // access to Call fuzion.sys.misc(outer fuzion.sys) fuzion.sys.misc eliminated
     //   16: Call fuzion.sys.misc.unique_id(outer fuzion.sys.misc) u64
     fzT_1u64 fzM_1;
     fzM_1 = fzC__L4058fuzion__sy__ique_u_id();
@@ -16140,22 +16045,22 @@
   {
     fzCur->fzF_0_val = arg0;
     //    0: Call property(outer universe#0) property
-    fzC_property();
+    // access to Call property(outer universe#0) property eliminated
     //    1: Pop
     //    2: Call property(outer universe#0) property
-    fzC_property();
+    // access to Call property(outer universe#0) property eliminated
     //    3: Pop
     //    4: Call property(outer universe#0) property
-    fzC_property();
+    // access to Call property(outer universe#0) property eliminated
     //    5: Pop
     //    6: Call property(outer universe#0) property
-    fzC_property();
+    // access to Call property(outer universe#0) property eliminated
     //    7: Pop
     //    8: Call property(outer universe#0) property
-    fzC_property();
+    // access to Call property(outer universe#0) property eliminated
     //    9: Pop
     //   10: Call property(outer universe#0) property
-    fzC_property();
+    // access to Call property(outer universe#0) property eliminated
     //   11: Pop
     return *fzCur;
   }
@@ -16173,13 +16078,13 @@
     //    0: Call debug(outer universe#0) bool
     fzT_bool fzM_0;
     fzM_0 = fzC_debug();
-    //    1: Match 0=>l14 1=>l15
+    //    1: Match 0=>l38 1=>l39
     switch (fzM_0.fzTag)
     {
       case 1/* TRUE */:
       {
         //    0: Call Types(outer universe#0) Types
-        fzC_Types();
+        // access to Call Types(outer universe#0) Types eliminated
         //    1: Call Types.get codepoint(outer Types) codepoint.#type codepoint
         fzC_Types__get_w_codepoint();
         //    2: Call (codepoint.#type codepoint).range(outer codepoint.#type codepoint) interval u32
@@ -16216,13 +16121,13 @@
     //    0: Call debug(outer universe#0) bool
     fzT_bool fzM_4;
     fzM_4 = fzC_debug();
-    //    1: Match 0=>l48 1=>l49
+    //    1: Match 0=>l73 1=>l74
     switch (fzM_4.fzTag)
     {
       case 1/* TRUE */:
       {
         //    0: Call Types(outer universe#0) Types
-        fzC_Types();
+        // access to Call Types(outer universe#0) Types eliminated
         //    1: Call Types.get codepoint(outer Types) codepoint.#type codepoint
         fzC_Types__get_w_codepoint();
         //    2: Call (codepoint.#type codepoint).utf16_surrogate(outer codepoint.#type codepoint) interval u32
@@ -16235,7 +16140,7 @@
         //    5: Call (interval u32).contains(outer interval u32, e u32) bool
         fzT_bool fzM_7;
         fzM_7 = fzC_3interval_w_u32__1contains((fzT_3interval_w_u32*)fzM_6,fzCur->fzF_0_val);
-        //    6: Match 0=>l46 1=>l47
+        //    6: Match 0=>l71 1=>l72
         switch (fzM_7.fzTag)
         {
           case 1/* TRUE */:
@@ -16291,7 +16196,7 @@
   {
     fzCur->fzF_1__H_c_codepoint_o_utf8 = fzouter;
     //    0: Call Types(outer universe#0) Types
-    fzC_Types();
+    // access to Call Types(outer universe#0) Types eliminated
     //    1: Call Types.get codepoint(outer Types) codepoint.#type codepoint
     fzC_Types__get_w_codepoint();
     //    2: Call (codepoint.#type codepoint).utf8_encoded_in_one_byte(outer codepoint.#type codepoint) interval u32
@@ -16305,15 +16210,15 @@
     //    6: Call (interval u32).contains(outer interval u32, e u32) bool
     fzT_bool fzM_2;
     fzM_2 = fzC_3interval_w_u32__1contains((fzT_3interval_w_u32*)fzM_1,fzCur->fzF_1__H_c_codepoint_o_utf8->fzF_0_val);
-    //    7: Match 0=>l60 1=>l67
+    //    7: Match 0=>l83 1=>l90
     switch (fzM_2.fzTag)
     {
       case 1/* TRUE */:
       {
         //    0: Call fuzion(outer universe#0) fuzion
-        fzC_fuzion();
+        // access to Call fuzion(outer universe#0) fuzion eliminated
         //    1: Call fuzion.sys(outer fuzion) fuzion.sys
-        fzC_fuzion__sys();
+        // access to Call fuzion.sys(outer fuzion) fuzion.sys eliminated
         //    2: Const of type i32 04 00 00 00 01 00 00 00
         //    3: Call fuzion.sys.internal_array_init u8(outer fuzion.sys, length i32) fuzion.sys.internal_array u8
         fzT__L3877fuzion__sy__rray_w_u8 fzM_3;
@@ -16337,11 +16242,11 @@
         //   15: Current
         //   16: Call codepoint.utf8.#inlineSysArray8(outer codepoint.utf8) fuzion.sys.internal_array u8
         //   17: Call unit(outer universe#0) unit
-        fzC_unit();
+        // access to Call unit(outer universe#0) unit eliminated
         //   18: Call unit(outer universe#0) unit
-        fzC_unit();
+        // access to Call unit(outer universe#0) unit eliminated
         //   19: Call unit(outer universe#0) unit
-        fzC_unit();
+        // access to Call unit(outer universe#0) unit eliminated
         //   20: Call array u8(outer universe#0, internal_array fuzion.sys.internal_array u8, #_2 unit, #_3 unit, #_4 unit) array u8
         fzT_4array_w_u8 fzM_5;
         fzM_5 = fzC_4array_w_u8(fzCur->fzF_3__HinlineSysArray8);
@@ -16359,7 +16264,7 @@
       case 0/* FALSE */:
       {
         //    0: Call Types(outer universe#0) Types
-        fzC_Types();
+        // access to Call Types(outer universe#0) Types eliminated
         //    1: Call Types.get codepoint(outer Types) codepoint.#type codepoint
         fzC_Types__get_w_codepoint();
         //    2: Call (codepoint.#type codepoint).utf8_encoded_in_two_bytes(outer codepoint.#type codepoint) interval u32
@@ -16373,15 +16278,15 @@
         //    6: Call (interval u32).contains(outer interval u32, e u32) bool
         fzT_bool fzM_9;
         fzM_9 = fzC_3interval_w_u32__1contains((fzT_3interval_w_u32*)fzM_8,fzCur->fzF_1__H_c_codepoint_o_utf8->fzF_0_val);
-        //    7: Match 0=>l61 1=>l66
+        //    7: Match 0=>l84 1=>l89
         switch (fzM_9.fzTag)
         {
           case 1/* TRUE */:
           {
             //    0: Call fuzion(outer universe#0) fuzion
-            fzC_fuzion();
+            // access to Call fuzion(outer universe#0) fuzion eliminated
             //    1: Call fuzion.sys(outer fuzion) fuzion.sys
-            fzC_fuzion__sys();
+            // access to Call fuzion.sys(outer fuzion) fuzion.sys eliminated
             //    2: Const of type i32 04 00 00 00 02 00 00 00
             //    3: Call fuzion.sys.internal_array_init u8(outer fuzion.sys, length i32) fuzion.sys.internal_array u8
             fzT__L3877fuzion__sy__rray_w_u8 fzM_10;
@@ -16438,11 +16343,11 @@
             //   34: Current
             //   35: Call codepoint.utf8.#inlineSysArray9(outer codepoint.utf8) fuzion.sys.internal_array u8
             //   36: Call unit(outer universe#0) unit
-            fzC_unit();
+            // access to Call unit(outer universe#0) unit eliminated
             //   37: Call unit(outer universe#0) unit
-            fzC_unit();
+            // access to Call unit(outer universe#0) unit eliminated
             //   38: Call unit(outer universe#0) unit
-            fzC_unit();
+            // access to Call unit(outer universe#0) unit eliminated
             //   39: Call array u8(outer universe#0, internal_array fuzion.sys.internal_array u8, #_2 unit, #_3 unit, #_4 unit) array u8
             fzT_4array_w_u8 fzM_18;
             fzM_18 = fzC_4array_w_u8(fzCur->fzF_4__HinlineSysArray9);
@@ -16460,7 +16365,7 @@
           case 0/* FALSE */:
           {
             //    0: Call Types(outer universe#0) Types
-            fzC_Types();
+            // access to Call Types(outer universe#0) Types eliminated
             //    1: Call Types.get codepoint(outer Types) codepoint.#type codepoint
             fzC_Types__get_w_codepoint();
             //    2: Call (codepoint.#type codepoint).utf8_encoded_in_three_bytes(outer codepoint.#type codepoint) interval u32
@@ -16474,15 +16379,15 @@
             //    6: Call (interval u32).contains(outer interval u32, e u32) bool
             fzT_bool fzM_22;
             fzM_22 = fzC_3interval_w_u32__1contains((fzT_3interval_w_u32*)fzM_21,fzCur->fzF_1__H_c_codepoint_o_utf8->fzF_0_val);
-            //    7: Match 0=>l62 1=>l65
+            //    7: Match 0=>l85 1=>l88
             switch (fzM_22.fzTag)
             {
               case 1/* TRUE */:
               {
                 //    0: Call fuzion(outer universe#0) fuzion
-                fzC_fuzion();
+                // access to Call fuzion(outer universe#0) fuzion eliminated
                 //    1: Call fuzion.sys(outer fuzion) fuzion.sys
-                fzC_fuzion__sys();
+                // access to Call fuzion.sys(outer fuzion) fuzion.sys eliminated
                 //    2: Const of type i32 04 00 00 00 03 00 00 00
                 //    3: Call fuzion.sys.internal_array_init u8(outer fuzion.sys, length i32) fuzion.sys.internal_array u8
                 fzT__L3877fuzion__sy__rray_w_u8 fzM_23;
@@ -16564,11 +16469,11 @@
                 //   49: Current
                 //   50: Call codepoint.utf8.#inlineSysArray10(outer codepoint.utf8) fuzion.sys.internal_array u8
                 //   51: Call unit(outer universe#0) unit
-                fzC_unit();
+                // access to Call unit(outer universe#0) unit eliminated
                 //   52: Call unit(outer universe#0) unit
-                fzC_unit();
+                // access to Call unit(outer universe#0) unit eliminated
                 //   53: Call unit(outer universe#0) unit
-                fzC_unit();
+                // access to Call unit(outer universe#0) unit eliminated
                 //   54: Call array u8(outer universe#0, internal_array fuzion.sys.internal_array u8, #_2 unit, #_3 unit, #_4 unit) array u8
                 fzT_4array_w_u8 fzM_35;
                 fzM_35 = fzC_4array_w_u8(fzCur->fzF_5__HinlineSysArray10);
@@ -16586,7 +16491,7 @@
               case 0/* FALSE */:
               {
                 //    0: Call Types(outer universe#0) Types
-                fzC_Types();
+                // access to Call Types(outer universe#0) Types eliminated
                 //    1: Call Types.get codepoint(outer Types) codepoint.#type codepoint
                 fzC_Types__get_w_codepoint();
                 //    2: Call (codepoint.#type codepoint).utf8_encoded_in_four_bytes(outer codepoint.#type codepoint) interval u32
@@ -16600,15 +16505,15 @@
                 //    6: Call (interval u32).contains(outer interval u32, e u32) bool
                 fzT_bool fzM_39;
                 fzM_39 = fzC_3interval_w_u32__1contains((fzT_3interval_w_u32*)fzM_38,fzCur->fzF_1__H_c_codepoint_o_utf8->fzF_0_val);
-                //    7: Match 0=>l63 1=>l64
+                //    7: Match 0=>l86 1=>l87
                 switch (fzM_39.fzTag)
                 {
                   case 1/* TRUE */:
                   {
                     //    0: Call fuzion(outer universe#0) fuzion
-                    fzC_fuzion();
+                    // access to Call fuzion(outer universe#0) fuzion eliminated
                     //    1: Call fuzion.sys(outer fuzion) fuzion.sys
-                    fzC_fuzion__sys();
+                    // access to Call fuzion.sys(outer fuzion) fuzion.sys eliminated
                     //    2: Const of type i32 04 00 00 00 04 00 00 00
                     //    3: Call fuzion.sys.internal_array_init u8(outer fuzion.sys, length i32) fuzion.sys.internal_array u8
                     fzT__L3877fuzion__sy__rray_w_u8 fzM_40;
@@ -16715,11 +16620,11 @@
                     //   64: Current
                     //   65: Call codepoint.utf8.#inlineSysArray11(outer codepoint.utf8) fuzion.sys.internal_array u8
                     //   66: Call unit(outer universe#0) unit
-                    fzC_unit();
+                    // access to Call unit(outer universe#0) unit eliminated
                     //   67: Call unit(outer universe#0) unit
-                    fzC_unit();
+                    // access to Call unit(outer universe#0) unit eliminated
                     //   68: Call unit(outer universe#0) unit
-                    fzC_unit();
+                    // access to Call unit(outer universe#0) unit eliminated
                     //   69: Call array u8(outer universe#0, internal_array fuzion.sys.internal_array u8, #_2 unit, #_3 unit, #_4 unit) array u8
                     fzT_4array_w_u8 fzM_56;
                     fzM_56 = fzC_4array_w_u8(fzCur->fzF_6__HinlineSysArray11);
@@ -16737,9 +16642,9 @@
                   case 0/* FALSE */:
                   {
                     //    0: Call fuzion(outer universe#0) fuzion
-                    fzC_fuzion();
+                    // access to Call fuzion(outer universe#0) fuzion eliminated
                     //    1: Call fuzion.std(outer fuzion) fuzion.std
-                    fzC_fuzion__std();
+                    // access to Call fuzion.std(outer fuzion) fuzion.std eliminated
                     //    2: Const of type Const_String 1c 00 00 00 66 61 69 6c
                     //    3: Current
                     //    4: Call codepoint.utf8.#^codepoint.utf8(outer codepoint.utf8) codepoint
@@ -16778,17 +16683,6 @@
     return fzCur->fzF_0_result;
   }
 }
-// code for clazz#2610 container:
-void fzC_container()
-{
-  // cur may escape, so use malloc
-  fzT_container* fzCur;
-  fzCur = fzE_malloc_safe(sizeof(fzT_container));
-
-  start:
-  {
-  }
-}
 // code for clazz#2621 debug:
 fzT_bool fzC_debug()
 {
@@ -16844,7 +16738,7 @@
   {
     fzCur->fields.fzF_0_f = (fzT__RFunction_wC_array_w_u8_D*)arg0;
     //    0: Call nil(outer universe#0) nil
-    fzC_nil();
+    // access to Call nil(outer universe#0) nil eliminated
     //    1: Tag
     // Tag a value to be of choice type option (array u8) static value type nil
     fzT_option_wC_array_w_u8_D fzM_0;
@@ -16885,17 +16779,6 @@
     // access to Assign to ((list u8).as_array.lm.Effect_Call (array u8)).call.result eliminated
   }
 }
-// code for clazz#3635 effect_mode:
-void fzC_effect_u_mode()
-{
-  // cur may escape, so use malloc
-  fzT_effect_u_mode* fzCur;
-  fzCur = fzE_malloc_safe(sizeof(fzT_effect_u_mode));
-
-  start:
-  {
-  }
-}
 // code for clazz#3648 (list u8).as_array.lm.go (array u8):
 fzT_4array_w_u8 fzC__L3648list_w_u8___ay_w_u8_D(fzT_list_w_u8__as_u_array__lm* fzouter, fzT__RFunction_wC_array_w_u8_D* arg0)
 {
@@ -16929,14 +16812,14 @@
     //   13: Current
     //   14: Call ((list u8).as_array.lm.go (array u8)).cf(outer (list u8).as_array.lm.go (array u8)) (list u8).as_array.lm.Effect_Call (array u8)
     //   15: Call ((list u8).as_array.lm.Effect_Call (array u8)).res(outer (list u8).as_array.lm.Effect_Call (array u8)) option (array u8)
-    //   16: Match 0=>l213 1(array u8)=>l214
+    //   16: Match 0=>l244 1(array u8)=>l245
     switch (fzCur->fzF_5_cf->fields.fzF_1_res.fzTag)
     {
       case 1/* nil */:
       {
         //    0: Const of type Const_String 18 00 00 00 2a 2a 2a 20
         //    1: Call Types(outer universe#0) Types
-        fzC_Types();
+        // access to Call Types(outer universe#0) Types eliminated
         //    2: Call Types.get (list u8).as_array#0.lm(outer Types) ((list.#type (list u8) u8).as_array._0#type (list u8).as_array#0).lm.#type (list u8).as_array#0.lm
         fzC__L1968Types__get__y_H0_o_lm();
         //    3: Box ((list.#type (list u8) u8).as_array._0#type (list u8).as_array#0).lm.#type (list u8).as_array#0.lm => ((list.#type (list u8) u8).as_array._0#type (list u8).as_array#0).ref lm.#type (list u8).as_array#0.lm
@@ -16960,7 +16843,7 @@
         //   11: Call (list u8).as_array.lm.abortable(outer (list u8).as_array.lm) bool
         fzT_bool fzM_5;
         fzM_5 = fzC__L5114list_w_u8___abortable();
-        //   12: Match 0=>l211 1=>l212
+        //   12: Match 0=>l242 1=>l243
         switch (fzM_5.fzTag)
         {
           case 1/* TRUE */:
@@ -16974,9 +16857,9 @@
           case 0/* FALSE */:
           {
             //    0: Call fuzion(outer universe#0) fuzion
-            fzC_fuzion();
+            // access to Call fuzion(outer universe#0) fuzion eliminated
             //    1: Call fuzion.std(outer fuzion) fuzion.std
-            fzC_fuzion__std();
+            // access to Call fuzion.std(outer fuzion) fuzion.std eliminated
             //    2: Current
             //    3: Call ((list u8).as_array.lm.go (array u8)).msg(outer (list u8).as_array.lm.go (array u8)) String
             //    4: Call fuzion.std.panic(outer fuzion.std, msg String) void
@@ -17058,7 +16941,7 @@
     fzCur.fzF_0_a = arg0;
     fzCur.fzF_1_b = arg1;
     //    0: Call Types(outer universe#0) Types
-    fzC_Types();
+    // access to Call Types(outer universe#0) Types eliminated
     //    1: Call Types.get i32(outer Types) i32.#type i32
     fzC_Types__get_w_i32();
     //    2: Current
@@ -17089,7 +16972,7 @@
     fzCur.fzF_0_a = arg0;
     fzCur.fzF_1_b = arg1;
     //    0: Call Types(outer universe#0) Types
-    fzC_Types();
+    // access to Call Types(outer universe#0) Types eliminated
     //    1: Call Types.get u32(outer Types) u32.#type u32
     fzC_Types__get_w_u32();
     //    2: Current
@@ -17120,7 +17003,7 @@
     fzCur.fzF_0_a = arg0;
     fzCur.fzF_1_b = arg1;
     //    0: Call Types(outer universe#0) Types
-    fzC_Types();
+    // access to Call Types(outer universe#0) Types eliminated
     //    1: Call Types.get u64(outer Types) u64.#type u64
     fzC_Types__get_w_u64();
     //    2: Current
@@ -17242,7 +17125,7 @@
     //    6: Call equals i32(outer universe#0, a i32, b i32) bool
     fzT_bool fzM_0;
     fzM_0 = fzC_2equals_w_i32(fzCur.fzF_0_a,fzCur.fzF_1_b);
-    //    7: Match 0=>l123 1=>l124
+    //    7: Match 0=>l150 1=>l151
     switch (fzM_0.fzTag)
     {
       case 1/* TRUE */:
@@ -17291,7 +17174,7 @@
     //    6: Call equals u32(outer universe#0, a u32, b u32) bool
     fzT_bool fzM_0;
     fzM_0 = fzC_2equals_w_u32(fzCur.fzF_0_a,fzCur.fzF_1_b);
-    //    7: Match 0=>l123 1=>l124
+    //    7: Match 0=>l150 1=>l151
     switch (fzM_0.fzTag)
     {
       case 1/* TRUE */:
@@ -17340,7 +17223,7 @@
     //    6: Call equals u64(outer universe#0, a u64, b u64) bool
     fzT_bool fzM_0;
     fzM_0 = fzC_2equals_w_u64(fzCur.fzF_0_a,fzCur.fzF_1_b);
-    //    7: Match 0=>l123 1=>l124
+    //    7: Match 0=>l150 1=>l151
     switch (fzM_0.fzTag)
     {
       case 1/* TRUE */:
@@ -17497,7 +17380,7 @@
     //    6: Call infix < i32(outer universe#0, a i32, b i32) bool
     fzT_bool fzM_0;
     fzM_0 = fzC_2infix_wlw_i32(fzCur.fzF_0_a,fzCur.fzF_1_b);
-    //    7: Match 0=>l288 1=>l291
+    //    7: Match 0=>l318 1=>l321
     switch (fzM_0.fzTag)
     {
       case 1/* TRUE */:
@@ -17521,7 +17404,7 @@
         //    6: Call infix > i32(outer universe#0, a i32, b i32) bool
         fzT_bool fzM_1;
         fzM_1 = fzC_2infix_wgw_i32(fzCur.fzF_0_a,fzCur.fzF_1_b);
-        //    7: Match 0=>l289 1=>l290
+        //    7: Match 0=>l319 1=>l320
         switch (fzM_1.fzTag)
         {
           case 1/* TRUE */:
@@ -17654,7 +17537,7 @@
     //    6: Call lteq i32(outer universe#0, a i32, b i32) bool
     fzT_bool fzM_0;
     fzM_0 = fzC_2lteq_w_i32(fzCur.fzF_0_a,fzCur.fzF_1_b);
-    //    7: Match 0=>l72 1=>l73
+    //    7: Match 0=>l95 1=>l96
     switch (fzM_0.fzTag)
     {
       case 1/* TRUE */:
@@ -17703,7 +17586,7 @@
     //    6: Call lteq i64(outer universe#0, a i64, b i64) bool
     fzT_bool fzM_0;
     fzM_0 = fzC_2lteq_w_i64(fzCur.fzF_0_a,fzCur.fzF_1_b);
-    //    7: Match 0=>l72 1=>l73
+    //    7: Match 0=>l95 1=>l96
     switch (fzM_0.fzTag)
     {
       case 1/* TRUE */:
@@ -17752,7 +17635,7 @@
     //    6: Call lteq u32(outer universe#0, a u32, b u32) bool
     fzT_bool fzM_0;
     fzM_0 = fzC_2lteq_w_u32(fzCur.fzF_0_a,fzCur.fzF_1_b);
-    //    7: Match 0=>l72 1=>l73
+    //    7: Match 0=>l95 1=>l96
     switch (fzM_0.fzTag)
     {
       case 1/* TRUE */:
@@ -17801,7 +17684,7 @@
     //    6: Call lteq i32(outer universe#0, a i32, b i32) bool
     fzT_bool fzM_0;
     fzM_0 = fzC_2lteq_w_i32(fzCur.fzF_1_b,fzCur.fzF_0_a);
-    //    7: Match 0=>l127 1=>l128
+    //    7: Match 0=>l154 1=>l155
     switch (fzM_0.fzTag)
     {
       case 1/* TRUE */:
@@ -17850,7 +17733,7 @@
     //    6: Call lteq i64(outer universe#0, a i64, b i64) bool
     fzT_bool fzM_0;
     fzM_0 = fzC_2lteq_w_i64(fzCur.fzF_1_b,fzCur.fzF_0_a);
-    //    7: Match 0=>l127 1=>l128
+    //    7: Match 0=>l154 1=>l155
     switch (fzM_0.fzTag)
     {
       case 1/* TRUE */:
@@ -17899,7 +17782,7 @@
     //    6: Call lteq u32(outer universe#0, a u32, b u32) bool
     fzT_bool fzM_0;
     fzM_0 = fzC_2lteq_w_u32(fzCur.fzF_1_b,fzCur.fzF_0_a);
-    //    7: Match 0=>l127 1=>l128
+    //    7: Match 0=>l154 1=>l155
     switch (fzM_0.fzTag)
     {
       case 1/* TRUE */:
@@ -17948,7 +17831,7 @@
     //    6: Call lteq u8(outer universe#0, a u8, b u8) bool
     fzT_bool fzM_0;
     fzM_0 = fzC_2lteq_w_u8(fzCur.fzF_1_b,fzCur.fzF_0_a);
-    //    7: Match 0=>l127 1=>l128
+    //    7: Match 0=>l154 1=>l155
     switch (fzM_0.fzTag)
     {
       case 1/* TRUE */:
@@ -17976,28 +17859,6 @@
     return fzCur.fzF_2_result;
   }
 }
-// code for clazz#3854 fuzion:
-void fzC_fuzion()
-{
-  // cur may escape, so use malloc
-  fzT_fuzion* fzCur;
-  fzCur = fzE_malloc_safe(sizeof(fzT_fuzion));
-
-  start:
-  {
-  }
-}
-// code for clazz#3863 fuzion.std:
-void fzC_fuzion__std()
-{
-  // cur may escape, so use malloc
-  fzT_fuzion__std* fzCur;
-  fzCur = fzE_malloc_safe(sizeof(fzT_fuzion__std));
-
-  start:
-  {
-  }
-}
 // code for clazz#3865 fuzion.std.exit:
 void fzC_fuzion__std__1exit(fzT_1i32 arg0)
 {
@@ -18013,11 +17874,11 @@
   {
     fzCur.fzF_0_msg = (fzT__RString*)arg0;
     //    0: Call fuzion(outer universe#0) fuzion
-    fzC_fuzion();
+    // access to Call fuzion(outer universe#0) fuzion eliminated
     //    1: Call fuzion.sys(outer fuzion) fuzion.sys
-    fzC_fuzion__sys();
+    // access to Call fuzion.sys(outer fuzion) fuzion.sys eliminated
     //    2: Call fuzion.sys.err(outer fuzion.sys) fuzion.sys.err
-    fzC_fuzion__sys__err();
+    // access to Call fuzion.sys.err(outer fuzion.sys) fuzion.sys.err eliminated
     //    3: Const of type Const_String 0b 00 00 00 2a 2a 2a 20
     //    4: Current
     //    5: Call fuzion.std.panic.msg(outer fuzion.std.panic) String
@@ -18039,17 +17900,6 @@
     fzC_fuzion__std__1exit(1);
   }
 }
-// code for clazz#3872 fuzion.sys:
-void fzC_fuzion__sys()
-{
-  // cur may escape, so use malloc
-  fzT_fuzion__sys* fzCur;
-  fzCur = fzE_malloc_safe(sizeof(fzT_fuzion__sys));
-
-  start:
-  {
-  }
-}
 // code for clazz#3893 (fuzion.sys.internal_array u8).index [ ]:
 fzT_1u8 fzC__L3893fuzion__sy__U5b_wU5d_(fzT__L3877fuzion__sy__rray_w_u8* fzouter, fzT_1i32 arg0)
 {
@@ -18093,7 +17943,7 @@
     //    0: Call safety(outer universe#0) bool
     fzT_bool fzM_0;
     fzM_0 = fzC_safety();
-    //    1: Match 0=>l196 1=>l197
+    //    1: Match 0=>l230 1=>l231
     switch (fzM_0.fzTag)
     {
       case 1/* TRUE */:
@@ -18109,7 +17959,7 @@
         //    7: Call infix ≤ i32(outer universe#0, a i32, b i32) bool
         fzT_bool fzM_1;
         fzM_1 = fzC_2infix_wU2264_w_i32(0,fzCur->fzF_3__HchainedBoolTemp26);
-        //    8: Match 0=>l194 1=>l195
+        //    8: Match 0=>l228 1=>l229
         switch (fzM_1.fzTag)
         {
           case 1/* TRUE */:
@@ -18211,7 +18061,7 @@
     //    0: Call safety(outer universe#0) bool
     fzT_bool fzM_0;
     fzM_0 = fzC_safety();
-    //    1: Match 0=>l144 1=>l145
+    //    1: Match 0=>l171 1=>l172
     switch (fzM_0.fzTag)
     {
       case 1/* TRUE */:
@@ -18227,7 +18077,7 @@
         //    7: Call infix ≤ i32(outer universe#0, a i32, b i32) bool
         fzT_bool fzM_1;
         fzM_1 = fzC_2infix_wU2264_w_i32(0,fzCur->fzF_4__HchainedBoolTemp0);
-        //    8: Match 0=>l142 1=>l143
+        //    8: Match 0=>l169 1=>l170
         switch (fzM_1.fzTag)
         {
           case 1/* TRUE */:
@@ -18288,17 +18138,6 @@
 {
   ((fzT_1u8*)arg0)[arg1] = arg2;
 }
-// code for clazz#3994 fuzion.sys.err:
-void fzC_fuzion__sys__err()
-{
-  // cur may escape, so use malloc
-  fzT_fuzion__sys__err* fzCur;
-  fzCur = fzE_malloc_safe(sizeof(fzT_fuzion__sys__err));
-
-  start:
-  {
-  }
-}
 // code for clazz#4000 fuzion.sys.err.println:
 void fzC_fuzion__sys__err__1println(fzT__RAny* arg0)
 {
@@ -18321,9 +18160,9 @@
     fzT__RSequence_w_u8* fzM_1;
     fzM_1 = fzC__L5721String_oHt__us2__utf8((fzT__L5717String_oHt__nonymous2*)fzM_0);
     //    6: Call fuzion(outer universe#0) fuzion
-    fzC_fuzion();
+    // access to Call fuzion(outer universe#0) fuzion eliminated
     //    7: Call fuzion.sys(outer fuzion) fuzion.sys
-    fzC_fuzion__sys();
+    // access to Call fuzion.sys(outer fuzion) fuzion.sys eliminated
     //    8: Const of type i32 04 00 00 00 01 00 00 00
     //    9: Call fuzion.sys.internal_array_init u8(outer fuzion.sys, length i32) fuzion.sys.internal_array u8
     fzT__L3877fuzion__sy__rray_w_u8 fzM_2;
@@ -18338,7 +18177,7 @@
     //   16: Call fuzion.sys.err.println.#^fuzion.sys.err.println(outer fuzion.sys.err.println) fuzion.sys.err
     // access to Call fuzion.sys.err.println.#^fuzion.sys.err.println(outer fuzion.sys.err.println) fuzion.sys.err eliminated
     //   17: Call fuzion.sys.err.ascii(outer fuzion.sys.err) fuzion.sys.err.ascii
-    fzC_fuzion__sys__err__ascii();
+    // access to Call fuzion.sys.err.ascii(outer fuzion.sys.err) fuzion.sys.err.ascii eliminated
     //   18: Call fuzion.sys.err.ascii.lf(outer fuzion.sys.err.ascii) u8
     fzT_1u8 fzM_3;
     fzM_3 = fzC_fuzion__sys__err__ascii__lf();
@@ -18349,11 +18188,11 @@
     //   21: Current
     //   22: Call fuzion.sys.err.println.#inlineSysArray0(outer fuzion.sys.err.println) fuzion.sys.internal_array u8
     //   23: Call unit(outer universe#0) unit
-    fzC_unit();
+    // access to Call unit(outer universe#0) unit eliminated
     //   24: Call unit(outer universe#0) unit
-    fzC_unit();
+    // access to Call unit(outer universe#0) unit eliminated
     //   25: Call unit(outer universe#0) unit
-    fzC_unit();
+    // access to Call unit(outer universe#0) unit eliminated
     //   26: Call array u8(outer universe#0, internal_array fuzion.sys.internal_array u8, #_2 unit, #_3 unit, #_4 unit) array u8
     fzT_4array_w_u8 fzM_4;
     fzM_4 = fzC_4array_w_u8(fzCur->fzF_3__HinlineSysArray0);
@@ -18393,11 +18232,11 @@
   {
     fzCur.fzF_0_arr = arg0;
     //    0: Call fuzion(outer universe#0) fuzion
-    fzC_fuzion();
+    // access to Call fuzion(outer universe#0) fuzion eliminated
     //    1: Call fuzion.sys(outer fuzion) fuzion.sys
-    fzC_fuzion__sys();
+    // access to Call fuzion.sys(outer fuzion) fuzion.sys eliminated
     //    2: Call fuzion.sys.fileio(outer fuzion.sys) fuzion.sys.fileio
-    fzC_fuzion__sys__fileio();
+    // access to Call fuzion.sys.fileio(outer fuzion.sys) fuzion.sys.fileio eliminated
     //    3: Current
     //    4: Call fuzion.sys.err.write.#^fuzion.sys.err.write(outer fuzion.sys.err.write) fuzion.sys.err
     // access to Call fuzion.sys.err.write.#^fuzion.sys.err.write(outer fuzion.sys.err.write) fuzion.sys.err eliminated
@@ -18416,17 +18255,6 @@
     // access to Assign to fuzion.sys.err.write.result eliminated
   }
 }
-// code for clazz#4014 fuzion.sys.fileio:
-void fzC_fuzion__sys__fileio()
-{
-  // cur may escape, so use malloc
-  fzT_fuzion__sys__fileio* fzCur;
-  fzCur = fzE_malloc_safe(sizeof(fzT_fuzion__sys__fileio));
-
-  start:
-  {
-  }
-}
 // code for clazz#4016 fuzion.sys.fileio.write:
 fzT_outcome_w_unit fzC_fuzion__sys__fileio__2write(fzT_1i64 arg0, fzT_4array_w_u8 arg1)
 {
@@ -18463,13 +18291,13 @@
     //   17: Call infix = i32(outer universe#0, a i32, b i32) bool
     fzT_bool fzM_2;
     fzM_2 = fzC_2infix_wew_i32(fzCur.fzF_4_res,0);
-    //   18: Match 0=>l349 1=>l350
+    //   18: Match 0=>l379 1=>l380
     switch (fzM_2.fzTag)
     {
       case 1/* TRUE */:
       {
         //    0: Call unit(outer universe#0) unit
-        fzC_unit();
+        // access to Call unit(outer universe#0) unit eliminated
         //    1: Tag
         // Tag a value to be of choice type outcome unit static value type unit
         fzT_outcome_w_unit fzM_3;
@@ -18565,34 +18393,12 @@
 {
   return fzE_malloc_safe(sizeof(fzT_1u8)*arg0);
 }
-// code for clazz#4056 fuzion.sys.misc:
-void fzC_fuzion__sys__misc()
-{
-  // cur may escape, so use malloc
-  fzT_fuzion__sys__misc* fzCur;
-  fzCur = fzE_malloc_safe(sizeof(fzT_fuzion__sys__misc));
-
-  start:
-  {
-  }
-}
 // code for clazz#4058 fuzion.sys.misc.unique_id:
 fzT_1u64 fzC__L4058fuzion__sy__ique_u_id()
 {
   static atomic_uint_least64_t last_id = 0ULL;
   return ++last_id;
 }
-// code for clazz#4060 fuzion.sys.out:
-void fzC_fuzion__sys__out()
-{
-  // cur may escape, so use malloc
-  fzT_fuzion__sys__out* fzCur;
-  fzCur = fzE_malloc_safe(sizeof(fzT_fuzion__sys__out));
-
-  start:
-  {
-  }
-}
 // code for clazz#4062 fuzion.sys.out.print:
 void fzC_fuzion__sys__out__1print(fzT__RAny* arg0)
 {
@@ -18633,11 +18439,11 @@
   {
     fzCur.fzF_0_arr = arg0;
     //    0: Call fuzion(outer universe#0) fuzion
-    fzC_fuzion();
+    // access to Call fuzion(outer universe#0) fuzion eliminated
     //    1: Call fuzion.sys(outer fuzion) fuzion.sys
-    fzC_fuzion__sys();
+    // access to Call fuzion.sys(outer fuzion) fuzion.sys eliminated
     //    2: Call fuzion.sys.fileio(outer fuzion.sys) fuzion.sys.fileio
-    fzC_fuzion__sys__fileio();
+    // access to Call fuzion.sys.fileio(outer fuzion.sys) fuzion.sys.fileio eliminated
     //    3: Current
     //    4: Call fuzion.sys.out.write.#^fuzion.sys.out.write(outer fuzion.sys.out.write) fuzion.sys.out
     // access to Call fuzion.sys.out.write.#^fuzion.sys.out.write(outer fuzion.sys.out.write) fuzion.sys.out eliminated
@@ -18698,7 +18504,7 @@
     //    0: Call safety(outer universe#0) bool
     fzT_bool fzM_0;
     fzM_0 = fzC_safety();
-    //    1: Match 0=>l381 1=>l382
+    //    1: Match 0=>l410 1=>l411
     switch (fzM_0.fzTag)
     {
       case 1/* TRUE */:
@@ -18769,7 +18575,7 @@
     //    0: Call safety(outer universe#0) bool
     fzT_bool fzM_0;
     fzM_0 = fzC_safety();
-    //    1: Match 0=>l423 1=>l424
+    //    1: Match 0=>l452 1=>l453
     switch (fzM_0.fzTag)
     {
       case 1/* TRUE */:
@@ -18870,13 +18676,13 @@
     //    4: Call infix > i32(outer universe#0, a i32, b i32) bool
     fzT_bool fzM_1;
     fzM_1 = fzC_2infix_wgw_i32(fzM_0,0);
-    //    5: Match 0=>l238 1=>l239
+    //    5: Match 0=>l269 1=>l270
     switch (fzM_1.fzTag)
     {
       case 1/* TRUE */:
       {
         //    0: Call Types(outer universe#0) Types
-        fzC_Types();
+        // access to Call Types(outer universe#0) Types eliminated
         //    1: Call Types.get i32(outer Types) i32.#type i32
         fzC_Types__get_w_i32();
         //    2: Call (i32.#type i32).max(outer i32.#type i32) i32
@@ -18936,13 +18742,13 @@
     //    4: Call infix < i32(outer universe#0, a i32, b i32) bool
     fzT_bool fzM_1;
     fzM_1 = fzC_2infix_wlw_i32(fzM_0,0);
-    //    5: Match 0=>l248 1=>l249
+    //    5: Match 0=>l279 1=>l280
     switch (fzM_1.fzTag)
     {
       case 1/* TRUE */:
       {
         //    0: Call Types(outer universe#0) Types
-        fzC_Types();
+        // access to Call Types(outer universe#0) Types eliminated
         //    1: Call Types.get i32(outer Types) i32.#type i32
         fzC_Types__get_w_i32();
         //    2: Call (i32.#type i32).min(outer i32.#type i32) i32
@@ -19002,7 +18808,7 @@
     //    4: Call infix > i32(outer universe#0, a i32, b i32) bool
     fzT_bool fzM_1;
     fzM_1 = fzC_2infix_wgw_i32(fzM_0,0);
-    //    5: Match 0=>l263 1=>l264
+    //    5: Match 0=>l292 1=>l293
     switch (fzM_1.fzTag)
     {
       case 1/* TRUE */:
@@ -19013,7 +18819,7 @@
         fzT_1i32 fzM_2;
         fzM_2 = fzC_1i32__thiz(fzCur.fzF_2__H_c_i32_o_overflow_u_on_u_sub);
         //    3: Call Types(outer universe#0) Types
-        fzC_Types();
+        // access to Call Types(outer universe#0) Types eliminated
         //    4: Call Types.get i32(outer Types) i32.#type i32
         fzC_Types__get_w_i32();
         //    5: Call (i32.#type i32).max(outer i32.#type i32) i32
@@ -19068,7 +18874,7 @@
     //    4: Call infix < i32(outer universe#0, a i32, b i32) bool
     fzT_bool fzM_1;
     fzM_1 = fzC_2infix_wlw_i32(fzM_0,0);
-    //    5: Match 0=>l271 1=>l272
+    //    5: Match 0=>l300 1=>l301
     switch (fzM_1.fzTag)
     {
       case 1/* TRUE */:
@@ -19079,7 +18885,7 @@
         fzT_1i32 fzM_2;
         fzM_2 = fzC_1i32__thiz(fzCur.fzF_2__H_c_i32_o_underflow_u_on_u_sub);
         //    3: Call Types(outer universe#0) Types
-        fzC_Types();
+        // access to Call Types(outer universe#0) Types eliminated
         //    4: Call Types.get i32(outer Types) i32.#type i32
         fzC_Types__get_w_i32();
         //    5: Call (i32.#type i32).min(outer i32.#type i32) i32
@@ -19139,7 +18945,7 @@
     fzT_1i64 fzM_2;
     fzM_2 = fzC_1i64__1infix_wtO(fzM_0,fzM_1);
     //    7: Call Types(outer universe#0) Types
-    fzC_Types();
+    // access to Call Types(outer universe#0) Types eliminated
     //    8: Call Types.get i32(outer Types) i32.#type i32
     fzC_Types__get_w_i32();
     //    9: Call (i32.#type i32).max(outer i32.#type i32) i32
@@ -19181,7 +18987,7 @@
     fzT_1i64 fzM_2;
     fzM_2 = fzC_1i64__1infix_wtO(fzM_0,fzM_1);
     //    7: Call Types(outer universe#0) Types
-    fzC_Types();
+    // access to Call Types(outer universe#0) Types eliminated
     //    8: Call Types.get i32(outer Types) i32.#type i32
     fzC_Types__get_w_i32();
     //    9: Call (i32.#type i32).min(outer i32.#type i32) i32
@@ -19265,7 +19071,7 @@
     fzT_1i32 fzM_0;
     fzM_0 = fzC_1i32__thiz(fzCur->fzF_1__H_c_i32_o_as_u_u8);
     //    3: Call Types(outer universe#0) Types
-    fzC_Types();
+    // access to Call Types(outer universe#0) Types eliminated
     //    4: Call Types.get u8(outer Types) u8.#type u8
     fzC_Types__get_w_u8();
     //    5: Call (u8.#type u8).min(outer u8.#type u8) u8
@@ -19288,7 +19094,7 @@
     fzT_1i32 fzM_4;
     fzM_4 = fzC_1i32__thiz(fzCur->fzF_1__H_c_i32_o_as_u_u8);
     //    3: Call Types(outer universe#0) Types
-    fzC_Types();
+    // access to Call Types(outer universe#0) Types eliminated
     //    4: Call Types.get u8(outer Types) u8.#type u8
     fzC_Types__get_w_u8();
     //    5: Call (u8.#type u8).max(outer u8.#type u8) u8
@@ -19369,7 +19175,7 @@
     fzCur->fzF_2__H_c_integer_o_as_u_string = fzouter;
     fzCur->fzF_0_base = arg0;
     //    0: Call Types(outer universe#0) Types
-    fzC_Types();
+    // access to Call Types(outer universe#0) Types eliminated
     //    1: Call Types.get i32(outer Types) i32.#type i32
     fzC_Types__get_w_i32();
     //    2: Current
@@ -19391,7 +19197,7 @@
     //   12: Call infix < i32(outer universe#0, a i32, b i32) bool
     fzT_bool fzM_2;
     fzM_2 = fzC_2infix_wlw_i32(fzM_1,0);
-    //   13: Match 0=>l361 1=>l362
+    //   13: Match 0=>l390 1=>l391
     switch (fzM_2.fzTag)
     {
       case 1/* TRUE */:
@@ -19401,7 +19207,7 @@
         //    2: Call i32.prefix -?(outer i32) num_option i32
         fzT_num_u_option_w_i32 fzM_3;
         fzM_3 = fzC_1i32__prefix_wmQ(fzCur->fzF_2__H_c_integer_o_as_u_string);
-        //    3: Match 0(i32)=>l359 1=>l360
+        //    3: Match 0(i32)=>l388 1=>l389
         switch (fzM_3.fzTag)
         {
           case 0/* i32 */:
@@ -19484,7 +19290,7 @@
       case 0/* FALSE */:
       {
         //    0: Call Types(outer universe#0) Types
-        fzC_Types();
+        // access to Call Types(outer universe#0) Types eliminated
         //    1: Call Types.get String(outer Types) String.#type String
         fzC_Types__get_w_String();
         //    2: Current
@@ -19540,7 +19346,7 @@
     //    0: Call debug(outer universe#0) bool
     fzT_bool fzM_0;
     fzM_0 = fzC_debug();
-    //    1: Match 0=>l355 1=>l356
+    //    1: Match 0=>l384 1=>l385
     switch (fzM_0.fzTag)
     {
       case 1/* TRUE */:
@@ -19556,7 +19362,7 @@
         //    7: Call infix < u32(outer universe#0, a u32, b u32) bool
         fzT_bool fzM_1;
         fzM_1 = fzC_2infix_wlw_u32(1U,fzCur->fzF_5__HchainedBoolTemp42);
-        //    8: Match 0=>l353 1=>l354
+        //    8: Match 0=>l382 1=>l383
         switch (fzM_1.fzTag)
         {
           case 1/* TRUE */:
@@ -19621,13 +19427,13 @@
     //    3: Call infix < u8(outer universe#0, a u8, b u8) bool
     fzT_bool fzM_0;
     fzM_0 = fzC_2infix_wlw_u8(fzCur.fzF_0_d,((uint8_t)10U));
-    //    4: Match 0=>l434 1=>l435
+    //    4: Match 0=>l463 1=>l464
     switch (fzM_0.fzTag)
     {
       case 1/* TRUE */:
       {
         //    0: Call Types(outer universe#0) Types
-        fzC_Types();
+        // access to Call Types(outer universe#0) Types eliminated
         //    1: Call Types.get String(outer Types) String.#type String
         fzC_Types__get_w_String();
         //    2: Call (String.#type String).zero_char(outer String.#type String) u8
@@ -19647,7 +19453,7 @@
       case 0/* FALSE */:
       {
         //    0: Call Types(outer universe#0) Types
-        fzC_Types();
+        // access to Call Types(outer universe#0) Types eliminated
         //    1: Call Types.get String(outer Types) String.#type String
         fzC_Types__get_w_String();
         //    2: Call (String.#type String).a_char(outer String.#type String) u8
@@ -19721,13 +19527,13 @@
     //    4: Call infix <= i32(outer universe#0, a i32, b i32) bool
     fzT_bool fzM_1;
     fzM_1 = fzC_2infix_wlew_i32(fzM_0,0);
-    //    5: Match 0=>l420 1=>l421
+    //    5: Match 0=>l449 1=>l450
     switch (fzM_1.fzTag)
     {
       case 1/* TRUE */:
       {
         //    0: Call nil(outer universe#0) nil
-        fzC_nil();
+        // access to Call nil(outer universe#0) nil eliminated
         //    1: Tag
         // Tag a value to be of choice type list u8 static value type Any
         fzT_list_w_u8 fzM_2;
@@ -19861,7 +19667,7 @@
     fzCur->fzF_1_through = arg1;
     fzCur->fzF_2_step = arg2;
     //    0: Call container(outer universe#0) container
-    fzC_container();
+    // access to Call container(outer universe#0) container eliminated
     //    1: Pop
     return *fzCur;
   }
@@ -19881,7 +19687,7 @@
     //    0: Call debug(outer universe#0) bool
     fzT_bool fzM_0;
     fzM_0 = fzC_debug();
-    //    1: Match 0=>l276 1=>l23
+    //    1: Match 0=>l305 1=>l47
     switch (fzM_0.fzTag)
     {
       case 1/* TRUE */:
@@ -19895,7 +19701,7 @@
         //    4: Call infix = i32(outer universe#0, a i32, b i32) bool
         fzT_bool fzM_2;
         fzM_2 = fzC_2infix_wew_i32(fzM_1,0);
-        //    5: Match 0=>l20 1=>l21
+        //    5: Match 0=>l44 1=>l45
         switch (fzM_2.fzTag)
         {
           case 1/* TRUE */:
@@ -19967,7 +19773,7 @@
     fzCur->fzF_1_through = arg1;
     fzCur->fzF_2_step = arg2;
     //    0: Call container(outer universe#0) container
-    fzC_container();
+    // access to Call container(outer universe#0) container eliminated
     //    1: Pop
     return *fzCur;
   }
@@ -19987,7 +19793,7 @@
     //    0: Call debug(outer universe#0) bool
     fzT_bool fzM_0;
     fzM_0 = fzC_debug();
-    //    1: Match 0=>l22 1=>l23
+    //    1: Match 0=>l46 1=>l47
     switch (fzM_0.fzTag)
     {
       case 1/* TRUE */:
@@ -20001,7 +19807,7 @@
         //    4: Call infix = i32(outer universe#0, a i32, b i32) bool
         fzT_bool fzM_2;
         fzM_2 = fzC_2infix_wew_i32(fzM_1,0);
-        //    5: Match 0=>l20 1=>l21
+        //    5: Match 0=>l44 1=>l45
         switch (fzM_2.fzTag)
         {
           case 1/* TRUE */:
@@ -20073,7 +19879,7 @@
     //    0: Current
     //    1: Call (interval i32).as_list.#^interval.as_list(outer (interval i32).as_list) interval i32
     //    2: Call (interval i32).through(outer interval i32) option i32
-    //    3: Match 0=>l283 1(i32)=>l284
+    //    3: Match 0=>l313 1(i32)=>l314
     switch (fzCur->fzF_1__H_c_interval_o_as_u_list->fzF_1_through.fzTag)
     {
       case 1/* nil */:
@@ -20118,13 +19924,13 @@
     }
     //    6: Current
     //    7: Call (interval i32).as_list.#exprResult483(outer (interval i32).as_list) bool
-    //    8: Match 0=>l285 1=>l286
+    //    8: Match 0=>l315 1=>l316
     switch (fzCur->fzF_3__HexprResult483.fzTag)
     {
       case 1/* TRUE */:
       {
         //    0: Call nil(outer universe#0) nil
-        fzC_nil();
+        // access to Call nil(outer universe#0) nil eliminated
         //    1: Tag
         // Tag a value to be of choice type list i32 static value type Any
         fzT_list_w_i32 fzM_4;
@@ -20184,7 +19990,7 @@
     //    9: Call i32.infix +?(outer i32, other i32) num_option i32
     fzT_num_u_option_w_i32 fzM_0;
     fzM_0 = 
...
```