### PR TITLE
tests: for simple tests, preprocess err output to avoid common false pos errors

### DIFF
--- a/tests/_diff_err.sh
+++ b/tests/_diff_err.sh
@@ -36,8 +36,8 @@ set -euo pipefail
 tmp1="$(mktemp)"
 tmp2="$(mktemp)"
 
-cat "$1" | "$STRIP_ERR" >"$tmp1"
-cat "$2" | "$STRIP_ERR" >"$tmp2"
+"$STRIP_ERR" <"$1" >"$tmp1"
+"$STRIP_ERR" <"$2" >"$tmp2"
 
 diff "$tmp1" "$tmp2"; rc=$?
 

--- a/tests/_diff_err.sh
+++ b/tests/_diff_err.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of _diff_err.sh
+#
+# -----------------------------------------------------------------------
+
+# _diff_err expects two file names as arguments and calls `diff` on these files
+# after first replacing common internal strings that change frequently, e.g., due to
+# the compiler adding internal ids, by dummy strings that are all the same.
+#
+
+SCRIPTPATH="$(dirname "$(readlink -f "$0")")"
+STRIP_ERR="$SCRIPTPATH"/_strip_err.sh
+
+set -euo pipefail
+
+tmp1="`mktemp`"
+tmp2="`mktemp`"
+
+cat "$1" | "$STRIP_ERR" >"$tmp1"
+cat "$2" | "$STRIP_ERR" >"$tmp2"
+
+diff "$tmp1" "$tmp2"

--- a/tests/_diff_err.sh
+++ b/tests/_diff_err.sh
@@ -33,10 +33,13 @@ STRIP_ERR="$SCRIPTPATH"/_strip_err.sh
 
 set -euo pipefail
 
-tmp1="`mktemp`"
-tmp2="`mktemp`"
+tmp1="$(mktemp)"
+tmp2="$(mktemp)"
 
 cat "$1" | "$STRIP_ERR" >"$tmp1"
 cat "$2" | "$STRIP_ERR" >"$tmp2"
 
-diff "$tmp1" "$tmp2"
+diff "$tmp1" "$tmp2"; rc=$?
+
+rm "$tmp1" "$tmp2"
+exit $rc

--- a/tests/_strip_err.sh
+++ b/tests/_strip_err.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of _strip_err.sh
+#
+# -----------------------------------------------------------------------
+
+# _strip_err expects fuzion error output from stdin and replaces common internal
+# strings that change frequently, e.g., due to the compiler adding internal ids,
+# by dummy strings that are all the same. Result is written to stdout.
+#
+
+set -euo pipefail
+
+sed <&0 -E "s \.fz:[0-9]+:[0-9]+: \.fz:n:n: g" |                                                # line numbers \
+    sed -E "s #fun[0-9]+ fun g"                | sed -E "s INTERN_fun[0-9]+ fun g "         |   # lambdas      \
+    sed -E "s #loop[0-9]+ loop g"              | sed -E "s INTERN_loop[0-9]+ loop g "           # loops

--- a/tests/check_simple_example_c.sh
+++ b/tests/check_simple_example_c.sh
@@ -38,6 +38,7 @@ set -euo pipefail
 
 SCRIPTPATH="$(dirname "$(readlink -f "$0")")"
 CURDIR=$("$SCRIPTPATH"/_cur_dir.sh)
+DIFFERR="$SCRIPTPATH"/_diff_err.sh
 
 
 RC=0
@@ -91,8 +92,8 @@ else
     fi
 
     # show diff in stdout unless an unexpected output occurred to stderr
-    (diff "$experr" tmp_err.txt && diff "$expout" tmp_out.txt) || echo -e "\033[31;1m*** FAILED\033[0m out on $2"
-    diff "$expout" tmp_out.txt >/dev/null && diff "$experr" tmp_err.txt >/dev/null && echo -e "\033[32;1mPASSED\033[0m."
+    ($DIFFERR "$experr" tmp_err.txt && diff "$expout" tmp_out.txt) || echo -e "\033[31;1m*** FAILED\033[0m out on $2"
+    diff "$expout" tmp_out.txt >/dev/null && $DIFFERR "$experr" tmp_err.txt >/dev/null && echo -e "\033[32;1mPASSED\033[0m."
     RC=$?
     if [ -f testbin ]; then
         echo " (binary)"

--- a/tests/check_simple_example_int.sh
+++ b/tests/check_simple_example_int.sh
@@ -38,6 +38,7 @@ set -euo pipefail
 
 SCRIPTPATH="$(dirname "$(readlink -f "$0")")"
 CURDIR=$("$SCRIPTPATH"/_cur_dir.sh)
+DIFFERR="$SCRIPTPATH"/_diff_err.sh
 
 
 RC=0
@@ -81,8 +82,8 @@ else
     fi
 
     # show diff in stdout unless an unexpected output occurred to stderr:
-    (diff "$experr" tmp_err.txt && diff "$expout" tmp_out.txt) || echo -e "\033[31;1m*** FAILED\033[0m out on $2"
-    diff "$expout" tmp_out.txt >/dev/null && diff "$experr" tmp_err.txt >/dev/null && echo -e "\033[32;1mPASSED\033[0m."
+    ($DIFFERR "$experr" tmp_err.txt && diff "$expout" tmp_out.txt) || echo -e "\033[31;1m*** FAILED\033[0m out on $2"
+    diff "$expout" tmp_out.txt >/dev/null && $DIFFERR "$experr" tmp_err.txt >/dev/null && echo -e "\033[32;1mPASSED\033[0m."
     RC=$?
     rm tmp_out.txt tmp_err.txt
 fi

--- a/tests/check_simple_example_jvm.sh
+++ b/tests/check_simple_example_jvm.sh
@@ -38,7 +38,7 @@ set -euo pipefail
 
 SCRIPTPATH="$(dirname "$(readlink -f "$0")")"
 CURDIR=$("$SCRIPTPATH"/_cur_dir.sh)
-
+DIFFERR="$SCRIPTPATH"/_diff_err.sh
 
 RC=0
 if [ -f "$2".skip ]; then
@@ -81,8 +81,8 @@ else
     fi
 
     # show diff in stdout unless an unexpected output occurred to stderr:
-    (diff "$experr" tmp_err.txt && diff "$expout" tmp_out.txt) || echo -e "\033[31;1m*** FAILED\033[0m out on $2"
-    diff "$expout" tmp_out.txt >/dev/null && diff "$experr" tmp_err.txt >/dev/null && echo -e "\033[32;1mPASSED\033[0m."
+    ($DIFFERR "$experr" tmp_err.txt && diff "$expout" tmp_out.txt) || echo -e "\033[31;1m*** FAILED\033[0m out on $2"
+    diff "$expout" tmp_out.txt >/dev/null && $DIFFERR "$experr" tmp_err.txt >/dev/null && echo -e "\033[32;1mPASSED\033[0m."
     RC=$?
     rm tmp_out.txt tmp_err.txt
 fi


### PR DESCRIPTION
This discards line and column number information and ids from loops and lambdas generated by fz, such that any slight changes in source code positions or internal numbering do not cause tests to fail
