### PR TITLE
lib: add `as_persistent_map` to `lock_free.map`

### DIFF
--- a/lib/container/Persistent_Map.fz
+++ b/lib/container/Persistent_Map.fz
@@ -30,5 +30,5 @@ public Persistent_Map(public K type : property.hashable, public V type) ref : Ma
   # current Map and k,v.
   # An already existing k will be replaced.
   #
-  public put(k K, v V) Persistent_Map K V => abstract
+  public put(k K, v V) container.Persistent_Map K V => abstract
 

--- a/modules/lock_free/src/lock_free/map.fz
+++ b/modules/lock_free/src/lock_free/map.fz
@@ -680,6 +680,23 @@ is
       .as_list (i -> gcas_read i)
 
 
+  # this ctrie as a persistent map
+  #
+  # a snapshot is taken every time
+  # the map is modified.
+  #
+  as_persistent_map container.Persistent_Map CTK CTV =>
+    s := snapshot false
+    ref : container.Persistent_Map CTK CTV
+      public size i32 => s.size
+      public index [] (k CTK) option CTV => s[k]
+      public items Sequence (tuple CTK CTV) => s.items
+      public put(k CTK, v CTV) container.Persistent_Map CTK CTV =>
+        sp := s.snapshot false
+        sp.add k v
+        sp.as_persistent_map
+
+
   # initialize a new ctrie
   public fixed type.empty =>
 


### PR DESCRIPTION
Provide an implementation of Persistent_Map by using lock_free.map aka ctrie