### PR TITLE
be/c: add option `-Wno-c23-extensions`

### DIFF
--- a/src/dev/flang/be/c/C.java
+++ b/src/dev/flang/be/c/C.java
@@ -773,6 +773,8 @@ public class C extends ANY
           // NYI: UNDER DEVELOPEMENT:
           "-Wno-gnu-empty-initializer",
           // NYI: UNDER DEVELOPEMENT:
+          "-Wno-c23-extensions",
+          // NYI: UNDER DEVELOPEMENT:
           "-Wno-zero-length-array",
           "-Wno-trigraphs",
           "-Wno-gnu-empty-struct",


### PR DESCRIPTION
fixes some failures when using clang 18 or higher.
