### PR TITLE
ast: Fix postcondition failure on fuzion-lang.dev's `design/examples/arg_choice.fz`

### DIFF
--- a/doc/ref_manual/fuzion_reference_manual.adoc
+++ b/doc/ref_manual/fuzion_reference_manual.adoc
@@ -367,6 +367,11 @@ include::rule.adoc[]
 :RULE_ID: PARS_CONTR_POST_THEN
 include::rule.adoc[]
 
+==== Choice features
+
+:RULE_SRC: src/dev/flang/ast/Feature.java
+:RULE_ID: CHOICE_RESULT
+include::rule.adoc[]
 
 == Semantics
 

--- a/src/dev/flang/ast/Feature.java
+++ b/src/dev/flang/ast/Feature.java
@@ -1563,6 +1563,11 @@ public class Feature extends AbstractFeature
           { // choice type must not have a result type
             if (!(Errors.any() && _returnType == RefType.INSTANCE))  // this was covered by AstErrors.choiceMustNotBeRef
               {
+                /*
+    // tag::fuzion_rule_CHOICE_RESULT[]
+A ((Choice)) declaration must not contain a result type.
+    // end::fuzion_rule_CHOICE_RESULT[]
+                */
                 AstErrors.choiceMustNotHaveResultType(_pos, _returnType);
               }
           }
@@ -1868,7 +1873,13 @@ public class Feature extends AbstractFeature
     Feature result = _resultField;
 
     if (POSTCONDITIONS) ensure
-      (Errors.any() || hasResultField() == (result != null));
+      (Errors.any() ||
+       hasResultField() == (result != null) ||
+
+       // the following will later be checked by checkChoiceAndAddInternalFields() and
+       // reported as an error (fuzion rule CHOICE_RESULT):
+       isChoice() && (result != null)
+       );
     return result;
   }
 


### PR DESCRIPTION
The problem is that a choice feature must not have a result type, but here it has and the result field is created early, which is reported as an error but only after a failing postcondition check.

So this patch relaxes the postcondition and adds a corresponding rule for the reference manual.
