### PR TITLE
lib: remove `numeric.to_u32`, fix #3021

### DIFF
--- a/lib/i16.fz
+++ b/lib/i16.fz
@@ -73,10 +73,6 @@ public i16(public val i16) : num.wrap_around, has_interval is
   #
   public fixed redef fits_in_u8  => 0 ≤ val ≤ u8.max.as_i16
 
-  # does this i16 fit into an u32?
-  #
-  public fixed redef fits_in_u32 => 0 ≤ val
-
   # conversion to u32, i64 and u64, with range check
   public as_i8 i8
     pre

--- a/lib/i32.fz
+++ b/lib/i32.fz
@@ -73,10 +73,6 @@ public i32(public val i32) : num.wrap_around, has_interval is
   #
   public fixed redef fits_in_u8  => 0 ≤ val ≤ u8.max.as_i32
 
-  # does this i32 fit into an u32?
-  #
-  public fixed redef fits_in_u32 => 0 ≤ val
-
   # conversion to u32, i64 and u64, with range check
   public as_i8 i8
     pre

--- a/lib/i64.fz
+++ b/lib/i64.fz
@@ -99,10 +99,6 @@ public i64(public val i64) : num.wrap_around, has_interval is
   #
   public fixed redef fits_in_u8  => 0 ≤ val ≤ u8.max.as_i64
 
-  # does this i64 fit into an u32?
-  #
-  public fixed redef fits_in_u32 => 0 ≤ val ≤ u32.max.as_i64
-
 
   # this i64 as an u8
   public as_u8 u8

--- a/lib/i8.fz
+++ b/lib/i8.fz
@@ -79,10 +79,6 @@ public i8(public val i8) : num.wrap_around, has_interval is
   #
   public redef fixed fits_in_u8  => 0 ≤ val
 
-  # does this i8 fit into an u32?  This is true for all non-negative values.
-  #
-  public redef fixed fits_in_u32 => 0 ≤ val
-
   public as_u8  u8  => cast_to_u8
   public as_u16 u16
     pre

--- a/lib/numeric.fz
+++ b/lib/numeric.fz
@@ -130,23 +130,6 @@ module:public numeric : property.hashable, property.orderable is
   public fits_in_u8 => false
 
 
-  # does this numeric value fit into an u32? This is redefined by children
-  # of numeric that support `as_u32`.
-  #
-  public fits_in_u32 => false
-
-
-  # the u32 value corresponding to this
-  # note: potential fraction will be discarded
-  # NYI replace this by as_u32?
-  to_u32 u32
-    pre
-      debug: fits_in_u32
-  =>
-    if (numeric.this ≥ numeric.this.one) ((numeric.this - numeric.this.one).to_u32 + 1)
-    else 0
-
-
   # this numeric value as an u8
   public as_u8 u8
     pre

--- a/lib/u128.fz
+++ b/lib/u128.fz
@@ -147,10 +147,6 @@ public u128(public hi u64, public lo u64) : num.wrap_around, has_interval is
   #
   public fixed redef fits_in_u8  => u128.this ≤ u8.max.as_u128
 
-  # does this u128 fit into an u32?
-  #
-  public fixed redef fits_in_u32 => u128.this ≤ u32.max.as_u128
-
   public as_i8 i8
     pre
       thiz ≤ i8.max.as_u128

--- a/lib/u16.fz
+++ b/lib/u16.fz
@@ -73,10 +73,6 @@ public u16(public val u16) : num.wrap_around, has_interval is
   #
   public redef fixed fits_in_u8  => val ≤ u8.max.as_u16
 
-  # does this u16 fit into an u8? This is always true.
-  #
-  public redef fixed fits_in_u32 => true
-
   public as_i8 i8
     pre
       debug: thiz ≤ i8.max.as_u16

--- a/lib/u32.fz
+++ b/lib/u32.fz
@@ -73,10 +73,6 @@ public u32(public val u32) : num.wrap_around, has_interval is
   #
   public redef fixed fits_in_u8  => val ≤ u8.max.as_u32
 
-  # does this u32 fit into an u32? This is always true.
-  #
-  public redef fixed fits_in_u32 => true
-
 
   # this u32 as an i8
   public as_i8 i8

--- a/lib/uint.fz
+++ b/lib/uint.fz
@@ -306,12 +306,6 @@ is
     as_u32.as_u8
 
 
-  # does this uint fit into an u32?
-  #
-  public redef fits_in_u32 =>
-    data.count ≤ 1
-
-
   # does this uint fit into an u8?
   #
   public redef fits_in_u8 =>
@@ -319,10 +313,11 @@ is
 
 
   # this uint as an u32
-  public as_u32 u32
-  pre fits_in_u32
+  public fixed as_u32 u32
+    pre
+      debug: (uint.this ≤ uint.type.from_u32 u32.max)
   =>
-    data.first (u32 0)
+    data.first 0
 
 
   # does this uint fit in 64 bits?
@@ -364,6 +359,11 @@ is
       "0"
     else
       as_string0
+
+
+  # helper feature to init uint from an u32
+  public redef fixed type.from_u32(val u32) uint =>
+    uint [val] unit
 
 
   # helper feature to init uint from an u64


### PR DESCRIPTION
Also remove `fits_in_u32` since this is then no longer used and re-implemented precondition of `uint.as_u32`.

