### PR TITLE
lib/be: add fuzion.java.create_jvm, allowing to supply custom class path

### DIFF
--- a/include/fz.h
+++ b/include/fz.h
@@ -284,7 +284,7 @@ struct fzE_jvm_result
 
 // initialize the JVM
 // executed once at the start of the application
-void fzE_init_jvm();
+void fzE_create_jvm(char * option_string);
 
 // close the JVM.
 void fzE_destroy_jvm();

--- a/include/shared.c
+++ b/include/shared.c
@@ -206,11 +206,15 @@ JNIEnv * getJNIEnv()
 
 // initialize the JVM
 // executed once at the start of the application
-void fzE_init_jvm() {
+void fzE_create_jvm(char * option_string) {
   JavaVMInitArgs vm_args;
 
+  JavaVMOption options[1];
+  options[0].optionString = option_string;
+
   vm_args.version = JNI_VERSION_10;
-  vm_args.nOptions = 0;
+  vm_args.options = options;
+  vm_args.nOptions = 1;
   if (JNI_CreateJavaVM(&fzE_jvm, (void **)&fzE_jni_env, &vm_args) != JNI_OK) {
     printf("Failed to start Java VM");
     exit(EXIT_FAILURE);

--- a/lib/fuzion/java.fz
+++ b/lib/fuzion/java.fz
@@ -27,6 +27,12 @@
 #
 public fuzion.java is
 
+  // NYI: UNDER DEVELOPMENT remove this, replace with effect
+  public create_jvm0(class_path String) =>
+    create_jvm (sys.c_string "-Djava.class.path=$class_path")
+
+  create_jvm(option_string fuzion.sys.Pointer) unit => intrinsic
+
 
   # read a static field of given name in class with given name.  Wrap result into
   # an instance of T.

--- a/src/dev/flang/be/c/C.java
+++ b/src/dev/flang/be/c/C.java
@@ -1007,7 +1007,8 @@ public class C extends ANY
         _fuir.isIntrinsicUsed("fuzion.java.i64_to_java_object") ||
         _fuir.isIntrinsicUsed("fuzion.java.u16_to_java_object") ||
         _fuir.isIntrinsicUsed("fuzion.java.java_string_to_string") ||
-        _fuir.isIntrinsicUsed("fuzion.java.string_to_java_object0"));
+        _fuir.isIntrinsicUsed("fuzion.java.string_to_java_object0") ||
+        _fuir.isIntrinsicUsed("fuzion.java.fuzion.java.create_jvm"));
   }
 
 
@@ -1171,11 +1172,6 @@ public class C extends ANY
     cf.println("int main(int argc, char **argv) { ");
 
     cf.println("fzE_init();");
-
-    if (linkJVM())
-      {
-        cf.println("fzE_init_jvm();");
-      }
 
     cf.print(initializeEffectsEnvironment());
 

--- a/src/dev/flang/be/c/Intrinsics.java
+++ b/src/dev/flang/be/c/Intrinsics.java
@@ -1207,6 +1207,12 @@ public class Intrinsics extends ANY
           )), false)
        );
 
+
+    put("fuzion.java.create_jvm", (c,cl,outer,in) -> {
+      return CExpr.call("fzE_create_jvm", new List<>(A0.castTo("char *")));
+    });
+    // NYI: UNDER DEVELOPMENT: put("fuzion.java.destroy_jvm", (c,cl,outer,in) -> {});
+
   }
 
 

--- a/src/dev/flang/be/interpreter/Intrinsics.java
+++ b/src/dev/flang/be/interpreter/Intrinsics.java
@@ -793,6 +793,7 @@ public class Intrinsics extends ANY
           var resultClazz = executor.fuir().clazzResultClazz(innerClazz);
           return JavaInterface.javaObjectToInstance(res, resultClazz);
         });
+    putUnsafe("fuzion.java.create_jvm", (executor, innerClazz) -> args -> Value.EMPTY_VALUE);
     putUnsafe("fuzion.java.string_to_java_object0", (executor, innerClazz) -> args ->
         {
           var argz = args.get(1);

--- a/src/dev/flang/be/jvm/Intrinsix.java
+++ b/src/dev/flang/be/jvm/Intrinsix.java
@@ -281,6 +281,9 @@ public class Intrinsix extends ANY implements ClassFileConstants
             });
       }
 
+    put("fuzion.java.create_jvm",
+        (jvm, si, cc, tvalue, args) -> new Pair<>(Expr.UNIT, Expr.UNIT));
+
     put("fuzion.java.string_to_java_object0",
         (jvm, si, cc, tvalue, args) ->
         {

--- a/src/dev/flang/fuir/analysis/dfa/DFA.java
+++ b/src/dev/flang/fuir/analysis/dfa/DFA.java
@@ -1888,6 +1888,7 @@ public class DFA extends ANY
           cl._dfa._readFields.add(jref);
           return cl._dfa.newConstString(null, cl);
         });
+    put("fuzion.java.create_jvm", cl -> Value.UNIT);
     put("fuzion.java.string_to_java_object0", cl ->
       {
         var rc = cl._dfa._fuir.clazzResultClazz(cl._cc);

--- a/src/dev/flang/fuir/cfg/CFG.java
+++ b/src/dev/flang/fuir/cfg/CFG.java
@@ -537,6 +537,7 @@ public class CFG extends ANY
     put("fuzion.java.i8_to_java_object"     , (cfg, cl) -> { } );
     put("fuzion.java.java_string_to_string" , (cfg, cl) -> { } );
     put("fuzion.java.string_to_java_object0", (cfg, cl) -> { } );
+    put("fuzion.java.create_jvm"            , (cfg, cl) -> { } );
     put("fuzion.java.u16_to_java_object"    , (cfg, cl) -> { } );
   }
 

--- a/tests/javaBase/javaHello.fz
+++ b/tests/javaBase/javaHello.fz
@@ -30,6 +30,8 @@
 #
 javaHello : Java is
 
+  fuzion.java.create_jvm0 ""
+
   # we can call code in Java package directly using fully
   # qualified class names
   #

--- a/tests/reg_issue2740/reg_issue2740.fz
+++ b/tests/reg_issue2740/reg_issue2740.fz
@@ -22,4 +22,5 @@
 # -----------------------------------------------------------------------
 
 reg_issue2740 =>
+  fuzion.java.create_jvm0 ""
   Java.java.nio.file.Path.__k__of "not a valid file" []


### PR DESCRIPTION
With this change fuzion_lang webserver does not crash anymore when run with c backend but response is empty.
On the terminal the application prints some weird stuff:
`instance[webserver.request_method] 1o2.0rtl.c*`

Probably a zero termination missing somewhere...