### PR TITLE
air: Implicitly instantiate type features

### DIFF
--- a/src/dev/flang/air/Clazz.java
+++ b/src/dev/flang/air/Clazz.java
@@ -1925,8 +1925,11 @@ public class Clazz extends ANY implements Comparable<Clazz>
     return _isInstantiated
       && (_checkingInstantiatedHeirs > 0
           || (isOuterInstantiated()
-            || isChoice()
-            || _outer.isRef() && _outer.hasInstantiatedHeirs()));
+              || isChoice()
+              || _outer.isRef() && _outer.hasInstantiatedHeirs()))
+
+      // type features are implicitly instantiated unit types:
+      || feature().isTypeFeature();
   }
 
 

--- a/src/dev/flang/air/Clazz.java
+++ b/src/dev/flang/air/Clazz.java
@@ -1837,9 +1837,13 @@ public class Clazz extends ANY implements Comparable<Clazz>
    */
   public boolean isCalled()
   {
-    return _isCalled && isOuterInstantiated() && !feature().isAbstract() &&
-      (_argumentFields == null || /* this may happen when creating deterḿining isUnitType() on cyclic value type, will cause an error during layout() */
-       !isAbsurd());
+    return _isCalled &&
+      (isOuterInstantiated()            ||
+       _outer.feature().isTypeFeature()         // type features are implicitly instantiated unit types:
+                                           ) &&
+      !feature().isAbstract()                &&
+      (_argumentFields == null          ||      // this may happen when creating deterḿining isUnitType() on cyclic value type, will cause an error during layout() */
+       !isAbsurd()                         );
   }
 
   /**
@@ -1926,10 +1930,7 @@ public class Clazz extends ANY implements Comparable<Clazz>
       && (_checkingInstantiatedHeirs > 0
           || (isOuterInstantiated()
               || isChoice()
-              || _outer.isRef() && _outer.hasInstantiatedHeirs()))
-
-      // type features are implicitly instantiated unit types:
-      || feature().isTypeFeature();
+              || _outer.isRef() && _outer.hasInstantiatedHeirs()));
   }
 
 


### PR DESCRIPTION
This solves a tricky problem with idim87ex.fz: Here, `effect.is_installed` is called, which is an intrinsic constructor defined in a type feature that results in a bool. Since the type feature's clazz was not marked as instantiated, Clazz.isInstantiated() for `effect.is_installed` also returned `false` and the choice generics TRUE and FALSE of the bool result did hance not get marked as instantiated.

Finally, since in `idiom87ex.fz`, there was no other instantiation of values `TRUE` or `FALSE`, no code was created for any match on the bool result of `isInstantiated`, resulting in the default `exit` effect not being installed.
