### PR TITLE
ast: Remove error for ref to choice type

### DIFF
--- a/src/dev/flang/ast/AbstractType.java
+++ b/src/dev/flang/ast/AbstractType.java
@@ -1021,10 +1021,8 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
     if (isChoice())
       {
         var g = choiceGenerics();
-        if (isRef())
-          {
-            AstErrors.refToChoice(pos);
-          }
+        if (CHECKS) check
+          (Errors.any() || !isRef());
 
         int i1 = 0;
         for (var t1 : g)

--- a/src/dev/flang/ast/AstErrors.java
+++ b/src/dev/flang/ast/AstErrors.java
@@ -1430,13 +1430,6 @@ public class AstErrors extends ANY
           "Formal type parameter declared in " + generic.typeParameter().pos().show() + "\n");
   }
 
-  static void refToChoice(SourcePosition pos)
-  {
-    error(pos,
-          "ref to a choice type is not allowed",
-          "a choice is always a value type");
-  }
-
   static void genericsMustBeDisjoint(SourcePosition pos, AbstractType t1, AbstractType t2)
   {
     error(pos,


### PR DESCRIPTION
This error is redundant with the check that a choice should not have a return type which is added in #3103.

