### PR TITLE
util: Avoid repeated output of warning statistics

### DIFF
--- a/src/dev/flang/util/Errors.java
+++ b/src/dev/flang/util/Errors.java
@@ -610,6 +610,7 @@ public class Errors extends ANY
     else if (warningStatistics && warningCount() > 0)
       {
         println(singularOrPlural(warningCount(), "warning") + ".");
+        _warnings_.clear();  // there might be repeated calls to `showAndExit`, so do not repeat the warnings statistics
       }
   }
 


### PR DESCRIPTION
This fixes the repeated output of
```
  3 warnings.
  3 warnings.
```
in fuzion-lang.dev's `design/examples/arg_intri.fz` example.
