### PR TITLE
macOS: fix building java.base.fum

### DIFF
--- a/src/dev/flang/tools/fzjava/FZJava.java
+++ b/src/dev/flang/tools/fzjava/FZJava.java
@@ -266,7 +266,7 @@ public class FZJava extends Tool
       {
         var str = new StringBuilder(
                     "public Java.as_java_object(T type : Java.java.lang.Object, seq Sequence T) =>\n");
-        str.append("  res := (Java.java.lang.reflect.Array.newInstance T.get_java_class seq.count).val\n");
+        str.append("  res := (Java.java.lang.reflect.Array.newInstance_Ljava_7_lang_7_Class_s_I T.get_java_class seq.count).val\n");
         str.append("  for idx := 0, idx+1\n");
         str.append("      el in seq\n");
         str.append("  do\n");


### PR DESCRIPTION
It seems the features selected for generating shortHands is not stable.
This is a workaround by not using the `newInstance` short hand but its full name.