### PR TITLE
parser: when parsing `name` and the result is dumped. do not create ParsedName

### DIFF
--- a/src/dev/flang/ast/ParsedName.java
+++ b/src/dev/flang/ast/ParsedName.java
@@ -28,6 +28,7 @@ package dev.flang.ast;
 
 import dev.flang.util.ANY;
 import dev.flang.util.Errors;
+import dev.flang.util.FuzionConstants;
 import dev.flang.util.HasSourcePosition;
 import dev.flang.util.SourcePosition;
 
@@ -49,6 +50,13 @@ public class ParsedName extends ANY implements HasSourcePosition
    */
   public final static ParsedName ERROR_NAME = new ParsedName(SourcePosition.builtIn,
                                                              Errors.ERROR_STRING);
+
+
+  /**
+   * Name to be used in case the actual name is to be ignored.
+   */
+  public final static ParsedName DUMMY = new ParsedName(SourcePosition.builtIn,
+                                                        FuzionConstants.DUMMY_NAME_STRING);
 
 
   /*----------------------------  variables  ----------------------------*/

--- a/src/dev/flang/parser/Parser.java
+++ b/src/dev/flang/parser/Parser.java
@@ -668,7 +668,10 @@ name        : IDENT                            // all parts of name must be in s
         var oldLine = sameLine(line());
         switch (current(mayBeAtMinIndent))
           {
-          case t_ident  : result = new ParsedName(tokenSourceRange(), identifier(mayBeAtMinIndent)); next(); break;
+          case t_ident  : result = ignoreError ? ParsedName.DUMMY
+                                               : new ParsedName(tokenSourceRange(), identifier(mayBeAtMinIndent));
+                          next();
+                          break;
           case t_infix  :
           case t_prefix :
           case t_postfix: result = opName(mayBeAtMinIndent, ignoreError);  break;

--- a/src/dev/flang/util/FuzionConstants.java
+++ b/src/dev/flang/util/FuzionConstants.java
@@ -47,6 +47,13 @@ public class FuzionConstants extends ANY
    */
   public static final String NO_VALUE_STRING = "**no value**";
 
+
+  /**
+   * String used in the dummy ParsedName.
+   */
+  public static final String DUMMY_NAME_STRING = "## dummy name ##";
+
+
   /**
    * Names of Java properties accepted by fz command:
    */


### PR DESCRIPTION
This results in not creating the String for the identifier which reduces the time required to build java.base.fum by about 4%.
