### PR TITLE
parser. Parse `.this` as part of `callTail` or `typeTail`

### DIFF
--- a/src/dev/flang/ast/AstErrors.java
+++ b/src/dev/flang/ast/AstErrors.java
@@ -35,6 +35,7 @@ import java.util.stream.Collectors;
 import dev.flang.util.ANY;
 import static dev.flang.util.Errors.*;
 import dev.flang.util.FuzionConstants;
+import dev.flang.util.HasSourcePosition;
 import dev.flang.util.List;
 import dev.flang.util.Pair;
 import dev.flang.util.SourcePosition;
@@ -1995,6 +1996,13 @@ public class AstErrors extends ANY
       "or                     : " + s(tf) + "\n" +
       "To solve this, rename one of the called features.");
   }
+
+  public static void qualifierExpectedForDotThis(SourcePosition pos, HasSourcePosition e)
+  {
+    error(pos, "Qualifier expected for "+code(".this")+" expression.",
+          "Found expression "+e.pos().show()+" where a simple qualifier " +  code("a.b.c") + " was expected");
+  }
+
 
 }
 

--- a/src/dev/flang/ast/Expr.java
+++ b/src/dev/flang/ast/Expr.java
@@ -553,6 +553,17 @@ public abstract class Expr extends HasGlobalIndex implements HasSourcePosition
   }
 
 
+  /**
+   * Return this expression as a simple qualifier. This is null by default
+   * except for calls without explicit target or one whose asQualifier() is not
+   * null and without any actual arguments or select clause.
+   */
+  public List<ParsedName> asQualifier()
+  {
+    return null;
+  }
+
+
   protected Expr addFieldForResult(Resolution res, AbstractFeature outer, AbstractType t)
   {
     var result = this;

--- a/src/dev/flang/ast/ParsedCall.java
+++ b/src/dev/flang/ast/ParsedCall.java
@@ -213,11 +213,28 @@ public class ParsedCall extends Call
   @Override
   public ParsedName asParsedName()
   {
-    if (!_actuals.isEmpty() && _select == -1)
+    if (!_actuals.isEmpty() || _select != -1)
       {
         return null;
       }
     return _parsedName;
+  }
+
+
+  @Override
+  public List<ParsedName> asQualifier()
+  {
+    if (!_actuals.isEmpty() || _select != -1)
+      {
+        return null;
+      }
+    var t = target();
+    var l = t == null ? new List<ParsedName>() : t.asQualifier();
+    if (l != null)
+      {
+        l.add(_parsedName);
+      }
+    return l;
   }
 
 

--- a/src/dev/flang/ast/Partial.java
+++ b/src/dev/flang/ast/Partial.java
@@ -125,7 +125,7 @@ public class Partial extends AbstractLambda
    *
    * @return the corresponding lambda expression.
    */
-  public static Function dotCall(SourcePosition pos, java.util.function.Function<Expr,Call> call)
+  public static Function dotCall(SourcePosition pos, java.util.function.Function<Call,Call> call)
   {
     var a = argName(pos);
     var c = call.apply(a);

--- a/src/dev/flang/ast/UnresolvedType.java
+++ b/src/dev/flang/ast/UnresolvedType.java
@@ -317,6 +317,30 @@ public abstract class UnresolvedType extends AbstractType implements HasSourcePo
 
 
   /**
+   * Return this type as a simple qualifier.  This is null by default except for
+   * types without generics and without `ref` modifier.
+   */
+  public List<ParsedName> asQualifier()
+  {
+    List<ParsedName> res = _outer instanceof UnresolvedType uo ? uo.asQualifier()
+                                                               : new List<>();
+
+    if (res == null ||
+        !_generics.isEmpty() ||
+        _refOrVal != RefOrVal.LikeUnderlyingFeature)
+      {
+        res = null;
+      }
+    else
+      {
+        res.add(new ParsedName(pos(), _name));
+      }
+    return res;
+  }
+
+
+
+  /**
    * This method usually just returns currentOuter. Only for clone()d types that
    * are used in a different outer context, this permits to look up features the
    * type is based on in the original context.

--- a/src/dev/flang/parser/Lexer.java
+++ b/src/dev/flang/parser/Lexer.java
@@ -1179,6 +1179,21 @@ public class Lexer extends SourceFile
 
 
   /**
+   * Obtain the given range pos.bytePos()..lastTokenEndPos() as a SourceRange object.
+   *
+   * @param pos a source position within this file, must be before lastTokenEndPos().
+   */
+  public SourceRange sourceRange(SourcePosition pos)
+  {
+    if (PRECONDITIONS) require
+      (pos != null,
+       Errors.any() || pos.bytePos() < lastTokenEndPos());
+
+    return sourceRange(pos.bytePos());
+  }
+
+
+  /**
    * Obtain the given range pos..lastTokenEndPos() as a SourceRange object.
    *
    * @param pos a byte position within this file, must be smaller than

--- a/src/dev/flang/parser/Parser.java
+++ b/src/dev/flang/parser/Parser.java
@@ -1530,11 +1530,11 @@ callTail    : indexCall  callTail
       {
         if (skip(Token.t_env))
           {
-            result = callTail(false, new Env    (tokenSourcePos(), result.asParsedType()));
+            result = callTail(false, new Env    (sourceRange(target.pos()), result.asParsedType()));
           }
         else if (skip(Token.t_type))
           {
-            result = callTail(false, new DotType(tokenSourcePos(), result.asParsedType()));
+            result = callTail(false, new DotType(sourceRange(target.pos()), result.asParsedType()));
           }
         else
           {

--- a/src/dev/flang/parser/Parser.java
+++ b/src/dev/flang/parser/Parser.java
@@ -899,7 +899,7 @@ formArgsOpt : formArgs
 
 
   /**
-   * Parse optional formal argument list. Result is empty List in case no formArgs is found.
+   * Parse optional formal argument list. Result is true in case no formArgs is found.
    */
   boolean isEmptyFormArgs()
   {

--- a/src/dev/flang/parser/Parser.java
+++ b/src/dev/flang/parser/Parser.java
@@ -57,18 +57,6 @@ public class Parser extends Lexer
   }
 
 
-  /**
-   * Enum returned by isDotEnvOrTypePrefix and skipDotEnvOrType to
-   * indicate if .env or .type expression or something else was found.
-   */
-  static enum EnvOrType
-  {
-    env,
-    type,
-    none
-  }
-
-
   /*----------------------------  constants  ----------------------------*/
 
 
@@ -1346,10 +1334,10 @@ callList    : call ( COMMA callList
    */
   List<AbstractCall> callList()
   {
-    var result = new List<AbstractCall>(call(null));
+    var result = new List<AbstractCall>(pureCall(null));
     while (skipComma())
       {
-        result.add(call(null));
+        result.add(pureCall(null));
       }
     return result;
   }
@@ -1379,15 +1367,43 @@ callList    : call ( COMMA callList
 
 
   /**
-   * Parse call
+   * Parse pure call, i.e. a call that is really a call and not a.b.env or x.y.type.
    *
+   * @param target the target of the call or null if none.
+   */
+  Call pureCall(Call target)
+  {
+    return (Call) call(true, target);
+  }
+
+
+  /**
+   * Parse call, including `.env` and `.type` calls
+   *
+   * @param target the target of the call or null if none.
+   */
+  Expr call(Expr target)
+  {
+    return call(false, target);
+  }
+
+
+  /**
+   * Parse pure or non-pure call depending on `pure` argument.
+   *
+   * @param pure true iff `pureCall` is to be parsed, otherwise `call` is parsed.
+   *
+   * @param target the target of the call or null if none.
+   *
+pureCall    : name actuals pureCallTail
+            ;
 call        : name actuals callTail
             ;
 actuals     : actualArgs
             | dot NUM_LITERAL
             ;
    */
-  Call call(Expr target)
+  Expr call(boolean pure, Expr target)
   {
     SourcePosition pos = tokenSourcePos();
     var n = name();
@@ -1422,8 +1438,8 @@ actuals     : actualArgs
         var l = actualArgs();
         result = new ParsedCall(target, n, l);
       }
-    result = callTail(skippedDot, result);
-    return result;
+    return pure ? pureCallTail(skippedDot, result)
+                : callTail(    skippedDot, result);
   }
 
 
@@ -1463,33 +1479,67 @@ indexTail   : ":=" exprInLine
 
 
   /**
+   * Parse callTail and pureCallTail
+   *
+   * @param skippedDot true if a dot was already skipDot()ed.
+   *
+   * @param target the target of the call
+   *
+pureCallTail: indexCall pureCallTail
+            | dot call  pureCallTail
+            |
+            ;
+   */
+  Call pureCallTail(boolean skippedDot, Call target)
+  {
+    var result = target;
+    if (!skippedDot && !ignoredTokenBefore() && current() == Token.t_lcrochet)
+      {
+        result = pureCallTail(false, indexCall(result));
+      }
+    else if (skippedDot || skipDot())
+      {
+        result = pureCallTail(false, pureCall(result));
+      }
+    return result;
+  }
+
+
+  /**
    * Parse callTail
    *
    * @param skippedDot true if a dot was already skipDot()ed.
    *
    * @param target the target of the call
    *
-callTail    : indexCallOpt dotCallOpt
-            ;
-indexCallOpt: indexCall
+callTail    : indexCall  callTail
+            | dot call   callTail
+            | dot "env"  callTail
+            | dot "type" callTail
             |
-            ;
-dotCallOpt  : dotCall
-            |
-            ;
-dotCall     : dot call
             ;
    */
-  Call callTail(boolean skippedDot, Call target)
+  Expr callTail(boolean skippedDot, Expr target)
   {
-    var result = target;
+    Expr result = target;
     if (!skippedDot && !ignoredTokenBefore() && current() == Token.t_lcrochet)
       {
-        result = indexCall(result);
+        result = callTail(false, indexCall(result));
       }
-    if (skippedDot || skipDot())
+    else if (skippedDot || skipDot())
       {
-        result = call(result);
+        if (skip(Token.t_env))
+          {
+            result = callTail(false, new Env    (tokenSourcePos(), result.asParsedType()));
+          }
+        else if (skip(Token.t_type))
+          {
+            result = callTail(false, new DotType(tokenSourcePos(), result.asParsedType()));
+          }
+        else
+          {
+            result = call(result);
+          }
       }
     return result;
   }
@@ -1795,7 +1845,7 @@ operatorExpr  : opExpr
 opExpr      :     opTail
             | ops opTail
             | op
-            | dotCall
+            | dot call
             ;
    */
   Expr opExpr()
@@ -1817,7 +1867,7 @@ opExpr      :     opTail
        }
      else
        {
-         return Partial.dotCall(tokenSourcePos(), a->call(a));
+         return Partial.dotCall(tokenSourcePos(), a->pureCall(a));
        }
   }
 
@@ -2022,11 +2072,7 @@ addSemiElmts: SEMI semiSepElmts
   /**
    * Parse term
    *
-term        : simpleterm ( indexCall
-                         |
-                         )           ( dot call
-                                     |
-                                     )
+term        : simpleterm callTail
             ;
 simpleterm  : bracketTerm
             | stringTerm
@@ -2034,66 +2080,49 @@ simpleterm  : bracketTerm
             | match
             | loop
             | ifexpr
-            | dotEnv
-            | dotType
             | callOrFeatOrThis
             ;
    */
   Expr term()
   {
-    Expr result;
     int pos = tokenPos();
-    switch (isDotEnvOrTypePrefix())    // starts with name or '('
+    var result = switch (current()) // even if this is t_lbrace, we want a term to be indented, so do not use currentAtMinIndent().
       {
-      case env : result = dotEnv(); break;
-      case type: result = dotType(); break;
-      case none:
-        switch (current()) // even if this is t_lbrace, we want a term to be indented, so do not use currentAtMinIndent().
-          {
-          case t_lbrace    :
-          case t_lparen    :
-          case t_lcrochet  :         result = bracketTerm();                            break;
-          case t_numliteral: var l = skipNumLiteral();
+      case t_lbrace, t_lparen, t_lcrochet ->  bracketTerm();
+      case t_numliteral -> {
+                             var l = skipNumLiteral();
                              var m = l.mantissaValue();
                              var b = l.mantissaBase();
                              var d = l.mantissaDotAt();
                              var e = l.exponent();
                              var eb = l.exponentBase();
                              var o = l._originalString;
-                             result = new NumLiteral(sourceRange(pos), o, b, m, d, e, eb); break;
-          case t_match     :         result = match();                                  break;
-          case t_for       :
-          case t_variant   :
-          case t_while     :
-          case t_do        :         result = loop();                                   break;
-          case t_if        :         result = ifexpr();                                 break;
-          default          :
-            if (isStartedString(current()))
-              {
-                result = stringTerm(null, Optional.empty());
-              }
-            else
-              {
-                result = callOrFeatOrThis();
-                if (result == null)
-                  {
-                    syntaxError(pos, "term (lbrace, lparen, lcrochet, fun, string, integer, old, match, or name)", "term");
-                    result = Expr.ERROR_VALUE;
-                  }
-              }
-            break;
-          }
-        break;
-      default: throw new Error("unhandled switch case");
-      }
-    if (!ignoredTokenBefore() && current() == Token.t_lcrochet)
-      {
-        result = indexCall(result);
-      }
-    if (skipDot())
-      {
-        result = call(result);
-      }
+                             yield new NumLiteral(sourceRange(pos), o, b, m, d, e, eb);
+                           }
+      case t_match     -> match();
+      case t_for,
+           t_variant,
+           t_while,
+           t_do        -> loop();
+      case t_if        -> ifexpr();
+      default          -> {
+                            if (isStartedString(current()))
+                              {
+                                yield stringTerm(null, Optional.empty());
+                              }
+                            else
+                              {
+                                var res = callOrFeatOrThis();
+                                if (res == null)
+                                  {
+                                    syntaxError(pos, "term (lbrace, lparen, lcrochet, fun, string, integer, old, match, or name)", "term");
+                                    res = Expr.ERROR_VALUE;
+                                  }
+                                yield res;
+                              }
+                          }
+      };
+    result = callTail(false, result);
     result.setSourceRange(sourceRange(pos));
     return result;
   }
@@ -3193,44 +3222,6 @@ qualThis    : name ( dot name )* dot "this"
 
 
   /**
-   * Parse dotEnv
-   *
-   + NYI: This should be `dotEnv : expr dot "env"` and use
-   * `expr.asParsedType()`, then the grammar would be simpler and repeated
-   * parsing would be avoided.
-   *
-dotEnv      : typeInParens dot "env"
-            ;
-   */
-  Env dotEnv()
-  {
-    var p0 = tokenPos();
-    var t = typeInParens();
-    skipDot();
-    var pos = sourceRange(p0, tokenEndPos());
-    match(Token.t_env, "env");
-    return new Env(pos, t);
-  }
-
-
-  /**
-   * Parse dotType
-   *
-   + NYI: This should be `dotType : expr dotTypeSuffix` and use
-   * `expr.asParsedType()`, then the grammar would be simpler and repeated
-   * parsing would be avoided.
-   *
-dotType     : typeInParens dotTypeSuffx
-            ;
-   */
-  Expr dotType()
-  {
-    var t = typeInParens();
-    return dotTypeSuffx(t);
-  }
-
-
-  /**
    * Parse dotTypeSuffx
    *
 dotTypeSuffx: dot "type"
@@ -3242,53 +3233,6 @@ dotTypeSuffx: dot "type"
     matchOperator(".", "dotTypeSuffx");
     match(Token.t_type, "dotTypeSuffx");
     return new DotType(p, t);
-  }
-
-
-  /**
-   * Check if the current position starts an env.  Does not change the
-   * position of the parser.
-   *
-   * @return true iff the next token(s) start a env
-   */
-  EnvOrType isDotEnvOrTypePrefix()
-  {
-    return (isNamePrefix() || current() == Token.t_lparen) ? fork().skipDotEnvOrType()
-      : EnvOrType.none;
-  }
-
-
-  /**
-   * Check if the current position can be parsed as a dotEnv or dotType and skip
-   * it if this is the case.
-
-   * @return true iff a dotEnv or dotType was found and skipped, otherwise no
-   * dotEnv nor dotType was found and the parser/lexer is at an undefined
-   * position.
-   */
-  EnvOrType skipDotEnvOrType()
-  {
-    return
-      !(skipTypeInParens() && skipDot()) ? EnvOrType.none :
-      skip(Token.t_env )                 ? EnvOrType.env  :
-      skip(Token.t_type)                 ? EnvOrType.type
-                                         : EnvOrType.none;
-  }
-
-
-  /**
-   * Check if the current position can be parsed as a dotType and skip it if
-   * this is the case.
-
-   * @return true iff a dotType was found and skipped, otherwise no dotType was
-   * found and the parser/lexer is at an undefined position.
-   */
-  boolean skipDotType()
-  {
-    return
-      skipTypeInParens()
-      && skipDot()
-      && skip(Token.t_type);
   }
 
 
@@ -3777,24 +3721,6 @@ simpletype  : name typePars typeTail
 
 
   /**
-   * Check if the current position is a dot followed by "env" or "type".  Does
-   * not change the position of the parser.
-   *
-   * @return true iff the next token(s) is a dot followed by "env"
-   */
-  boolean isDotEnvOrType()
-  {
-    if (isDot())
-      {
-        var f = fork();
-        return f.skipDot() && (f.skip(Token.t_env ) ||
-                               f.skip(Token.t_type)    );
-      }
-    return false;
-  }
-
-
-  /**
    * Parse typeTail
    *
    * @param lhs the left hand side for this type that was already parsed, null
@@ -3807,7 +3733,7 @@ typeTail    : dot simpletype
   UnresolvedType typeTail(UnresolvedType lhs)
   {
     var result = lhs;
-    if (!isDotEnvOrType() && skipDot())
+    if (skipDot())
       {
         result = simpletype(lhs);
       }
@@ -3824,7 +3750,7 @@ typeTail    : dot simpletype
   boolean skipTypeTail()
   {
     return
-      isDotEnvOrType() || !skipDot() || skipSimpletype();
+      !skipDot() || skipSimpletype();
   }
 
 


### PR DESCRIPTION
This builds on top of PR #2979, only the last two commits were added. 

This reduces the parser complexity since there is no longer a need to look ahead up to `this` when parsing `a.b.c.this`, instead we produce an error if `.this` follows an expression or type that is not a simple qualified name.
