### PR TITLE
lib: move features declared in inner scopes

### DIFF
--- a/lib/container/ps_map.fz
+++ b/lib/container/ps_map.fz
@@ -251,28 +251,29 @@ O(n log n).
   # get the lowest key in this map
   #
   public min option PK =>
+
+    min0 (m PK, l i32, r i32) PK =>
+      (lk, _) := data[l]
+      if (m ≤ lk) m else lk
+
+    min (m PK, at i32, sz i32, tail i32) PK =>
+      if sz = 0
+        m
+      else
+        sz0 := sz / 2
+        nt := (tail - sz0) / 2
+        at0 := (at
+                + (if (size & sz0) != 0 nt else 0)
+                + (if (size & sz ) != 0 sz else 0))
+        m0 := if (size & sz) != 0
+            min0 m at at+sz-1
+          else
+            m
+        min m0 at0 sz0 nt
+
     if size = 0
       nil
     else
-      min0 (m PK, l i32, r i32) PK =>
-        (lk, _) := data[l]
-        if (m ≤ lk) m else lk
-
-      min (m PK, at i32, sz i32, tail i32) PK =>
-        if sz = 0
-          m
-        else
-          sz0 := sz / 2
-          nt := (tail - sz0) / 2
-          at0 := (at
-                  + (if (size & sz0) != 0 nt else 0)
-                  + (if (size & sz ) != 0 sz else 0))
-          m0 := if (size & sz) != 0
-              min0 m at at+sz-1
-            else
-              m
-          min m0 at0 sz0 nt
-
       sub_sz := size.highest_one_bit
       min data[0].values.0 0 sub_sz (data.length - sub_sz)
 
@@ -280,28 +281,29 @@ O(n log n).
   # get the highest key in this map
   #
   public max option PK =>
+
+    max0 (m PK, l i32, r i32) PK =>
+      (rk, _) := data[r]
+      if (m ≥ rk) m else rk
+
+    max (m PK, at i32, sz i32, tail i32) PK =>
+      if sz = 0
+        m
+      else
+        sz0 := sz / 2
+        nt := (tail - sz0) / 2
+        at0 := (at
+                + (if (size & sz0) != 0 nt else 0)
+                + (if (size & sz ) != 0 sz else 0))
+        m0 := if (size & sz) != 0
+            max0 m at at+sz-1
+          else
+            m
+        max m0 at0 sz0 nt
+
     if size = 0
       nil
     else
-      max0 (m PK, l i32, r i32) PK =>
-        (rk, _) := data[r]
-        if (m ≥ rk) m else rk
-
-      max (m PK, at i32, sz i32, tail i32) PK =>
-        if sz = 0
-          m
-        else
-          sz0 := sz / 2
-          nt := (tail - sz0) / 2
-          at0 := (at
-                  + (if (size & sz0) != 0 nt else 0)
-                  + (if (size & sz ) != 0 sz else 0))
-          m0 := if (size & sz) != 0
-              max0 m at at+sz-1
-            else
-              m
-          max m0 at0 sz0 nt
-
       sub_sz := size.highest_one_bit
       max data[0].values.0 0 sub_sz (data.length - sub_sz)
 
@@ -314,40 +316,41 @@ O(n log n).
   # but it is undefined to which of these two.
   #
   public fixed union (other ps_map PK V) ps_map PK V =>
+
+    # helper to add 'ps_map.this.data[l..r]' to 'a' and return the resulting map.
+    #
+    add_all (a ps_map PK V, l i32, r i32) ps_map PK V =>
+      if l > r
+        a
+      else
+        kv := data[l]
+        a0 := if (a.has kv.values.0) a else a.add kv
+        add_all a0 l+1 r
+
+    # helper to add 'sz' elements from 'ps_map.this.data[at..at+sz]' to 'a', with
+    # 'tail' elements at indices larger or equal to 'at+sz' added recursively as
+    # well.
+    #
+    add_all (a ps_map PK V, at i32, sz i32, tail i32) ps_map PK V =>
+      if sz = 0
+        a
+      else
+        sz0 := sz / 2
+        nt := (tail - sz0) / 2
+        at0 := (at
+                + (if (size & sz0) != 0 nt else 0)
+                + (if (size & sz ) != 0 sz else 0))
+        a0 := if (size & sz) != 0
+            add_all a at at+sz-1
+          else
+            a
+        add_all a0 at0 sz0 nt
+
     if other.size < size
       other ∪ ps_map.this
     else
-
-      # helper to add 'ps_map.this.data[l..r]' to 'a' and return the resulting map.
-      #
-      add_all (a ps_map PK V, l i32, r i32) ps_map PK V =>
-        if l > r
-          a
-        else
-          kv := data[l]
-          a0 := if (a.has kv.values.0) a else a.add kv
-          add_all a0 l+1 r
-
-      # helper to add 'sz' elements from 'ps_map.this.data[at..at+sz]' to 'a', with
-      # 'tail' elements at indices larger or equal to 'at+sz' added recursively as
-      # well.
-      #
-      add_all (a ps_map PK V, at i32, sz i32, tail i32) ps_map PK V =>
-        if sz = 0
-          a
-        else
-          sz0 := sz / 2
-          nt := (tail - sz0) / 2
-          at0 := (at
-                  + (if (size & sz0) != 0 nt else 0)
-                  + (if (size & sz ) != 0 sz else 0))
-          a0 := if (size & sz) != 0
-              add_all a at at+sz-1
-            else
-              a
-          add_all a0 at0 sz0 nt
-
-      add_all other 0 size.highest_one_bit (data.length - size.highest_one_bit)
+      sub_sz := size.highest_one_bit
+      add_all other 0 sub_sz (data.length - sub_sz)
 
 
   # infix operator synonym for union of two ps_maps

--- a/lib/integer.fz
+++ b/lib/integer.fz
@@ -105,25 +105,25 @@ module:public integer : numeric is
   =>
     b := integer.this.from_u32 base
 
+    # this digit as an UTF-8 byte
+    digit_as_utf8_byte(d u8) u8
+    pre d ≤ 35 # 35 would be a Z
+    =>
+      if d < 10 then String.zero_char + d else String.a_char + d - 10
+
+    as_list0 (power integer.this) =>
+      if power.sign <= 0
+        nil
+      else
+        digit := (integer.this / power % b).as_u8
+        list (digit_as_utf8_byte digit) (()-> as_list0 power/b)
+
     if integer.this.sign < 0
       # there could be an overflow on negation
       match -? integer.this
         v integer.this => "-" + v.as_string base
         nil => ("-" + (-(integer.this / b)).as_string base) + (-(integer.this % b)).as_string base
     else
-      # this digit as an UTF-8 byte
-      digit_as_utf8_byte(d u8) u8
-      pre d ≤ 35 # 35 would be a Z
-      =>
-        if d < 10 then String.zero_char + d else String.a_char + d - 10
-
-      as_list0 (power integer.this) =>
-        if power.sign <= 0
-          nil
-        else
-          digit := (integer.this / power % b).as_u8
-          list (digit_as_utf8_byte digit) (()-> as_list0 power/b)
-
       String.from_bytes (as_list0 (integer.this.highest b))
 
 

--- a/lib/num/ryu.fz
+++ b/lib/num/ryu.fz
@@ -104,6 +104,7 @@ public ryū(public T type : float) is
   step_3(exponent, smaller_halfway_point, mv, larger_halfway_point i64, mm_shift bool, is_even bool, rounding_mode rounding_mode) tuple i64 i64 i64 bool bool i64 =>
 
     # calculates: ⌈log₂ 5ᵉ⌉
+    #
     pow5bits(e i64)
     pre debug: (e >= 0)
         debug: (e <= 3528)
@@ -111,6 +112,30 @@ public ryū(public T type : float) is
       pow5bits.this.result = (T.log T.two (five ** T.from_i64 e)).as_i64
     =>
       (e * 1217359) >> 19
+
+
+    # computes ⌊log₁₀ 2ᵉ⌋
+    #
+    floor_log₁₀_pow_2(e i64) i64
+    pre debug: (e >= 0)
+        debug: (e <= 1650)
+    post
+      # NYI ugly that we have to qualify this
+      floor_log₁₀_pow_2.this.result = (T.log T.ten (T.two ** T.from_i64 e)).floor.as_i64
+    =>
+      e*78913 >> 18
+
+
+    # computes ⌊log₁₀ 5ᵉ⌋
+    #
+    floor_log₁₀_pow_5 (e i64) i64
+    pre debug: (e >= 0)
+        debug: (e <= 2620)
+    post
+      ( T.log T.ten (five ** T.from_i64 e) = T.infinity
+        || floor_log₁₀_pow_5.this.result = (T.log T.ten (five ** T.from_i64 e)).floor.as_i64)
+    =>
+      e*732923 >> 20
 
 
     # max 3*31 = 124
@@ -824,16 +849,6 @@ public ryū(public T type : float) is
 
     if (exponent >= 0)
 
-      # computes ⌊log₁₀ 2ᵉ⌋
-      floor_log₁₀_pow_2(e i64) i64
-      pre debug: (e >= 0)
-          debug: (e <= 1650)
-      post
-        floor_log₁₀_pow_2.this.result = (T.log T.ten (T.two ** T.from_i64 e)).floor.as_i64
-      =>
-        exponent*78913 >> 18
-
-
       q := max (i64 0) (floor_log₁₀_pow_2 exponent)-1
       k := pow5_inv_bitcount + pow5bits q
       i := -exponent + q + k
@@ -854,18 +869,6 @@ public ryū(public T type : float) is
       else
         (dv, dp, dm, false, false, q)
     else
-
-
-      # computes ⌊log₁₀ 5ᵉ⌋
-      floor_log₁₀_pow_5 (e i64) i64
-      pre debug: (e >= 0)
-          debug: (e <= 2620)
-      post
-        ( T.log T.ten (five ** T.from_i64 e) = T.infinity
-          || floor_log₁₀_pow_5.this.result = (T.log T.ten (five ** T.from_i64 e)).floor.as_i64)
-      =>
-        e*732923 >> 20
-
 
       q := max (i64 0) (floor_log₁₀_pow_5 -exponent)-1
       i := -exponent - q


### PR DESCRIPTION
e.g. max0 was previously declared inside of a case-block/(else-block) even though it did not call/access any field from that block.