### PR TITLE
util: Supress any further error output during shutdown due to errors, fix #3142

### DIFF
--- a/tests/catch_postcondition/catch_postcondition.fz.expected_err
+++ b/tests/catch_postcondition/catch_postcondition.fz.expected_err
@@ -570,3 +570,4 @@ catch_postcondition: --CURDIR--/catch_postcondition.fz:86:32:
 -------------------------------^^^
 
 *** fatal errors encountered, stopping.
+one error.

--- a/tests/catch_postcondition/catch_postcondition.fz.expected_err_jvm
+++ b/tests/catch_postcondition/catch_postcondition.fz.expected_err_jvm
@@ -14,3 +14,4 @@ catch_postcondition__test_i32
 catch_postcondition
 
 *** fatal errors encountered, stopping.
+one error.

--- a/tests/contracts_negative/SquareRoot.fz.expected_err
+++ b/tests/contracts_negative/SquareRoot.fz.expected_err
@@ -9,3 +9,4 @@ SquareRoot: --CURDIR--/SquareRoot.fz:44:21:
 --------------------^^^^
 
 *** fatal errors encountered, stopping.
+one error.

--- a/tests/contracts_negative/SquareRoot.fz.expected_err_jvm
+++ b/tests/contracts_negative/SquareRoot.fz.expected_err_jvm
@@ -5,3 +5,4 @@ precondition of SquareRoot__1sqrt
 SquareRoot
 
 *** fatal errors encountered, stopping.
+one error.

--- a/tests/fz_cmd/fz_cmd.fz.expected_err
+++ b/tests/fz_cmd/fz_cmd.fz.expected_err
@@ -7,3 +7,4 @@ Usage: ../../bin/fz [-h|--help|-version]  --or--
        ../../bin/fz -acemode [-noANSI] [-verbose[=<n>]]   --or--
 
 *** fatal errors encountered, stopping.
+one error.

--- a/tests/reg_issue270/issue270.fz.expected_err
+++ b/tests/reg_issue270/issue270.fz.expected_err
@@ -6,3 +6,4 @@ For call to issue270#0
 Call stack:
 
 *** fatal errors encountered, stopping.
+one error.

--- a/tests/reg_issue270/issue270.fz.expected_err_jvm
+++ b/tests/reg_issue270/issue270.fz.expected_err_jvm
@@ -4,3 +4,4 @@ Call stack:
 precondition of issue270
 
 *** fatal errors encountered, stopping.
+one error.


### PR DESCRIPTION
The problem was that `Errors.exit` throws a `FatalError`, which means that the synchronized methods for error output are exited and any other thread may produce error output during their own shutdown.

Now, a flag supresses further error output once we have started shutting down due to errors.

To avoid running into this problem again this patch removes `Errors.exit` and instead sets the `_shutting_down_ ` flag in `showAndExit`, which is synchronized and combines the final error statistic reporting with shutting down.

This has the side-effect that the error statistics are also shown in case of a fatal error, so some expected error output has to be updated.
