### PR TITLE
air: do not automatically mark ref results from intrinsics as instantiated

### DIFF
--- a/src/dev/flang/air/Clazz.java
+++ b/src/dev/flang/air/Clazz.java
@@ -1812,13 +1812,16 @@ public class Clazz extends ANY implements Comparable<Clazz>
           {
             for (var cg : rc.choiceGenerics())
               {
-                cg.instantiated(at);
+                if (!cg.isRef())
+                  {
+                    cg.instantiated(at);
+                  }
               }
             // e.g. `java.call_c0` may return `outcome x`
             rc.instantiated(at);
           }
       }
-    else if (!rc.isRef() || feature().isIntrinsic())
+    else if (!rc.isRef())
       {
         rc.instantiated(at);
       }
@@ -1982,7 +1985,7 @@ public class Clazz extends ANY implements Comparable<Clazz>
    */
   public void check()
   {
-    if (isCalled() && _abstractCalled != null)
+    if (isInstantiated() && _abstractCalled != null)
       {
         AirErrors.abstractFeatureNotImplemented(feature(), _abstractCalled, _instantiationPos);
       }

--- a/src/dev/flang/air/Clazz.java
+++ b/src/dev/flang/air/Clazz.java
@@ -89,6 +89,43 @@ public class Clazz extends ANY implements Comparable<Clazz>
   public static FeatureLookup _flu;
 
 
+  /**
+   * Set of intrinsics that implicitly create an instance of their reference
+   * result value.
+   */
+  static TreeSet<String> _intrinsicConstructors_ = new TreeSet<String>();
+  static
+  {
+    _intrinsicConstructors_.add("fuzion.java.get_static_field0"     );
+    _intrinsicConstructors_.add("fuzion.java.get_field0"            );
+    _intrinsicConstructors_.add("fuzion.java.call_v0"               );
+    _intrinsicConstructors_.add("fuzion.java.call_c0"               );
+    _intrinsicConstructors_.add("fuzion.java.call_s0"               );
+    _intrinsicConstructors_.add("fuzion.java.array_to_java_object0" );
+    _intrinsicConstructors_.add("fuzion.java.string_to_java_object0");
+    _intrinsicConstructors_.add("fuzion.java.i8_to_java_object"     );
+    _intrinsicConstructors_.add("fuzion.java.u16_to_java_object"    );
+    _intrinsicConstructors_.add("fuzion.java.i16_to_java_object"    );
+    _intrinsicConstructors_.add("fuzion.java.i32_to_java_object"    );
+    _intrinsicConstructors_.add("fuzion.java.i64_to_java_object"    );
+    _intrinsicConstructors_.add("fuzion.java.f32_to_java_object"    );
+    _intrinsicConstructors_.add("fuzion.java.f64_to_java_object"    );
+    _intrinsicConstructors_.add("fuzion.java.bool_to_java_object"   );
+  }
+
+
+  /*-------------------------  static methods  --------------------------*/
+
+
+  /**
+   * Get the names of all intrinsics supported by this backend.
+   */
+  public static Set<String> supportedIntrinsics()
+  {
+    return _intrinsicConstructors_;
+  }
+
+
   /*-----------------------------  classes  -----------------------------*/
 
 
@@ -1803,6 +1840,9 @@ public class Clazz extends ANY implements Comparable<Clazz>
       (feature().isIntrinsic(),
        isCalled());
 
+    var name = feature().qualifiedName();
+    var implicitConstructor = _intrinsicConstructors_.contains(name);
+
     // instances returned from intrinsics are automatically
     // recorded to be instantiated.
     var rc = resultClazz();
@@ -1812,7 +1852,7 @@ public class Clazz extends ANY implements Comparable<Clazz>
           {
             for (var cg : rc.choiceGenerics())
               {
-                if (!cg.isRef())
+                if (!cg.isRef() || implicitConstructor)
                   {
                     cg.instantiated(at);
                   }
@@ -1821,12 +1861,12 @@ public class Clazz extends ANY implements Comparable<Clazz>
             rc.instantiated(at);
           }
       }
-    else if (!rc.isRef())
+    else if (!rc.isRef() || implicitConstructor)
       {
         rc.instantiated(at);
       }
 
-    switch (feature().qualifiedName())
+    switch (name)
       {
       case "effect.abortable":
         argumentFields()[0].resultClazz().lookup(Types.resolved.f_Function_call, at);

--- a/src/dev/flang/tools/CheckIntrinsics.java
+++ b/src/dev/flang/tools/CheckIntrinsics.java
@@ -59,15 +59,17 @@ class CheckIntrinsics extends ANY
     getAll(all, fe, fe._universe);
 
     var i = dev.flang.be.interpreter.Intrinsics.supportedIntrinsics();
-    checkIntrinsics(all, i, "Interpreter backend", x->x);
+    checkIntrinsics(all, true, i, "Interpreter backend", x->x);
     var c = dev.flang.be.c.Intrinsics.supportedIntrinsics();
-    checkIntrinsics(all, c, "C backend", x->x);
+    checkIntrinsics(all, true, c, "C backend", x->x);
     var jvm = dev.flang.be.jvm.Intrinsix.supportedIntrinsics();
-    checkIntrinsics(all, jvm, "JVM backend", x->dev.flang.be.jvm.Intrinsix.backendName(x));
+    checkIntrinsics(all, true, jvm, "JVM backend", x->dev.flang.be.jvm.Intrinsix.backendName(x));
     var dfa = dev.flang.fuir.analysis.dfa.DFA.supportedIntrinsics();
-    checkIntrinsics(all, dfa, "DFA", x->x);
+    checkIntrinsics(all, true, dfa, "DFA", x->x);
     var cfg = dev.flang.fuir.cfg.CFG.supportedIntrinsics();
-    checkIntrinsics(all, cfg, "CFG", x->x);
+    checkIntrinsics(all, true, cfg, "CFG", x->x);
+    var air = dev.flang.air.Clazz.supportedIntrinsics();
+    checkIntrinsics(all, false, air, "AIR", x->x);
   }
 
 
@@ -93,11 +95,18 @@ class CheckIntrinsics extends ANY
    *
    * @param all set of names of required intrinsics
    *
+   * @param complete true if `implemented` should cover all intrinsics, false if
+   * some might be missing.
+   *
    * @param implemented set of names of implemented intrinsics
    *
    * @param where module that provides implemented intrinsics, e.g., "C backend".
    */
-  void checkIntrinsics(Set<String> all, Set<String> implemented, String where, Mangle m)
+  void checkIntrinsics(Set<String> all,
+                       boolean complete,
+                       Set<String> implemented,
+                       String where,
+                       Mangle m)
   {
     var used = new TreeSet<String>();
     for (var a : all)
@@ -105,7 +114,10 @@ class CheckIntrinsics extends ANY
         var ma = m.doit(a);
         if (!implemented.contains(ma))
           {
-            Errors.warning(where + " does not implement intrinsic '" + a + "'.");
+            if (complete)
+              {
+                Errors.warning(where + " does not implement intrinsic '" + a + "'.");
+              }
           }
         else
           {


### PR DESCRIPTION
This is required to properly detect missing implementations of abstract features and fix #3199.
