### PR TITLE
lib/parser/tests: `pre`/`post` conditions in redef now need `else`/`then`

### DIFF
--- a/doc/ref_manual/fuzion_reference_manual.adoc
+++ b/doc/ref_manual/fuzion_reference_manual.adoc
@@ -349,7 +349,8 @@ include::rule.adoc[]
 :RULE_ID: PARS_CONTR_POST_NO_THEN
 include::rule.adoc[]
 
-In case of redefining an inhertied feature. pre- and postconditions are introduced using the `pre else` or `post then`, respectively.
+In case of redefining an inhertied feature, pre- and postconditions are
+introduced using `pre else` or `post then`, respectively:
 
 :RULE_SRC: src/dev/flang/fe/SourceModule.java
 :RULE_ID: PARS_CONTR_PRE_ELSE

--- a/doc/ref_manual/fuzion_reference_manual.adoc
+++ b/doc/ref_manual/fuzion_reference_manual.adoc
@@ -321,11 +321,51 @@ include::rule.adoc[]
 
 CAUTION: *NYI*: Text Missing
 
+
+==== Redefining inherited features
+
+If and only if a feature redefines an inherited feature, it must use the
+modifier `redef` in its declaration:
+
+:RULE_SRC: src/dev/flang/fe/SourceModule.java
+:RULE_ID: PARS_NO_REDEF
+include::rule.adoc[]
+
+:RULE_SRC: src/dev/flang/fe/SourceModule.java
+:RULE_ID: PARS_REDEF
+include::rule.adoc[]
+
+
+==== Redefining inherited features
+
+Pre- and postconditions of features are introduced using the `pre` or `post`
+keyword if those features do not redefine an inherited feature:
+
+:RULE_SRC: src/dev/flang/fe/SourceModule.java
+:RULE_ID: PARS_CONTR_PRE_NO_ELSE
+include::rule.adoc[]
+
+:RULE_SRC: src/dev/flang/fe/SourceModule.java
+:RULE_ID: PARS_CONTR_POST_NO_THEN
+include::rule.adoc[]
+
+In case of redefining an inhertied feature. pre- and postconditions are introduced using the `pre else` or `post then`, respectively.
+
+:RULE_SRC: src/dev/flang/fe/SourceModule.java
+:RULE_ID: PARS_CONTR_PRE_ELSE
+include::rule.adoc[]
+
+:RULE_SRC: src/dev/flang/fe/SourceModule.java
+:RULE_ID: PARS_CONTR_POST_THEN
+include::rule.adoc[]
+
+
 == Semantics
 
 CAUTION: *NYI*: Text Missing
 
 [appendix]
+
 == Glossary
 
 [#fuzion_abstract]

--- a/lib/Sequence.fz
+++ b/lib/Sequence.fz
@@ -240,7 +240,11 @@ public Sequence(public T type) ref is
   # create a slice from this Sequence that consists of the elements starting at index
   # from (including) up to index to (excluding).
   #
-  public slice(from, to i32) Sequence T =>
+  public slice(from, to i32) Sequence T
+    pre
+      debug: from ≥ 0
+      debug: to = 0 || is_valid_index to-1
+  =>
     drop(from).take to-from
 
 
@@ -553,13 +557,21 @@ public Sequence(public T type) ref is
       c Cons => c.head
 
 
+  # check if argument is a valid index in this sequence.
+  #
+  # Note that this may have has performance in O(i) unless this
+  # Sequence is_array_backed.
+  #
+  public is_valid_index(i i32) =>
+    (0 ≤ i && (if is_array_backed then i ≤ count
+                                  else !(drop i-1).is_empty))
+
+
   # the nth element in the sequence, must exist
   #
   public index [] (i i32) T
     pre
-      debug: 0 ≤ i
-      debug: finite: i < count
-      debug: !finite: !(drop i-1).is_empty
+      debug: is_valid_index(i)
   =>
     (nth i).get
 

--- a/lib/array.fz
+++ b/lib/array.fz
@@ -61,6 +61,13 @@ module:public array(
   public redef is_array_backed => true
 
 
+  # check if argument is a valid index in this array.
+  #
+  # Unlike for general Sequences, this perfoms in O(1).
+  #
+  public redef is_valid_index(i i32) => 0 ≤ i ≤ length
+
+
   # create a list that consists of the elements of this Sequence except the first
   # n elements
   #
@@ -82,9 +89,6 @@ module:public array(
   # get the contents of this array at the given index
   #
   public redef index [ ] (i i32) T
-    pre
-      safety: 0 ≤ i
-      safety: i < length
   =>
     internal_array[i]
 
@@ -144,12 +148,8 @@ module:public array(
   # count        : O(1)
   #
   public redef slice(from, to i32) Sequence T
-    pre
-      debug: from ≥ 0
-      debug: to <= length
   =>
-
-    ref : Sequence T
+    arrayslice : Sequence T is
 
       # this array slice as a list
       #
@@ -183,6 +183,13 @@ module:public array(
       public redef count => to-from
 
 
+      # check if argument is a valid index in this array.
+      #
+      # Unlike for general Sequences, this perfoms in O(1).
+      #
+      public redef is_valid_index(i i32) => 0 ≤ i ≤ arrayslice.this.count
+
+
       # create a list that consists of the elements of this Sequence except the first
       # n elements
       #
@@ -191,6 +198,8 @@ module:public array(
       public redef drop (n i32) =>
         array.this.slice from+(max 0 n) to
                   .as_list
+
+    arrayslice
 
 
   # create a cons cell for a list of this array starting at the given

--- a/lib/exit.fz
+++ b/lib/exit.fz
@@ -86,9 +86,7 @@ is
     # set the stored exit code
     #
     set_exit_code(code i32) outcome unit
-      pre
-        0 ≤ code ≤ 127
-      post
+      post then
         exit_code = code
       =>
         if exit_code = 0

--- a/lib/f64.fz
+++ b/lib/f64.fz
@@ -61,14 +61,11 @@ public f64(public val f64) : float is
   public as_i64_lax i64 => intrinsic
 
 
-  public fits_in_i64 =>
+  public redef fits_in_i64 =>
     (thiz ≥ i64.min.as_f64) && (thiz ≤ i64.max.as_f64)
 
 
-  public redef as_i64
-  pre
-    safety: fits_in_i64
-  => as_i64_lax
+  public redef as_i64 => as_i64_lax
 
 
   public as_f32 f32 => intrinsic

--- a/lib/float.fz
+++ b/lib/float.fz
@@ -61,10 +61,19 @@ public float : numeric is
   public infix < (other float.this) bool => abstract
 
 
+  # does this float value fit into an i64? This is redefined by children
+  # of float that support `as_i64`.
+  #
+  public fits_in_i64 => false
+
+
   # convert a float value to i64 dropping any fraction.
   # the value must be in the range of i64
   #
-  public as_i64 i64 => abstract
+  public as_i64 i64
+    pre
+      safety: fits_in_i64
+  => abstract
 
 
   # convert a float value to i32 dropping any fraction.

--- a/lib/i16.fz
+++ b/lib/i16.fz
@@ -53,14 +53,8 @@ public i16(public val i16) : num.wrap_around, has_interval is
   public fixed infix *° (other i16) i16 => intrinsic
 
   # division and remainder with check for div-by-zero
-  public fixed infix / (other i16)
-  pre
-    safety: other != 0
-  => div other
-  public fixed infix % (other i16)
-  pre
-    safety: other != 0
-  => mod other
+  public fixed infix / (other i16) => div other
+  public fixed infix % (other i16) => mod other
 
   # division and remainder with crash in case of div-by-zero
   div (other i16) i16 => intrinsic
@@ -75,6 +69,14 @@ public i16(public val i16) : num.wrap_around, has_interval is
   public fixed infix >> (other i16) i16 => intrinsic
   public fixed infix << (other i16) i16 => intrinsic
 
+  # does this i16 fit into an u8?
+  #
+  public fixed redef fits_in_u8  => 0 ≤ val ≤ u8.max.as_i16
+
+  # does this i16 fit into an u32?
+  #
+  public fixed redef fits_in_u32 => 0 ≤ val
+
   # conversion to u32, i64 and u64, with range check
   public as_i8 i8
     pre
@@ -86,11 +88,7 @@ public i16(public val i16) : num.wrap_around, has_interval is
   public as_i64  => thiz.as_i32.as_i64
 # as_i128 => thiz.as_i32.as_i128
 
-  public as_u8 u8
-    pre
-      debug: (thiz ≥ 0) && (thiz ≤ u8.max.as_i16)
-    =>
-      low8bits
+  public as_u8  u8  => low8bits
   public as_u16 u16
     pre
       debug: thiz ≥ 0

--- a/lib/i32.fz
+++ b/lib/i32.fz
@@ -53,14 +53,8 @@ public i32(public val i32) : num.wrap_around, has_interval is
   public fixed infix *° (other i32) i32 => intrinsic
 
   # division and remainder with check for div-by-zero
-  public fixed infix / (other i32)
-  pre
-    safety: other != 0
-  => div other
-  public fixed infix % (other i32)
-  pre
-    safety: other != 0
-  => mod other
+  public fixed infix / (other i32) => div other
+  public fixed infix % (other i32) => mod other
 
   # division and remainder with crash in case of div-by-zero
   div (other i32) i32 => intrinsic
@@ -74,6 +68,14 @@ public i32(public val i32) : num.wrap_around, has_interval is
   # shift operations (signed)
   public fixed infix >> (other i32) i32 => intrinsic
   public fixed infix << (other i32) i32 => intrinsic
+
+  # does this i32 fit into an u8?
+  #
+  public fixed redef fits_in_u8  => 0 ≤ val ≤ u8.max.as_i32
+
+  # does this i32 fit into an u32?
+  #
+  public fixed redef fits_in_u32 => 0 ≤ val
 
   # conversion to u32, i64 and u64, with range check
   public as_i8 i8
@@ -90,12 +92,7 @@ public i32(public val i32) : num.wrap_around, has_interval is
       low16bits.cast_to_i16
   public as_i64 i64 => intrinsic
 # as_i128 NYI
-  public as_u8 u8
-    pre
-      thiz ≥ u8.min.as_i32
-      thiz ≤ u8.max.as_i32
-    =>
-      low8bits
+  public as_u8  u8  => low8bits
   public as_u16 u16
     pre
       thiz ≥ u16.min.as_i32

--- a/lib/i64.fz
+++ b/lib/i64.fz
@@ -53,14 +53,8 @@ public i64(public val i64) : num.wrap_around, has_interval is
   public fixed infix *° (other i64) i64 => intrinsic
 
   # division and remainder with check for div-by-zero
-  public fixed infix / (other i64)
-  pre
-    safety: other != i64 0
-  => div other
-  public fixed infix % (other i64)
-  pre
-    safety: other != i64 0
-  => mod other
+  public fixed infix / (other i64) => div other
+  public fixed infix % (other i64) => mod other
 
   # division and remainder with crash in case of div-by-zero
   div (other i64) i64 => intrinsic
@@ -101,12 +95,17 @@ public i64(public val i64) : num.wrap_around, has_interval is
     =>
       low32bits.cast_to_i32
 
+  # does this i64 fit into an u8?
+  #
+  public fixed redef fits_in_u8  => 0 ≤ val ≤ u8.max.as_i64
+
+  # does this i64 fit into an u32?
+  #
+  public fixed redef fits_in_u32 => 0 ≤ val ≤ u32.max.as_i64
+
 
   # this i64 as an u8
   public as_u8 u8
-    pre
-      thiz ≥ (i64 0)
-#      thiz ≤ u8.max.as_i64
 #    post
 #      analysis: result.as_u64 = thiz
     =>
@@ -126,10 +125,7 @@ public i64(public val i64) : num.wrap_around, has_interval is
 
   # this i64 as an u32
   public as_u32 u32
-    pre
-      thiz ≥ (i64 0)
-#      thiz ≤ u32.max.as_i64
-#    post
+#    post then
 #      analysis:  result.as_i64 = thiz
     =>
       low32bits

--- a/lib/i8.fz
+++ b/lib/i8.fz
@@ -53,14 +53,8 @@ public i8(public val i8) : num.wrap_around, has_interval is
   public fixed infix *° (other i8) i8 => intrinsic
 
   # division and remainder with check for div-by-zero
-  public fixed infix / (other i8)
-  pre
-    safety: other != 0
-  => div other
-  fixed redef infix % (other i8)
-  pre
-    safety: other != 0
-  => mod other
+  public fixed infix / (other i8) => div other
+  public fixed infix % (other i8) => mod other
 
   # division and remainder with crash in case of div-by-zero
   div (other i8) i8 => intrinsic
@@ -81,21 +75,21 @@ public i8(public val i8) : num.wrap_around, has_interval is
   public as_i64  => as_i32.as_i64
 # as_i128 => as_i32.as_i128
 
-  public as_u8 u8
-    pre
-      debug: thiz ≥ 0
-    =>
-      cast_to_u8
+  # does this i8 fit into an u8?  This is true for all non-negative values.
+  #
+  public redef fixed fits_in_u8  => 0 ≤ val
+
+  # does this i8 fit into an u32?  This is true for all non-negative values.
+  #
+  public redef fixed fits_in_u32 => 0 ≤ val
+
+  public as_u8  u8  => cast_to_u8
   public as_u16 u16
     pre
       debug: thiz ≥ 0
     =>
       cast_to_u16
-  public as_u32 u32
-    pre
-      debug: thiz ≥ 0
-    =>
-      cast_to_u32
+  public as_u32 u32 => cast_to_u32
   public as_u64 u64
     pre
       debug: thiz ≥ 0

--- a/lib/int.fz
+++ b/lib/int.fz
@@ -87,7 +87,6 @@ is
 
   # divide this int by other
   public fixed infix /  (other int) int
-  pre other != int.zero
   =>
     s num.sign := result_sign_mul_div other
     int s n/other.n
@@ -102,7 +101,6 @@ is
   # exponentation operator:
   # this int to the power of other
   public fixed infix ** (other int) int
-  pre other ≥ int.zero
   =>
     match s
       num.plus => int num.plus (n ** other.n)

--- a/lib/integer.fz
+++ b/lib/integer.fz
@@ -31,12 +31,6 @@
 #
 module:public integer : numeric is
 
-  # division remainder
-  public redef infix % (other integer.this) integer.this
-    pre
-      safety: other != integer.this.zero
-  => abstract
-
   # test divisibility by other
   public infix %% (other integer.this) bool
     pre

--- a/lib/io/file/open.fz
+++ b/lib/io/file/open.fz
@@ -116,8 +116,6 @@ module:public open(public T type,
     # get byte at given index i
     #
     public index [ ] (i i64) u8 ! open T
-      pre
-        safety: i64 0 ≤ i < length
     =>
       mapped_buffer_get memory i
 
@@ -125,8 +123,6 @@ module:public open(public T type,
     # set byte at given index i to given value o
     #
     public set [ ] (i i64, o u8) unit ! io.file.open T
-      pre
-        safety: i64 0 ≤ i < length
     =>
       mapped_buffer_set memory i o
 

--- a/lib/list.fz
+++ b/lib/list.fz
@@ -115,9 +115,8 @@ public list(public A type) : choice nil (Cons A (list A)), Sequence A is
   # list must not be empty, causes precondition failure if debug is enabled.
   #
   public redef first
-  pre
-    debug: !is_empty
-  => head.get
+  =>
+    head.get
 
 
   # returns the list of all but the last element of this list
@@ -155,8 +154,6 @@ public list(public A type) : choice nil (Cons A (list A)), Sequence A is
   # for an infinite list.
   #
   public redef last A
-    pre
-      debug: !is_empty
   =>
     force_tail ? nil    => first
                | c Cons => force_tail.last
@@ -229,8 +226,6 @@ public list(public A type) : choice nil (Cons A (list A)), Sequence A is
   # e.g., to find the minimum of a list of i32, use `l.fold1 (<=)`
   #
   public redef fold1 (f (A,A)->A) A
-  pre
-    debug: !is_empty
   => (list.this ? nil    => panic "list.fold1 called on empty list"
                 | c Cons => c.tail.foldf f c.head)
 

--- a/lib/mutate.fz
+++ b/lib/mutate.fz
@@ -218,8 +218,6 @@ public mutate : simple_effect is
     # get element at given index i
     #
     public redef index [ ] (i i64) T
-      pre
-        safety: (i64 0) ≤ i < length
     =>
       data[i.as_i32]
 
@@ -227,8 +225,6 @@ public mutate : simple_effect is
     # set element at given index i to given value o
     #
     public set [ ] (i i64, o T) unit
-      pre
-        safety: (i64 0) ≤ i < length
     =>
       check_and_replace
       data[i.as_i32] := o
@@ -309,4 +305,3 @@ public mut =>
 # create a new mutable value of type T with initial value v
 #
 public mut(T type, v T) => mut.new T v
-

--- a/lib/num/complex.fz
+++ b/lib/num/complex.fz
@@ -45,8 +45,6 @@ is
   public fixed redef infix - (b complex.this) => complex real-b.real imag-b.imag
   public fixed redef infix * (b complex.this) => complex real*b.real-imag*b.imag real*b.imag+imag*b.real
   public fixed redef infix / (b complex.this)
-  pre
-    safety: b.real != C.zero || b.imag != C.zero
   =>
     n := b.real*b.real+b.imag*b.imag
     complex (real*b.real+imag*b.imag)/n (imag*b.real-real*b.imag)/n

--- a/lib/num/fraction.fz
+++ b/lib/num/fraction.fz
@@ -65,10 +65,7 @@ is
   public fixed redef infix +  (b fraction.this) => (fraction (numerator * b.denominator + b.numerator * denominator) (denominator * b.denominator)).reduce
   public fixed redef infix -  (b fraction.this) => (fraction (numerator * b.denominator - b.numerator * denominator) (denominator * b.denominator)).reduce
   public fixed redef infix *  (b fraction.this) => (fraction (numerator * b.numerator                              ) (denominator * b.denominator)).reduce
-  public fixed redef infix /  (b fraction.this)
-  pre
-    safety: b.numerator != B.zero
-  => (fraction (numerator * b.denominator) (denominator * b.numerator)).reduce
+  public fixed redef infix /  (b fraction.this) => (fraction (numerator * b.denominator) (denominator * b.numerator)).reduce
 
   public redef as_string => "" + numerator + "⁄" + denominator
 

--- a/lib/num/wrap_around.fz
+++ b/lib/num/wrap_around.fz
@@ -79,27 +79,27 @@ module:public wrap_around : integer is
 
   # negation, with check for overflow
   public redef prefix - wrap_around.this
-    pre
+    pre else
       debug: !wrapped_on_neg
   => -° wrap_around.this
 
   # addition, with check for overflow
   public redef infix +  (other wrap_around.this) wrap_around.this
-    pre
+    pre else
       debug: !(overflow_on_add other)
       debug: !(underflow_on_add other)
   => wrap_around.this +° other
 
   # subtraction, with check for overflow
   public redef infix -  (other wrap_around.this) wrap_around.this
-    pre
+    pre else
       debug: !(overflow_on_sub other)
       debug: !(underflow_on_sub other)
   => wrap_around.this -° other
 
   # multiplication, with check for overflow
   public redef infix *  (other wrap_around.this) wrap_around.this
-    pre
+    pre else
       debug: !(overflow_on_mul other)
       debug: !(underflow_on_mul other)
   => wrap_around.this *° other
@@ -123,9 +123,6 @@ module:public wrap_around : integer is
   # 'zero ** zero' is permitted and results in 'one'.
   #
   public infix ** (other wrap_around.this) wrap_around.this
-    pre
-      safety: (other ≥ wrap_around.this.zero)
-      debug: (!overflow_on_exp other)
   =>
     wrap_around.this **° other
 
@@ -153,8 +150,6 @@ module:public wrap_around : integer is
   # 'zero **? zero' is permitted and results in 'one'.
   #
   public infix **? (other wrap_around.this) num_option wrap_around.this
-    pre
-      safety: (other ≥ wrap_around.this.zero)
   =>
     if      (other = wrap_around.this.zero) wrap_around.this.one
     else if (other = wrap_around.this.one ) wrap_around.this
@@ -176,8 +171,6 @@ module:public wrap_around : integer is
   # 'zero **^ zero' is permitted and results in 'one'.
   #
   public infix **^ (other wrap_around.this) wrap_around.this
-    pre
-      safety: (other ≥ wrap_around.this.zero)
   =>
     if overflow_on_exp other
       if (wrap_around.this ≥ wrap_around.this.zero) || (other %% wrap_around.this.two)
@@ -189,8 +182,6 @@ module:public wrap_around : integer is
 
   # bitwise NOT
   public redef prefix ~ wrap_around.this
-    pre
-      is_bounded
   =>
     wrap_around.this ^ wrap_around.this.all_bits_set
 

--- a/lib/numeric.fz
+++ b/lib/numeric.fz
@@ -103,14 +103,20 @@ module:public numeric : property.hashable, property.orderable is
   public infix +? (other numeric.this) num_option numeric.this => numeric.this + other
   public infix -? (other numeric.this) num_option numeric.this => numeric.this - other
   public infix *? (other numeric.this) num_option numeric.this => numeric.this * other
-  public infix **?(other numeric.this) num_option numeric.this => abstract
+  public infix **?(other numeric.this) num_option numeric.this
+    pre
+      safety: (other ≥ numeric.this.zero)
+  => abstract
 
   # saturating  operations
   public prefix -^  numeric.this => - numeric.this
   public infix +^ (other numeric.this) numeric.this => numeric.this + other
   public infix -^ (other numeric.this) numeric.this => numeric.this - other
   public infix *^ (other numeric.this) numeric.this => numeric.this * other
-  public infix **^(other numeric.this) numeric.this => abstract
+  public infix **^(other numeric.this) numeric.this
+    pre
+      safety: (other ≥ numeric.this.zero)
+  => abstract
 
 
   public sign => if numeric.this = numeric.this.zero then 0 else if numeric.this > numeric.this.zero then 1 else -1
@@ -118,12 +124,24 @@ module:public numeric : property.hashable, property.orderable is
   public abs => if sign ≥ 0 then numeric.this else -numeric.this
 
 
+  # does this numeric value fit into an u8? This is redefined by children
+  # of numeric that support `as_u8`.
+  #
+  public fits_in_u8 => false
+
+
+  # does this numeric value fit into an u32? This is redefined by children
+  # of numeric that support `as_u32`.
+  #
+  public fits_in_u32 => false
+
+
   # the u32 value corresponding to this
   # note: potential fraction will be discarded
   # NYI replace this by as_u32?
   to_u32 u32
     pre
-      debug: (numeric.this ≥ numeric.this.zero)
+      debug: fits_in_u32
   =>
     if (numeric.this ≥ numeric.this.one) ((numeric.this - numeric.this.one).to_u32 + 1)
     else 0
@@ -132,7 +150,7 @@ module:public numeric : property.hashable, property.orderable is
   # this numeric value as an u8
   public as_u8 u8
     pre
-      debug: (numeric.this ≥ numeric.this.zero)
+      debug: fits_in_u8
   => abstract
 
 

--- a/lib/u128.fz
+++ b/lib/u128.fz
@@ -81,14 +81,8 @@ public u128(public hi u64, public lo u64) : num.wrap_around, has_interval is
      u128 p03<<32 0         )
 
   # division and remainder with check for div-by-zero
-  public fixed infix / (other u128)
-  pre
-    safety: other != u128.zero
-  => div other
-  public fixed infix %  (other u128)
-  pre
-    safety: other != u128.zero
-  => mod other
+  public fixed infix / (other u128) => div other
+  public fixed infix % (other u128) => mod other
 
   # division and remainder with crash in case of div-by-zero
   div (other u128) u128 =>
@@ -149,6 +143,14 @@ public u128(public hi u64, public lo u64) : num.wrap_around, has_interval is
   fixed type.lteq(a, b u128) =>
     a.hi < b.hi || (a.hi = b.hi) && (a.lo ≤ b.lo)
 
+  # does this u128 fit into an u8?
+  #
+  public fixed redef fits_in_u8  => u128.this ≤ u8.max.as_u128
+
+  # does this u128 fit into an u32?
+  #
+  public fixed redef fits_in_u32 => u128.this ≤ u32.max.as_u128
+
   public as_i8 i8
     pre
       thiz ≤ i8.max.as_u128
@@ -172,9 +174,7 @@ public u128(public hi u64, public lo u64) : num.wrap_around, has_interval is
     =>
       lo.as_i64
   public as_u8 u8
-    pre
-      thiz ≤ u8.max.as_u128
-    post
+    post then
       analysis: result.as_u128 = thiz
     =>
       lo.as_u8

--- a/lib/u16.fz
+++ b/lib/u16.fz
@@ -53,14 +53,8 @@ public u16(public val u16) : num.wrap_around, has_interval is
   public fixed infix *° (other u16) u16 => intrinsic
 
   # division and remainder with check for div-by-zero
-  public fixed infix / (other u16)
-  pre
-    safety: other != 0
-  => div other
-  public fixed infix % (other u16)
-  pre
-    safety: other != 0
-  => mod other
+  public fixed infix / (other u16) => div other
+  public fixed infix % (other u16) => mod other
 
   # division and remainder with crash in case of div-by-zero
   div (other u16) u16 => intrinsic
@@ -75,6 +69,14 @@ public u16(public val u16) : num.wrap_around, has_interval is
   public fixed infix >> (other u16) u16 => intrinsic
   public fixed infix << (other u16) u16 => intrinsic
 
+  # does this u16 fit into an u8?
+  #
+  public redef fixed fits_in_u8  => val ≤ u8.max.as_u16
+
+  # does this u16 fit into an u8? This is always true.
+  #
+  public redef fixed fits_in_u32 => true
+
   public as_i8 i8
     pre
       debug: thiz ≤ i8.max.as_u16
@@ -88,11 +90,7 @@ public u16(public val u16) : num.wrap_around, has_interval is
   public as_i32 i32 => intrinsic
   public as_i64  => thiz.as_i32.as_i64
 # as_i128 => thiz.as_i32.as_i128
-  public as_u8 u8
-    pre
-      thiz ≤ u8.max.as_u16
-    =>
-      low8bits
+  public as_u8   => low8bits
   public as_u32  => thiz.as_i32.as_u32
   public as_u64  => thiz.as_i32.as_u64
   public as_u128 => thiz.as_i32.as_u128

--- a/lib/u32.fz
+++ b/lib/u32.fz
@@ -53,14 +53,8 @@ public u32(public val u32) : num.wrap_around, has_interval is
   public fixed infix *° (other u32) u32 => intrinsic
 
   # division and remainder with check for div-by-zero
-  public fixed infix / (other u32)
-  pre
-    safety: other != u32 0
-  => div other
-  public fixed infix % (other u32)
-  pre
-    safety: other != u32 0
-  => mod other
+  public fixed infix / (other u32) => div other
+  public fixed infix % (other u32) => mod other
 
   # division and remainder with crash in case of div-by-zero
   div (other u32) u32 => intrinsic
@@ -74,6 +68,15 @@ public u32(public val u32) : num.wrap_around, has_interval is
   # shift operations (unsigned)
   public fixed infix >> (other u32) u32 => intrinsic
   public fixed infix << (other u32) u32 => intrinsic
+
+  # does this u32 fit into an u8?
+  #
+  public redef fixed fits_in_u8  => val ≤ u8.max.as_u32
+
+  # does this u32 fit into an u32? This is always true.
+  #
+  public redef fixed fits_in_u32 => true
+
 
   # this u32 as an i8
   public as_i8 i8
@@ -110,11 +113,7 @@ public u32(public val u32) : num.wrap_around, has_interval is
 
 
   # this u32 as an u8
-  public as_u8 u8
-    pre
-      debug: thiz ≤ u8.max.as_u32
-    =>
-      cast_to_i32.as_u8
+  public as_u8 => cast_to_i32.as_u8
 
 
   # this u32 as an u16

--- a/lib/u64.fz
+++ b/lib/u64.fz
@@ -53,14 +53,8 @@ public u64(public val u64) : num.wrap_around, has_interval is
   public fixed infix *° (other u64) u64 => intrinsic
 
   # division and remainder with check for div-by-zero
-  public fixed infix / (other u64)
-  pre
-    safety: other != u64 0
-  => div other
-  public fixed infix %  (other u64)
-  pre
-    safety: other != u64 0
-  => mod other
+  public fixed infix / (other u64) => div other
+  public fixed infix % (other u64) => mod other
 
   # division and remainder with crash in case of div-by-zero
   div (other u64) u64 => intrinsic

--- a/lib/u8.fz
+++ b/lib/u8.fz
@@ -53,14 +53,8 @@ public u8(public val u8) : num.wrap_around, has_interval is
   public fixed infix *° (other u8) u8 => intrinsic
 
   # division and remainder with check for div-by-zero
-  public fixed infix / (other u8)
-  pre
-    safety: other != 0
-  => div other
-  public fixed infix % (other u8)
-  pre
-    safety: other != 0
-  => mod other
+  public fixed infix / (other u8) => div other
+  public fixed infix % (other u8) => mod other
 
   # division and remainder with crash in case of div-by-zero
   div (other u8) u8 => intrinsic

--- a/lib/uint.fz
+++ b/lib/uint.fz
@@ -55,8 +55,9 @@ is
 
   # shift right
   public fixed infix >> (other uint) uint
-  pre other ≤ uint i32.max.as_u64
   =>
+    check
+      other ≤ uint i32.max.as_u64
     if other = uint.zero
       thiz
     else if other ≥ uint 32
@@ -75,8 +76,9 @@ is
 
   # shift left
   public fixed infix << (other uint) uint
-  pre other ≤ uint i32.max.as_u64
   =>
+    check
+      other ≤ uint i32.max.as_u64
     if other = uint.zero
       thiz
     else if other ≥ uint 32
@@ -160,7 +162,6 @@ is
 
   # subtract other from this unsigned int
   public fixed infix - (other uint) uint
-  pre thiz ≥ other
   =>
     two_pow_32 := ((u64 1)<<32)
     (b1, b2) := equalize other
@@ -208,7 +209,6 @@ is
 
   # divide these unsigned ints
   public fixed infix /  (other uint) uint
-  pre other != uint.zero
   =>
     (quotient,_) := (divide_with_remainder other)
     quotient
@@ -216,7 +216,8 @@ is
 
   # modulo
   # returns the remainder of the division
-  public fixed infix %  (other uint) uint =>
+  public fixed infix %  (other uint) uint
+  =>
     (_,remainder) := (divide_with_remainder other)
     remainder
 
@@ -305,9 +306,16 @@ is
     as_u32.as_u8
 
 
-  # does this uint fit in 32 bits?
-  public fits_in_u32 =>
+  # does this uint fit into an u32?
+  #
+  public redef fits_in_u32 =>
     data.count ≤ 1
+
+
+  # does this uint fit into an u8?
+  #
+  public redef fits_in_u8 =>
+    data.count ≤ 1 && data[0].fits_in_u8
 
 
   # this uint as an u32

--- a/src/dev/flang/ast/AstErrors.java
+++ b/src/dev/flang/ast/AstErrors.java
@@ -54,7 +54,7 @@ public class AstErrors extends ANY
 
 
   /**
-   * Enum to distringuish contract parts: precondition vs. postcondition.
+   * Enum to distinguish contract parts: precondition vs. postcondition.
    */
   enum PreOrPost
   {

--- a/src/dev/flang/ast/Contract.java
+++ b/src/dev/flang/ast/Contract.java
@@ -27,6 +27,7 @@ Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
 package dev.flang.ast;
 
 import dev.flang.util.List;
+import dev.flang.util.SourceRange;
 
 
 /**
@@ -49,7 +50,8 @@ public class Contract
   /**
    * Empty contract
    */
-  public static final Contract EMPTY_CONTRACT = new Contract(NO_COND, NO_COND);
+  public static final Contract EMPTY_CONTRACT = new Contract(NO_COND, null, null,
+                                                             NO_COND, null, null);
 
 
   /*----------------------------  variables  ----------------------------*/
@@ -66,17 +68,38 @@ public class Contract
   public List<Cond> ens;
 
 
+  /**
+   * Did the parser find `pre` / `post` or even `pre else` / `post then` ? These
+   * might be present even if the condition list is NO_COND.
+   */
+  public final SourceRange _hasPre,     _hasPost;
+  public final SourceRange _hasPreElse, _hasPostThen;
+
+
   /*--------------------------  constructors  ---------------------------*/
 
 
   /**
    * Constructor
    */
-  public Contract(List<Cond> r,
-                  List<Cond> e)
+  public Contract(List<Cond> r, SourceRange hasPre,  SourceRange hasElse,
+                  List<Cond> e, SourceRange hasPost, SourceRange hasThen)
   {
+    _hasPre  = hasPre;
+    _hasPost = hasPost;
+    _hasPreElse  = hasElse;
+    _hasPostThen = hasThen;
     req = r == null || r.isEmpty() ? NO_COND : r;
     ens = e == null || e.isEmpty() ? NO_COND : e;
+  }
+
+
+  /**
+   * Constructor
+   */
+  public Contract(List<Cond> r, List<Cond> e)
+  {
+    this(r, null, null, e, null, null);
   }
 
 

--- a/src/dev/flang/fe/LibraryOut.java
+++ b/src/dev/flang/fe/LibraryOut.java
@@ -43,6 +43,7 @@ import dev.flang.ast.AbstractType;
 import dev.flang.ast.Box;
 import dev.flang.ast.Call;
 import dev.flang.ast.Constant;
+import dev.flang.ast.Cond;
 import dev.flang.ast.Env;
 import dev.flang.ast.Expr;
 import dev.flang.ast.Feature;
@@ -495,14 +496,15 @@ class LibraryOut extends ANY
       {
         code(c.cond, false);
       }
-    _data.writeInt(f.contract().ens.size());
-    for (var c : f.contract().ens)
+    var post = f.contract().ens;
+    _data.writeInt(post.size());
+    for (var c : post)
       {
         code(c.cond, false);
       }
-    var r = f.redefines();
-    _data.writeInt(r.size());
-    for(var rf : r)
+    var redefines = f.redefines();
+    _data.writeInt(redefines.size());
+    for(var rf : redefines)
       {
         _data.writeOffset(rf);
       }

--- a/src/dev/flang/fe/SourceModule.java
+++ b/src/dev/flang/fe/SourceModule.java
@@ -873,7 +873,7 @@ A post-condition of a feature that does not redefine an inherited featue must st
           {
                 /*
     // tag::fuzion_rule_PARS_REDEF[]
-A feature that redefines at least one an inherited featue must use the `redef` modifier unless all redefined, inherited feature are `abstract`.
+A feature that redefines at least one inherited feature must use the `redef` modifier unless all redefined, inherited features are `abstract`.
     // end::fuzion_rule_PARS_REDEF[]
                 */
             AstErrors.redefineModifierMissing(f.pos(), f, existing);
@@ -886,7 +886,7 @@ A feature that redefines at least one an inherited featue must use the `redef` m
           {
               /*
     // tag::fuzion_rule_PARS_CONTR_PRE_ELSE[]
-A pre-condition of a feature that redefines one or several inherited featues must start with `pre else`, indepdentent of wether the redefined, inherited features are `abstract` or not.
+A pre-condition of a feature that redefines one or several inherited features must start with `pre else`, independent of whether the redefined, inherited features are `abstract` or not.
     // end::fuzion_rule_PARS_CONTR_PRE_ELSE[]
               */
             AstErrors.redefinePreconditionMustUseElse(c._hasPre, f);
@@ -895,7 +895,7 @@ A pre-condition of a feature that redefines one or several inherited featues mus
           {
               /*
     // tag::fuzion_rule_PARS_CONTR_POST_THEN[]
-A post-condition of a feature that redefines one or several inherited featues must start with `post else`, indepdentent of wether the redefined, inherited features are `abstract` or not.
+A post-condition of a feature that redefines one or several inherited features must start with `post else`, independent of whether the redefined, inherited features are `abstract` or not.
     // end::fuzion_rule_PARS_CONTR_POST_THEN[]
               */
             AstErrors.redefinePostconditionMustUseThen(c._hasPost, f);

--- a/src/dev/flang/fe/SourceModule.java
+++ b/src/dev/flang/fe/SourceModule.java
@@ -836,7 +836,7 @@ part of the (((inner features))) declarations of the corresponding
               {
                 /*
     // tag::fuzion_rule_PARS_NO_REDEF[]
-A feature that does not redefine an inherited featue must use the `redef` modifier.
+A feature that does not redefine an inherited featue must not use the `redef` modifier.
     // end::fuzion_rule_PARS_NO_REDEF[]
                 */
                 AstErrors.redefineModifierDoesNotRedefine(f);
@@ -873,7 +873,7 @@ A post-condition of a feature that does not redefine an inherited featue must st
           {
                 /*
     // tag::fuzion_rule_PARS_REDEF[]
-A feature that redefines an inherited featue must use the `redef` modifier unless the inherited fature is `abstract`.
+A feature that redefines at least one an inherited featue must use the `redef` modifier unless all redefined, inherited feature are `abstract`.
     // end::fuzion_rule_PARS_REDEF[]
                 */
             AstErrors.redefineModifierMissing(f.pos(), f, existing);
@@ -886,7 +886,7 @@ A feature that redefines an inherited featue must use the `redef` modifier unles
           {
               /*
     // tag::fuzion_rule_PARS_CONTR_PRE_ELSE[]
-A pre-condition of a feature that redefines an inherited featue must start with `pre else`.
+A pre-condition of a feature that redefines one or several inherited featues must start with `pre else`, indepdentent of wether the redefined, inherited features are `abstract` or not.
     // end::fuzion_rule_PARS_CONTR_PRE_ELSE[]
               */
             AstErrors.redefinePreconditionMustUseElse(c._hasPre, f);
@@ -895,7 +895,7 @@ A pre-condition of a feature that redefines an inherited featue must start with 
           {
               /*
     // tag::fuzion_rule_PARS_CONTR_POST_THEN[]
-A post-condition of a feature that redefines an inherited featue must start with `post else`.
+A post-condition of a feature that redefines one or several inherited featues must start with `post else`, indepdentent of wether the redefined, inherited features are `abstract` or not.
     // end::fuzion_rule_PARS_CONTR_POST_THEN[]
               */
             AstErrors.redefinePostconditionMustUseThen(c._hasPost, f);

--- a/src/dev/flang/fe/SourceModule.java
+++ b/src/dev/flang/fe/SourceModule.java
@@ -836,11 +836,38 @@ part of the (((inner features))) declarations of the corresponding
     var fn = f.featureName();
     var doi = declaredOrInheritedFeatures(outer);
     var existing = doi.get(fn);
+    var c = f.contract();
     if (existing == null)
       {
-        if (f instanceof Feature ff && (ff._modifiers & FuzionConstants.MODIFIER_REDEFINE) != 0)
+        if (f instanceof Feature ff)
           {
-            AstErrors.redefineModifierDoesNotRedefine(f);
+            if ((ff._modifiers & FuzionConstants.MODIFIER_REDEFINE) != 0)
+              {
+                /*
+    // tag::fuzion_rule_PARS_NO_REDEF[]
+A feature that does not redefine an inherited featue must use the `redef` modifier.
+    // end::fuzion_rule_PARS_NO_REDEF[]
+                */
+                AstErrors.redefineModifierDoesNotRedefine(f);
+              }
+            else if (c._hasPreElse != null)
+              {
+              /*
+    // tag::fuzion_rule_PARS_CONTR_PRE_NO_ELSE[]
+A pre-condition of a feature that does not redefine an inherited featue must start with `pre`, not `pre else`.
+    // end::fuzion_rule_PARS_CONTR_PRE_NO_ELSE[]
+              */
+                AstErrors.notRedefinedPreconditionMustNotUseElse(c._hasPreElse, f);
+              }
+            else if (c._hasPostThen != null)
+              {
+              /*
+    // tag::fuzion_rule_PARS_CONTR_POST_NO_THEN[]
+A post-condition of a feature that does not redefine an inherited featue must start with `post`, not `post then`.
+    // end::fuzion_rule_PARS_CONTR_POST_NO_THEN[]
+              */
+                AstErrors.notRedefinedPostconditionMustNotUseThen(c._hasPostThen, f);
+              }
           }
       }
     else if (existing == f)
@@ -853,12 +880,35 @@ part of the (((inner features))) declarations of the corresponding
          */
         if ((!Errors.any() || !f.isTypeFeature()) && visibleFor(existing, f))
           {
+                /*
+    // tag::fuzion_rule_PARS_REDEF[]
+A feature that redefines an inherited featue must use the `redef` modifier unless the inherited fature is `abstract`.
+    // end::fuzion_rule_PARS_REDEF[]
+                */
             AstErrors.redefineModifierMissing(f.pos(), f, existing);
           }
       }
     else
       {
         f.redefines().add(existing);
+        if (c._hasPre != null && c._hasPreElse == null)
+          {
+              /*
+    // tag::fuzion_rule_PARS_CONTR_PRE_ELSE[]
+A pre-condition of a feature that redefines an inherited featue must start with `pre else`.
+    // end::fuzion_rule_PARS_CONTR_PRE_ELSE[]
+              */
+            AstErrors.redefinePreconditionMustUseElse(c._hasPre, f);
+          }
+        else if (c._hasPost != null && c._hasPostThen == null)
+          {
+              /*
+    // tag::fuzion_rule_PARS_CONTR_POST_THEN[]
+A post-condition of a feature that redefines an inherited featue must start with `post else`.
+    // end::fuzion_rule_PARS_CONTR_POST_THEN[]
+              */
+            AstErrors.redefinePostconditionMustUseThen(c._hasPost, f);
+          }
       }
     if (f     instanceof Feature ff &&
         outer.state().atLeast(State.RESOLVED_DECLARATIONS))

--- a/src/dev/flang/parser/Lexer.java
+++ b/src/dev/flang/parser/Lexer.java
@@ -1170,6 +1170,15 @@ public class Lexer extends SourceFile
 
 
   /**
+   * The start and end position of the previous token as a SourceRange instance
+   */
+  SourceRange lastTokenSourceRange()
+  {
+    return sourceRange(lastTokenPos(), lastTokenEndPos());
+  }
+
+
+  /**
    * Position of the first byte in source file after the current token.
    */
   int tokenEndPos()

--- a/tests/partial_application_negative/partial_application_negative.fz.expected_err
+++ b/tests/partial_application_negative/partial_application_negative.fz.expected_err
@@ -81,7 +81,7 @@ In call: '3.postfix*'
 Feature not found: 'map' (no arguments)
 Target feature: 'interval'
 In call: 'map'
-To solve this, you might change the actual number of arguments to match the feature 'map' (2 arguments) at $MODULE/Sequence.fz:343:10:
+To solve this, you might change the actual number of arguments to match the feature 'map' (2 arguments) at $MODULE/Sequence.fz:340:10:
   public map(B type, f Unary B T) Sequence B =>
 ---------^^^
 

--- a/tests/partial_application_negative/partial_application_negative.fz.expected_err
+++ b/tests/partial_application_negative/partial_application_negative.fz.expected_err
@@ -81,7 +81,7 @@ In call: '3.postfix*'
 Feature not found: 'map' (no arguments)
 Target feature: 'interval'
 In call: 'map'
-To solve this, you might change the actual number of arguments to match the feature 'map' (2 arguments) at $MODULE/Sequence.fz:339:10:
+To solve this, you might change the actual number of arguments to match the feature 'map' (2 arguments) at $MODULE/Sequence.fz:343:10:
   public map(B type, f Unary B T) Sequence B =>
 ---------^^^
 

--- a/tests/reg_issue2273/reg_issue2273.fz.expected_err
+++ b/tests/reg_issue2273/reg_issue2273.fz.expected_err
@@ -1,5 +1,5 @@
 
-$MODULE/mutate.fz:286:7: error 1: Failed to verify that effect 'mutate' is installed in current environment.
+$MODULE/mutate.fz:282:7: error 1: Failed to verify that effect 'mutate' is installed in current environment.
       LM.env.array T length data unit
 ------^^^^^^
 Callchain that lead to this point:


### PR DESCRIPTION
As a first step towards properly inheriting pre- and postconditions, this commit changes the grammar and fron end to require that redefined features use `pre else` to relax a precondition and `post then` to strenghten a postcondition.

This patch does not change the semantics, i.e., inherited pre- and postconditions are still ignored after the front-end phase, this will be changed next.

The base library had to be changed at many places to use `else` or `then` in their contracts, and contracts that are redundant with the inherited contract have been removed.

To avoid poor performance when inheriting index checks from `Sequence`, added a new feature `Sequence.is_valid_index` that is redefined by 'array`.

Added `check` where a precondition would otherwise have to be strengthened: shift operation for `uint`.

Added rules for `redef`, and contracts with `else`/`then` to reference manual.