### PR TITLE
tools: add option `-frontend-only` change `-no-backend`

### DIFF
--- a/src/dev/flang/tools/Fuzion.java
+++ b/src/dev/flang/tools/Fuzion.java
@@ -374,10 +374,24 @@ public class Fuzion extends Tool
      * any errors that happened in the frontend.
      * Can be used for syntax checking of fz files.
      */
-    noBackend("-no-backend")
+    frontEndOnly("-frontend-only")
     {
       void processFrontEnd(Fuzion f, FrontEnd fe)
       {
+        Errors.showAndExit();
+      }
+    },
+
+    /**
+     * This backend does nothing except showing
+     * any errors that happened in the stages up to
+     * and including the DFA.
+     */
+    noBackend("-no-backend")
+    {
+      void process(FuzionOptions options, FUIR fuir)
+      {
+        new DFA(options, fuir).new_fuir();
         Errors.showAndExit();
       }
     },

--- a/tests/ctrie_threads/Makefile
+++ b/tests/ctrie_threads/Makefile
@@ -25,4 +25,4 @@
 
 override NAME = ctrie_threads
 FUZION_OPTIONS = -modules=lock_free
-include ../dfa.mk  # NYI: BUG: snapshots do not work yet
+include ../fe.mk  # NYI: BUG: #2967 + snapshots do not work yet

--- a/tests/fe.mk
+++ b/tests/fe.mk
@@ -17,11 +17,26 @@
 #
 #  Tokiwa Software GmbH, Germany
 #
-#  Source code of Fuzion test Makefile
-#
-#  Author: Fridtjof Siebert (siebert@tokiwa.software)
+#  Source code of Fuzion test Makefile to be included for fe tests
+#  This is used e.g. for tests that do not fully work yet.
 #
 # -----------------------------------------------------------------------
 
-override NAME = mix_inheritance_and_outer
-include ../fe.mk # NYI: BUG see #88
+# expected variables
+#
+#  NAME -- the name of the main feature to be tested
+#  FUZION -- the fz command
+
+FUZION_OPTIONS ?=
+FUZION = ../../bin/fz $(FUZION_OPTIONS)
+
+all: jvm c int
+
+int:
+	$(FUZION) -frontend-only $(NAME) 2>err.txt || (RC=$$? && cat err.txt && exit $$RC)
+
+jvm:
+	$(FUZION) -frontend-only $(NAME) 2>err.txt || (RC=$$? && cat err.txt && exit $$RC)
+
+c:
+	$(FUZION) -frontend-only $(NAME) 2>err.txt || (RC=$$? && cat err.txt && exit $$RC)

--- a/tests/fz_cmd/fz_cmd.fz.expected_err
+++ b/tests/fz_cmd/fz_cmd.fz.expected_err
@@ -1,7 +1,7 @@
 
 error 1: missing main feature name in command line args
 Usage: ../../bin/fz [-h|--help|-version]  --or--
-       ../../bin/fz [-c|-classes|-dfa|-effects|-interpreter|-jar|-java|-jvm|-llvm|-no-backend|-saveLib=<file>] [-h|--help|-version] [<backend specific options>]  --or--
+       ../../bin/fz [-c|-classes|-dfa|-effects|-frontend-only|-interpreter|-jar|-java|-jvm|-llvm|-no-backend|-saveLib=<file>] [-h|--help|-version] [<backend specific options>]  --or--
        ../../bin/fz -pretty [-noANSI] [-verbose[=<n>]]  ({<file>} | - | -e <code> | -execute <code>)  --or--
        ../../bin/fz -latex [-noANSI] [-verbose[=<n>]]   --or--
        ../../bin/fz -acemode [-noANSI] [-verbose[=<n>]]   --or--

--- a/tests/reg_issue118/Makefile
+++ b/tests/reg_issue118/Makefile
@@ -24,4 +24,4 @@
 # -----------------------------------------------------------------------
 
 override NAME = issue118
-include ../dfa.mk # NYI: BUG: see #2146
+include ../fe.mk # NYI: BUG: see #2146


### PR DESCRIPTION
... to actually do what the name implies.
Now:
-no-backend also does the DFA stage while -frontend-only really does only the frontend.

