### PR TITLE
fe: extend type visibility into type features

### DIFF
--- a/src/dev/flang/fe/SourceModule.java
+++ b/src/dev/flang/fe/SourceModule.java
@@ -1034,6 +1034,9 @@ part of the (((inner features))) declarations of the corresponding
    * outer's outer (i.e., use is unqualified), false to search in outer only
    * (i.e., use is qualified with outer).
    *
+   * @param hidden true to return features that are not visible, used for error
+   * messages.
+   *
    * @return in case we found features visible in the call's scope, the features
    * together with the outer feature where they were found.
    */
@@ -1072,6 +1075,9 @@ part of the (((inner features))) declarations of the corresponding
    * @param traverseOuter true to collect all the features found in outer and
    * outer's outer (i.e., use is unqualified), false to search in outer only
    * (i.e., use is qualified with outer).
+   *
+   * @param hidden true to return features that are not visible, used for error
+   * messages.
    *
    * @return in case we found features visible in the call's scope, the features
    * together with the outer feature where they were found.
@@ -1193,6 +1199,17 @@ part of the (((inner features))) declarations of the corresponding
         var type_fs = new List<AbstractFeature>();
         var nontype_fs = new List<AbstractFeature>();
         var fs = lookup(outer, name, null, traverseOuter, false);
+        while (traverseOuter && outer != null)
+          {
+            if (outer.isTypeFeature())
+              {
+                lookup(outer._typeFeatureOrigin, name, null, false, false)
+                  .stream()
+                  .filter(fo -> !fo._feature.isTypeParameter())  // type parameters are duplicated in type feature and taken from there
+                  .forEach(fo -> fs.add(fo));
+              }
+            outer = outer.outer();
+          }
         for (var fo : fs)
           {
             var f = fo._feature;

--- a/src/dev/flang/fe/SourceModule.java
+++ b/src/dev/flang/fe/SourceModule.java
@@ -1199,16 +1199,17 @@ part of the (((inner features))) declarations of the corresponding
         var type_fs = new List<AbstractFeature>();
         var nontype_fs = new List<AbstractFeature>();
         var fs = lookup(outer, name, null, traverseOuter, false);
-        while (traverseOuter && outer != null)
+        var o = outer;
+        while (traverseOuter && o != null)
           {
-            if (outer.isTypeFeature())
+            if (o.isTypeFeature())
               {
-                lookup(outer._typeFeatureOrigin, name, null, false, false)
+                lookup(o._typeFeatureOrigin, name, null, false, false)
                   .stream()
                   .filter(fo -> !fo._feature.isTypeParameter())  // type parameters are duplicated in type feature and taken from there
                   .forEach(fo -> fs.add(fo));
               }
-            outer = outer.outer();
+            o = o.outer();
           }
         for (var fo : fs)
           {


### PR DESCRIPTION
Within type features, types that are visible at the original feature are now also visible for the type feature, e.g., in
```
  abc is
    def is

    type.test(x abc.def) is
      say x
```

it is no longer required to qualify the type `abc.def`, one can use `def` instead:

```
  abc is
    def is
    type.test(x def) is
      say x
```
