### PR TITLE
parser: remove `t_inv` from `isContractPrefix`

### DIFF
--- a/src/dev/flang/parser/Parser.java
+++ b/src/dev/flang/parser/Parser.java
@@ -3149,13 +3149,11 @@ contract    : require
    */
   boolean isContractPrefix()
   {
-    switch (currentAtMinIndent())
+    return switch (currentAtMinIndent())
       {
-      case t_pre      :
-      case t_post     :
-      case t_inv      : return true;
-      default         : return false;
-      }
+      case t_pre, t_post -> true;
+      default            -> false;
+      };
   }
 
 


### PR DESCRIPTION
With instances being mostly immutable the concept of an invariant no longer makes sense and invariants have been removed in an earlier change to the grammar.
