### PR TITLE
ast: In containsThisType: Fix check-fail on call to `outer()` on type parameter

### DIFF
--- a/src/dev/flang/ast/AbstractType.java
+++ b/src/dev/flang/ast/AbstractType.java
@@ -1723,8 +1723,8 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
   {
     return
       isThisType() ||
-      !isGenericArgument() && generics().stream().anyMatch(g -> g.containsThisType()) ||
-      outer() != null && outer().containsThisType();
+      !isGenericArgument() && (generics().stream().anyMatch(g -> g.containsThisType()) ||
+                               outer() != null && outer().containsThisType());
   }
 
 


### PR DESCRIPTION
This bug is triggered by my upcoming workaround for #3160, but it is a bug independent of this.
