### PR TITLE
ast/tests: Nicer types in error messages

### DIFF
--- a/src/dev/flang/ast/AbstractType.java
+++ b/src/dev/flang/ast/AbstractType.java
@@ -1766,6 +1766,11 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
         var o = outer();
         String outer = o != null && !o.feature().isUniverse() ? o.asStringWrapped() + "." : "";
         var f = feature();
+        var typeType = f.isTypeFeature();
+        if (typeType)
+          {
+            f = f._typeFeatureOrigin;
+          }
         var fn = f.featureName();
         // for a feature that does not define a type itself, the name is not
         // unique due to overloading with different argument counts. So we add
@@ -1778,9 +1783,18 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
           {
             result = result + ".this";
           }
+        else if (typeType)
+          {
+            result = result + ".type";
+          }
+        var skip = typeType;
         for (var g : generics())
           {
-            result = result + " " + g.asStringWrapped();
+            if (!skip) // skip first generic 'THIS#TYPE' for types of type features.
+              {
+                result = result + " " + g.asStringWrapped();
+              }
+            skip = false;
           }
       }
     return result;

--- a/src/dev/flang/ast/AstErrors.java
+++ b/src/dev/flang/ast/AstErrors.java
@@ -1956,8 +1956,9 @@ public class AstErrors extends ANY
 
   public static void contractExpressionMustResultInBool(Expr cond)
   {
-    error(cond.pos(), "A expression of a contract must result in bool.",
-      "To solve this, change the expression to return a bool.");
+    error(cond.pos(), "A expression of a contract must result in type " + st("bool") + ".",
+          "Expression type is " + s(cond.type()) + "\n" +
+          "To solve this, change the expression to return a value of type " + st("bool") + ".");
   }
 
   public static void partialApplicationAmbiguity(SourcePosition pos,

--- a/tests/reg_issue1838/test_issue1838.fz.expected_err
+++ b/tests/reg_issue1838/test_issue1838.fz.expected_err
@@ -1,7 +1,8 @@
 
---CURDIR--/test_issue1838.fz:27:7: error 1: A expression of a contract must result in bool.
+--CURDIR--/test_issue1838.fz:27:7: error 1: A expression of a contract must result in type 'bool'.
   pre c
 ------^
-To solve this, change the expression to return a bool.
+Expression type is 'Any.type'
+To solve this, change the expression to return a value of type 'bool'.
 
 one error.

--- a/tests/reg_issue2402/reg_issue2402.fz.expected_out
+++ b/tests/reg_issue2402/reg_issue2402.fz.expected_out
@@ -1,1 +1,1 @@
-Type of '(String.#type#1 String).concat#2.#anonymous2'
+Type of 'String.type.concat#2.#anonymous2'


### PR DESCRIPTION
First, produce a nicer error message for an expression in a contract that is not boolean, include the actual type and highlight the expected type.

Since the actual type in `tests/reg_issu1838` is the type of a type parameter, also improve the output generated for types of type parameters, in particular, use `Any.type` or `String.type` instead of `Any.#type#1 Any` or `String.#type#1 String`.
