### PR TITLE
lib: Make `Print_Handler.println` public

### DIFF
--- a/lib/io/print_effect.fz
+++ b/lib/io/print_effect.fz
@@ -51,10 +51,10 @@ is
 
 public Print_Handler ref is
 
-  println(s Any) =>
+  public println(s Any) =>
     print (s.as_string + (codepoint 10))
 
-  println =>
+  public println =>
     print (codepoint 10)
 
   public print(s Any) unit => abstract


### PR DESCRIPTION
This solves current failures in fuzion-lang.org's examples `design/examples/monadiclifting_hello*.fz`.
