### PR TITLE
be/c: fix void function should not return void expression

### DIFF
--- a/src/dev/flang/be/c/Intrinsics.java
+++ b/src/dev/flang/be/c/Intrinsics.java
@@ -448,7 +448,7 @@ public class Intrinsics extends ANY
     put("fuzion.sys.fileio.open_dir", (c,cl,outer,in) -> CExpr.call("fzE_opendir", new List<CExpr>(
       A0.castTo("char *"),
       A1.castTo("int64_t *")
-    )).ret());
+    )));
     put("fuzion.sys.fileio.read_dir", (c,cl,outer,in) ->
       {
         var d_name = new CIdent("d_name");


### PR DESCRIPTION
```
/tmp/fuzion_ex_5696977685467859599.c:40530:3: error: void function 'fzC__L8472fuzion__sy__pen_u_dir' should not return void expression [-Werror,-Wpedantic]
  return fzE_opendir((char *)arg0,(int64_t *)arg1);
  ^      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
```


