### PR TITLE
parser: set source range for `expr`

### DIFF
--- a/src/dev/flang/parser/Parser.java
+++ b/src/dev/flang/parser/Parser.java
@@ -2631,11 +2631,16 @@ expr        : checkexpr
    */
   Expr expr()
   {
-    return
+    var p0 = lastTokenEndPos();
+    var p1 = tokenPos();
+    var e =
       isCheckPrefix()       ? checkexpr()   :
       isAssignPrefix()      ? assign()      :
       isDestructurePrefix() ? destructure() :
       isFeaturePrefix()     ? feature()     : operatorExpr();
+    var p2 = lastTokenEndPos();
+    e.setSourceRange(sourceRange(p0, p1, p2));
+    return e;
   }
 
 

--- a/tests/free_types_negative/test_free_types_negative.fz.expected_err
+++ b/tests/free_types_negative/test_free_types_negative.fz.expected_err
@@ -50,7 +50,7 @@ Types inferred for first type parameter '#_0':
 ----------------^
 Feature not found: 'prefix -' (no arguments)
 Target feature: 'Any'
-In call: '-'
+In call: '-x'
 To solve this, you might replace the free type 'test_free_type_negative.neg.i33' by a different type.  Is the type name spelled correctly?  The free type is declared at --CURDIR--/test_free_types_negative.fz:115:9:
   neg(x i33) => -x   # 8. should flag an error that is not too confusing
 --------^^^


### PR DESCRIPTION
This will be needed in a following patch to implement `check` expressions to get hold of the original expression.
