### PR TITLE
ast: Support redefinition of feature with type parameters, fix #3136

### DIFF
--- a/src/dev/flang/fe/SourceModule.java
+++ b/src/dev/flang/fe/SourceModule.java
@@ -1442,7 +1442,7 @@ A post-condition of a feature that does not redefine an inherited feature must s
           {
             for (int i = 0; i < ta.length; i++)
               {
-                var t1 = ta[i];
+                var t1 = ta[i].applyTypePars(o, f.generics().asActuals());
                 var t2 = ra[i];
                 if (!isLegalCovariantThisType(o, f, t1, t2, fixed))
                   {
@@ -1462,7 +1462,7 @@ A post-condition of a feature that does not redefine an inherited feature must s
               }
           }
 
-        var t1 = o.handDownNonOpen(_res, o.resultType(), f.outer());
+        var t1 = o.handDownNonOpen(_res, o.resultType(), f).applyTypePars(o, f.generics().asActuals());
         var t2 = f.resultType();
         if (o.isTypeFeaturesThisType() && f.isTypeFeaturesThisType())
           { // NYI: CLEANUP: #706: allow redefinition of THIS_TYPE in type features for now, these are created internally.

--- a/src/dev/flang/fe/SourceModule.java
+++ b/src/dev/flang/fe/SourceModule.java
@@ -1442,7 +1442,7 @@ A post-condition of a feature that does not redefine an inherited feature must s
           {
             for (int i = 0; i < ta.length; i++)
               {
-                var t1 = ta[i].applyTypePars(o, f.generics().asActuals());
+                var t1 = ta[i].applyTypePars(o, f.generics().asActuals());  /* replace o's type pars by f's */
                 var t2 = ra[i];
                 if (!isLegalCovariantThisType(o, f, t1, t2, fixed))
                   {
@@ -1462,7 +1462,8 @@ A post-condition of a feature that does not redefine an inherited feature must s
               }
           }
 
-        var t1 = o.handDownNonOpen(_res, o.resultType(), f).applyTypePars(o, f.generics().asActuals());
+        var t1 = o.handDownNonOpen(_res, o.resultType(), f)
+                  .applyTypePars(o, f.generics().asActuals());    /* replace o's type pars by f's */
         var t2 = f.resultType();
         if (o.isTypeFeaturesThisType() && f.isTypeFeaturesThisType())
           { // NYI: CLEANUP: #706: allow redefinition of THIS_TYPE in type features for now, these are created internally.

--- a/src/dev/flang/fe/SourceModule.java
+++ b/src/dev/flang/fe/SourceModule.java
@@ -1462,7 +1462,7 @@ A post-condition of a feature that does not redefine an inherited feature must s
               }
           }
 
-        var t1 = o.handDownNonOpen(_res, o.resultType(), f)
+        var t1 = o.handDownNonOpen(_res, o.resultType(), f.outer())
                   .applyTypePars(o, f.generics().asActuals());    /* replace o's type pars by f's */
         var t2 = f.resultType();
         if (o.isTypeFeaturesThisType() && f.isTypeFeaturesThisType())

--- a/tests/reg_issue3136/Makefile
+++ b/tests/reg_issue3136/Makefile
@@ -1,0 +1,27 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test Makefile
+#
+#  Author: Fridtjof Siebert (siebert@tokiwa.software)
+#
+# -----------------------------------------------------------------------
+
+override NAME = redef_with_type_pars
+include ../simple.mk

--- a/tests/reg_issue3136/redef_with_type_pars.fz
+++ b/tests/reg_issue3136/redef_with_type_pars.fz
@@ -1,0 +1,47 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test redef_with_type_pars
+#
+#  Author: Fridtjof Siebert (siebert@tokiwa.software)
+#
+# -----------------------------------------------------------------------
+
+# Regression test for #3136.
+#
+# This redefines a feature `f` that has type parameters and shuffles
+# around the names of the type parameters while doing so.
+#
+redef_with_type_pars is
+
+  a is
+    f      (X, Y, Z type, p X, q Y, r Z) X => abstract
+
+  b : a is
+    redef f(Z, Y, X type, r Z, q Y, p X) Z => r
+
+  c : b is
+    redef f(A, B, C type, x A, y B, z C) A => x
+
+  show(x T) => say "$x ($T)"
+
+  show (b.f i32 String unit 42 "fourty-two" unit)
+  show (c.f i32 String unit 42 "fourty-two" unit)
+  show (b.f String bool i32 "fourty-two" false 42)
+  show (c.f String bool i32 "fourty-two" false 42)

--- a/tests/reg_issue3136/redef_with_type_pars.fz.expected_out
+++ b/tests/reg_issue3136/redef_with_type_pars.fz.expected_out
@@ -1,0 +1,4 @@
+42 (Type of 'i32')
+42 (Type of 'i32')
+fourty-two (Type of 'String')
+fourty-two (Type of 'String')


### PR DESCRIPTION
Since a redefinition has its own type parameters, when checking whether the argument and result types match the redefined feature we need to replace type parameters by those of the redefined version.

Also add a regression test.