### PR TITLE
be/c: add compiler switch `-ftrapv`

### DIFF
--- a/src/dev/flang/be/c/C.java
+++ b/src/dev/flang/be/c/C.java
@@ -744,10 +744,23 @@ public class C extends ANY
     var cCompiler = _options._cCompiler != null ? _options._cCompiler : "clang";
     var cTarget = _options._cTarget != null ? Optional.of(_options._cTarget) : getClangDefaultTarget();
     var command = new List<String>(cCompiler);
+
     if (cTarget.isPresent())
       {
         command.add("--target=" + cTarget.get());
       }
+
+    /*
+     * "Generate code to catch integer overflow errors.
+     *  Signed integer overflow is undefined in C. With this flag,
+     *  extra code is generated to detect this and abort when it happens."
+     * source: man clang
+     */
+    command.add("-ftrapv");
+
+    // NYI: UNDER DEVELOPMENT: enable this once we have gotten rid of implicit conversions
+    // command.add("-Wconversion");
+
     if(_options._cFlags != null)
       {
         command.addAll(_options._cFlags.split(" "));
@@ -774,14 +787,17 @@ public class C extends ANY
 
         command.addAll("-O3");
       }
+
     if(_options._useBoehmGC)
       {
         command.addAll("-lgc", "-DGC_THREADS", "-DGC_PTHREADS", "-DPTW32_STATIC_LIB", "-DGC_WIN32_PTHREADS");
       }
+
     if (linkJVM())
       {
         command.addAll("-DFUZION_LINK_JVM");
       }
+
     if (usesThreads())
       {
         command.addAll("-DFUZION_ENABLE_THREADS");
@@ -821,6 +837,7 @@ public class C extends ANY
       {
         command.addAll(_options.pathOf("include/posix.c"));
       }
+
     command.addAll(cf.fileName());
 
     if (linkJVM())

--- a/src/dev/flang/be/c/Intrinsics.java
+++ b/src/dev/flang/be/c/Intrinsics.java
@@ -527,7 +527,14 @@ public class Intrinsics extends ANY
     put("i32.infix +°"         , (c,cl,outer,in) -> castToUnsignedForArithmetic(c, outer, A0, '+', FUIR.SpecialClazzes.c_u32, FUIR.SpecialClazzes.c_i32).ret());
     put("i64.infix +°"         , (c,cl,outer,in) -> castToUnsignedForArithmetic(c, outer, A0, '+', FUIR.SpecialClazzes.c_u64, FUIR.SpecialClazzes.c_i64).ret());
     put("i8.infix *°"          , (c,cl,outer,in) -> castToUnsignedForArithmetic(c, outer, A0, '*', FUIR.SpecialClazzes.c_u8 , FUIR.SpecialClazzes.c_i8 ).ret());
-    put("i16.infix *°"         , (c,cl,outer,in) -> castToUnsignedForArithmetic(c, outer, A0, '*', FUIR.SpecialClazzes.c_u16, FUIR.SpecialClazzes.c_i16).ret());
+    /**
+     * This is intentionally cast to u32 and not u16.
+     * Read why here:
+     * https://stackoverflow.com/questions/24371868/why-must-a-short-be-converted-to-an-int-before-arithmetic-operations-in-c-and-c
+     * https://github.com/llvm/llvm-project/issues/25954
+     * https://stackoverflow.com/questions/23994293/inconsistent-behaviour-of-implicit-conversion-between-unsigned-and-bigger-signed
+     */
+    put("i16.infix *°"         , (c,cl,outer,in) -> castToUnsignedForArithmetic(c, outer, A0, '*', FUIR.SpecialClazzes.c_u32, FUIR.SpecialClazzes.c_i16).ret());
     put("i32.infix *°"         , (c,cl,outer,in) -> castToUnsignedForArithmetic(c, outer, A0, '*', FUIR.SpecialClazzes.c_u32, FUIR.SpecialClazzes.c_i32).ret());
     put("i64.infix *°"         , (c,cl,outer,in) -> castToUnsignedForArithmetic(c, outer, A0, '*', FUIR.SpecialClazzes.c_u64, FUIR.SpecialClazzes.c_i64).ret());
     put("i8.div"               ,
@@ -581,9 +588,16 @@ public class Intrinsics extends ANY
         "u32.infix +°"         ,
         "u64.infix +°"         , (c,cl,outer,in) -> outer.add(A0).ret());
     put("u8.infix *°"          ,
-        "u16.infix *°"         ,
         "u32.infix *°"         ,
         "u64.infix *°"         , (c,cl,outer,in) -> outer.mul(A0).ret());
+    /**
+     * This is intentionally cast to u32 and not u16.
+     * Read why here:
+     * https://stackoverflow.com/questions/24371868/why-must-a-short-be-converted-to-an-int-before-arithmetic-operations-in-c-and-c
+     * https://github.com/llvm/llvm-project/issues/25954
+     * https://stackoverflow.com/questions/23994293/inconsistent-behaviour-of-implicit-conversion-between-unsigned-and-bigger-signed
+     */
+    put("u16.infix *°"         , (c,cl,outer,in) -> castToUnsignedForArithmetic(c, outer, A0, '*', FUIR.SpecialClazzes.c_u32, FUIR.SpecialClazzes.c_i16).ret());
     put("u8.div"               ,
         "u16.div"              ,
         "u32.div"              ,


### PR DESCRIPTION
fixes wrap around multiplication of i16/u16.
I'm all but certain that this is just an issue for i16/u16...
