### PR TITLE
dfa: Use `StringBuilder` instead of `say` in `showWhy`

### DIFF
--- a/src/dev/flang/be/effects/Effects.java
+++ b/src/dev/flang/be/effects/Effects.java
@@ -100,7 +100,9 @@ public class Effects extends ANY
                  if (_options.verbose(1))
                    {
                      say("EFFECT type "+_fuir.clazzAsString(t)+" default used is "+dfa._defaultEffects.get(t));
-                     say(dfa._defaultEffectContexts.get(t).showWhy());
+                     var sb = new StringBuilder();
+                     var ignore = dfa._defaultEffectContexts.get(t).showWhy(sb);
+                     say(sb);
                    }
                  else
                    {

--- a/src/dev/flang/fuir/analysis/dfa/Call.java
+++ b/src/dev/flang/fuir/analysis/dfa/Call.java
@@ -358,17 +358,20 @@ public class Call extends ANY implements Comparable<Call>, Context
 
   /**
    * Show the context that caused the inclusion of this call into the analysis.
+   *
+   * @param sb the context information will be appended to this StringBuilder.
+   *
+   * @return a string providing the indentation level for the caller in case of
+   * nested contexts.  "  " is to be added to the result on each recursive call.
    */
-  public String showWhy()
+  public String showWhy(StringBuilder sb)
   {
-    var indent = _context.showWhy();
-    say(indent + "  |");
-    say(indent + "  +- performs call " + this);
+    var indent = _context.showWhy(sb);
     var pos = callSitePos();
-    if (pos != null)
-      {
-        say(pos.pos().show());
-      }
+    sb.append(indent).append("  |\n")
+      .append(indent).append("  +- performs call ").append(this).append("\n")
+      .append(pos != null ? pos.pos().show() + "\n"
+                          : "");
     return indent + "  ";
   }
 

--- a/src/dev/flang/fuir/analysis/dfa/Context.java
+++ b/src/dev/flang/fuir/analysis/dfa/Context.java
@@ -47,9 +47,10 @@ public interface Context
    */
   static class MainEntryPoint extends ANY implements Context
   {
-    public String showWhy()
+    public String showWhy(StringBuilder sb)
     {
-      say("program entry point");
+      sb.append("program entry point")
+        .append("\n");
       return "  ";
     }
     public String toString(boolean forEnv)
@@ -85,10 +86,12 @@ public interface Context
    * Show the context that caused the inclusion of this instance into the
    * analysis.
    *
+   * @param sb the context information will be appended to this StringBuilder.
+   *
    * @return a string providing the indentation level for the caller in case of
    * nested contexts.  "  " is to be added to the result on each recursive call.
    */
-  String showWhy();
+  String showWhy(StringBuilder sb);
 
 
   /**

--- a/src/dev/flang/fuir/analysis/dfa/DFA.java
+++ b/src/dev/flang/fuir/analysis/dfa/DFA.java
@@ -301,16 +301,15 @@ public class DFA extends ANY
       var res = resf[0];
       if (!found[0])
         { // NYI: proper error reporting
-          var detail = "Considered targets: ";
+          var detail = new StringBuilder("Considered targets: ");
           for (var ccii = 0; ccii < ccs.length; ccii += 2)
             {
-              detail += _fuir.clazzAsStringNew(ccs[ccii]) + ", ";
+              detail.append(_fuir.clazzAsStringNew(ccs[ccii])).append(ccii+2 < ccs.length ? ", " : "\n");
             }
+          var ignore = _call.showWhy(detail);
           Errors.error(_fuir.sitePos(s),
                        "NYI: in "+_fuir.siteAsString(s)+" no targets for "+_fuir.codeAtAsString(s)+" target "+tvalue,
                        detail);
-
-          _call.showWhy();
         }
       else if (res != null &&
                tvalue instanceof EmbeddedValue &&
@@ -1154,7 +1153,10 @@ public class DFA extends ANY
                 say(("----------------"+c+
                                     "----------------------------------------------------------------------------------------------------")
                                    .substring(0,100));
-                c.showWhy();
+
+                var sb = new StringBuilder();
+                var ignore = c.showWhy(sb);
+                say(sb);
               }
             analyze(c);
           }
@@ -1218,12 +1220,14 @@ public class DFA extends ANY
         // NYI: Proper error handling.
         Errors.error("NYI: Support for intrinsic '" + name + "' missing");
 
-        // cl.showWhy() may try to print result values that depend on
+        // cl.showWhy(sb) may try to print result values that depend on
         // intrinsics, so we risk running into an endless recursion here:
         if (!_recursion_in_NYIintrinsicMissing)
           {
             _recursion_in_NYIintrinsicMissing = true;
-            cl.showWhy();
+            var sb = new StringBuilder();
+            var ignore = cl.showWhy(sb);
+            say_err(sb);
             _recursion_in_NYIintrinsicMissing = false;
           }
       }

--- a/src/dev/flang/fuir/analysis/dfa/DFA.java
+++ b/src/dev/flang/fuir/analysis/dfa/DFA.java
@@ -309,7 +309,7 @@ public class DFA extends ANY
           var ignore = _call.showWhy(detail);
           Errors.error(_fuir.sitePos(s),
                        "NYI: in "+_fuir.siteAsString(s)+" no targets for "+_fuir.codeAtAsString(s)+" target "+tvalue,
-                       detail);
+                       detail.toString());
         }
       else if (res != null &&
                tvalue instanceof EmbeddedValue &&


### PR DESCRIPTION
Prooblem was that `showWhy` was sometimes called to give details for an error and somtimes to give details for normal output.  Now, the detailed stack trace is printed either to stdout or stderr depending on what it is for.

This was triggerd by fuzion-lang.dev's `design/examples/dec_choice.fz` that prints part of the error output to stdout.