### PR TITLE
ast: fix check-failure if redefinition is a choice

### DIFF
--- a/src/dev/flang/ast/AstErrors.java
+++ b/src/dev/flang/ast/AstErrors.java
@@ -999,6 +999,12 @@ public class AstErrors extends ANY
       {
         cannotRedefineChoice(f, existing);
       }
+    else if (f.isChoice())
+      {
+        cannotRedefine(f.pos(), f, existing,
+                       "Redefinition cannot be a choice",
+                       "To solve this, re-think what you want to do.  Maybe define a new choice type with a different name instead.");
+      }
     else if (existing.isConstructor() || f.isConstructor())
       {
         cannotRedefine(f.pos(), f, existing,


### PR DESCRIPTION
This problem occurs in fuzion-lang.dev's design/examples/red_choice.fz example. With this patch, a proper error is produced.
