### PR TITLE
be/c: fix "use of an empty initializer is a C23 extension"

### DIFF
--- a/src/dev/flang/be/c/C.java
+++ b/src/dev/flang/be/c/C.java
@@ -397,6 +397,12 @@ public class C extends ANY
           var bb = ByteBuffer.wrap(d).order(ByteOrder.LITTLE_ENDIAN);
           var elCount = bb.getInt();
 
+          // empty initializer is only allowed since C23
+          if (elCount == 0 && !_fuir.clazzIsUnitType(elementType))
+            {
+              sb.append("0");
+            }
+
           for (int idx = 0; idx < elCount; idx++)
             {
               var b = _fuir.deseralizeConst(elementType, bb);


### PR DESCRIPTION
see: https://github.com/tokiwa-software/fuzion/actions/runs/9190304838/job/25274227621

some newer clang versions complain about this
