### PR TITLE
ir/fuir/be: Change `statement` into `expression`

### DIFF
--- a/bin/aspell.dict
+++ b/bin/aspell.dict
@@ -1021,7 +1021,7 @@ Prepend
 println
 PRNG
 processModule
-ProcessStatement
+ProcessExpression
 Profiler
 prolog
 prologSuccessBlock
@@ -1193,7 +1193,6 @@ startRow
 startSampler
 startsWith
 statbuf
-StatementVisitor
 staticClazz
 staticTypeOfValue
 stdbool

--- a/src/dev/flang/be/c/C.java
+++ b/src/dev/flang/be/c/C.java
@@ -61,9 +61,9 @@ public class C extends ANY
 
 
   /**
-   * Statement processor used with AbstractInterpreter to generate C code.
+   * Expression processor used with AbstractInterpreter to generate C code.
    */
-  class CodeGen extends AbstractInterpreter.ProcessStatement<CExpr,CStmnt>
+  class CodeGen extends AbstractInterpreter.ProcessExpression<CExpr,CStmnt>
   {
 
 
@@ -91,11 +91,11 @@ public class C extends ANY
 
 
     /**
-     * Called before each statement is processed. May be used to, e.g., produce
+     * Called before each expression is processed. May be used to, e.g., produce
      * tracing code for debugging or a comment.
      */
     @Override
-    public CStmnt statementHeader(int cl, int s)
+    public CStmnt expressionHeader(int cl, int s)
     {
       return comment(String.format("%4d: %s", s, _fuir.codeAtAsString(cl, s)));
     }
@@ -1327,7 +1327,7 @@ public class C extends ANY
         ol.add(acc);
         res = _fuir.clazzIsVoidType(rt)
           ? null
-          : callsResultEscapes || isCall && _fuir.hasData(rt) && _fuir.clazzFieldIsAdrOfValue(cc0)  // NYI: deref an outer ref to value type. Would be nice to have a separate statement for this
+          : callsResultEscapes || isCall && _fuir.hasData(rt) && _fuir.clazzFieldIsAdrOfValue(cc0)  // NYI: deref an outer ref to value type. Would be nice to have a separate expression for this
             ? res.deref()
             : res;
       }

--- a/src/dev/flang/be/interpreter/Excecutor.java
+++ b/src/dev/flang/be/interpreter/Excecutor.java
@@ -34,7 +34,7 @@ import java.util.Arrays;
 import dev.flang.fuir.FUIR;
 import dev.flang.fuir.FUIR.ContractKind;
 import dev.flang.fuir.analysis.AbstractInterpreter;
-import dev.flang.fuir.analysis.AbstractInterpreter.ProcessStatement;
+import dev.flang.fuir.analysis.AbstractInterpreter.ProcessExpression;
 
 import dev.flang.util.Errors;
 import dev.flang.util.FuzionOptions;
@@ -43,10 +43,10 @@ import dev.flang.util.Pair;
 
 
 /**
- * The class Excecutor implements ProcessStatement of the AbstractInterpreter.
+ * The class Excecutor implements ProcessExpression of the AbstractInterpreter.
  * It does the actual execution of the code.
  */
-public class Excecutor extends ProcessStatement<Value, Object>
+public class Excecutor extends ProcessExpression<Value, Object>
 {
 
 
@@ -172,7 +172,7 @@ public class Excecutor extends ProcessStatement<Value, Object>
   }
 
   @Override
-  public Object statementHeader(int cl, int s)
+  public Object expressionHeader(int cl, int s)
   {
     return null;
   }
@@ -239,7 +239,7 @@ public class Excecutor extends ProcessStatement<Value, Object>
     var result = switch (_fuir.clazzKind(cc))
       {
       case Routine :
-        // NYI change call to pass in ai as in match statement?
+        // NYI change call to pass in ai as in match expression?
         var cur = new Instance(cc);
 
         callOnInstance(cc, cur, tvalue, args, true);

--- a/src/dev/flang/be/jvm/CodeGen.java
+++ b/src/dev/flang/be/jvm/CodeGen.java
@@ -51,7 +51,7 @@ import java.util.Arrays;
  * @author Fridtjof Siebert (siebert@tokiwa.software)
  */
 class CodeGen
-  extends AbstractInterpreter.ProcessStatement<Expr, Expr>  // both, values and statements are implemented by Expr
+  extends AbstractInterpreter.ProcessExpression<Expr, Expr>  // both, values and statements are implemented by Expr
   implements ClassFileConstants
 {
 
@@ -151,7 +151,7 @@ class CodeGen
    * @param s site of the next expression
    */
   @Override
-  public Expr statementHeader(int cl, int s)
+  public Expr expressionHeader(int cl, int s)
   {
     return _jvm.trace(cl, s);
   }

--- a/src/dev/flang/fuir/FUIR.java
+++ b/src/dev/flang/fuir/FUIR.java
@@ -1379,7 +1379,7 @@ hw25 is
     if (result == null)
       {
         Errors.fatal(codeAtAsPos(s),
-                     "Expr not supported in FUIR.codeAt", "Statement class: " + e.getClass());
+                     "Expr not supported in FUIR.codeAt", "Expression class: " + e.getClass());
         result = ExprKind.Current; // keep javac from complaining.
       }
     return result;

--- a/src/dev/flang/fuir/analysis/AbstractInterpreter.java
+++ b/src/dev/flang/fuir/analysis/AbstractInterpreter.java
@@ -65,7 +65,7 @@ public class AbstractInterpreter<VALUE, RESULT> extends ANY
    * Interface that defines the operations of the actual interpreter
    * that processes this code.
    */
-  public static abstract class ProcessStatement<VALUE, RESULT> extends ANY implements HasSourcePosition
+  public static abstract class ProcessExpression<VALUE, RESULT> extends ANY implements HasSourcePosition
   {
 
     /**
@@ -114,8 +114,8 @@ public class AbstractInterpreter<VALUE, RESULT> extends ANY
 
 
     /**
-     * Join a List of RESULT from subsequent statements into a compound
-     * statement.  For a code generator, this could, e.g., join statements "a :=
+     * Join a List of RESULT from subsequent expressions into a compound
+     * expression.  For a code generator, this could, e.g., join expressions "a :=
      * 3;" and "b(x);" into a block "{ a := 3; b(x); }".
      */
     public abstract RESULT sequence(List<RESULT> l);
@@ -127,16 +127,14 @@ public class AbstractInterpreter<VALUE, RESULT> extends ANY
     public abstract VALUE unitValue();
 
     /**
-     * Called before each statement is processed. May be used to, e.g., produce
+     * Called before each expression is processed. May be used to, e.g., produce
      * tracing code for debugging or a comment.
-     *
-     * NYI: This should be renamed as expressionHeader, we no longer have statements.
      *
      * @param cl id of clazz we are interpreting
      *
      * @param s site of the next expression
      */
-    public abstract RESULT statementHeader(int cl, int s);
+    public abstract RESULT expressionHeader(int cl, int s);
 
     /**
      * A comment, adds human readable information
@@ -337,7 +335,7 @@ public class AbstractInterpreter<VALUE, RESULT> extends ANY
   /**
    * The processor provided to the constructor.
    */
-  public final ProcessStatement<VALUE, RESULT> _processor;
+  public final ProcessExpression<VALUE, RESULT> _processor;
 
 
   /*---------------------------  constructors  ---------------------------*/
@@ -348,7 +346,7 @@ public class AbstractInterpreter<VALUE, RESULT> extends ANY
    *
    * @param fuir the intermediate code.
    */
-  public AbstractInterpreter(FUIR fuir, ProcessStatement<VALUE, RESULT> processor)
+  public AbstractInterpreter(FUIR fuir, ProcessExpression<VALUE, RESULT> processor)
   {
     if (PRECONDITIONS) require
       (fuir != null,
@@ -560,7 +558,7 @@ public class AbstractInterpreter<VALUE, RESULT> extends ANY
     int last_s = -1;
     for (var s = s0; !containsVoid(stack) && _fuir.withinCode(s) && !_fuir.alwaysResultsInVoid(cl, last_s); s = s + _fuir.codeSizeAt(s))
       {
-        l.add(_processor.statementHeader(cl, s));
+        l.add(_processor.expressionHeader(cl, s));
         l.add(process(cl, pre, stack, s));
         last_s = s;
       }
@@ -614,7 +612,7 @@ public class AbstractInterpreter<VALUE, RESULT> extends ANY
         var stack = new Stack<VALUE>();
         for (var s = c; !containsVoid(stack) && _fuir.withinCode(s); s = s + _fuir.codeSizeAt(s))
           {
-            l.add(_processor.statementHeader(cl, s));
+            l.add(_processor.expressionHeader(cl, s));
             l.add(process(cl, ck == FUIR.ContractKind.Pre, stack, s));
           }
         if (!containsVoid(stack))
@@ -780,7 +778,7 @@ public class AbstractInterpreter<VALUE, RESULT> extends ANY
         }
       default:
         {
-          Errors.fatal("AbstractInterpreter backend does not handle statements of type " + e);
+          Errors.fatal("AbstractInterpreter backend does not handle expressions of type " + e);
           return null;
         }
       }

--- a/src/dev/flang/fuir/analysis/dfa/DFA.java
+++ b/src/dev/flang/fuir/analysis/dfa/DFA.java
@@ -77,7 +77,7 @@ public class DFA extends ANY
 
 
   /**
-   * Dummy unit type as type parameter for AbstractInterpreter.ProcessStatement.
+   * Dummy unit type as type parameter for AbstractInterpreter.ProcessExpression.
    */
   static class Unit
   {
@@ -87,7 +87,7 @@ public class DFA extends ANY
   /**
    * Statement processor used with AbstractInterpreter to perform DFA analysis
    */
-  class Analyze extends AbstractInterpreter.ProcessStatement<Val,Unit>
+  class Analyze extends AbstractInterpreter.ProcessExpression<Val,Unit>
   {
 
 
@@ -133,7 +133,7 @@ public class DFA extends ANY
      * Called before each statement is processed. May be used to, e.g., produce
      * tracing code for debugging or a comment.
      */
-    public Unit statementHeader(int cl, int s)
+    public Unit expressionHeader(int cl, int s)
     {
       if (_reportResults && _options.verbose(9))
         {

--- a/src/dev/flang/fuir/cfg/CFG.java
+++ b/src/dev/flang/fuir/cfg/CFG.java
@@ -558,8 +558,7 @@ public class CFG extends ANY
 
 
   /**
-   * Create call graph for calls made by statement s at index i in code block c
-   * of clazz cl.
+   * Create call graph for calls made by expression at site s of clazz cl.
    *
    * @param cl clazz id
    *
@@ -607,7 +606,7 @@ public class CFG extends ANY
       case Pop: break;
       default:
         {
-          Errors.fatal("Effects backend does not handle statements of type " + s);
+          Errors.fatal("Effects backend does not handle expressions of type " + s);
         }
       }
   }

--- a/src/dev/flang/ir/IR.java
+++ b/src/dev/flang/ir/IR.java
@@ -153,7 +153,7 @@ public abstract class IR extends ANY
    *
    * This also sets _siteStart in case `b` was not already added.
    *
-   * @param b a list of Expr statements to be added.
+   * @param b a list of Exprs, might contain non-Expr values for special cases.
    *
    * @return the index of b
    */


### PR DESCRIPTION
The IR no longer contains statements, these are called expressions now.

