### PR TITLE
be/c: fix test process on windows

### DIFF
--- a/lib/process/spawn.fz
+++ b/lib/process/spawn.fz
@@ -194,6 +194,7 @@ pre
 spawn0(process_and_args array String) outcome (tuple i64 i64 i64 i64)
 pre process_and_args.length > 0
 # NYI allow utf-8?
+# NYI what about quotes(") ?
     process_and_args ∀ (x -> x.as_codepoints ∀ (y -> y.is_ascii))
 =>
 
@@ -214,7 +215,7 @@ pre process_and_args.length > 0
   env_data := array fuzion.sys.Pointer env_var_strings.count+1 (i -> if i<env_var_strings.count then sys.c_string env_var_strings[i] else NULL)
 
   # args as string for windows to avoid malloc in backend
-  args_str := sys.c_string (String.type.join process_and_args " ")
+  args_str := sys.c_string (String.type.join (process_and_args.map (x -> x.replace "'" "\\'")) " ")
 
   # environment variables for windows to avoid malloc in backend
   # NULL terminates each environment variable


### PR DESCRIPTION
args need to be wrapped in quotes.
fixes:
```
< 'feed me to cat'
---
> feed me to cat
```
