### PR TITLE
ast: make error handling for types more fault tolerant

### DIFF
--- a/src/dev/flang/ast/AbstractFeature.java
+++ b/src/dev/flang/ast/AbstractFeature.java
@@ -891,7 +891,16 @@ public abstract class AbstractFeature extends Expr implements Comparable<Abstrac
                     for (var atp : pc.actualTypeParameters())
                       {
                         tp.set(i+1, atp);
-                        ((Call)inh.get(iif))._generics.set(i+1, atp);
+                        var g = ((Call)inh.get(iif))._generics;
+                        if (g.isFrozen())
+                          {
+                            if (CHECKS) check
+                              (Errors.any());
+                          }
+                        else
+                          {
+                            g.set(i+1, atp);
+                          }
                         i++;
                       }
                   });

--- a/src/dev/flang/ast/ArtificialBuiltInType.java
+++ b/src/dev/flang/ast/ArtificialBuiltInType.java
@@ -26,6 +26,8 @@ Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
 
 package dev.flang.ast;
 
+import dev.flang.util.SourcePosition;
+
 
 /**
  * A BuiltInType is an unresolved type representing a built-in type that does
@@ -68,6 +70,17 @@ public class ArtificialBuiltInType extends ResolvedNormalType
     _name = name;
     _id = ids++;
   }
+
+
+  /*-----------------------------  methods  -----------------------------*/
+
+
+  /**
+   * The sourcecode position of the declaration point of this type, or, for
+   * unresolved types, the source code position of its use.
+   */
+  @Override
+  public SourcePosition declarationPos() { return SourcePosition.builtIn; }
 
 
   /**

--- a/src/dev/flang/ast/ResolvedNormalType.java
+++ b/src/dev/flang/ast/ResolvedNormalType.java
@@ -50,7 +50,7 @@ public class ResolvedNormalType extends ResolvedType
    * The sourcecode position of the declaration point of this type, or, for
    * unresolved types, the source code position of its use.
    */
-  public SourcePosition declarationPos() { return _feature.pos(); }
+  public SourcePosition declarationPos() { return _feature == null ? SourcePosition.notAvailable : _feature.pos(); }
 
 
   /**
@@ -281,6 +281,7 @@ public class ResolvedNormalType extends ResolvedType
       (feature().generics().sizeMatches(generics()));
   }
 
+
   /**
    * Instantiate a new ResolvedNormalType and return its unique instance.
    */
@@ -507,10 +508,11 @@ public class ResolvedNormalType extends ResolvedType
     else
       {
         result =
-          (_refOrVal == RefOrVal.Boxed && (_feature == null || !_feature.isThisRef()) ? "ref " :
-           _refOrVal == RefOrVal.Value &&  _feature != null &&  _feature.isThisRef()  ? "value "
+          _feature == null ? "<null-feature>" :
+          ((_refOrVal == RefOrVal.Boxed && (_feature == null || !_feature.isThisRef()) ? "ref " :
+            _refOrVal == RefOrVal.Value &&  _feature != null &&  _feature.isThisRef()  ? "value "
                                                                                     : ""       )
-          + _feature.qualifiedName();
+           + _feature.qualifiedName());
       }
     if (isThisType())
       {
@@ -613,7 +615,7 @@ public class ResolvedNormalType extends ResolvedType
    */
   AbstractType clone(AbstractFeature originalOuterFeature)
   {
-    return
+    return this == Types.t_UNDEFINED ? this :
       new ResolvedNormalType(this, originalOuterFeature)
       {
         AbstractFeature originalOuterFeature(AbstractFeature currentOuter)


### PR DESCRIPTION
This avoids a number of runtime errors in `fz` that occured as a consequence of errors I ran into while woring on `eff.fallible` and `fuzion.runtime.*fault`.

Avoid `null` pointer exceptions due to `ResolvedNormalType._feature` being `null` or `declaredPos()` returning `null` or actual type parameters being resolved repeatedly as a result of errors.
