### PR TITLE
Remove state from abstract interpreter

### DIFF
--- a/src/dev/flang/be/c/C.java
+++ b/src/dev/flang/be/c/C.java
@@ -244,7 +244,7 @@ public class C extends ANY
      * Get a constant value of type constCl with given byte data d.
      */
     @Override
-    public Pair<CExpr, CStmnt> constData(int constCl, byte[] d)
+    public Pair<CExpr, CStmnt> constData(int s, int constCl, byte[] d)
     {
       return constData(constCl, d, true);
     }
@@ -529,7 +529,7 @@ public class C extends ANY
     /**
      * Access the effect of type ecl that is installed in the environment.
      */
-    public Pair<CExpr, CStmnt> env(int ecl)
+    public Pair<CExpr, CStmnt> env(int s, int ecl)
     {
       var res = CNames.fzThreadEffectsEnvironment.deref().field(_names.env(ecl));
       var evi = CNames.fzThreadEffectsEnvironment.deref().field(_names.envInstalled(ecl));

--- a/src/dev/flang/be/c/C.java
+++ b/src/dev/flang/be/c/C.java
@@ -197,7 +197,7 @@ public class C extends ANY
      * For a given value v of value type vc create a boxed ref value of type rc.
      */
     @Override
-    public Pair<CExpr, CStmnt> box(CExpr val, int vc, int rc)
+    public Pair<CExpr, CStmnt> box(int s, CExpr val, int vc, int rc)
     {
       var t = _names.newTemp();
       var o = CStmnt.seq(CStmnt.lineComment("Box " + _fuir.clazzAsString(vc)),

--- a/src/dev/flang/be/interpreter/Executor.java
+++ b/src/dev/flang/be/interpreter/Executor.java
@@ -242,8 +242,8 @@ public class Executor extends ProcessExpression<Value, Object>
         // NYI change call to pass in ai as in match expression?
         var cur = new Instance(cc);
 
-        callOnInstance(cc, cur, tvalue, args, true);
-        callOnInstance(cc, cur, tvalue, args, false);
+        callOnInstance(s, cc, cur, tvalue, args, true);
+        callOnInstance(s, cc, cur, tvalue, args, false);
 
         Value rres = cur;
         var resf = _fuir.clazzResultField(cc);
@@ -353,7 +353,7 @@ public class Executor extends ProcessExpression<Value, Object>
   }
 
   @Override
-  public Pair<Value, Object> constData(int constCl, byte[] d)
+  public Pair<Value, Object> constData(int s, int constCl, byte[] d)
   {
     // NYI: UNDERDEVELOPEMENT: cache?
     var val = switch (_fuir.getSpecialClazz(constCl))
@@ -384,7 +384,7 @@ public class Executor extends ProcessExpression<Value, Object>
             for (int idx = 0; idx < elCount; idx++)
               {
                 var b = _fuir.deseralizeConst(elementType, bb);
-                var c = constData(elementType, b).v0();
+                var c = constData(s, elementType, b).v0();
                 switch (_fuir.getSpecialClazz(elementType))
                   {
                     case c_i8   : ((byte[])   (arrayData._array))[idx] = (byte)c.i8Value(); break;
@@ -421,7 +421,7 @@ public class Executor extends ProcessExpression<Value, Object>
                 var fr = _fuir.clazzArgClazz(constCl, index);
 
                 var bytes = _fuir.deseralizeConst(fr, b);
-                var c = constData(fr, bytes).v0();
+                var c = constData(s, fr, bytes).v0();
                 var acl = _fuir.clazzArg(constCl, index);
                 Interpreter.setField(acl, constCl, result, c);
               }
@@ -516,7 +516,7 @@ public class Executor extends ProcessExpression<Value, Object>
   }
 
   @Override
-  public Pair<Value, Object> env(int ecl)
+  public Pair<Value, Object> env(int s, int ecl)
   {
     var result = FuzionThread.current()._effects.get(ecl);
     if (result == null)
@@ -536,7 +536,7 @@ public class Executor extends ProcessExpression<Value, Object>
     if (!cc.boolValue())
       {
         var cl = _fuir.clazzAt(s);
-        Errors.runTime(pos(),
+        Errors.runTime(_fuir.codeAtAsPos(s),
                        (ck == ContractKind.Pre ? "Precondition" : "Postcondition") + " does not hold",
                        (ck == ContractKind.Pre ? "For" : "After") + " call to " + _fuir.clazzAsStringNew(cl) + "\n" + callStack(fuir()));
       }
@@ -548,6 +548,10 @@ public class Executor extends ProcessExpression<Value, Object>
    * callOnInstance assigns the arguments to the argument fields of a newly
    * created instance, calls the parents and then this feature.
    *
+   * @parm s site of the call or NO_SITE if unknown (e.g., form instrinsic)
+   *
+   * @param cc clazz id of the called clazz
+   *
    * @param cur the newly created instance
    *
    * @param outer the target of the call
@@ -558,10 +562,10 @@ public class Executor extends ProcessExpression<Value, Object>
    *
    * @return
    */
-  Value callOnInstance(int cc, Instance cur, Value outer, List<Value> args, boolean pre)
+  Value callOnInstance(int s, int cc, Instance cur, Value outer, List<Value> args, boolean pre)
   {
     FuzionThread.current()._callStackFrames.push(cc);
-    FuzionThread.current()._callStack.push(site());
+    FuzionThread.current()._callStack.push(s);
 
     new AbstractInterpreter<>(_fuir, new Executor(cur, outer, args))
       .process(cc, pre);

--- a/src/dev/flang/be/interpreter/Executor.java
+++ b/src/dev/flang/be/interpreter/Executor.java
@@ -536,7 +536,7 @@ public class Executor extends ProcessExpression<Value, Object>
     if (!cc.boolValue())
       {
         var cl = _fuir.clazzAt(s);
-        Errors.runTime(_fuir.codeAtAsPos(s),
+        Errors.runTime(_fuir.sitePos(s),
                        (ck == ContractKind.Pre ? "Precondition" : "Postcondition") + " does not hold",
                        (ck == ContractKind.Pre ? "For" : "After") + " call to " + _fuir.clazzAsStringNew(cl) + "\n" + callStack(fuir()));
       }
@@ -590,7 +590,7 @@ public class Executor extends ProcessExpression<Value, Object>
       {
         sb.append(_fuir.clazzAsStringNew(frame)).append(": ");
       }
-    sb.append(_fuir.codeAtAsPos(callSite).show()).append("\n");
+    sb.append(_fuir.sitePos(callSite).show()).append("\n");
   }
 
 

--- a/src/dev/flang/be/interpreter/Executor.java
+++ b/src/dev/flang/be/interpreter/Executor.java
@@ -326,7 +326,7 @@ public class Executor extends ProcessExpression<Value, Object>
 
 
   @Override
-  public Pair<Value, Object> box(Value v, int vc, int rc)
+  public Pair<Value, Object> box(int s, Value v, int vc, int rc)
   {
     return pair(new Boxed(rc, vc, v /* .cloneValue(vcc) */));
   }

--- a/src/dev/flang/be/interpreter/Intrinsics.java
+++ b/src/dev/flang/be/interpreter/Intrinsics.java
@@ -61,6 +61,8 @@ import java.util.stream.Collectors;
 
 import dev.flang.fuir.FUIR;
 
+import static dev.flang.ir.IR.NO_SITE;
+
 import dev.flang.util.ANY;
 import dev.flang.util.Errors;
 import dev.flang.util.List;
@@ -902,7 +904,7 @@ public class Intrinsics extends ANY
         {
           var oc   = executor.fuir().clazzArgClazz(innerClazz, 0);
           var call = executor.fuir().lookupCall(oc);
-          var t = new Thread(() -> executor.callOnInstance(call, new Instance(call), args.get(1), new List<>(), false));
+          var t = new Thread(() -> executor.callOnInstance(NO_SITE, call, new Instance(call), args.get(1), new List<>(), false));
           t.setDaemon(true);
           t.start();
           return new i64Value(_startedThreads_.add(t));
@@ -1515,7 +1517,7 @@ public class Intrinsics extends ANY
               var oc   = executor.fuir().clazzActualGeneric(innerClazz, 0);
               var call = executor.fuir().lookupCall(oc);
               try {
-                var ignore = executor.callOnInstance(call, new Instance(call), args.get(1), new List<>(), false);
+                var ignore = executor.callOnInstance(NO_SITE, call, new Instance(call), args.get(1), new List<>(), false);
                 return new boolValue(true);
               } catch (Abort a) {
                 if (a._effect == cl)

--- a/src/dev/flang/be/jvm/Choices.java
+++ b/src/dev/flang/be/jvm/Choices.java
@@ -578,7 +578,7 @@ public class Choices extends ANY implements ClassFileConstants
                                           _names.getTag(subjClazz),
                                           "()I",
                                           PrimitiveType.type_int,
-                                          ai._processor.pos().line()));
+                                          _fuir.codeAtAsPos(s).line()));
 
           var lEnd = new Label();
           for (var mc = 0; mc < _fuir.matchCaseCount(s); mc++)

--- a/src/dev/flang/be/jvm/Choices.java
+++ b/src/dev/flang/be/jvm/Choices.java
@@ -578,7 +578,7 @@ public class Choices extends ANY implements ClassFileConstants
                                           _names.getTag(subjClazz),
                                           "()I",
                                           PrimitiveType.type_int,
-                                          _fuir.codeAtAsPos(s).line()));
+                                          _fuir.sitePos(s).line()));
 
           var lEnd = new Label();
           for (var mc = 0; mc < _fuir.matchCaseCount(s); mc++)

--- a/src/dev/flang/be/jvm/CodeGen.java
+++ b/src/dev/flang/be/jvm/CodeGen.java
@@ -378,7 +378,7 @@ class CodeGen
                 tvalue = tvalue.andThen(Expr.checkcast(_types.javaType(tc)));
               }
             var call = args(false, tvalue, args, cc, _fuir.clazzArgCount(cc))
-              .andThen(_types.invokeStaticCombindedPreAndCall(cc, _fuir.codeAtAsPos(s).line()));
+              .andThen(_types.invokeStaticCombindedPreAndCall(cc, _fuir.sitePos(s).line()));
 
             var rt = _fuir.clazzResultClazz(cc);
             res = makePair(call, rt);
@@ -540,7 +540,7 @@ class CodeGen
           }
         addStub(si, tt, cc, dn, ds, isCall, initLocals);
       }
-    return Expr.invokeInterface(intfc._name, dn, ds, dr, _fuir.codeAtAsPos(si).line());
+    return Expr.invokeInterface(intfc._name, dn, ds, dr, _fuir.sitePos(si).line());
   }
 
 
@@ -726,7 +726,7 @@ class CodeGen
                       tvalue = tvalue.andThen(Expr.checkcast(_types.resultType(oc)));
                     }
                   var call = args(false, tvalue, args, cc, _fuir.clazzArgCount(cc))
-                    .andThen(_types.invokeStatic(cc, preCalled, _fuir.codeAtAsPos(si).line()));
+                    .andThen(_types.invokeStatic(cc, preCalled, _fuir.sitePos(si).line()));
 
                   res = makePair(call, rt);
                 }
@@ -1000,7 +1000,7 @@ class CodeGen
                     .andThen(c.v0());
                 }
               result = result
-                .andThen(_types.invokeStaticCombindedPreAndCall(constCl, _fuir.codeAtAsPos(si).line()));
+                .andThen(_types.invokeStaticCombindedPreAndCall(constCl, _fuir.sitePos(si).line()));
 
               yield new Pair<>(result, Expr.UNIT);
             }

--- a/src/dev/flang/be/jvm/CodeGen.java
+++ b/src/dev/flang/be/jvm/CodeGen.java
@@ -780,7 +780,7 @@ class CodeGen
    * For a given value v of value type vc create a boxed ref value of type rc.
    */
   @Override
-  public Pair<Expr, Expr> box(Expr val, int vc, int rc)
+  public Pair<Expr, Expr> box(int s, Expr val, int vc, int rc)
   {
     var res = val;
     if (!_fuir.clazzIsRef(vc) && _fuir.clazzIsRef(rc))  // NYI: CLEANUP: would be good if the AbstractInterpreter would not call box() in this case

--- a/src/dev/flang/be/jvm/CodeGen.java
+++ b/src/dev/flang/be/jvm/CodeGen.java
@@ -378,7 +378,7 @@ class CodeGen
                 tvalue = tvalue.andThen(Expr.checkcast(_types.javaType(tc)));
               }
             var call = args(false, tvalue, args, cc, _fuir.clazzArgCount(cc))
-              .andThen(_types.invokeStaticCombindedPreAndCall(cc, pos().line()));
+              .andThen(_types.invokeStaticCombindedPreAndCall(cc, _fuir.codeAtAsPos(s).line()));
 
             var rt = _fuir.clazzResultClazz(cc);
             res = makePair(call, rt);
@@ -466,7 +466,7 @@ class CodeGen
 
         var dynCall = args(true, tvalue, args, cc0, isCall ? _fuir.clazzArgCount(cc0) : 1)
           .andThen(Expr.comment("Dynamic access of " + _fuir.clazzAsString(cc0)))
-          .andThen(addDynamicFunctionAndStubs(cc0, ccs, isCall));
+          .andThen(addDynamicFunctionAndStubs(si, cc0, ccs, isCall));
         if (AbstractInterpreter.clazzHasUnitValue(_fuir, rt))
           {
             s = dynCall;  // make sure we do not throw away the code even if it is of unit type
@@ -506,17 +506,19 @@ class CodeGen
    * interface with a dynamic function and add implementations to each actual
    * target.
    *
+   * @param si site of the access expression, must be ExprKind.Assign or ExprKind.Call
+   *
    * @param cc0 a feature whose outer feature is a ref that has several actual instances.
    *
    * @return the invokeinterface expression that performs the call
    */
-  private Expr addDynamicFunctionAndStubs(int cc0, int[] ccs, boolean isCall)
+  private Expr addDynamicFunctionAndStubs(int si, int cc0, int[] ccs, boolean isCall)
   {
     var intfc = _types.interfaceFile(_fuir.clazzOuterClazz(cc0));
     var rc = _fuir.clazzResultClazz(cc0);
     var dn = _names.dynamicFunction(cc0);
-    var ds = isCall ? _types.dynDescriptor(cc0, false)          : "(" + _types.javaType(rc).argDescriptor() + ")V";
-    var dr = isCall ? _types.resultType(rc)                       : PrimitiveType.type_void;
+    var ds = isCall ? _types.dynDescriptor(cc0, false) : "(" + _types.javaType(rc).argDescriptor() + ")V";
+    var dr = isCall ? _types.resultType(rc)            : PrimitiveType.type_void;
     if (!intfc.hasMethod(dn))
       {
         intfc.method(ACC_PUBLIC | ACC_ABSTRACT, dn, ds, new List<>());
@@ -534,17 +536,19 @@ class CodeGen
           }
         else
           {
-            initLocals = Types.addToLocals(initLocals,  _types.javaType(rc));
+            initLocals = Types.addToLocals(initLocals, _types.javaType(rc));
           }
-        addStub(tt, cc, dn, ds, isCall, initLocals);
+        addStub(si, tt, cc, dn, ds, isCall, initLocals);
       }
-    return Expr.invokeInterface(intfc._name, dn, ds, dr, pos().line());
+    return Expr.invokeInterface(intfc._name, dn, ds, dr, _fuir.codeAtAsPos(si).line());
   }
 
 
   /**
    * Create a stub method, i.e., an implementation of a dynamic function defined
    * in an interface that performs a static access for the given target type.
+   *
+   * @param si site of the access expression, must be ExprKind.Assign or ExprKind.Call
    *
    * @param tt the target clazz. Note that tt may be different to
    * _fuir.clazzOuterClazz(cc), e.g., if tt is some type defining abstract
@@ -560,7 +564,7 @@ class CodeGen
    * @param isCall true if the access is a call, false if it is an assignment to
    * a field.
    */
-  private void addStub(int tt, int cc, String dn, String ds, boolean isCall, List<VerificationType> initLocals)
+  private void addStub(int si, int tt, int cc, String dn, String ds, boolean isCall, List<VerificationType> initLocals)
   {
     var cf = _types.classFile(tt);
     if (!cf.hasMethod(dn))
@@ -586,7 +590,7 @@ class CodeGen
             var t = _types.javaType(_fuir.clazzResultClazz(cc));
             na.add(t.load(1));
           }
-        var p = staticAccess(NO_SITE, tt, cc, tv, na, isCall);
+        var p = staticAccess(si, tt, cc, tv, na, isCall);
         var code = p.v1()
           .andThen(p.v0() == null ? Expr.UNIT : p.v0())
           .andThen(retoern);
@@ -602,7 +606,7 @@ class CodeGen
    * access to create code if there is only one possible target and by stubs to
    * perform the actual access.
    *
-   * @param s site of the access or NO_SITE if this is a call in an interface method stub.
+   * @param si site of the access or NO_SITE if this is a call in an interface method stub.
    *
    * @param tt the target clazz. Note that tt may be different to
    * _fuir.clazzOuterClazz(cc), e.g., if tt is some type defining abstract
@@ -722,7 +726,7 @@ class CodeGen
                       tvalue = tvalue.andThen(Expr.checkcast(_types.resultType(oc)));
                     }
                   var call = args(false, tvalue, args, cc, _fuir.clazzArgCount(cc))
-                    .andThen(_types.invokeStatic(cc, preCalled, pos().line()));
+                    .andThen(_types.invokeStatic(cc, preCalled, _fuir.codeAtAsPos(si).line()));
 
                   res = makePair(call, rt);
                 }
@@ -878,9 +882,9 @@ class CodeGen
   /**
    * Get a constant value of type constCl with given byte data d.
    */
-  public Pair<Expr, Expr> constData(int constCl, byte[] d)
+  public Pair<Expr, Expr> constData(int si, int constCl, byte[] d)
   {
-    var c = createConstant(constCl, d);
+    var c = createConstant(si, constCl, d);
     return switch (constantCreationStrategy(constCl))
       {
       case onEveryUse               -> c;  // create constant inline
@@ -936,7 +940,7 @@ class CodeGen
    *
    * @return the value and code to produce the constant
    */
-  Pair<Expr, Expr> createConstant(int constCl, byte[] d)
+  Pair<Expr, Expr> createConstant(int si, int constCl, byte[] d)
   {
     return switch (_fuir.getSpecialClazz(constCl))
       {
@@ -971,7 +975,7 @@ class CodeGen
               for (int idx = 0; idx < elCount; idx++)
                 {
                   var b = _fuir.deseralizeConst(elementType, bb);
-                  var c = createConstant(elementType, b);
+                  var c = createConstant(si, elementType, b);
                   result = result
                     .andThen(Expr.DUP)                             // T[], T[]
                     .andThen(Expr.checkcast(jt.array()))
@@ -990,13 +994,13 @@ class CodeGen
                 {
                   var fr = _fuir.clazzArgClazz(constCl, index);
                   var bytes = _fuir.deseralizeConst(fr, b);
-                  var c = createConstant(fr, bytes);
+                  var c = createConstant(si, fr, bytes);
                   result = result
                     .andThen(c.v1())
                     .andThen(c.v0());
                 }
               result = result
-                .andThen(_types.invokeStaticCombindedPreAndCall(constCl, pos().line()));
+                .andThen(_types.invokeStaticCombindedPreAndCall(constCl, _fuir.codeAtAsPos(si).line()));
 
               yield new Pair<>(result, Expr.UNIT);
             }
@@ -1053,7 +1057,7 @@ class CodeGen
   /**
    * Access the effect of type ecl that is installed in the environment.
    */
-  public Pair<Expr, Expr> env(int ecl)
+  public Pair<Expr, Expr> env(int s, int ecl)
   {
     var res =
       Expr.iconst(_fuir.clazzId2num(ecl))

--- a/src/dev/flang/be/jvm/CodeGen.java
+++ b/src/dev/flang/be/jvm/CodeGen.java
@@ -779,6 +779,7 @@ class CodeGen
   /**
    * For a given value v of value type vc create a boxed ref value of type rc.
    */
+  @Override
   public Pair<Expr, Expr> box(Expr val, int vc, int rc)
   {
     var res = val;
@@ -799,6 +800,7 @@ class CodeGen
   /**
    * Get the current instance
    */
+  @Override
   public Pair<Expr, Expr> current(int s)
   {
     var cl = _fuir.clazzAt(s);
@@ -816,6 +818,7 @@ class CodeGen
   /**
    * Get the outer instance the given clazz is called on.
    */
+  @Override
   public Pair<Expr, Expr> outer(int s)
   {
     if (PRECONDITIONS) require
@@ -837,6 +840,7 @@ class CodeGen
    *
    * @return code to read arg #i from its slot.
    */
+  @Override
   public Expr arg(int s, int i)
   {
     if (PRECONDITIONS) require
@@ -882,6 +886,7 @@ class CodeGen
   /**
    * Get a constant value of type constCl with given byte data d.
    */
+  @Override
   public Pair<Expr, Expr> constData(int si, int constCl, byte[] d)
   {
     var c = createConstant(si, constCl, d);
@@ -1026,6 +1031,7 @@ class CodeGen
    *
    * @return the code for the match, produces unit type result.
    */
+  @Override
   public Pair<Expr, Expr> match(int s, AbstractInterpreter<Expr, Expr> ai, Expr sub)
   {
     var code = _choices.match(_jvm, ai, s, sub);
@@ -1047,6 +1053,7 @@ class CodeGen
    *
    * @return code to produce the tagged value as a result.
    */
+  @Override
   public Pair<Expr, Expr> tag(int s, Expr value, int newcl, int tagNum)
   {
     var res = _choices.tag(_jvm, s, value, newcl, tagNum);
@@ -1057,6 +1064,7 @@ class CodeGen
   /**
    * Access the effect of type ecl that is installed in the environment.
    */
+  @Override
   public Pair<Expr, Expr> env(int s, int ecl)
   {
     var res =
@@ -1074,6 +1082,7 @@ class CodeGen
    * Process a contract of kind ck of clazz cl that results in bool value cc
    * (i.e., the contract fails if !cc).
    */
+  @Override
   public Expr contract(int s, FUIR.ContractKind ck, Expr cc)
   {
     var cl = _fuir.clazzAt(s);

--- a/src/dev/flang/be/jvm/JVM.java
+++ b/src/dev/flang/be/jvm/JVM.java
@@ -1032,7 +1032,7 @@ should be avoided as much as possible.
   {
     if (TRACE)
       {
-        var p = _fuir.codeAtAsPos(s);
+        var p = _fuir.sitePos(s);
         var msg = "IN " + _fuir.siteAsString(s) + ": " + _fuir.codeAtAsString(s) +
           (p == null ? "" : " " + p.show());
         return callRuntimeTrace(msg);

--- a/src/dev/flang/be/jvm/Types.java
+++ b/src/dev/flang/be/jvm/Types.java
@@ -28,6 +28,8 @@ package dev.flang.be.jvm;
 
 import dev.flang.fuir.FUIR;
 
+import static dev.flang.ir.IR.NO_SITE;
+
 import dev.flang.be.jvm.classfile.ClassFile;
 import dev.flang.be.jvm.classfile.ClassFileConstants;
 import dev.flang.be.jvm.classfile.Expr;
@@ -236,8 +238,8 @@ public class Types extends ANY implements ClassFileConstants
   Expr invokeStaticCombindedPreAndCall(int cc, int line)
   {
     var cls   = _names.javaClass(cc);
-    var fname = _fuir.clazzContract(cc, FUIR.ContractKind.Pre, 0) >= 0 ? Names.COMBINED_NAME
-                                                                       : Names.ROUTINE_NAME;
+    var fname = _fuir.clazzContract(cc, FUIR.ContractKind.Pre, 0) != NO_SITE ? Names.COMBINED_NAME
+                                                                             : Names.ROUTINE_NAME;
     return Expr.invokeStatic(cls,
                              fname,
                              descriptor(cc, false),

--- a/src/dev/flang/fe/DFA.java
+++ b/src/dev/flang/fe/DFA.java
@@ -130,7 +130,7 @@ public class DFA extends ANY
                         !_mir.fieldIsOuterRef(af) &&
                         !giveUpDueToControlFlowNYI)
                       {
-                        FeErrors.fieldNotInitialized(_mir, _mir.codeAtAsPos(s), af);
+                        FeErrors.fieldNotInitialized(_mir, _mir.sitePos(s), af);
                       }
                   }
                 lastWasCurrent = false;

--- a/src/dev/flang/fuir/FUIR.java
+++ b/src/dev/flang/fuir/FUIR.java
@@ -1081,7 +1081,7 @@ hw25 is
    * @param ix the index of the pre- or post-condition, 0 for the first
    * condition
    *
-   * @return a code id referring to cl's pre- or post-condition, -1 if cl does
+   * @return a site referring to cl's pre- or post-condition, NO_SITE if cl does
    * not have a pre- or post-condition with the given index
    */
   public int clazzContract(int cl, ContractKind ck, int ix)
@@ -1112,7 +1112,7 @@ hw25 is
           }
         i++;
       }
-    var res = -1;
+    var res = NO_SITE;
     if (cond != null && i < cond.size())
       {
         // create 64-bit key from cl, ck and ix as follows:
@@ -2552,7 +2552,7 @@ hw25 is
    */
   public boolean hasPrecondition(int cl)
   {
-    return clazzContract(cl, FUIR.ContractKind.Pre, 0) != -1;
+    return clazzContract(cl, FUIR.ContractKind.Pre, 0) != NO_SITE;
   }
 
 

--- a/src/dev/flang/fuir/FUIR.java
+++ b/src/dev/flang/fuir/FUIR.java
@@ -1483,7 +1483,7 @@ hw25 is
       }
     if (result == null)
       {
-        Errors.fatal(codeAtAsPos(s),
+        Errors.fatal(sitePos(s),
                      "Expr not supported in FUIR.codeAt", "Expression class: " + e.getClass());
         result = ExprKind.Current; // keep javac from complaining.
       }
@@ -1730,7 +1730,7 @@ hw25 is
         else
           {
             throw new Error("Unexpected expression in accessedClazzesDynamic, must be ExprKind.Call or ExprKind.Assign, is " +
-                            codeAt(s) + " " + e.getClass() + " at " + codeAtAsPos(s).show());
+                            codeAt(s) + " " + e.getClass() + " at " + sitePos(s).show());
           }
         var found = new TreeSet<Integer>();
         var result = new List<Integer>();
@@ -2198,7 +2198,7 @@ hw25 is
 
 
   /**
-   * Helper for dumpCode and codeAtAsPos to create a label for given code block.
+   * Helper for dumpCode and sitePos to create a label for given code block.
    *
    * @param c a code block;
    *
@@ -2265,7 +2265,7 @@ hw25 is
    *
    * @return the source code position or null if not available.
    */
-  public SourcePosition codeAtAsPos(int s)
+  public SourcePosition sitePos(int s)
   {
     if (PRECONDITIONS) require
       (s >= 0,

--- a/src/dev/flang/fuir/FUIR.java
+++ b/src/dev/flang/fuir/FUIR.java
@@ -1469,7 +1469,8 @@ hw25 is
   public ExprKind codeAt(int s)
   {
     if (PRECONDITIONS) require
-      (s >= SITE_BASE, withinCode(s));
+      (s >= SITE_BASE,
+       withinCode(s));
 
     ExprKind result;
     var e = getExpr(s);
@@ -2268,7 +2269,7 @@ hw25 is
   public SourcePosition sitePos(int s)
   {
     if (PRECONDITIONS) require
-      (s >= 0,
+      (s >= SITE_BASE,
        withinCode(s));
 
     var e = getExpr(s);
@@ -2394,7 +2395,7 @@ hw25 is
   private int codeIndex2(int si, int s, int delta)
   {
     check
-      (si >= 0 && s >= 0); // this code uses negative results if site was not found yet, so better make sure a site is never negative!
+      (si >= SITE_BASE && s >= SITE_BASE); // this code uses negative results if site was not found yet, so better make sure a site is never negative!
 
     if (si == s)
       {

--- a/src/dev/flang/fuir/analysis/AbstractInterpreter.java
+++ b/src/dev/flang/fuir/analysis/AbstractInterpreter.java
@@ -70,12 +70,6 @@ public class AbstractInterpreter<VALUE, RESULT> extends ANY
   {
 
     /**
-     * FUIR we are currently interpreting
-     */
-    FUIR _fuir;
-
-
-    /**
      * Join a List of RESULT from subsequent expressions into a compound
      * expression.  For a code generator, this could, e.g., join expressions "a :=
      * 3;" and "b(x);" into a block "{ a := 3; b(x); }".
@@ -444,7 +438,6 @@ public class AbstractInterpreter<VALUE, RESULT> extends ANY
    */
   void assignOuterAndArgFields(List<RESULT> l, int s)
   {
-    _processor._fuir = _fuir;
     var cl = _fuir.clazzAt(s);
     var or = _fuir.clazzOuterRef(cl);
     if (or != -1)
@@ -611,7 +604,6 @@ public class AbstractInterpreter<VALUE, RESULT> extends ANY
       }
     var e = _fuir.codeAt(s);
 
-    _processor._fuir = _fuir;
     switch (e)
       {
       case Assign:

--- a/src/dev/flang/fuir/analysis/AbstractInterpreter.java
+++ b/src/dev/flang/fuir/analysis/AbstractInterpreter.java
@@ -176,8 +176,14 @@ public class AbstractInterpreter<VALUE, RESULT> extends ANY
 
     /**
      * For a given value v of value type vc create a boxed ref value of type rc.
+     *
+     * @param s site of the box expression
+     *
+     * @param vc the clazz id of the type of the unboxed value
+     *
+     * @param rc the clazz id of the type of the boxed value
      */
-    public abstract Pair<VALUE, RESULT> box(VALUE v, int vc, int rc);
+    public abstract Pair<VALUE, RESULT> box(int s, VALUE v, int vc, int rc);
 
     /**
      * Get the current instance
@@ -639,7 +645,7 @@ public class AbstractInterpreter<VALUE, RESULT> extends ANY
           else
             {
               var val = pop(stack, vc);
-              var r = _processor.box(val, vc, rc);
+              var r = _processor.box(s, val, vc, rc);
               push(stack, rc, r.v0());
               return r.v1();
             }

--- a/src/dev/flang/fuir/analysis/AbstractInterpreter.java
+++ b/src/dev/flang/fuir/analysis/AbstractInterpreter.java
@@ -572,8 +572,9 @@ public class AbstractInterpreter<VALUE, RESULT> extends ANY
       {
         var s = _fuir.clazzContract(cl, ck, ci);
         var stack = new Stack<VALUE>();
-        for (; !containsVoid(stack) && _fuir.withinCode(s); s = s + _fuir.codeSizeAt(s))
+        for (var si = s; !containsVoid(stack) && _fuir.withinCode(si); si = si + _fuir.codeSizeAt(si))
           {
+            s = si; // when exiting this loop, s will be the site of the last expression, while si no be within the code
             l.add(_processor.expressionHeader(s));
             l.add(process(s, stack));
           }

--- a/src/dev/flang/fuir/analysis/AbstractInterpreter.java
+++ b/src/dev/flang/fuir/analysis/AbstractInterpreter.java
@@ -574,7 +574,7 @@ public class AbstractInterpreter<VALUE, RESULT> extends ANY
         var stack = new Stack<VALUE>();
         for (var si = s; !containsVoid(stack) && _fuir.withinCode(si); si = si + _fuir.codeSizeAt(si))
           {
-            s = si; // when exiting this loop, s will be the site of the last expression, while si no be within the code
+            s = si; // when exiting this loop, s will be the site of the last expression, while si will not be within the code
             l.add(_processor.expressionHeader(s));
             l.add(process(s, stack));
           }

--- a/src/dev/flang/fuir/analysis/AbstractInterpreter.java
+++ b/src/dev/flang/fuir/analysis/AbstractInterpreter.java
@@ -36,7 +36,6 @@ import dev.flang.util.ANY;
 import dev.flang.util.Errors;
 import dev.flang.util.List;
 import dev.flang.util.Pair;
-import dev.flang.util.HasSourcePosition;
 import dev.flang.util.SourcePosition;
 
 

--- a/src/dev/flang/fuir/analysis/AbstractInterpreter.java
+++ b/src/dev/flang/fuir/analysis/AbstractInterpreter.java
@@ -30,6 +30,8 @@ import java.util.Stack;
 
 import dev.flang.fuir.FUIR;
 
+import static dev.flang.ir.IR.NO_SITE;
+
 import dev.flang.util.ANY;
 import dev.flang.util.Errors;
 import dev.flang.util.List;
@@ -65,52 +67,13 @@ public class AbstractInterpreter<VALUE, RESULT> extends ANY
    * Interface that defines the operations of the actual interpreter
    * that processes this code.
    */
-  public static abstract class ProcessExpression<VALUE, RESULT> extends ANY implements HasSourcePosition
+  public static abstract class ProcessExpression<VALUE, RESULT> extends ANY
   {
 
     /**
      * FUIR we are currently interpreting
      */
     FUIR _fuir;
-
-
-    /**
-     * id of clazz we are interpreting, will be set by AbstractInterpreter before
-     * performing an Expression.
-     */
-    int _cl = -1;
-
-
-    /**
-     * true iff interpreting _cl's precondition, false for _cl itself, will be
-     * set by AbstractInterpreter before performing an Expression.
-     */
-    boolean _pre = false;
-
-
-    /**
-     * current site, will be set by AbstractInterpreter before performing an
-     * Expression.
-     */
-    int _s;
-
-
-    /**
-     * Create and return the actual source code position held by this instance.
-     */
-    public SourcePosition pos()
-    {
-      return _fuir.codeAtAsPos(_s);
-    }
-
-
-    /**
-     * Return the actual source code position held by this instance.
-     */
-    public int site()
-    {
-      return _s;
-    }
 
 
     /**
@@ -241,8 +204,14 @@ public class AbstractInterpreter<VALUE, RESULT> extends ANY
 
     /**
      * Get a constant value of type constCl with given byte data d.
+     *
+     * @param s site of the constant
+     *
+     * @param constCl clazz id of the type of the constant
+     *
+     * @param d the constants as serialized bytes.
      */
-    public abstract Pair<VALUE, RESULT> constData(int constCl, byte[] d);
+    public abstract Pair<VALUE, RESULT> constData(int s, int constCl, byte[] d);
 
     /**
      * Perform a match on value subv.
@@ -257,13 +226,26 @@ public class AbstractInterpreter<VALUE, RESULT> extends ANY
 
     /**
      * Create a tagged value of type newcl from an untagged value for type valuecl.
+     *
+     * @param s site of the match
+     *
+     * @param value the value that is to be tagged
+     *
+     * @param newcl the clazz id of the new choice type of the tagged value
+     *
+     * @param tagNum the number of the of the choice types's variant value is
+     * tagged as
      */
     public abstract Pair<VALUE, RESULT> tag(int s, VALUE value, int newcl, int tagNum);
 
     /**
      * Access the effect of type ecl that is installed in the environment.
+     *
+     * @param s site of the env expression
+     *
+     * @param ecl clazz id of the effect type
      */
-    public abstract Pair<VALUE, RESULT> env(int ecl);
+    public abstract Pair<VALUE, RESULT> env(int s, int ecl);
 
     /**
      * Process a contract of kind ck of clazz cl that results in bool value cc
@@ -503,7 +485,7 @@ public class AbstractInterpreter<VALUE, RESULT> extends ANY
     var l = new List<RESULT>();
     var s = pre ? _fuir.clazzContract(cl, FUIR.ContractKind.Pre, 0)
                 : _fuir.clazzCode(cl);
-    if (s != -1) // NYI: NO_SITE?
+    if (s != NO_SITE)
       {
         assignOuterAndArgFields(l, s);
       }
@@ -587,7 +569,7 @@ public class AbstractInterpreter<VALUE, RESULT> extends ANY
   {
     var l = new List<RESULT>();
     for (var ci = 0;
-         _fuir.clazzContract(cl, ck, ci) != -1;
+         _fuir.clazzContract(cl, ck, ci) != NO_SITE;
          ci++)
       {
         var s = _fuir.clazzContract(cl, ck, ci);
@@ -624,12 +606,7 @@ public class AbstractInterpreter<VALUE, RESULT> extends ANY
       }
     var e = _fuir.codeAt(s);
 
-    var cl = _fuir.clazzAt(s);
-    var pre = _fuir.isPreconditionAt(s);
     _processor._fuir = _fuir;
-    _processor._cl = cl;
-    _processor._pre = pre;
-    _processor._s = s;
     switch (e)
       {
       case Assign:
@@ -692,6 +669,7 @@ public class AbstractInterpreter<VALUE, RESULT> extends ANY
       case Current:
         {
           var r = _processor.current(s);
+          var cl = _fuir.clazzAt(s);
           push(stack, cl, r.v0());
           return r.v1();
         }
@@ -699,7 +677,7 @@ public class AbstractInterpreter<VALUE, RESULT> extends ANY
         {
           var constCl = _fuir.constClazz(s);
           var d = _fuir.constData(s);
-          var r = _processor.constData(constCl, d);
+          var r = _processor.constData(s, constCl, d);
 
           if (CHECKS) check
             // check that constant creation has no side effects.
@@ -736,7 +714,7 @@ public class AbstractInterpreter<VALUE, RESULT> extends ANY
       case Env:
         {
           var ecl = _fuir.envClazz(s);
-          var r = _processor.env(ecl);
+          var r = _processor.env(s, ecl);
           push(stack, ecl, r.v0());
           return r.v1();
         }

--- a/src/dev/flang/fuir/analysis/AbstractInterpreter.java
+++ b/src/dev/flang/fuir/analysis/AbstractInterpreter.java
@@ -232,7 +232,7 @@ public class AbstractInterpreter<VALUE, RESULT> extends ANY
      *
      * @param newcl the clazz id of the new choice type of the tagged value
      *
-     * @param tagNum the number of the of the choice types's variant value is
+     * @param tagNum the number of the choice types's variant value is
      * tagged as
      */
     public abstract Pair<VALUE, RESULT> tag(int s, VALUE value, int newcl, int tagNum);

--- a/src/dev/flang/fuir/analysis/dfa/Call.java
+++ b/src/dev/flang/fuir/analysis/dfa/Call.java
@@ -391,7 +391,7 @@ public class Call extends ANY implements Comparable<Call>, Context
   {
     var s = site();
     return s == IR.NO_SITE ? null
-                           : _dfa._fuir.codeAtAsPos(s);
+                           : _dfa._fuir.sitePos(s);
   }
 
 
@@ -429,7 +429,7 @@ public class Call extends ANY implements Comparable<Call>, Context
     var result = getEffectCheck(ecl);
     if (result == null && _dfa._reportResults && !_dfa._fuir.clazzOriginalName(_cc).equals("effect.type.unsafe_get"))
       {
-        DfaErrors.usedEffectNeverInstantiated(_dfa._fuir.codeAtAsPos(s),
+        DfaErrors.usedEffectNeverInstantiated(_dfa._fuir.sitePos(s),
                                               _dfa._fuir.clazzAsString(ecl),
                                               this);
         _dfa._missingEffects.add(ecl);

--- a/src/dev/flang/fuir/analysis/dfa/Call.java
+++ b/src/dev/flang/fuir/analysis/dfa/Call.java
@@ -418,18 +418,18 @@ public class Call extends ANY implements Comparable<Call>, Context
    * Report an error if no effect found during last pass (i.e.,
    * _dfa._reportResults is set).
    *
-   * @param pos a source for a position to be used in error produced
+   * @param s site of the code requiring the effect
    *
    * @param ecl clazz defining the effect type.
    *
    * @return null in case no effect of type ecl was found
    */
-  Value getEffectForce(HasSourcePosition pos, int ecl)
+  Value getEffectForce(int s, int ecl)
   {
     var result = getEffectCheck(ecl);
     if (result == null && _dfa._reportResults && !_dfa._fuir.clazzOriginalName(_cc).equals("effect.type.unsafe_get"))
       {
-        DfaErrors.usedEffectNeverInstantiated(pos,
+        DfaErrors.usedEffectNeverInstantiated(_dfa._fuir.codeAtAsPos(s),
                                               _dfa._fuir.clazzAsString(ecl),
                                               this);
         _dfa._missingEffects.add(ecl);

--- a/src/dev/flang/fuir/analysis/dfa/DFA.java
+++ b/src/dev/flang/fuir/analysis/dfa/DFA.java
@@ -299,7 +299,7 @@ public class DFA extends ANY
             {
               detail += _fuir.clazzAsStringNew(ccs[ccii]) + ", ";
             }
-          Errors.error(_fuir.codeAtAsPos(s),
+          Errors.error(_fuir.sitePos(s),
                        "NYI: in "+_fuir.siteAsString(s)+" no targets for "+_fuir.codeAtAsString(s)+" target "+tvalue,
                        detail);
 

--- a/src/dev/flang/fuir/analysis/dfa/DFA.java
+++ b/src/dev/flang/fuir/analysis/dfa/DFA.java
@@ -471,7 +471,7 @@ public class DFA extends ANY
     /**
      * Get a constant value of type constCl with given byte data d.
      */
-    public Pair<Val, Unit> constData(int constCl, byte[] d)
+    public Pair<Val, Unit> constData(int s, int constCl, byte[] d)
     {
       var o = _unit_;
       var r = switch (_fuir.getSpecialClazz(constCl))
@@ -493,8 +493,8 @@ public class DFA extends ANY
             if (!_fuir.clazzIsChoice(constCl))
               {
                 yield _fuir.clazzIsArray(constCl)
-                  ? newArrayConst(constCl, _call, ByteBuffer.wrap(d).order(ByteOrder.LITTLE_ENDIAN))
-                  : newValueConst(constCl, _call, ByteBuffer.wrap(d).order(ByteOrder.LITTLE_ENDIAN));
+                  ? newArrayConst(s, constCl, _call, ByteBuffer.wrap(d).order(ByteOrder.LITTLE_ENDIAN))
+                  : newValueConst(s, constCl, _call, ByteBuffer.wrap(d).order(ByteOrder.LITTLE_ENDIAN));
               }
             else
               {
@@ -511,6 +511,8 @@ public class DFA extends ANY
     /**
      * deserialize value constant of type `constCl` from `b`
      *
+     * @param s the site of the constant
+     *
      * @param constCl the constants clazz, e.g. `(tuple u32 codepoint)`
      *
      * @param context for debugging: Reason that causes this const string to be
@@ -520,7 +522,7 @@ public class DFA extends ANY
      *
      * @return an instance of `constCl` with fields initialized using the data from `b`.
      */
-    private Value newValueConst(int constCl, Context context, ByteBuffer b)
+    private Value newValueConst(int s, int constCl, Context context, ByteBuffer b)
     {
       var result = newInstance(constCl, NO_SITE, context);
       var args = new List<Val>();
@@ -529,7 +531,7 @@ public class DFA extends ANY
           var f = _fuir.clazzArg(constCl, index);
           var fr = _fuir.clazzArgClazz(constCl, index);
           var bytes = _fuir.deseralizeConst(fr, b);
-          var arg = constData(fr, bytes).v0().value();
+          var arg = constData(s, fr, bytes).v0().value();
           args.add(arg);
           result.setField(DFA.this, f, arg);
         }
@@ -549,6 +551,8 @@ public class DFA extends ANY
     /**
      * deserialize array constant of type `constCl` from `d`
      *
+     * @param s the site of the constant
+     *
      * @param constCl the constants clazz, e.g. `array (tuple i32 codepoint)`
      *
      * @param context for debugging: Reason that causes this const string to be
@@ -558,7 +562,7 @@ public class DFA extends ANY
      *
      * @return an instance of `constCl` with fields initialized using the data from `d`.
      */
-    private Value newArrayConst(int constCl, Call context, ByteBuffer d)
+    private Value newArrayConst(int s, int constCl, Call context, ByteBuffer d)
     {
       var result = newInstance(constCl, NO_SITE, context);
       var sa = _fuir.clazzField(constCl, 0);
@@ -577,8 +581,8 @@ public class DFA extends ANY
         {
           var b = _fuir.deseralizeConst(elementClazz, d);
           elements = elements == null
-            ? constData(elementClazz, b).v0().value()
-            : elements.join(constData(elementClazz, b).v0().value());
+            ? constData(s, elementClazz, b).v0().value()
+            : elements.join(constData(s, elementClazz, b).v0().value());
         }
       SysArray sysArray = elCount == 0 ? new SysArray(DFA.this, new byte[0], elementClazz) :  new SysArray(DFA.this, elements);
 
@@ -657,9 +661,9 @@ public class DFA extends ANY
     /**
      * Access the effect of type ecl that is installed in the environment.
      */
-    public Pair<Val, Unit> env(int ecl)
+    public Pair<Val, Unit> env(int s, int ecl)
     {
-      return new Pair<>(_call.getEffectForce(Analyze.this, ecl), _unit_);
+      return new Pair<>(_call.getEffectForce(s, ecl), _unit_);
     }
 
 

--- a/src/dev/flang/fuir/analysis/dfa/DFA.java
+++ b/src/dev/flang/fuir/analysis/dfa/DFA.java
@@ -433,7 +433,7 @@ public class DFA extends ANY
      * For a given value v of value type vc create a boxed ref value of type rc.
      */
     @Override
-    public Pair<Val, Unit> box(Val val, int vc, int rc)
+    public Pair<Val, Unit> box(int s, Val val, int vc, int rc)
     {
       var boxed = val.value().box(DFA.this, vc, rc, _call);
       return new Pair<>(boxed, _unit_);

--- a/src/dev/flang/fuir/analysis/dfa/DFA.java
+++ b/src/dev/flang/fuir/analysis/dfa/DFA.java
@@ -113,6 +113,7 @@ public class DFA extends ANY
      * statement.  For a code generator, this could, e.g., join statements "a :=
      * 3;" and "b(x);" into a block "{ a := 3; b(x); }".
      */
+    @Override
     public Unit sequence(List<Unit> l)
     {
       return _unit_;
@@ -123,6 +124,7 @@ public class DFA extends ANY
      * Produce the unit type value.  This is used as a placeholder
      * for the universe instance as well as for the instance 'unit'.
      */
+    @Override
     public Val unitValue()
     {
       return Value.UNIT;
@@ -133,6 +135,7 @@ public class DFA extends ANY
      * Called before each statement is processed. May be used to, e.g., produce
      * tracing code for debugging or a comment.
      */
+    @Override
     public Unit expressionHeader(int s)
     {
       if (_reportResults && _options.verbose(9))
@@ -146,6 +149,7 @@ public class DFA extends ANY
     /**
      * A comment, adds human readable information
      */
+    @Override
     public Unit comment(String s)
     {
       return _unit_;
@@ -155,6 +159,7 @@ public class DFA extends ANY
     /**
      * no operation, like comment, but without giving any comment.
      */
+    @Override
     public Unit nop()
     {
       return _unit_;
@@ -180,6 +185,7 @@ public class DFA extends ANY
      *
      * @return resulting code of this assignment.
      */
+    @Override
     public Unit assignStatic(int s, int tc, int f, int rt, Val tvalue, Val val)
     {
       tvalue.value().setField(DFA.this, f, val.value());
@@ -234,6 +240,7 @@ public class DFA extends ANY
      * Result.v0() may be null to indicate that code generation should stop here
      * (due to an error or tail recursion optimization).
      */
+    @Override
     public Pair<Val, Unit> call(int s, Val tvalue, List<Val> args)
     {
       var ccP = _fuir.accessedPreconditionClazz(s);
@@ -425,6 +432,7 @@ public class DFA extends ANY
     /**
      * For a given value v of value type vc create a boxed ref value of type rc.
      */
+    @Override
     public Pair<Val, Unit> box(Val val, int vc, int rc)
     {
       var boxed = val.value().box(DFA.this, vc, rc, _call);
@@ -445,6 +453,7 @@ public class DFA extends ANY
     /**
      * Get the current instance
      */
+    @Override
     public Pair<Val, Unit> current(int s)
     {
       return new Pair<>(_call._instance, _unit_);
@@ -454,6 +463,7 @@ public class DFA extends ANY
     /**
      * Get the outer instance
      */
+    @Override
     public Pair<Val, Unit> outer(int s)
     {
       return new Pair<>(_call._target, _unit_);
@@ -462,6 +472,7 @@ public class DFA extends ANY
     /**
      * Get the argument #i
      */
+    @Override
     public Val arg(int s, int i)
     {
       return _call._args.get(i);
@@ -471,6 +482,7 @@ public class DFA extends ANY
     /**
      * Get a constant value of type constCl with given byte data d.
      */
+    @Override
     public Pair<Val, Unit> constData(int s, int constCl, byte[] d)
     {
       var o = _unit_;
@@ -596,6 +608,7 @@ public class DFA extends ANY
     /**
      * Perform a match on value subv.
      */
+    @Override
     public Pair<Val, Unit> match(int s, AbstractInterpreter<Val,Unit> ai, Val subv)
     {
       Val r = null; // result value null <=> does not return.  Will be set to Value.UNIT if returning case was found.
@@ -651,6 +664,7 @@ public class DFA extends ANY
     /**
      * Create a tagged value of type newcl from an untagged value.
      */
+    @Override
     public Pair<Val, Unit> tag(int s, Val value, int newcl, int tagNum)
     {
       Val res = value.value().tag(_call._dfa, newcl, tagNum);
@@ -661,6 +675,7 @@ public class DFA extends ANY
     /**
      * Access the effect of type ecl that is installed in the environment.
      */
+    @Override
     public Pair<Val, Unit> env(int s, int ecl)
     {
       return new Pair<>(_call.getEffectForce(s, ecl), _unit_);
@@ -671,6 +686,7 @@ public class DFA extends ANY
      * Process a contract of kind ck of clazz cl that results in bool value cc
      * (i.e., the contract fails if !cc).
      */
+    @Override
     public Unit contract(int s, FUIR.ContractKind ck, Val cc)
     {
       return _unit_;

--- a/src/dev/flang/fuir/analysis/dfa/DFA.java
+++ b/src/dev/flang/fuir/analysis/dfa/DFA.java
@@ -441,16 +441,6 @@ public class DFA extends ANY
 
 
     /**
-     * For a given reference value v create an unboxed value of type vc.
-     */
-    public Pair<Val, Unit> unbox(Val val, int orc)
-    {
-      var unboxed = val.value().unbox(orc);
-      return new Pair<>(unboxed, _unit_);
-    }
-
-
-    /**
      * Get the current instance
      */
     @Override

--- a/src/dev/flang/fuir/analysis/dfa/Instance.java
+++ b/src/dev/flang/fuir/analysis/dfa/Instance.java
@@ -212,7 +212,7 @@ public class Instance extends Value implements Comparable<Instance>
       {
         if (dfa._reportResults)
           {
-            DfaErrors.readingUninitializedField(dfa._fuir.codeAtAsPos(site),
+            DfaErrors.readingUninitializedField(dfa._fuir.sitePos(site),
                                                 dfa._fuir.clazzAsString(field),
                                                 dfa._fuir.clazzAsString(_clazz) + (_isBoxed ? " Boxed!" : ""),
                                                 why);
@@ -242,7 +242,7 @@ public class Instance extends Value implements Comparable<Instance>
    */
   public String toString()
   {
-    return _dfa._fuir.clazzAsString(_clazz) + "@" + _dfa._fuir.codeAtAsPos(_site);
+    return _dfa._fuir.clazzAsString(_clazz) + "@" + _dfa._fuir.sitePos(_site);
   }
 
 }

--- a/src/dev/flang/ir/IR.java
+++ b/src/dev/flang/ir/IR.java
@@ -388,7 +388,8 @@ public abstract class IR extends ANY
   public ExprKind codeAt(int s)
   {
     if (PRECONDITIONS) require
-      (s >= SITE_BASE, withinCode(s));
+      (s >= SITE_BASE,
+       withinCode(s));
 
     return exprKind(getExpr(s));
   }

--- a/src/dev/flang/ir/IR.java
+++ b/src/dev/flang/ir/IR.java
@@ -462,7 +462,7 @@ public abstract class IR extends ANY
    *
    * @return the source code position or null if not available.
    */
-  public SourcePosition codeAtAsPos(int s)
+  public SourcePosition sitePos(int s)
   {
     if (PRECONDITIONS) require
       (s >= 0,


### PR DESCRIPTION
Remove fields `_fuir`, `_cl`, `_pre` and `_s` from `ProcessExpression` . Had to add `site` parameter to `ProcessExpression.env` and `ProcessExpression.box`. 

Added `@Override` annotations to implementations of `ProcessExpression`. Renamed `codeAtAsPos` as `sitePos`. Removed unused imporant and unused `unbox()` in DFA's `ProcessExpression` implementation. 