### PR TITLE
fuir: remove call to add in `clazz(SpecialClazzes)`

### DIFF
--- a/src/dev/flang/fuir/FUIR.java
+++ b/src/dev/flang/fuir/FUIR.java
@@ -1344,10 +1344,6 @@ hw25 is
   {
     addClasses();
     var cc = c.getIfCreated();
-    if (cc != null)
-      {
-        add(cc);
-      }
     return cc == null ? -1 : id(cc);
   }
 


### PR DESCRIPTION
this improves interpreter performance by roughly 75%.