### PR TITLE
lib: change `exit(handler, code)` to return unit

### DIFF
--- a/lib/exit.fz
+++ b/lib/exit.fz
@@ -124,7 +124,7 @@ pre code ≤ 127
 # install given exit handler and run code with it.
 #
 public exit(handler Exit_Handler, code ()->unit) =>
-  exit handler (effect_mode.inst code) unit
+  _ := exit handler (effect_mode.inst code) unit
 
 
 # Exit_Handler -- abstract exit


### PR DESCRIPTION
fixes idiom186 and idiom198

