### PR TITLE
ast: Fix post condition for constructors

### DIFF
--- a/src/dev/flang/ast/Contract.java
+++ b/src/dev/flang/ast/Contract.java
@@ -291,6 +291,10 @@ public class Contract extends ANY
         c2 = c2.resolveTypes(res, outer);
         args.add(c2);
       }
+    else if (outer.isConstructor())
+      {
+        args.add(new Current(p, outer));
+      }
     return callPostCondition(res, outer, outer, args);
   }
 
@@ -356,7 +360,9 @@ public class Contract extends ANY
         var pos = fc._hasPost != null ? fc._hasPost : f.pos();
         var resultField = new Feature(pos,
                                       Visi.PRIV,
-                                      f.resultType(), // NYI: replace type parameter of f by type parameters of _postFeature!
+                                      f.isConstructor()
+                                      ? f.thisType()
+                                      : f.resultType(), // NYI: replace type parameter of f by type parameters of _postFeature!
                                       FuzionConstants.RESULT_NAME)
           {
             public boolean isResultField() { return true; }


### PR DESCRIPTION
The result of a constructor is the new instance, so we need to pass `Current` as the result argument.

For this to be possible, the type of the result in the post condition feature must be `f.thisType()`, ie. exactly `f` and not `f.this`.

This fixes current failures in fuzion-lang.dev's tutorial examples like `modify_array1.fz`.

This does not work for post conditions in constructors that are called in an inherits clause, will create an issue for this.
