### PR TITLE
ast: move choiceTypeCheck from type inf to type check

### DIFF
--- a/src/dev/flang/ast/Feature.java
+++ b/src/dev/flang/ast/Feature.java
@@ -1702,7 +1702,6 @@ public class Feature extends AbstractFeature
           {
             o.typeInference(res);
           }
-        choiceTypeCheckAndInternalFields(res);
 
         _resultType = resultTypeIfPresent(res);
         if (_resultType == null)
@@ -1833,6 +1832,8 @@ public class Feature extends AbstractFeature
     _state =
       (_state == State.BOXED          ) ? State.CHECKING_TYPES1 :
       (_state == State.RESOLVED_SUGAR2) ? State.CHECKING_TYPES2 : _state;
+
+    choiceTypeCheckAndInternalFields(res);
 
     if ((_state == State.CHECKING_TYPES1) ||
         (_state == State.CHECKING_TYPES2)    )


### PR DESCRIPTION
when applying a diff to base lib similar to the one found in #1567 I found that this check is done too early.

This is because it relies on that the inherited features are at least in state RESOLVED_INHERITANCE which is not necessarily true.
