### PR TITLE
ast: supress subsequent errors for type features

### DIFF
--- a/src/dev/flang/ast/AstErrors.java
+++ b/src/dev/flang/ast/AstErrors.java
@@ -647,23 +647,30 @@ public class AstErrors extends ANY
   public static void argumentTypeMismatchInRedefinition(AbstractFeature originalFeature, AbstractFeature originalArg, AbstractType originalArgType,
                                                         AbstractFeature redefinedFeature, AbstractFeature redefinedArg, boolean suggestAddingFixed)
   {
-    error(redefinedArg.pos(),
-          "Wrong argument type in redefined feature",
-          "In " + s(redefinedFeature) + " that redefines " + s(originalFeature) + "\n" +
-          "argument type is       : " + s(redefinedArg.resultType()) + "\n" +
-          "argument type should be: " +
-          // originalArg.resultType() might be a type parameter that has been replaced by originalArgType:
-          typeWithFrom(originalArgType, originalArg.resultType()) + "\n\n" +
-          "Original argument declared at " + originalArg.pos().show() + "\n" +
-          (suggestAddingFixed ? "To solve this, add " + code("fixed") + " modifier at declaration of "+s(redefinedFeature) + " at " + redefinedFeature.pos().show()
-                              : "To solve this, change type of argument to " + s(originalArgType) + " at " + redefinedArg.pos().show()));
+    if (!any() || !redefinedFeature.isTypeFeature() // type features generated from broken original features may cause subsequent errors
+        )
+      {
+        error(redefinedArg.pos(),
+              "Wrong argument type in redefined feature",
+              "In " + s(redefinedFeature) + " that redefines " + s(originalFeature) + "\n" +
+              "argument type is       : " + s(redefinedArg.resultType()) + "\n" +
+              "argument type should be: " +
+              // originalArg.resultType() might be a type parameter that has been replaced by originalArgType:
+              typeWithFrom(originalArgType, originalArg.resultType()) + "\n\n" +
+              "Original argument declared at " + originalArg.pos().show() + "\n" +
+              (suggestAddingFixed ? "To solve this, add " + code("fixed") + " modifier at declaration of "+s(redefinedFeature) + " at " + redefinedFeature.pos().show()
+                                  : "To solve this, change type of argument to " + s(originalArgType) + " at " + redefinedArg.pos().show()));
+      }
   }
 
   public static void resultTypeMismatchInRedefinition(AbstractFeature originalFeature, AbstractType originalType,
                                                       AbstractFeature redefinedFeature, boolean suggestAddingFixed)
   {
     if (!any() || (originalType                  != Types.t_ERROR &&
-                         redefinedFeature.resultType() != Types.t_ERROR    ))
+                   redefinedFeature.resultType() != Types.t_ERROR &&
+                   !redefinedFeature.isTypeFeature() // type features generated from broken original features may cause subsequent errors
+                   )
+        )
       {
         error(redefinedFeature.pos(),
               "Wrong result type in redefined feature",


### PR DESCRIPTION
This removes two subsequent errors that are produces for fuzion-lang.dev's example `design/examples/typ_const2.fz` for type features generated from broken original features.
