### PR TITLE
air: for intrinsic constructors mark outers as instantiated as well

### DIFF
--- a/src/dev/flang/air/Clazz.java
+++ b/src/dev/flang/air/Clazz.java
@@ -1855,6 +1855,15 @@ public class Clazz extends ANY implements Comparable<Clazz>
                 if (!cg.isRef() || implicitConstructor)
                   {
                     cg.instantiated(at);
+                    if (implicitConstructor)
+                      {
+                        var o = cg._outer;
+                        while (o != null)
+                          {
+                            o.instantiated(at);
+                            o = o._outer;
+                          }
+                      }
                   }
               }
             // e.g. `java.call_c0` may return `outcome x`
@@ -1864,6 +1873,15 @@ public class Clazz extends ANY implements Comparable<Clazz>
     else if (!rc.isRef() || implicitConstructor)
       {
         rc.instantiated(at);
+        if (implicitConstructor)
+          {
+            var o = rc._outer;
+            while (o != null)
+              {
+                o.instantiated(at);
+                o = o._outer;
+              }
+          }
       }
 
     switch (name)


### PR DESCRIPTION
fixes #2677

`Java.java.util.Map` considered to not implement interface fuzion.java.Java_Object because `isInstantiated` relies on all outers being marked as instantiated.
