### PR TITLE
run_tests: add workaround for macOS

### DIFF
--- a/bin/run_tests.sh
+++ b/bin/run_tests.sh
@@ -43,7 +43,18 @@ trap "echo """"; cat ""$BUILD_DIR""/run_tests.results ""$BUILD_DIR""/run_tests.f
 
 echo "$(echo "$TESTS" | wc -l) tests."
 
-START_TIME_TOTAL=$(date +%s%N | cut -b1-13)
+
+# get nanoseconds, with workaround for macOS
+nanosec () {
+  if date --help | grep nanoseconds > /dev/null; then
+    date +%s%N | cut -b1-13
+  else
+    date +%s000000 | cut -b1-13
+  fi
+}
+
+
+START_TIME_TOTAL="$(nanosec)"
 for test in $TESTS; do
   if test -n "$VERBOSE"; then
     echo -en "\nrun $test: "
@@ -52,13 +63,13 @@ for test in $TESTS; do
     echo -n "_"
     echo "$test: skipped" >>"$BUILD_DIR"/run_tests.results
   else
-    START_TIME=$(date +%s%N | cut -b1-13)
+    START_TIME="$(nanosec)"
     if make "$TARGET" -e -C "$test" >"$test"/out.txt 2>"$test"/stderr.txt; then
        TEST_RESULT=true
     else
        TEST_RESULT=false
     fi
-    END_TIME=$(date +%s%N | cut -b1-13)
+    END_TIME="$(nanosec)"
     if $TEST_RESULT; then
       echo -n "."
       echo "$test in $((END_TIME-START_TIME))ms: ok"     >>"$BUILD_DIR"/run_tests.results
@@ -69,7 +80,7 @@ for test in $TESTS; do
     fi
   fi
 done
-END_TIME_TOTAL=$(date +%s%N | cut -b1-13)
+END_TIME_TOTAL="$(nanosec)"
 
 OK=$(     grep --count ok$      "$BUILD_DIR"/run_tests.results || true)
 SKIPPED=$(grep --count skipped$ "$BUILD_DIR"/run_tests.results || true)

--- a/bin/run_tests.sh
+++ b/bin/run_tests.sh
@@ -49,7 +49,7 @@ nanosec () {
   if date --help | grep nanoseconds > /dev/null; then
     date +%s%N | cut -b1-13
   else
-    date +%s000000 | cut -b1-13
+    date +%s000000000 | cut -b1-13
   fi
 }
 

--- a/bin/run_tests_parallel.sh
+++ b/bin/run_tests_parallel.sh
@@ -61,7 +61,7 @@ nanosec () {
   if date --help | grep nanoseconds > /dev/null; then
     date +%s%N | cut -b1-13
   else
-    date +%s000000 | cut -b1-13
+    date +%s000000000 | cut -b1-13
   fi
 }
 

--- a/bin/run_tests_parallel.sh
+++ b/bin/run_tests_parallel.sh
@@ -55,6 +55,17 @@ run_with_lock(){
     )&
 }
 
+
+# get nanoseconds, with workaround for macOS
+nanosec () {
+  if date --help | grep nanoseconds > /dev/null; then
+    date +%s%N | cut -b1-13
+  else
+    date +%s000000 | cut -b1-13
+  fi
+}
+
+
 # lower priority to prevent system getting unresponsive
 renice -n 19 $$ > /dev/null
 
@@ -75,7 +86,7 @@ echo "$(echo "$TESTS" | wc -l) tests, running $N tests in parallel."
 
 open_sem "$N"
 
-START_TIME_TOTAL=$(date +%s%N | cut -b1-13)
+START_TIME_TOTAL="$(nanosec)"
 for test in $TESTS; do
   task(){
     if test -n "$VERBOSE"; then
@@ -85,13 +96,13 @@ for test in $TESTS; do
       echo -n "_"
       echo "$test: skipped" >>"$BUILD_DIR"/run_tests.results
     else
-      START_TIME=$(date +%s%N | cut -b1-13)
+      START_TIME="$(nanosec)"
       if make "$TARGET" -e -C "$test" >"$test"/out.txt 2>"$test"/stderr.txt; then
          TEST_RESULT=true
       else
          TEST_RESULT=false
       fi
-      END_TIME=$(date +%s%N | cut -b1-13)
+      END_TIME="$(nanosec)"
       if $TEST_RESULT; then
         echo -n "."
         echo "$test in $((END_TIME-START_TIME))ms: ok"     >>"$BUILD_DIR"/run_tests.results
@@ -105,7 +116,7 @@ for test in $TESTS; do
   run_with_lock task
 done
 wait
-END_TIME_TOTAL=$(date +%s%N | cut -b1-13)
+END_TIME_TOTAL="$(nanosec)"
 
 OK=$(     grep --count ok$      "$BUILD_DIR"/run_tests.results || true)
 SKIPPED=$(grep --count skipped$ "$BUILD_DIR"/run_tests.results || true)


### PR DESCRIPTION
currently failing since date does not support nanosecond resolution on macOS
