### PR TITLE
Speedup line num

### DIFF
--- a/bin/aspell.dict
+++ b/bin/aspell.dict
@@ -1432,7 +1432,7 @@ byteLength
 checkIndentation
 clangVersion
 cloneValue
-codePointInLine
+codePointIndentation
 constraintMustNotBeGenericArgument
 curPos
 datagram

--- a/src/dev/flang/parser/Lexer.java
+++ b/src/dev/flang/parser/Lexer.java
@@ -751,7 +751,7 @@ public class Lexer extends SourceFile
   int setMinIndent(int startPos)
   {
     int result = _minIndentStartPos;
-    _minIndent = startPos >= 0 ? codePointInLine(startPos) : -1;
+    _minIndent = startPos >= 0 ? codePointIndentation(startPos) : -1;
     _minIndentStartPos = startPos;
 
     return result;
@@ -1015,18 +1015,18 @@ public class Lexer extends SourceFile
     int l = line();
     int p = _tokenPos;
     return
-      t == Token.t_eof                                     ? t                        :
-      sameLine  >= 0 && l != sameLine                      ? Token.t_lineLimit        :
-      p > endAtSpace && ignoredTokenBefore()               ? Token.t_spaceLimit       :
-      p == _minIndentStartPos                              ? t                        :
-      minIndent >= 0 && codePointInLine(p, l) <= minIndent ? Token.t_indentationLimit :
+      t == Token.t_eof                                       ? t                        :
+      sameLine  >= 0 && l != sameLine                        ? Token.t_lineLimit        :
+      p > endAtSpace && ignoredTokenBefore()                 ? Token.t_spaceLimit       :
+      p == _minIndentStartPos                                ? t                        :
+      minIndent >= 0 && codePointIndentation(p) <= minIndent ? Token.t_indentationLimit :
       endAtColon                  &&
       _curToken == Token.t_op     &&
-      tokenAsString().equals(":")                          ? Token.t_colonLimit       :
+      tokenAsString().equals(":")                            ? Token.t_colonLimit       :
       endAtBar                    &&
       _curToken == Token.t_op     &&
-      tokenAsString().equals("|")                          ? Token.t_barLimit
-                                                           : _curToken;
+      tokenAsString().equals("|")                            ? Token.t_barLimit
+                                                             : _curToken;
   }
 
 
@@ -1266,8 +1266,8 @@ A code point sharp 0x023 `#` that is not part of an operator starts a comment th
               boolean SHARP_COMMENT_ONLY_IF_IN_COL_1 = false;
               token =
                 !SHARP_COMMENT_ONLY_IF_IN_COL_1 ||
-                codePointInLine(_tokenPos) == 1      ? skipUntilEOL() // comment until end of line
-                                                   : skipOp(Token.t_op);
+                codePointIndentation(_tokenPos) == 1 ? skipUntilEOL() // comment until end of line
+                                                     : skipOp(Token.t_op);
               break;
             }
           /**
@@ -3032,7 +3032,7 @@ PIPE        : "|"
      */
     int column(Optional<Integer> pos)
     {
-      return codePointInLine(getPos(pos));
+      return codePointIndentation(getPos(pos));
     }
 
 

--- a/src/dev/flang/parser/Parser.java
+++ b/src/dev/flang/parser/Parser.java
@@ -2697,7 +2697,7 @@ exprs       : expr semiOrFlatLF exprs (semiOrFlatLF | )
    */
   int indent(int pos)
   {
-    return pos >= 0 ? codePointInLine(pos) : 0;
+    return pos >= 0 ? codePointIndentation(pos) : 0;
   }
 
 

--- a/src/dev/flang/util/SourceFile.java
+++ b/src/dev/flang/util/SourceFile.java
@@ -239,6 +239,10 @@ public class SourceFile extends ANY
     _pos = 0;
     _cur = BAD_CODEPOINT;
     _size = 0;
+    if (_FAST_LINE_NUM_)
+      {
+        lines();  // eagerly determine lines
+      }
   }
 
 
@@ -884,7 +888,6 @@ The end of a source code line is marked by one of the code points LF 0x000a, VT 
     int line;
     if (_FAST_LINE_NUM_)
       {
-        lines();
         line = _lineNumBase[pos / 128] + _lineNumOffset[pos];
       }
     else
@@ -943,7 +946,10 @@ The end of a source code line is marked by one of the code points LF 0x000a, VT 
    */
   public int codePointIndentation(int pos)
   {
-    lines();  // make sure indentation data is present.
+    if (!_FAST_LINE_NUM_)
+      {
+        lines();  // make sure indentation data is present.
+      }
     var res = _indentationByte[pos] & 0xff;
     if (res >= 128)
       {

--- a/src/dev/flang/util/SourcePosition.java
+++ b/src/dev/flang/util/SourcePosition.java
@@ -236,7 +236,7 @@ public class SourcePosition extends ANY implements Comparable<SourcePosition>, H
   {
     if (_column == null)
       {
-        _column = _sourceFile.codePointInLine(_bytePos);
+        _column = _sourceFile.codePointIndentation(_bytePos);
       }
     return _column;
   }


### PR DESCRIPTION
This is based on PR #2940 that should be merged first, only the added commits need to be reviewed. 

This avoids binary search for line numbers by storing line numbers with every position of a code point.