### PR TITLE
parser: Minor performance improvement when parsing `operatorExpr`

### DIFF
--- a/src/dev/flang/parser/Parser.java
+++ b/src/dev/flang/parser/Parser.java
@@ -1731,12 +1731,12 @@ operatorExpr  : opExpr
   Expr operatorExpr()
   {
     Expr result = opExpr();
-    SourcePosition pos = tokenSourcePos();
-    var f0 = fork();
-    if (f0.skip(Token.t_question))
+    if (current() == Token.t_question)
       {
+        SourcePosition pos = tokenSourcePos();
         var i = new Indentation();
         skip(Token.t_question);
+        var f0 = fork();
         if (f0.isCasesAndNotExpr())
           {
             result = new Match(pos, result, casesBars(i));


### PR DESCRIPTION
When a `?` is encountered, we will need a `fork()` and a `tokenSourcePos()`. This patch moves these two calls into an `if` such that they are performed only when actually needed.

This reduces the time to build java.base.fum by about 2% (with some uncertainty since I measured only once...).
