### PR TITLE
lib: add missing preconditions for numerical conversion, fixes #3191

### DIFF
--- a/lib/i64.fz
+++ b/lib/i64.fz
@@ -110,7 +110,7 @@ public i64(public val i64) : num.wrap_around, has_interval is
   public as_u16 u16
      pre
       val ≥ (i64 0)
-#      val ≤ u16.max.as_i64
+      val ≤ u16.max.as_i64
 #    post
 #      analysis: result.as_u64 = val
     =>
@@ -119,6 +119,9 @@ public i64(public val i64) : num.wrap_around, has_interval is
 
   # this i64 as an u32
   public as_u32 u32
+    pre
+      val ≥ (i64 0)
+      val ≤ u32.max.as_i64
 #    post then
 #      analysis:  result.as_i64 = val
     =>

--- a/lib/i8.fz
+++ b/lib/i8.fz
@@ -83,7 +83,11 @@ public i8(public val i8) : num.wrap_around, has_interval is
       debug: val ≥ 0
     =>
       cast_to_u16
-  public as_u32 u32 => cast_to_u32
+  public as_u32 u32
+    pre
+      val ≥ 0
+    =>
+      cast_to_u32
   public as_u64 u64
     pre
       debug: val ≥ 0


### PR DESCRIPTION
does not add preconditions for `as_u8` since they covered by `fits_in_u8` in numeric.fz once #3051 is fixed
