### PR TITLE
tests: Fix run_tests scripts in case of test failure

### DIFF
--- a/bin/run_tests.sh
+++ b/bin/run_tests.sh
@@ -52,7 +52,11 @@ for test in $TESTS; do
     echo "$test: skipped" >>"$BUILD_DIR"/run_tests.results
   else
     START_TIME=$(date +%s%N | cut -b1-13)
-    TEST_RESULT=$(make "$TARGET" -e -C "$test" >"$test"/out.txt 2>"$test"/stderr.txt) && echo 1 || echo 0
+    if make "$TARGET" -e -C "$test" >"$test"/out.txt 2>"$test"/stderr.txt; then
+       TEST_RESULT=true
+    else
+       TEST_RESULT=false
+    fi
     END_TIME=$(date +%s%N | cut -b1-13)
     if $TEST_RESULT; then
       echo -n "."

--- a/bin/run_tests_parallel.sh
+++ b/bin/run_tests_parallel.sh
@@ -85,7 +85,11 @@ for test in $TESTS; do
       echo "$test: skipped" >>"$BUILD_DIR"/run_tests.results
     else
       START_TIME=$(date +%s%N | cut -b1-13)
-      TEST_RESULT=$(make "$TARGET" -e -C "$test" >"$test"/out.txt 2>"$test"/stderr.txt) && echo 1 || echo 0
+      if make "$TARGET" -e -C "$test" >"$test"/out.txt 2>"$test"/stderr.txt; then
+         TEST_RESULT=true
+      else
+         TEST_RESULT=false
+      fi
       END_TIME=$(date +%s%N | cut -b1-13)
       if $TEST_RESULT; then
         echo -n "."


### PR DESCRIPTION
The script was stopped immediately in case of a failure, now it sets `$TEST_RESULT` to `1` or `0` in case of success or failure.
