### PR TITLE
air: in abstractCalled-check use `isCalled` instead of `isInstantiated`

### DIFF
--- a/src/dev/flang/air/Clazz.java
+++ b/src/dev/flang/air/Clazz.java
@@ -1985,7 +1985,7 @@ public class Clazz extends ANY implements Comparable<Clazz>
    */
   public void check()
   {
-    if (isInstantiated() && _abstractCalled != null)
+    if (isCalled() && _abstractCalled != null)
       {
         AirErrors.abstractFeatureNotImplemented(feature(), _abstractCalled, _instantiationPos);
       }


### PR DESCRIPTION
intrinsics may return `String` which will actually be `ConstString` so it would be okay if `String` is instantiad and and abstract is called on it.
