### PR TITLE
Support to redefine several features, fix #3027.

### DIFF
--- a/src/dev/flang/air/Clazzes.java
+++ b/src/dev/flang/air/Clazzes.java
@@ -729,7 +729,6 @@ public class Clazzes extends ANY
             calledDynamically(cf, typePars);
           }
 
-        try {
         var innerClazz        = tclazz.lookup(new FeatureAndActuals(cf, typePars, false), c.select(), c, c.isInheritanceCall());
         var preconditionClazz = tclazz.lookup(new FeatureAndActuals(cf, typePars, true ), c.select(), c, c.isInheritanceCall());
         if (outerClazz.hasActualClazzes(c, outer))
@@ -768,10 +767,6 @@ public class Clazzes extends ANY
               }
             while (tpc != null && !tpc.feature().isUniverse());
           }
-        } catch (Error e) {
-          System.out.println("IN "+outerClazz+" PROBLEM FOR "+c+" at "+c.pos().show());
-          throw e;
-        }
       }
   }
 

--- a/src/dev/flang/air/Clazzes.java
+++ b/src/dev/flang/air/Clazzes.java
@@ -729,6 +729,7 @@ public class Clazzes extends ANY
             calledDynamically(cf, typePars);
           }
 
+        try {
         var innerClazz        = tclazz.lookup(new FeatureAndActuals(cf, typePars, false), c.select(), c, c.isInheritanceCall());
         var preconditionClazz = tclazz.lookup(new FeatureAndActuals(cf, typePars, true ), c.select(), c, c.isInheritanceCall());
         if (outerClazz.hasActualClazzes(c, outer))
@@ -767,6 +768,10 @@ public class Clazzes extends ANY
               }
             while (tpc != null && !tpc.feature().isUniverse());
           }
+        } catch (Error e) {
+          System.out.println("IN "+outerClazz+" PROBLEM FOR "+c+" at "+c.pos().show());
+          throw e;
+        }
       }
   }
 

--- a/src/dev/flang/ast/AbstractFeature.java
+++ b/src/dev/flang/ast/AbstractFeature.java
@@ -80,6 +80,17 @@ public abstract class AbstractFeature extends Expr implements Comparable<Abstrac
     }
   }
 
+
+  /*----------------------------  constants  ----------------------------*/
+
+
+  /**
+   * empty list of AbstractFeature
+   */
+  public static List<AbstractFeature> _NO_FEATURES_ = new List<>();
+  static { _NO_FEATURES_.freeze(); }
+
+
   /*------------------------  static variables  -------------------------*/
 
 
@@ -920,8 +931,8 @@ public abstract class AbstractFeature extends Expr implements Comparable<Abstrac
     var outerType = outer().isUniverse()    ? universe() :
                     outer().isTypeFeature() ? outer()
                                             : outer().typeFeature(res);
-    var l = res._module.declaredOrInheritedFeatures(outerType).get(FeatureName.get(name, 0));
-    var result = l == null ? null : l.getFirst();
+    var result = res._module.declaredOrInheritedFeatures(outerType,
+                                                         FeatureName.get(name, 0)).getFirstOrNull();
     if (result == null)
       {
         var p = pos();

--- a/src/dev/flang/ast/AbstractFeature.java
+++ b/src/dev/flang/ast/AbstractFeature.java
@@ -920,7 +920,8 @@ public abstract class AbstractFeature extends Expr implements Comparable<Abstrac
     var outerType = outer().isUniverse()    ? universe() :
                     outer().isTypeFeature() ? outer()
                                             : outer().typeFeature(res);
-    var result = res._module.declaredOrInheritedFeatures(outerType).get(FeatureName.get(name, 0));
+    var l = res._module.declaredOrInheritedFeatures(outerType).get(FeatureName.get(name, 0));
+    var result = l == null ? null : l.getFirst();
     if (result == null)
       {
         var p = pos();

--- a/src/dev/flang/ast/Contract.java
+++ b/src/dev/flang/ast/Contract.java
@@ -140,6 +140,13 @@ public class Contract
   }
 
 
+  /**
+   * When redefining a feature, the original contract is inherited with
+   * preconditions ORed and postconditions ANDed.  This feature performs this
+   * condition inheritance.
+   *
+   * @param from the redefined feature this contract should inherit from.
+   */
   public void addInheritedContract(AbstractFeature from)
   {
     // precondition inheritance is the disjunction with the conjunction of all inherited conditions, i.e, in
@@ -172,7 +179,12 @@ public class Contract
     //
     for (var e : from.contract().ens)
       {
-        ens.add(e);
+        // NYI: missing support for postcondition inheritance, works for simple
+        // cases if `if (false)` is removed, but requires tests!
+        if (false)
+          {
+            ens.add(e);
+          }
       }
   }
 

--- a/src/dev/flang/ast/Contract.java
+++ b/src/dev/flang/ast/Contract.java
@@ -140,6 +140,43 @@ public class Contract
   }
 
 
+  public void addInheritedContract(AbstractFeature from)
+  {
+    // precondition inheritance is the disjunction with the conjunction of all inherited conditions, i.e, in
+    //
+    //   a is
+    //     f pre a; b; c => ...
+    //   b : a is
+    //     redef f pre else d; e; f =>
+    //
+    // b.f becomes
+    //
+    //   b : a is
+    //     redef f pre (a && b && c) || (d && e && f) =>
+    //
+    for (var e : from.contract().req)
+      {
+        // NYI: missing support precondition inheritance!
+      }
+
+    // postcondition inheritance is just the conjunction of all inherited conditions
+    //
+    //   a is
+    //     f post a; b; c => ...
+    //   b : a is
+    //     redef f post then d; e; f =>
+    //
+    // b.f becomes
+    //
+    //     redef f post a && b && c && d && e && f =>
+    //
+    for (var e : from.contract().ens)
+      {
+        ens.add(e);
+      }
+  }
+
+
   /**
    * toString
    *

--- a/src/dev/flang/ast/Feature.java
+++ b/src/dev/flang/ast/Feature.java
@@ -1445,7 +1445,8 @@ public class Feature extends AbstractFeature
   private List<AbstractCall> closureAccesses(Resolution res)
   {
     List<AbstractCall> result = new List<>();
-    for (AbstractFeature af : res._module.declaredOrInheritedFeatures(this).values())
+    for (var l: res._module.declaredOrInheritedFeatures(this).values())
+    for (var af : l)
       {
         af.visitExpressions(s -> {
             if (s instanceof AbstractCall c && dependsOnOuterRef(c))
@@ -1538,7 +1539,8 @@ public class Feature extends AbstractFeature
         AstErrors.choiceMustNotBeRef(_pos);
       }
 
-    for (AbstractFeature p : res._module.declaredOrInheritedFeatures(this).values())
+    for (var pl : res._module.declaredOrInheritedFeatures(this).values())
+    for (var p : pl)
       {
         // choice type must not have any fields
         if (p.isField() && !p.isOuterRef())
@@ -1659,7 +1661,8 @@ public class Feature extends AbstractFeature
    */
   private void checkBuiltInPrimitive(Resolution res)
   {
-    for (AbstractFeature p : res._module.declaredOrInheritedFeatures(this).values())
+    for (var pl : res._module.declaredOrInheritedFeatures(this).values())
+    for (var p : pl)
       {
         // primitives must not have any fields
         if (p.isField() && !p.isOuterRef() && !(p.featureName().baseName().equals("val") && p.resultType().compareTo(selfType())==0) )

--- a/src/dev/flang/ast/Feature.java
+++ b/src/dev/flang/ast/Feature.java
@@ -33,6 +33,7 @@ import java.util.ListIterator;
 import java.util.Set;
 import java.util.Stack;
 import java.util.TreeSet;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import dev.flang.util.Errors;
@@ -1445,16 +1446,14 @@ public class Feature extends AbstractFeature
   private List<AbstractCall> closureAccesses(Resolution res)
   {
     List<AbstractCall> result = new List<>();
-    for (var l: res._module.declaredOrInheritedFeatures(this).values())
-    for (var af : l)
-      {
-        af.visitExpressions(s -> {
-            if (s instanceof AbstractCall c && dependsOnOuterRef(c))
-              {
-                result.add(c);
-              }
-          });
-      }
+    res._module.forEachDeclaredOrInheritedFeature(this,
+                                                  af -> af.visitExpressions(s -> {
+          if (s instanceof AbstractCall c && dependsOnOuterRef(c))
+            {
+              result.add(c);
+            }
+        })
+      );
     return result;
   }
 
@@ -1539,15 +1538,15 @@ public class Feature extends AbstractFeature
         AstErrors.choiceMustNotBeRef(_pos);
       }
 
-    for (var pl : res._module.declaredOrInheritedFeatures(this).values())
-    for (var p : pl)
+    res._module.forEachDeclaredOrInheritedFeature(this,
+                                                  p ->
       {
         // choice type must not have any fields
         if (p.isField() && !p.isOuterRef())
           {
             AstErrors.mustNotContainFields(_pos, p, "Choice");
           }
-      }
+      });
     // choice type must not contain any code, but may contain inner features
     switch (_impl._kind)
       {
@@ -1661,15 +1660,15 @@ public class Feature extends AbstractFeature
    */
   private void checkBuiltInPrimitive(Resolution res)
   {
-    for (var pl : res._module.declaredOrInheritedFeatures(this).values())
-    for (var p : pl)
+    res._module.forEachDeclaredOrInheritedFeature(this,
+                                                  p ->
       {
         // primitives must not have any fields
         if (p.isField() && !p.isOuterRef() && !(p.featureName().baseName().equals("val") && p.resultType().compareTo(selfType())==0) )
           {
             AstErrors.mustNotContainFields(_pos, p, this.featureName().baseName());
           }
-      }
+      });
   }
 
 

--- a/src/dev/flang/ast/Function.java
+++ b/src/dev/flang/ast/Function.java
@@ -44,7 +44,6 @@ public class Function extends AbstractLambda
   /*----------------------------  constants  ----------------------------*/
 
 
-  static final List<AbstractFeature> NO_FEATURES = new List<>();
   static final List<AbstractCall> NO_CALLS = new List<>();
 
 
@@ -313,7 +312,7 @@ public class Function extends AbstractLambda
                                    0,
                                    RefType.INSTANCE,
                                    new List<String>(wrapperName),
-                                   NO_FEATURES,
+                                   AbstractFeature._NO_FEATURES_,
                                    new List<>(_inheritsCall),
                                    Contract.EMPTY_CONTRACT,
                                    new Impl(pos(), new Block(expressions), Impl.Kind.Routine));

--- a/src/dev/flang/ast/SrcModule.java
+++ b/src/dev/flang/ast/SrcModule.java
@@ -28,6 +28,7 @@ package dev.flang.ast;
 
 import java.util.Collection;
 import java.util.SortedMap;
+import java.util.function.Consumer;
 
 import dev.flang.util.List;
 import dev.flang.util.SourcePosition;
@@ -64,7 +65,8 @@ public interface SrcModule
   void findDeclarations(Feature inner, AbstractFeature outer);
 
 
-  SortedMap<FeatureName, List<AbstractFeature>> declaredOrInheritedFeatures(AbstractFeature outer);
+  List<AbstractFeature> declaredOrInheritedFeatures(AbstractFeature outer, FeatureName fn);
+  void forEachDeclaredOrInheritedFeature(AbstractFeature af, Consumer<AbstractFeature> f);
   AbstractFeature lookupFeature(AbstractFeature outer, FeatureName name, AbstractFeature original);
   void findDeclaredOrInheritedFeatures(Feature outer);
   List<FeatureAndOuter> lookup(AbstractFeature thiz, String name, Expr use, boolean traverseOuter, boolean hidden);

--- a/src/dev/flang/ast/SrcModule.java
+++ b/src/dev/flang/ast/SrcModule.java
@@ -64,7 +64,7 @@ public interface SrcModule
   void findDeclarations(Feature inner, AbstractFeature outer);
 
 
-  SortedMap<FeatureName, AbstractFeature> declaredOrInheritedFeatures(AbstractFeature outer);
+  SortedMap<FeatureName, List<AbstractFeature>> declaredOrInheritedFeatures(AbstractFeature outer);
   AbstractFeature lookupFeature(AbstractFeature outer, FeatureName name, AbstractFeature original);
   void findDeclaredOrInheritedFeatures(Feature outer);
   List<FeatureAndOuter> lookup(AbstractFeature thiz, String name, Expr use, boolean traverseOuter, boolean hidden);

--- a/src/dev/flang/fe/Module.java
+++ b/src/dev/flang/fe/Module.java
@@ -219,13 +219,11 @@ public abstract class Module extends ANY implements FeatureLookup
                   {
                 if (CHECKS) check
                   (cf != outer);
-        if (fn.baseName().equals("f")) System.out.println("findInheritedFeatures found "+f.qualifiedName()+" for "+outer.qualifiedName()+"...");
 
                 var res = this instanceof SourceModule sm ? sm._res : null;
                 if (!f.isFixed())
                   {
                     var newfn = cf.handDown(res, f, fn, p, outer);
-        if (fn.baseName().equals("f")) System.out.println("findInheritedFeatures found "+f.qualifiedName()+" for "+outer.qualifiedName()+" addDOI "+newfn+"..");
                     addDeclaredOrInherited(set, outer, newfn, f);
                   }
                 else
@@ -273,13 +271,21 @@ public abstract class Module extends ANY implements FeatureLookup
     if (l != null) for (var existing : l)
       {
 
-        if (fn.baseName().equals("f")) System.out.println("addDOI for "+f.qualifiedName()+" outer "+outer.qualifiedName()+" existing "+
-                                                          (existing == null ? "nulL ": existing.qualifiedName())+" new: "+(f != existing));
     if (f != existing)
       {
         var existing = set.get(fn);
 
-        if (existing != null && f != existing)
+        if (isInherited &&
+            // no error if redefinition
+            !redefines(f, existing) &&
+            !redefines(existing, f) &&
+            // no error if declared features already contains redefinition
+            (df == null || (df.modifiers() & FuzionConstants.MODIFIER_REDEFINE) == 0))
+          { // NYI: Should be ok if existing or f is abstract.
+            AstErrors.repeatedInheritanceCannotBeResolved(outer.pos(), outer, fn, existing, f);
+          }
+
+        if (!false) if (!isInherited && !sameModule(f, outer))
           {
             AstErrors.duplicateFeatureDeclaration(f.pos(), f, existing);
           }
@@ -287,17 +293,14 @@ public abstract class Module extends ANY implements FeatureLookup
       }
       }
 
-    if (true || redefinesAllExisting ||
+    if (redefinesAllExisting ||
         !isInherited && (sameModule(f, outer) || visibleFor(f, outer)))
       {
         set.put(fn, new List<>(f));
-        if (fn.baseName().equals("f")) System.out.println("addDOI for "+f.qualifiedName()+" outer "+outer.qualifiedName()+" existing "+
-                                                          (l == null ? "null" : l.map2(existing->existing.qualifiedName()))+" new: ADDED!!!");
       }
     else
       {
-        if (fn.baseName().equals("f")) System.out.println("addDOI for "+f.qualifiedName()+" outer "+outer.qualifiedName()+" existing "+
-                                                          (l == null ? "null" : l.map2(existing->existing.qualifiedName()))+" new: NOT ADDED!");
+        //        add(set, f);
       }
   }
 

--- a/src/dev/flang/fe/Module.java
+++ b/src/dev/flang/fe/Module.java
@@ -327,6 +327,7 @@ public abstract class Module extends ANY implements FeatureLookup
 
     if (visibleFor(f, outer) || !isInherited || isExtensionFeature)
     */
+    /*
     var redefinesAllExisting = true;
     var l = set.get(fn);
     if (l != null) for (var existing : l)

--- a/src/dev/flang/fe/Module.java
+++ b/src/dev/flang/fe/Module.java
@@ -112,7 +112,7 @@ public abstract class Module extends ANY implements FeatureLookup
 
 
   /**
-   * From the given map s, get the list of entries for given FeatureName. Wil
+   * From the given map s, get the list of entries for given FeatureName. Will
    * return an empty list if no mapping was found.
    *
    * @param s a set of features
@@ -135,8 +135,8 @@ public abstract class Module extends ANY implements FeatureLookup
    *
    * @param s a set of features we are modifying.
    *
-   * @param fn a name we want to map to `f`. Note that `fn` might be diffrent to
-   * `f.featureName()`.
+   * @param fn a name we want to map to `f`. Note that `fn` might be different
+   * to `f.featureName()`.
    *
    * @param f a feature.
    */

--- a/src/dev/flang/fe/Module.java
+++ b/src/dev/flang/fe/Module.java
@@ -599,7 +599,7 @@ public abstract class Module extends ANY implements FeatureLookup
       }
     check
       (l == null || l.size() == 1 || Errors.any());
-    var result = l.getFirst();
+    var result = l == null ? null : l.getFirst();
 
 
     /* NYI: CLEANUP: can this be removed?

--- a/src/dev/flang/fe/Module.java
+++ b/src/dev/flang/fe/Module.java
@@ -257,6 +257,67 @@ public abstract class Module extends ANY implements FeatureLookup
     if (PRECONDITIONS)
       require(!f.isFixed() || outer == f.outer());
 
+    //    add(set, fn, f);
+    var isInherited = outer != f.outer();
+
+    var l = set.get(fn);
+    if (l != null)
+      {
+        var it = l.listIterator();
+        while (f != null && it.hasNext())
+          {
+            var existing = it.next();
+            if (f != existing)
+              {
+                var df = declaredFeatures(outer).get(fn);
+
+                if (redefines(f, existing))
+                  {
+                    it.remove();
+                  }
+                else if (redefines(existing, f))
+                  {
+                    f = null;
+                  }
+                else if (isInherited && outer != existing.outer())
+                /*
+                // no error if declared features already contains redefinition
+                (df == null || (df.modifiers() & FuzionConstants.MODIFIER_REDEFINE) == 0))
+                */
+                  { // NYI: Should be ok if existing or f is abstract.
+                    //    AstErrors.repeatedInheritanceCannotBeResolved(outer.pos(), outer, fn, existing, f);
+                  }
+                else
+                  {
+                    // NYI: if (!isInherited && !sameModule(f, outer))
+                    //   AstErrors.duplicateFeatureDeclaration(f.pos(), f, existing);
+                  }
+              }
+          }
+      }
+    if (f != null)
+      {
+        add(set, fn, f);
+      }
+    /*
+        redefinesAllExisting = redefinesAllExisting && redefines(f, existing);
+      }
+      }
+
+    if (redefinesAllExisting ||
+        !isInherited && (sameModule(f, outer) || visibleFor(f, outer)))
+      {
+        set.put(fn, new List<>(f));
+      }
+    else
+      {
+        //        add(set, f);
+      }
+
+    */
+
+    //    add(set, f);
+    /*
     var isInherited = outer != f.outer();
 
     /* NYI:
@@ -302,6 +363,7 @@ public abstract class Module extends ANY implements FeatureLookup
       {
         //        add(set, f);
       }
+    */
   }
 
 
@@ -405,9 +467,8 @@ public abstract class Module extends ANY implements FeatureLookup
   }
 
 
-  void add(SortedMap<FeatureName, List<AbstractFeature>> s, AbstractFeature f)
+  void add(SortedMap<FeatureName, List<AbstractFeature>> s, FeatureName fn, AbstractFeature f)
   {
-    var fn =f.featureName();
     var l = s.get(fn);
     if (l == null)
       {
@@ -447,7 +508,7 @@ public abstract class Module extends ANY implements FeatureLookup
 
             for (var f : olf.declaredFeatures())
               {
-                add(s, f);
+                add(s, f.featureName(), f);
               }
           }
 

--- a/src/dev/flang/fe/Module.java
+++ b/src/dev/flang/fe/Module.java
@@ -108,6 +108,53 @@ public abstract class Module extends ANY implements FeatureLookup
   LibraryModule[] _dependsOn;
 
 
+  /*--------------------------  static methods  -------------------------*/
+
+
+  /**
+   * From the given map s, get the list of entries for given FeatureName. Wil
+   * return an empty list if no mapping was found.
+   *
+   * @param s a set of features
+   *
+   * @param fn a name we are looking for
+   *
+   * @return the list of features store for `fn`, never null.
+   */
+  protected static List<AbstractFeature> get(SortedMap<FeatureName, List<AbstractFeature>> s, FeatureName fn)
+  {
+    var result = s.get(fn);
+    return result == null ? AbstractFeature._NO_FEATURES_ : result;
+  }
+
+
+  /**
+   * Add feature `f` for name `fn` to the map `s`. If a mapping exists that does
+   * not contain `f`, add `f` to the existing mapping.  Otherwise, create a new
+   * mapping that only contains `f`.
+   *
+   * @param s a set of features we are modifying.
+   *
+   * @param fn a name we want to map to `f`. Note that `fn` might be diffrent to
+   * `f.featureName()`.
+   *
+   * @param f a feature.
+   */
+  protected static void add(SortedMap<FeatureName, List<AbstractFeature>> s, FeatureName fn, AbstractFeature f)
+  {
+    var l = s.get(fn);
+    if (l == null)
+      {
+        l = new List<>();
+        s.put(fn, l);
+      }
+    if (!l.stream().anyMatch(x->x==f))
+      {
+        l.add(f);
+      }
+  }
+
+
   /*--------------------------  constructors  ---------------------------*/
 
 
@@ -382,50 +429,6 @@ public abstract class Module extends ANY implements FeatureLookup
 
 
   /**
-   * From the given map s, get the list of entries for given FeatureName. Wil
-   * return an empty list if no mapping was found.
-   *
-   * @param s a set of features
-   *
-   * @param fn a name we are looking for
-   *
-   * @return the list of features store for `fn`, never null.
-   */
-  List<AbstractFeature> get(SortedMap<FeatureName, List<AbstractFeature>> s, FeatureName fn)
-  {
-    var result = s.get(fn);
-    return result == null ? AbstractFeature._NO_FEATURES_ : result;
-  }
-
-
-  /**
-   * Add feature `f` for name `fn` to the map `s`. If a mapping exists that does
-   * not contain `f`, add `f` to the existing mapping.  Otherwise, create a new
-   * mapping that only contains `f`.
-   *
-   * @param s a set of features we are modifying.
-   *
-   * @param fn a name we want to map to `f`. Note that `fn` might be diffrent to
-   * `f.featureName()`.
-   *
-   * @param f a feature.
-   */
-  void add(SortedMap<FeatureName, List<AbstractFeature>> s, FeatureName fn, AbstractFeature f)
-  {
-    var l = s.get(fn);
-    if (l == null)
-      {
-        l = new List<>();
-        s.put(fn, l);
-      }
-    if (!l.stream().anyMatch(x->x==f))
-      {
-        l.add(f);
-      }
-  }
-
-
-  /**
    * Get declared and inherited features for given outer Feature as seen by this
    * module.  Result is never null.
    *
@@ -517,6 +520,10 @@ public abstract class Module extends ANY implements FeatureLookup
 
   /**
    * Helper to apply given function to all declared or inherited features of this feature.
+   *
+   * @param af a feature as seen from this module
+   *
+   * @param fun operation to apply to all declared or inherited features of af.
    */
   public void forEachDeclaredOrInheritedFeature(AbstractFeature af, Consumer<AbstractFeature> fun)
   {

--- a/src/dev/flang/fe/SourceModule.java
+++ b/src/dev/flang/fe/SourceModule.java
@@ -1667,6 +1667,12 @@ A post-condition of a feature that does not redefine an inherited featue must st
   }
 
 
+  /**
+   * Check f's declared or inherited features for duplicates and flag errors if
+   * incompatible duplicates are encountered.
+   *
+   * @param f a feature
+   */
   private void checkDuplicateFeatures(Feature f)
   {
     var doi = data(f)._declaredOrInheritedFeatures;
@@ -1679,6 +1685,16 @@ A post-condition of a feature that does not redefine an inherited featue must st
       }
   }
 
+  /**
+   * Check outer's declared or inherited features with effective name `fn` for duplicates and flag errors if
+   * incompatible duplicates are encountered.
+   *
+   * @param outer a feature
+   *
+   * @param fn the effective feature name within outer, used for error messages only
+   *
+   * @param fl list of features declared or inherited by outer with effective name fn.
+   */
   private void checkDuplicateFeatures(AbstractFeature outer, FeatureName fn, List<AbstractFeature> fl)
   {
     if (PRECONDITIONS)
@@ -1697,10 +1713,6 @@ A post-condition of a feature that does not redefine an inherited featue must st
 
                 // NYI: take visibility into account!!!
                 if (isInherited1 && isInherited2)
-                /*
-                // no error if declared features already contains redefinition
-                (df == null || (df.modifiers() & FuzionConstants.MODIFIER_REDEFINE) == 0))
-                */
                   { // NYI: Should be ok if existing or f is abstract.
                     AstErrors.repeatedInheritanceCannotBeResolved(outer.pos(), outer, fn, f1, f2);
                   }

--- a/src/dev/flang/fe/SourceModule.java
+++ b/src/dev/flang/fe/SourceModule.java
@@ -843,8 +843,8 @@ part of the (((inner features))) declarations of the corresponding
       visibleFor(f, outer)
     )
       {
-        if (CHECKS) check
-          (existing == null || existing == f || visibleFor(existing, outer));
+        //        if (CHECKS) check
+        //          (existing == null || existing == f || visibleFor(existing, outer));
 
         if (existing == null)
           {
@@ -892,6 +892,7 @@ A post-condition of a feature that does not redefine an inherited featue must st
 A feature that redefines at least one inherited feature must use the `redef` modifier unless all redefined, inherited features are `abstract`.
     // end::fuzion_rule_PARS_REDEF[]
                 */
+                if (visibleFor(existing, f.outer()))
                 AstErrors.redefineModifierMissing(f.pos(), f, existing);
               }
             else

--- a/src/dev/flang/fe/SourceModule.java
+++ b/src/dev/flang/fe/SourceModule.java
@@ -684,7 +684,6 @@ part of the (((inner features))) declarations of the corresponding
         if (CHECKS) check
           (!d._declaredFeatures.containsKey(fn) || d._declaredFeatures.get(fn) == typeParameter);
         d._declaredFeatures.put(fn, typeParameter);
-        if (fn.baseName().equals("f")) System.out.println("addTypeParameter: "+typeParameter.qualifiedName()+" to "+outer.qualifiedName()+" PUT df!");
       }
     if (d._declaredOrInheritedFeatures != null)
       {
@@ -695,7 +694,6 @@ part of the (((inner features))) declarations of the corresponding
           {
             add(doi, typeParameter);
           }
-        if (fn.baseName().equals("f")) System.out.println("addTypeParameter: "+typeParameter.qualifiedName()+" to "+outer.qualifiedName()+" PUT doif!");
       }
   }
 
@@ -718,7 +716,6 @@ part of the (((inner features))) declarations of the corresponding
 
     var d = data(outer);
     var fn = inner.featureName();
-    if (fn.baseName().equals("f")) System.out.println("addDeclared: "+inner.qualifiedName()+" to "+outer.qualifiedName());
     if (d._declaredOrInheritedFeatures != null)
       {
         var doi = d._declaredOrInheritedFeatures;
@@ -728,7 +725,6 @@ part of the (((inner features))) declarations of the corresponding
           {
             add(doi, inner);
           }
-        if (fn.baseName().equals("f")) System.out.println("addDeclared: "+inner.qualifiedName()+" to "+outer.qualifiedName()+" PUT doif!");
       }
   }
 
@@ -838,13 +834,10 @@ part of the (((inner features))) declarations of the corresponding
   private void addToDeclaredOrInheritedFeatures(AbstractFeature outer, AbstractFeature f)
   {
     var fn = f.featureName();
-    if (fn.baseName().equals("f")) System.out.println("ADDING "+f.qualifiedName()+" to "+outer.qualifiedName());
     var doi = declaredOrInheritedFeatures(outer);
     var existingl = doi.get(fn);
-    if (fn.baseName().equals("f")) System.out.println("EXISTING "+f.qualifiedName()+": "+(existingl == null ? "--" : existingl.map2(x->x.qualifiedName())));
     if (existingl != null) for (var existing : existingl)
       {
-    if (fn.baseName().equals("f") && existing != null) System.out.println("EXISTING "+existing.qualifiedName()+" in "+outer.qualifiedName());
     var c = f.contract();
 
     var isInherited = outer != f.outer();
@@ -940,7 +933,6 @@ A post-condition of a feature that redefines one or several inherited features m
       {
         ff._addedLate = true;
       }
-        if (fn.baseName().equals("f")) System.out.println("addToDeclaredOrInheritedFeatures: "+f.qualifiedName()+" to "+outer.qualifiedName()+" PUT doi!");
     doi.remove(fn);
     add(doi, f);
   }
@@ -1003,7 +995,6 @@ A post-condition of a feature that redefines one or several inherited features m
           }
       }
     df.put(fn, f);
-        if (fn.baseName().equals("f")) System.out.println("addDeclaredInner: "+f.qualifiedName()+" to "+outer.qualifiedName()+" PUT df!");
     if (outer.state().atLeast(State.RESOLVED_DECLARATIONS))
       {
         addToDeclaredOrInheritedFeatures(outer, f);

--- a/src/dev/flang/util/List.java
+++ b/src/dev/flang/util/List.java
@@ -316,6 +316,15 @@ public class List<T>
 
 
   /**
+   * Get first element of the list, null if list is empty.
+   */
+  public T getFirstOrNull()
+  {
+    return size() == 0 ? null : get(0);
+  }
+
+
+  /**
    * Get last element of the list.
    */
   public T getLast()

--- a/tests/partial_application_negative/Makefile
+++ b/tests/partial_application_negative/Makefile
@@ -29,7 +29,7 @@
 #
 # Even though the negative variant could not fail if the simple variant fails,
 # running both ensures that an update of error output cannot accidentally
-# inctroduce some missing errors.
+# introduce some missing errors.
 #
 override NAME = partial_application_negative
 include ../simple_and_negative.mk

--- a/tests/reg_issue3027/Makefile
+++ b/tests/reg_issue3027/Makefile
@@ -23,6 +23,13 @@
 #
 # -----------------------------------------------------------------------
 
+# this is both a negative test to make sure that all required errors are
+# shown, and then, as a simple test to make sure that the
+# error output is correct.
+#
+# Even though the negative variant could not fail if the simple variant fails,
+# running both ensures that an update of error output cannot accidentally
+# inctroduce some missing errors.
+#
 override NAME = test_conflicting_inheritance
-override FUZION_OPTIONS = -XmaxErrors=-1
-include ../simple.mk
+include ../simple_and_negative.mk

--- a/tests/reg_issue3027/Makefile
+++ b/tests/reg_issue3027/Makefile
@@ -29,7 +29,7 @@
 #
 # Even though the negative variant could not fail if the simple variant fails,
 # running both ensures that an update of error output cannot accidentally
-# inctroduce some missing errors.
+# introduce some missing errors.
 #
 override NAME = test_conflicting_inheritance
 include ../simple_and_negative.mk

--- a/tests/reg_issue3027/Makefile
+++ b/tests/reg_issue3027/Makefile
@@ -1,0 +1,28 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test Makefile
+#
+#  Author: Fridtjof Siebert (siebert@tokiwa.software)
+#
+# -----------------------------------------------------------------------
+
+override NAME = test_conflicting_inheritance
+override FUZION_OPTIONS = -XmaxErrors=-1
+include ../simple.mk

--- a/tests/reg_issue3027/test_conflicting_inheritance.fz
+++ b/tests/reg_issue3027/test_conflicting_inheritance.fz
@@ -1,0 +1,60 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion example test_conflicting_inheritance.fz
+#
+#  Author: Fridtjof Siebert (siebert@tokiwa.software)
+#
+# -----------------------------------------------------------------------
+
+# test_conflicting_inheritance contains code that should produce compile time
+# errors due to inheritance of features with conflicting result or argument types
+#
+
+# original example from #3027
+a         is        f => 42
+B ref     is        f => "B.f"
+aB : a, B is  redef f => 4711
+
+b B := aB
+say b.f
+
+# systematic tests for result using different types, inheritance order and redefinitions types
+ri32    is        f => 42
+rString is        f => "B.f"
+rconflic_i32_String_i32    : ri32, rString is redef f => 4711
+rconflic_String_i32_i32    : rString, ri32 is redef f => 4711
+rconflic_i32_String_String : ri32, rString is redef f => "bla"
+rconflic_String_i32_String : rString, ri32 is redef f => "bla"
+rconflic_i32_String_f64    : ri32, rString is redef f => 3.14
+rconflic_String_i32_f64    : rString, ri32 is redef f => 3.14
+rconflic_i32_String_none   : ri32, rString is
+rconflic_String_i32_none   : rString, ri32 is
+
+# systematic tests for argument using different types, inheritance order and redefinitions types
+ai32    is        f(a i32   ) =>
+aString is        f(a String) =>
+aconflic_i32_String_i32    : ai32, aString is redef f(a i32) =>
+aconflic_String_i32_i32    : aString, ai32 is redef f(a i32) =>
+aconflic_i32_String_String : ai32, aString is redef f(a String) =>
+aconflic_String_i32_String : aString, ai32 is redef f(a String) =>
+aconflic_i32_String_f64    : ai32, aString is redef f(a f64) =>
+aconflic_String_i32_f64    : aString, ai32 is redef f(a f64) =>
+aconflic_i32_String_none   : ai32, aString is
+aconflic_String_i32_none   : aString, ai32 is

--- a/tests/reg_issue3027/test_conflicting_inheritance.fz
+++ b/tests/reg_issue3027/test_conflicting_inheritance.fz
@@ -30,7 +30,7 @@
 # original example from #3027
 a         is        f => 42
 B ref     is        f => "B.f"
-aB : a, B is  redef f => 4711
+aB : a, B is  redef f => 4711   # 1. should flag an error, B.f has wrong result type
 
 b B := aB
 say b.f
@@ -38,23 +38,23 @@ say b.f
 # systematic tests for result using different types, inheritance order and redefinitions types
 ri32    is        f => 42
 rString is        f => "B.f"
-rconflic_i32_String_i32    : ri32, rString is redef f => 4711
-rconflic_String_i32_i32    : rString, ri32 is redef f => 4711
-rconflic_i32_String_String : ri32, rString is redef f => "bla"
-rconflic_String_i32_String : rString, ri32 is redef f => "bla"
-rconflic_i32_String_f64    : ri32, rString is redef f => 3.14
-rconflic_String_i32_f64    : rString, ri32 is redef f => 3.14
-rconflic_i32_String_none   : ri32, rString is
-rconflic_String_i32_none   : rString, ri32 is
+rconflic_i32_String_i32    : ri32, rString is redef f => 4711    # 2. should flag an error, rString.f has wrong result type
+rconflic_String_i32_i32    : rString, ri32 is redef f => 4711    # 3. should flag an error, rString.f has wrong result type
+rconflic_i32_String_String : ri32, rString is redef f => "bla"   # 4. should flag an error, ri32.f has wrong result type
+rconflic_String_i32_String : rString, ri32 is redef f => "bla"   # 5. should flag an error, ri32.f has wrong result type
+rconflic_i32_String_f64    : ri32, rString is redef f => 3.14    # 6. should flag an error, ri32.f and rString.f have wrong result type
+rconflic_String_i32_f64    : rString, ri32 is redef f => 3.14    # 7. should flag an error, ri32.f and rString.f have wrong result type
+rconflic_i32_String_none   : ri32, rString is                    # 8. should flag an error, ri32.f and rString.f have incompatible result type
+rconflic_String_i32_none   : rString, ri32 is                    # 9. should flag an error, ri32.f and rString.f have incompatible result type
 
 # systematic tests for argument using different types, inheritance order and redefinitions types
 ai32    is        f(a i32   ) =>
 aString is        f(a String) =>
-aconflic_i32_String_i32    : ai32, aString is redef f(a i32) =>
-aconflic_String_i32_i32    : aString, ai32 is redef f(a i32) =>
-aconflic_i32_String_String : ai32, aString is redef f(a String) =>
-aconflic_String_i32_String : aString, ai32 is redef f(a String) =>
-aconflic_i32_String_f64    : ai32, aString is redef f(a f64) =>
-aconflic_String_i32_f64    : aString, ai32 is redef f(a f64) =>
-aconflic_i32_String_none   : ai32, aString is
-aconflic_String_i32_none   : aString, ai32 is
+aconflic_i32_String_i32    : ai32, aString is redef f(a i32) =>      # 10. should flag an error, rString.f has wrong argument type
+aconflic_String_i32_i32    : aString, ai32 is redef f(a i32) =>      # 11. should flag an error, rString.f has wrong argument type
+aconflic_i32_String_String : ai32, aString is redef f(a String) =>   # 12. should flag an error, ri32.f has wrong argument type
+aconflic_String_i32_String : aString, ai32 is redef f(a String) =>   # 13. should flag an error, ri32.f has wrong argument type
+aconflic_i32_String_f64    : ai32, aString is redef f(a f64) =>      # 14. should flag an error, ri32.f and rString.f have wrong argument type
+aconflic_String_i32_f64    : aString, ai32 is redef f(a f64) =>      # 15. should flag an error, ri32.f and rString.f have wrong argument type
+aconflic_i32_String_none   : ai32, aString is                        # 16. should flag an error, ri32.f and rString.f have incompatible argument type
+aconflic_String_i32_none   : aString, ai32 is                        # 17. should flag an error, ri32.f and rString.f have incompatible argument type

--- a/tests/reg_issue3027/test_conflicting_inheritance.fz.expected_err
+++ b/tests/reg_issue3027/test_conflicting_inheritance.fz.expected_err
@@ -1,0 +1,230 @@
+
+--CURDIR--/test_conflicting_inheritance.fz:47:1: error 1: Repeated inheritance of conflicting features
+rconflic_i32_String_none   : ri32, rString is
+^^^^^^^^^^^^^^^^^^^^^^^^
+Feature 'rconflic_i32_String_none' inherits feature 'f' (no arguments) repeatedly: 'ri32.f' defined at --CURDIR--/test_conflicting_inheritance.fz:39:19:
+ri32    is        f => 42
+------------------^
+and 'rString.f' defined at --CURDIR--/test_conflicting_inheritance.fz:40:19:
+rString is        f => "B.f"
+------------------^
+To solve this, you could add a redefinition of 'f' to 'rconflic_i32_String_none'.
+
+
+--CURDIR--/test_conflicting_inheritance.fz:48:1: error 2: Repeated inheritance of conflicting features
+rconflic_String_i32_none   : rString, ri32 is
+^^^^^^^^^^^^^^^^^^^^^^^^
+Feature 'rconflic_String_i32_none' inherits feature 'f' (no arguments) repeatedly: 'rString.f' defined at --CURDIR--/test_conflicting_inheritance.fz:40:19:
+rString is        f => "B.f"
+------------------^
+and 'ri32.f' defined at --CURDIR--/test_conflicting_inheritance.fz:39:19:
+ri32    is        f => 42
+------------------^
+To solve this, you could add a redefinition of 'f' to 'rconflic_String_i32_none'.
+
+
+--CURDIR--/test_conflicting_inheritance.fz:59:1: error 3: Repeated inheritance of conflicting features
+aconflic_i32_String_none   : ai32, aString is
+^^^^^^^^^^^^^^^^^^^^^^^^
+Feature 'aconflic_i32_String_none' inherits feature 'f' (one argument) repeatedly: 'ai32.f' defined at --CURDIR--/test_conflicting_inheritance.fz:51:19:
+ai32    is        f(a i32   ) =>
+------------------^
+and 'aString.f' defined at --CURDIR--/test_conflicting_inheritance.fz:52:19:
+aString is        f(a String) =>
+------------------^
+To solve this, you could add a redefinition of 'f' to 'aconflic_i32_String_none'.
+
+
+--CURDIR--/test_conflicting_inheritance.fz:60:1: error 4: Repeated inheritance of conflicting features
+aconflic_String_i32_none   : aString, ai32 is
+^^^^^^^^^^^^^^^^^^^^^^^^
+Feature 'aconflic_String_i32_none' inherits feature 'f' (one argument) repeatedly: 'aString.f' defined at --CURDIR--/test_conflicting_inheritance.fz:52:19:
+aString is        f(a String) =>
+------------------^
+and 'ai32.f' defined at --CURDIR--/test_conflicting_inheritance.fz:51:19:
+ai32    is        f(a i32   ) =>
+------------------^
+To solve this, you could add a redefinition of 'f' to 'aconflic_String_i32_none'.
+
+
+--CURDIR--/test_conflicting_inheritance.fz:33:21: error 5: Wrong result type in redefined feature
+aB : a, B is  redef f => 4711
+--------------------^
+In 'aB.f' that redefines 'B.f'
+result type is       : 'i32'
+result type should be: 'String'
+
+Original feature declared at --CURDIR--/test_conflicting_inheritance.fz:32:21:
+B ref     is        f => "B.f"
+--------------------^
+To solve this, change type of result to 'String'
+
+
+--CURDIR--/test_conflicting_inheritance.fz:41:53: error 6: Wrong result type in redefined feature
+rconflic_i32_String_i32    : ri32, rString is redef f => 4711
+----------------------------------------------------^
+In 'rconflic_i32_String_i32.f' that redefines 'rString.f'
+result type is       : 'i32'
+result type should be: 'String'
+
+Original feature declared at --CURDIR--/test_conflicting_inheritance.fz:40:19:
+rString is        f => "B.f"
+------------------^
+To solve this, change type of result to 'String'
+
+
+--CURDIR--/test_conflicting_inheritance.fz:42:53: error 7: Wrong result type in redefined feature
+rconflic_String_i32_i32    : rString, ri32 is redef f => 4711
+----------------------------------------------------^
+In 'rconflic_String_i32_i32.f' that redefines 'rString.f'
+result type is       : 'i32'
+result type should be: 'String'
+
+Original feature declared at --CURDIR--/test_conflicting_inheritance.fz:40:19:
+rString is        f => "B.f"
+------------------^
+To solve this, change type of result to 'String'
+
+
+--CURDIR--/test_conflicting_inheritance.fz:43:53: error 8: Wrong result type in redefined feature
+rconflic_i32_String_String : ri32, rString is redef f => "bla"
+----------------------------------------------------^
+In 'rconflic_i32_String_String.f' that redefines 'ri32.f'
+result type is       : 'String'
+result type should be: 'i32'
+
+Original feature declared at --CURDIR--/test_conflicting_inheritance.fz:39:19:
+ri32    is        f => 42
+------------------^
+To solve this, change type of result to 'i32'
+
+
+--CURDIR--/test_conflicting_inheritance.fz:44:53: error 9: Wrong result type in redefined feature
+rconflic_String_i32_String : rString, ri32 is redef f => "bla"
+----------------------------------------------------^
+In 'rconflic_String_i32_String.f' that redefines 'ri32.f'
+result type is       : 'String'
+result type should be: 'i32'
+
+Original feature declared at --CURDIR--/test_conflicting_inheritance.fz:39:19:
+ri32    is        f => 42
+------------------^
+To solve this, change type of result to 'i32'
+
+
+--CURDIR--/test_conflicting_inheritance.fz:45:53: error 10: Wrong result type in redefined feature
+rconflic_i32_String_f64    : ri32, rString is redef f => 3.14
+----------------------------------------------------^
+In 'rconflic_i32_String_f64.f' that redefines 'ri32.f'
+result type is       : 'f64'
+result type should be: 'i32'
+
+Original feature declared at --CURDIR--/test_conflicting_inheritance.fz:39:19:
+ri32    is        f => 42
+------------------^
+To solve this, change type of result to 'i32'
+
+
+--CURDIR--/test_conflicting_inheritance.fz:46:53: error 11: Wrong result type in redefined feature
+rconflic_String_i32_f64    : rString, ri32 is redef f => 3.14
+----------------------------------------------------^
+In 'rconflic_String_i32_f64.f' that redefines 'ri32.f'
+result type is       : 'f64'
+result type should be: 'i32'
+
+Original feature declared at --CURDIR--/test_conflicting_inheritance.fz:39:19:
+ri32    is        f => 42
+------------------^
+To solve this, change type of result to 'i32'
+
+
+--CURDIR--/test_conflicting_inheritance.fz:53:55: error 12: Wrong argument type in redefined feature
+aconflic_i32_String_i32    : ai32, aString is redef f(a i32) =>
+------------------------------------------------------^
+In 'aconflic_i32_String_i32.f' that redefines 'aString.f'
+argument type is       : 'i32'
+argument type should be: 'String'
+
+Original argument declared at --CURDIR--/test_conflicting_inheritance.fz:52:21:
+aString is        f(a String) =>
+--------------------^
+To solve this, change type of argument to 'String' at --CURDIR--/test_conflicting_inheritance.fz:53:55:
+aconflic_i32_String_i32    : ai32, aString is redef f(a i32) =>
+------------------------------------------------------^
+
+
+--CURDIR--/test_conflicting_inheritance.fz:54:55: error 13: Wrong argument type in redefined feature
+aconflic_String_i32_i32    : aString, ai32 is redef f(a i32) =>
+------------------------------------------------------^
+In 'aconflic_String_i32_i32.f' that redefines 'aString.f'
+argument type is       : 'i32'
+argument type should be: 'String'
+
+Original argument declared at --CURDIR--/test_conflicting_inheritance.fz:52:21:
+aString is        f(a String) =>
+--------------------^
+To solve this, change type of argument to 'String' at --CURDIR--/test_conflicting_inheritance.fz:54:55:
+aconflic_String_i32_i32    : aString, ai32 is redef f(a i32) =>
+------------------------------------------------------^
+
+
+--CURDIR--/test_conflicting_inheritance.fz:55:55: error 14: Wrong argument type in redefined feature
+aconflic_i32_String_String : ai32, aString is redef f(a String) =>
+------------------------------------------------------^
+In 'aconflic_i32_String_String.f' that redefines 'ai32.f'
+argument type is       : 'String'
+argument type should be: 'i32'
+
+Original argument declared at --CURDIR--/test_conflicting_inheritance.fz:51:21:
+ai32    is        f(a i32   ) =>
+--------------------^
+To solve this, change type of argument to 'i32' at --CURDIR--/test_conflicting_inheritance.fz:55:55:
+aconflic_i32_String_String : ai32, aString is redef f(a String) =>
+------------------------------------------------------^
+
+
+--CURDIR--/test_conflicting_inheritance.fz:56:55: error 15: Wrong argument type in redefined feature
+aconflic_String_i32_String : aString, ai32 is redef f(a String) =>
+------------------------------------------------------^
+In 'aconflic_String_i32_String.f' that redefines 'ai32.f'
+argument type is       : 'String'
+argument type should be: 'i32'
+
+Original argument declared at --CURDIR--/test_conflicting_inheritance.fz:51:21:
+ai32    is        f(a i32   ) =>
+--------------------^
+To solve this, change type of argument to 'i32' at --CURDIR--/test_conflicting_inheritance.fz:56:55:
+aconflic_String_i32_String : aString, ai32 is redef f(a String) =>
+------------------------------------------------------^
+
+
+--CURDIR--/test_conflicting_inheritance.fz:57:55: error 16: Wrong argument type in redefined feature
+aconflic_i32_String_f64    : ai32, aString is redef f(a f64) =>
+------------------------------------------------------^
+In 'aconflic_i32_String_f64.f' that redefines 'ai32.f'
+argument type is       : 'f64'
+argument type should be: 'i32'
+
+Original argument declared at --CURDIR--/test_conflicting_inheritance.fz:51:21:
+ai32    is        f(a i32   ) =>
+--------------------^
+To solve this, change type of argument to 'i32' at --CURDIR--/test_conflicting_inheritance.fz:57:55:
+aconflic_i32_String_f64    : ai32, aString is redef f(a f64) =>
+------------------------------------------------------^
+
+
+--CURDIR--/test_conflicting_inheritance.fz:58:55: error 17: Wrong argument type in redefined feature
+aconflic_String_i32_f64    : aString, ai32 is redef f(a f64) =>
+------------------------------------------------------^
+In 'aconflic_String_i32_f64.f' that redefines 'ai32.f'
+argument type is       : 'f64'
+argument type should be: 'i32'
+
+Original argument declared at --CURDIR--/test_conflicting_inheritance.fz:51:21:
+ai32    is        f(a i32   ) =>
+--------------------^
+To solve this, change type of argument to 'i32' at --CURDIR--/test_conflicting_inheritance.fz:58:55:
+aconflic_String_i32_f64    : aString, ai32 is redef f(a f64) =>
+------------------------------------------------------^
+
+17 errors.

--- a/tests/reg_issue3027/test_conflicting_inheritance.fz.expected_err
+++ b/tests/reg_issue3027/test_conflicting_inheritance.fz.expected_err
@@ -1,6 +1,6 @@
 
 --CURDIR--/test_conflicting_inheritance.fz:47:1: error 1: Repeated inheritance of conflicting features
-rconflic_i32_String_none   : ri32, rString is
+rconflic_i32_String_none   : ri32, rString is                    # 8. should flag an error, ri32.f and rString.f have incompatible result type
 ^^^^^^^^^^^^^^^^^^^^^^^^
 Feature 'rconflic_i32_String_none' inherits feature 'f' (no arguments) repeatedly: 'ri32.f' defined at --CURDIR--/test_conflicting_inheritance.fz:39:19:
 ri32    is        f => 42
@@ -12,7 +12,7 @@ To solve this, you could add a redefinition of 'f' to 'rconflic_i32_String_none'
 
 
 --CURDIR--/test_conflicting_inheritance.fz:48:1: error 2: Repeated inheritance of conflicting features
-rconflic_String_i32_none   : rString, ri32 is
+rconflic_String_i32_none   : rString, ri32 is                    # 9. should flag an error, ri32.f and rString.f have incompatible result type
 ^^^^^^^^^^^^^^^^^^^^^^^^
 Feature 'rconflic_String_i32_none' inherits feature 'f' (no arguments) repeatedly: 'rString.f' defined at --CURDIR--/test_conflicting_inheritance.fz:40:19:
 rString is        f => "B.f"
@@ -24,7 +24,7 @@ To solve this, you could add a redefinition of 'f' to 'rconflic_String_i32_none'
 
 
 --CURDIR--/test_conflicting_inheritance.fz:59:1: error 3: Repeated inheritance of conflicting features
-aconflic_i32_String_none   : ai32, aString is
+aconflic_i32_String_none   : ai32, aString is                        # 16. should flag an error, ri32.f and rString.f have incompatible argument type
 ^^^^^^^^^^^^^^^^^^^^^^^^
 Feature 'aconflic_i32_String_none' inherits feature 'f' (one argument) repeatedly: 'ai32.f' defined at --CURDIR--/test_conflicting_inheritance.fz:51:19:
 ai32    is        f(a i32   ) =>
@@ -36,7 +36,7 @@ To solve this, you could add a redefinition of 'f' to 'aconflic_i32_String_none'
 
 
 --CURDIR--/test_conflicting_inheritance.fz:60:1: error 4: Repeated inheritance of conflicting features
-aconflic_String_i32_none   : aString, ai32 is
+aconflic_String_i32_none   : aString, ai32 is                        # 17. should flag an error, ri32.f and rString.f have incompatible argument type
 ^^^^^^^^^^^^^^^^^^^^^^^^
 Feature 'aconflic_String_i32_none' inherits feature 'f' (one argument) repeatedly: 'aString.f' defined at --CURDIR--/test_conflicting_inheritance.fz:52:19:
 aString is        f(a String) =>
@@ -48,7 +48,7 @@ To solve this, you could add a redefinition of 'f' to 'aconflic_String_i32_none'
 
 
 --CURDIR--/test_conflicting_inheritance.fz:33:21: error 5: Wrong result type in redefined feature
-aB : a, B is  redef f => 4711
+aB : a, B is  redef f => 4711   # 1. should flag an error, B.f has wrong result type
 --------------------^
 In 'aB.f' that redefines 'B.f'
 result type is       : 'i32'
@@ -61,7 +61,7 @@ To solve this, change type of result to 'String'
 
 
 --CURDIR--/test_conflicting_inheritance.fz:41:53: error 6: Wrong result type in redefined feature
-rconflic_i32_String_i32    : ri32, rString is redef f => 4711
+rconflic_i32_String_i32    : ri32, rString is redef f => 4711    # 2. should flag an error, rString.f has wrong result type
 ----------------------------------------------------^
 In 'rconflic_i32_String_i32.f' that redefines 'rString.f'
 result type is       : 'i32'
@@ -74,7 +74,7 @@ To solve this, change type of result to 'String'
 
 
 --CURDIR--/test_conflicting_inheritance.fz:42:53: error 7: Wrong result type in redefined feature
-rconflic_String_i32_i32    : rString, ri32 is redef f => 4711
+rconflic_String_i32_i32    : rString, ri32 is redef f => 4711    # 3. should flag an error, rString.f has wrong result type
 ----------------------------------------------------^
 In 'rconflic_String_i32_i32.f' that redefines 'rString.f'
 result type is       : 'i32'
@@ -87,7 +87,7 @@ To solve this, change type of result to 'String'
 
 
 --CURDIR--/test_conflicting_inheritance.fz:43:53: error 8: Wrong result type in redefined feature
-rconflic_i32_String_String : ri32, rString is redef f => "bla"
+rconflic_i32_String_String : ri32, rString is redef f => "bla"   # 4. should flag an error, ri32.f has wrong result type
 ----------------------------------------------------^
 In 'rconflic_i32_String_String.f' that redefines 'ri32.f'
 result type is       : 'String'
@@ -100,7 +100,7 @@ To solve this, change type of result to 'i32'
 
 
 --CURDIR--/test_conflicting_inheritance.fz:44:53: error 9: Wrong result type in redefined feature
-rconflic_String_i32_String : rString, ri32 is redef f => "bla"
+rconflic_String_i32_String : rString, ri32 is redef f => "bla"   # 5. should flag an error, ri32.f has wrong result type
 ----------------------------------------------------^
 In 'rconflic_String_i32_String.f' that redefines 'ri32.f'
 result type is       : 'String'
@@ -113,7 +113,7 @@ To solve this, change type of result to 'i32'
 
 
 --CURDIR--/test_conflicting_inheritance.fz:45:53: error 10: Wrong result type in redefined feature
-rconflic_i32_String_f64    : ri32, rString is redef f => 3.14
+rconflic_i32_String_f64    : ri32, rString is redef f => 3.14    # 6. should flag an error, ri32.f and rString.f have wrong result type
 ----------------------------------------------------^
 In 'rconflic_i32_String_f64.f' that redefines 'ri32.f'
 result type is       : 'f64'
@@ -126,7 +126,7 @@ To solve this, change type of result to 'i32'
 
 
 --CURDIR--/test_conflicting_inheritance.fz:46:53: error 11: Wrong result type in redefined feature
-rconflic_String_i32_f64    : rString, ri32 is redef f => 3.14
+rconflic_String_i32_f64    : rString, ri32 is redef f => 3.14    # 7. should flag an error, ri32.f and rString.f have wrong result type
 ----------------------------------------------------^
 In 'rconflic_String_i32_f64.f' that redefines 'ri32.f'
 result type is       : 'f64'
@@ -139,7 +139,7 @@ To solve this, change type of result to 'i32'
 
 
 --CURDIR--/test_conflicting_inheritance.fz:53:55: error 12: Wrong argument type in redefined feature
-aconflic_i32_String_i32    : ai32, aString is redef f(a i32) =>
+aconflic_i32_String_i32    : ai32, aString is redef f(a i32) =>      # 10. should flag an error, rString.f has wrong argument type
 ------------------------------------------------------^
 In 'aconflic_i32_String_i32.f' that redefines 'aString.f'
 argument type is       : 'i32'
@@ -149,12 +149,12 @@ Original argument declared at --CURDIR--/test_conflicting_inheritance.fz:52:21:
 aString is        f(a String) =>
 --------------------^
 To solve this, change type of argument to 'String' at --CURDIR--/test_conflicting_inheritance.fz:53:55:
-aconflic_i32_String_i32    : ai32, aString is redef f(a i32) =>
+aconflic_i32_String_i32    : ai32, aString is redef f(a i32) =>      # 10. should flag an error, rString.f has wrong argument type
 ------------------------------------------------------^
 
 
 --CURDIR--/test_conflicting_inheritance.fz:54:55: error 13: Wrong argument type in redefined feature
-aconflic_String_i32_i32    : aString, ai32 is redef f(a i32) =>
+aconflic_String_i32_i32    : aString, ai32 is redef f(a i32) =>      # 11. should flag an error, rString.f has wrong argument type
 ------------------------------------------------------^
 In 'aconflic_String_i32_i32.f' that redefines 'aString.f'
 argument type is       : 'i32'
@@ -164,12 +164,12 @@ Original argument declared at --CURDIR--/test_conflicting_inheritance.fz:52:21:
 aString is        f(a String) =>
 --------------------^
 To solve this, change type of argument to 'String' at --CURDIR--/test_conflicting_inheritance.fz:54:55:
-aconflic_String_i32_i32    : aString, ai32 is redef f(a i32) =>
+aconflic_String_i32_i32    : aString, ai32 is redef f(a i32) =>      # 11. should flag an error, rString.f has wrong argument type
 ------------------------------------------------------^
 
 
 --CURDIR--/test_conflicting_inheritance.fz:55:55: error 14: Wrong argument type in redefined feature
-aconflic_i32_String_String : ai32, aString is redef f(a String) =>
+aconflic_i32_String_String : ai32, aString is redef f(a String) =>   # 12. should flag an error, ri32.f has wrong argument type
 ------------------------------------------------------^
 In 'aconflic_i32_String_String.f' that redefines 'ai32.f'
 argument type is       : 'String'
@@ -179,12 +179,12 @@ Original argument declared at --CURDIR--/test_conflicting_inheritance.fz:51:21:
 ai32    is        f(a i32   ) =>
 --------------------^
 To solve this, change type of argument to 'i32' at --CURDIR--/test_conflicting_inheritance.fz:55:55:
-aconflic_i32_String_String : ai32, aString is redef f(a String) =>
+aconflic_i32_String_String : ai32, aString is redef f(a String) =>   # 12. should flag an error, ri32.f has wrong argument type
 ------------------------------------------------------^
 
 
 --CURDIR--/test_conflicting_inheritance.fz:56:55: error 15: Wrong argument type in redefined feature
-aconflic_String_i32_String : aString, ai32 is redef f(a String) =>
+aconflic_String_i32_String : aString, ai32 is redef f(a String) =>   # 13. should flag an error, ri32.f has wrong argument type
 ------------------------------------------------------^
 In 'aconflic_String_i32_String.f' that redefines 'ai32.f'
 argument type is       : 'String'
@@ -194,12 +194,12 @@ Original argument declared at --CURDIR--/test_conflicting_inheritance.fz:51:21:
 ai32    is        f(a i32   ) =>
 --------------------^
 To solve this, change type of argument to 'i32' at --CURDIR--/test_conflicting_inheritance.fz:56:55:
-aconflic_String_i32_String : aString, ai32 is redef f(a String) =>
+aconflic_String_i32_String : aString, ai32 is redef f(a String) =>   # 13. should flag an error, ri32.f has wrong argument type
 ------------------------------------------------------^
 
 
 --CURDIR--/test_conflicting_inheritance.fz:57:55: error 16: Wrong argument type in redefined feature
-aconflic_i32_String_f64    : ai32, aString is redef f(a f64) =>
+aconflic_i32_String_f64    : ai32, aString is redef f(a f64) =>      # 14. should flag an error, ri32.f and rString.f have wrong argument type
 ------------------------------------------------------^
 In 'aconflic_i32_String_f64.f' that redefines 'ai32.f'
 argument type is       : 'f64'
@@ -209,12 +209,12 @@ Original argument declared at --CURDIR--/test_conflicting_inheritance.fz:51:21:
 ai32    is        f(a i32   ) =>
 --------------------^
 To solve this, change type of argument to 'i32' at --CURDIR--/test_conflicting_inheritance.fz:57:55:
-aconflic_i32_String_f64    : ai32, aString is redef f(a f64) =>
+aconflic_i32_String_f64    : ai32, aString is redef f(a f64) =>      # 14. should flag an error, ri32.f and rString.f have wrong argument type
 ------------------------------------------------------^
 
 
 --CURDIR--/test_conflicting_inheritance.fz:58:55: error 17: Wrong argument type in redefined feature
-aconflic_String_i32_f64    : aString, ai32 is redef f(a f64) =>
+aconflic_String_i32_f64    : aString, ai32 is redef f(a f64) =>      # 15. should flag an error, ri32.f and rString.f have wrong argument type
 ------------------------------------------------------^
 In 'aconflic_String_i32_f64.f' that redefines 'ai32.f'
 argument type is       : 'f64'
@@ -224,7 +224,7 @@ Original argument declared at --CURDIR--/test_conflicting_inheritance.fz:51:21:
 ai32    is        f(a i32   ) =>
 --------------------^
 To solve this, change type of argument to 'i32' at --CURDIR--/test_conflicting_inheritance.fz:58:55:
-aconflic_String_i32_f64    : aString, ai32 is redef f(a f64) =>
+aconflic_String_i32_f64    : aString, ai32 is redef f(a f64) =>      # 15. should flag an error, ri32.f and rString.f have wrong argument type
 ------------------------------------------------------^
 
 17 errors.

--- a/tests/simple_and_negative.mk
+++ b/tests/simple_and_negative.mk
@@ -23,13 +23,37 @@
 #
 # -----------------------------------------------------------------------
 
-# this is both a negative test to make sure that all required errors are
-# shown, and then, as a simple test to make sure that the
-# error output is correct, i.e., lists all the ambiguities correctly.
+# this runs the tests twice, once as a negative test to make sure that all
+# required errors are shown, and then as a simple test to make sure that the
+# error output is correct.
 #
-# Even though the negative variant could not fail if the simple variant fails,
+# Even though the negative variante could not fail if the simple variant fails,
 # running both ensures that an update of error output cannot accidentally
 # inctroduce some missing errors.
 #
-override NAME = partial_application_negative
-include ../simple_and_negative.mk
+all: jvm int c
+
+jvm:
+	NAME=$(NAME) make -f ../negative.mk jvm
+	NAME=$(NAME) FUZION_OPTIONS=-XmaxErrors=-1 make -f ../simple.mk jvm
+c:
+	NAME=$(NAME) make -f ../negative.mk c
+	NAME=$(NAME) FUZION_OPTIONS=-XmaxErrors=-1 make -f ../simple.mk c
+int:
+	NAME=$(NAME) make -f ../negative.mk int
+	NAME=$(NAME) FUZION_OPTIONS=-XmaxErrors=-1 make -f ../simple.mk int
+
+show:
+	NAME=$(NAME) make -f ../negative.mk show
+
+record:
+	NAME=$(NAME) FUZION_OPTIONS=-XmaxErrors=-1 make -f ../simple.mk record
+
+record_jvm:
+	NAME=$(NAME) FUZION_OPTIONS=-XmaxErrors=-1 make -f ../simple.mk record_jvm
+
+record_c:
+	NAME=$(NAME) FUZION_OPTIONS=-XmaxErrors=-1 make -f ../simple.mk record_c
+
+record_int:
+	NAME=$(NAME) FUZION_OPTIONS=-XmaxErrors=-1 make -f ../simple.mk record_int

--- a/tests/simple_and_negative.mk
+++ b/tests/simple_and_negative.mk
@@ -29,7 +29,7 @@
 #
 # Even though the negative variante could not fail if the simple variant fails,
 # running both ensures that an update of error output cannot accidentally
-# inctroduce some missing errors.
+# introduce some missing errors.
 #
 all: jvm int c
 


### PR DESCRIPTION
Fix #3027, multiple inheritance may result in crash, by first collecting all inherited features and moving the checks for redefinition to `SourceModule.checkDuplicateFeatures`.

This also adds basic infrastructure for pre- and postcondition inheritance, but the code is still disabled. 
