### PR TITLE
be/c: initial work for cross compilation

### DIFF
--- a/src/dev/flang/be/c/C.java
+++ b/src/dev/flang/be/c/C.java
@@ -34,6 +34,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.util.Arrays;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import dev.flang.fuir.FUIR;
@@ -729,7 +730,12 @@ public class C extends ANY
       }
 
     var cCompiler = _options._cCompiler != null ? _options._cCompiler : "clang";
+    var cTarget = _options._cTarget != null ? Optional.of(_options._cTarget) : getClangDefaultTarget();
     var command = new List<String>(cCompiler);
+    if (cTarget.isPresent())
+      {
+        command.add("--target=" + cTarget.get());
+      }
     if(_options._cFlags != null)
       {
         command.addAll(_options._cFlags.split(" "));
@@ -794,6 +800,7 @@ public class C extends ANY
 
     // add the c-files
     command.addAll(_options.pathOf("include/shared.c"));
+    // NYI: should select includes based on cTarget
     if (isWindows())
       {
         command.addAll(_options.pathOf("include/win.c"));
@@ -971,6 +978,29 @@ public class C extends ANY
     catch (IOException | InterruptedException | NumberFormatException e)
       {
         return -1;
+      }
+  }
+
+
+  /**
+   * @return The default clang target or optional.empty().
+   */
+  private Optional<String> getClangDefaultTarget()
+  {
+    try
+      {
+        var p = new ProcessBuilder().command(Arrays.asList("clang", "-print-target-triple"))
+          .start();
+        p.waitFor();
+        return new String(p
+          .getInputStream()
+          .readAllBytes())
+            .lines()
+            .findFirst();
+      }
+    catch (Exception e)
+      {
+        return Optional.empty();
       }
   }
 

--- a/src/dev/flang/be/c/COptions.java
+++ b/src/dev/flang/be/c/COptions.java
@@ -73,6 +73,15 @@ public class COptions extends FuzionOptions
 
 
   /**
+   * Target to use for compilation
+   * <arch><sub>-<vendor>-<sys>-<env>
+   *
+   * e.g.: x86_64-pc-linux-gnu
+   */
+  final String _cTarget;
+
+
+  /**
    * Flag to keep the generated c code after compilation.
    */
   final boolean _keepGeneratedCode;
@@ -85,7 +94,7 @@ public class COptions extends FuzionOptions
    * Constructor initializing fields as given.
    * @param keepGeneratedCode
    */
-  public COptions(FuzionOptions fo, String binaryName, boolean useBoehmGC, boolean Xdfa, String cCompiler, String cFlags, boolean keepGeneratedCode)
+  public COptions(FuzionOptions fo, String binaryName, boolean useBoehmGC, boolean Xdfa, String cCompiler, String cFlags, String cTarget, boolean keepGeneratedCode)
   {
     super(fo);
 
@@ -94,6 +103,7 @@ public class COptions extends FuzionOptions
     _Xdfa = Xdfa;
     _cCompiler = cCompiler;
     _cFlags = cFlags;
+    _cTarget = cTarget;
     _keepGeneratedCode = keepGeneratedCode;
   }
 

--- a/src/dev/flang/tools/Fuzion.java
+++ b/src/dev/flang/tools/Fuzion.java
@@ -90,6 +90,7 @@ public class Fuzion extends Tool
   static boolean _xdfa_ = true;
   static String _cCompiler_ = null;
   static String _cFlags_ = null;
+  static String _cTarget_ = null;
   static boolean _keepGeneratedCode_ = false;
   static String  _jvmOutName_ = null;
 
@@ -118,7 +119,7 @@ public class Fuzion extends Tool
     {
       String usage()
       {
-        return "[-o=<file>] [-Xgc=(on|off)] [-Xdfa=(on|off)] [-XkeepGeneratedCode=(on|off)] [-CC=<c compiler>] [-CFlags=\"list of c compiler flags\"]";
+        return "[-o=<file>] [-Xgc=(on|off)] [-Xdfa=(on|off)] [-XkeepGeneratedCode=(on|off)] [-CC=<c compiler>] [-CFlags=\"list of c compiler flags\"] [-CTarget=\"e.g. x86_64-pc-linux-gnu\"] ";
       }
       boolean handleOption(Fuzion f, String o)
       {
@@ -148,6 +149,11 @@ public class Fuzion extends Tool
             _cFlags_ = o.substring(8);
             result = true;
           }
+        else if (o.startsWith("-CTarget="))
+          {
+            _cTarget_ = o.substring(9);
+            result = true;
+          }
         else if (o.startsWith("-XkeepGeneratedCode="))
           {
             _keepGeneratedCode_ = parseOnOffArg(o);
@@ -157,7 +163,7 @@ public class Fuzion extends Tool
       }
       void process(FuzionOptions options, FUIR fuir)
       {
-        new C(new COptions(options, _binaryName_, _useBoehmGC_, _xdfa_, _cCompiler_, _cFlags_, _keepGeneratedCode_), fuir).compile();
+        new C(new COptions(options, _binaryName_, _useBoehmGC_, _xdfa_, _cCompiler_, _cFlags_, _cTarget_, _keepGeneratedCode_), fuir).compile();
       }
     },
 


### PR DESCRIPTION
added option -CTarget allowing to specify a target for compilation e.g.:
`fz -c -Xgc=off -CTarget=x86_64-pc-linux-musl tests/hello/HelloWorld.fz`