### PR TITLE
lib: Add missing argument `kind` to dafult `fuzion.runtime.fault` handler

### DIFF
--- a/lib/fuzion/runtime/fault.fz
+++ b/lib/fuzion/runtime/fault.fz
@@ -50,10 +50,17 @@ is
     cause "postcondition" msg
 
 
-  # cause fault with the given message
+  # cause fault of given kind with the given message
   #
-  cause(kind, msg String) =>
-    p.fail msg
+  cause(# the kind of failure, e.g., "precondition", "check", etc.
+        #
+        kind,
+
+        # message describing what failed, e.g. "debug: a > 0"
+        #
+        msg String)
+  =>
+    p.fail kind msg
     abort
 
 
@@ -68,7 +75,14 @@ is
 
     # fail with the given message and exit with return code 1
     #
-    fail(kind, msg String) =>
+    fail(# the kind of failure, e.g., "precondition", "check", etc.
+         #
+         kind,
+
+         # message describing what failed, e.g. "debug: a > 0"
+         #
+         msg String)
+    =>
       io.err.println "*** runtime failure: $kind $msg"
       exit 1
 
@@ -105,7 +119,7 @@ public Fault_Handler ref is
 
   # fault with the given message
   #
-  public fail(msg String) unit => abstract
+  public fail(kind, msg String) unit => abstract
 
   # Install this fault handler using a new instance of fault and run
   # `code` on it.  In case of an abort, return `def()` (NYI: def should be

--- a/lib/fuzion/runtime/fault.fz
+++ b/lib/fuzion/runtime/fault.fz
@@ -73,7 +73,10 @@ is
   #
   type.default_fault_handler : fuzion.runtime.Fault_Handler is
 
-    # fail with the given message and exit with return code 1
+    # fail with given kind and given message.
+    #
+    # This implementation will print "*** runtime failure: $kind $msg"
+    # and perform `exit 1`.
     #
     fail(# the kind of failure, e.g., "precondition", "check", etc.
          #
@@ -95,20 +98,20 @@ public fault =>
   fault.env
 
 
-# fault with a msg argument calls fault.cause_chekc msg, i.e., it uses the
-# current fault effect to cause an fault with the given message.
+# cause a check fault with given msg argument, i.e., call fault.cause_check msg, i.e.,
+# use the current fault effect to fail with the given message.
 #
 public check_fault(msg String) => fault.cause_check msg
 
 
-# fault with a msg argument calls fault.cause_pre msg, i.e., it uses the
-# current fault effect to cause an fault with the given message.
+# cause a precondition fault with given msg argument, i.e., call fault.cause_pre
+# msg, i.e., use the current fault effect to fail with the given message.
 #
 public precondition_fault(msg String) => fault.cause_pre msg
 
 
-# fault with a msg argument calls fault.cause_post msg, i.e., it uses the
-# current fault effect to cause an fault with the given message.
+# cause a postcondition fault with given msg argument, i.e., call fault.cause_post
+# msg, i.e., use the current fault effect to fail with the given message.
 #
 public postcondition_fault(msg String) => fault.cause_post msg
 
@@ -117,7 +120,7 @@ public postcondition_fault(msg String) => fault.cause_post msg
 #
 public Fault_Handler ref is
 
-  # fault with the given message
+  # fail with given kind and given message
   #
   public fail(kind, msg String) unit => abstract
 


### PR DESCRIPTION
Apparently I did not test the latest changes I made to the code such that it causes `Used abstract feature` errors.

