### PR TITLE
parser: create second fork in skipOneType a little less eagerly

### DIFF
--- a/src/dev/flang/parser/Parser.java
+++ b/src/dev/flang/parser/Parser.java
@@ -3816,9 +3816,9 @@ typeOpt     : type
   {
     boolean result;
     var f = fork();
-    var f2 = fork();
     if (f.skipBracketTermWithNLs(PARENS, () -> f.current() == Token.t_rparen || f.skipTypeList(allowTypeThatIsNotExpression)))
       {
+        var f2 = fork();
         result = skipBracketTermWithNLs(PARENS, () -> current() == Token.t_rparen || skipTypeList(allowTypeThatIsNotExpression));
         var p = tokenPos();
         var l = line();


### PR DESCRIPTION
This is only needed conditionally so we can delay that fork a little and move it into the condition.

This should increase parser performance slightly.
