### PR TITLE
parser: Permit `:=` in a field declaration at minimum indentation

### DIFF
--- a/src/dev/flang/parser/Parser.java
+++ b/src/dev/flang/parser/Parser.java
@@ -3250,8 +3250,8 @@ implRout    : "is" "abstract"
   /**
    * Parse implFldOrRout
    *
-implFldOrRout   : implRout
-                | implFldInit
+implFldOrRout   : implRout           // may start at min indent
+                | implFldInit        // may start at min indent
                 |
                 ;
    */
@@ -3280,13 +3280,13 @@ implFldOrRout   : implRout
   /**
    * Parse implFldInit
    *
-implFldInit : ":=" exprInLine
+implFldInit : ":=" exprInLine      // may start at min indent
             ;
    */
   Impl implFldInit(boolean hasType)
   {
     SourcePosition pos = tokenSourcePos();
-    if (!skip(":="))
+    if (!skip(true, ":="))
       {
         syntaxError(tokenPos(), "':='", "implFldInit");
       }


### PR DESCRIPTION
Before this the following code

  # a routine:
  abc
  pre
    true
  => 42

  # a field:
  def
  pre
    true
  := 4711

would reuslt in an error for the field declaration. Now, the parser accepts this, but fails due to #3092
