### PR TITLE
lib: Add redundant preconditions as workaround for #3051

### DIFF
--- a/lib/i32.fz
+++ b/lib/i32.fz
@@ -51,7 +51,12 @@ public i32(public val i32) : num.wrap_around, has_interval is
   public fixed infix *° (other i32) i32 => intrinsic
 
   # division and remainder with check for div-by-zero
-  public fixed infix / (other i32) => div other
+  public fixed infix / (other i32)
+    pre else
+      // NYI: #3051 precondition inheritance does not work yet
+      // remove this redundant precondition once #3051 is fixed
+      safety: other != 0
+  => div other
   public fixed infix % (other i32) => mod other
 
   # division and remainder with crash in case of div-by-zero

--- a/lib/num/wrap_around.fz
+++ b/lib/num/wrap_around.fz
@@ -123,6 +123,9 @@ module:public wrap_around : integer is
   # 'zero ** zero' is permitted and results in 'one'.
   #
   public infix ** (other wrap_around.this) wrap_around.this
+    pre else
+      // NYI: #3051 precondition inheritance does not work yet
+      debug: (!overflow_on_exp other)
   =>
     wrap_around.this **° other
 


### PR DESCRIPTION
This fixes jenkins failures when running fuzion-lang.dev examples.
