### PR TITLE
Make use of `redef` mandatory when implementing abstract features

### DIFF
--- a/lib/mutate/circular_buffer.fz
+++ b/lib/mutate/circular_buffer.fz
@@ -33,7 +33,7 @@ module:public circular_buffer (
        public T type,
 
        # length of the buffer
-       public length i64,
+       public redef length i64,
 
        # contents of the buffer
        module data fuzion.sys.internal_array T
@@ -82,7 +82,7 @@ is
 
   # amount of elements free for writing
   #
-  public available i64
+  public redef available i64
   =>
     if is_full
       0
@@ -94,7 +94,7 @@ is
 
   # amount of elements available for reading
   #
-  public buffered i64
+  public redef buffered i64
   =>
     if is_full
       length
@@ -109,7 +109,7 @@ is
   # returns an error if the new element does not fit into the
   # buffer
   #
-  public put (e T) outcome unit
+  public redef put (e T) outcome unit
   =>
     check_and_replace
 
@@ -122,7 +122,7 @@ is
 
   # read a single element from the buffer
   #
-  public get option T
+  public redef get option T
   =>
     check_and_replace
 
@@ -139,7 +139,7 @@ is
   # returns an error if the given sequence is too long to fit into
   # the buffer entirely
   #
-  public enqueue (s Sequence T) outcome unit
+  public redef enqueue (s Sequence T) outcome unit
   =>
     check_and_replace
 
@@ -158,7 +158,7 @@ is
 
   # read the elements from the buffer
   #
-  public flush (n i64) =>
+  public redef flush (n i64) =>
     check_and_replace
 
     x := array T n.as_i32 (i -> data[(modded_mod (start.get + i.as_i64) length).as_i32])
@@ -168,7 +168,7 @@ is
 
   # create immutable array from this
   #
-  public as_array =>
+  public redef as_array =>
     array T buffered.as_i32 (i -> data[(modded_mod (start.get + i.as_i64) length).as_i32])
 
 

--- a/src/dev/flang/ast/Function.java
+++ b/src/dev/flang/ast/Function.java
@@ -288,7 +288,7 @@ public class Function extends AbstractLambda
           {
             var rt = inferResultType ? NoType.INSTANCE      : new FunctionReturnType(gs.get(0));
             var im = inferResultType ? Impl.Kind.RoutineDef : Impl.Kind.Routine;
-            _feature = new Feature(pos(), rt, new List<String>("call"), a, NO_CALLS, Contract.EMPTY_CONTRACT, new Impl(_expr.pos(), _expr, im))
+            _feature = new Feature(pos(), Visi.PRIV, FuzionConstants.MODIFIER_REDEFINE, rt, new List<String>("call"), a, NO_CALLS, Contract.EMPTY_CONTRACT, new Impl(_expr.pos(), _expr, im))
               {
                 @Override
                 public boolean isLambdaCall()

--- a/src/dev/flang/fe/SourceModule.java
+++ b/src/dev/flang/fe/SourceModule.java
@@ -843,7 +843,6 @@ part of the (((inner features))) declarations of the corresponding
             )
           {
             if ((f.modifiers() & FuzionConstants.MODIFIER_REDEFINE) == 0 &&
-                !existing.isAbstract() &&
                 /* previous duplicate feature declaration could result in this error for
                 * type features, so suppress them in this case. See fuzion-lang.dev's
                 * design/examples/typ_const2.fz as an example.
@@ -852,7 +851,7 @@ part of the (((inner features))) declarations of the corresponding
               {
                 /*
     // tag::fuzion_rule_PARS_REDEF[]
-A feature that redefines at least one inherited feature must use the `redef` modifier unless all redefined, inherited features are `abstract`.
+A feature that redefines at least one inherited feature must use the `redef` modifier.
     // end::fuzion_rule_PARS_REDEF[]
                 */
                 if (visibleFor(existing, f.outer()))

--- a/tests/catch_postcondition/catch_postcondition.fz
+++ b/tests/catch_postcondition/catch_postcondition.fz
@@ -156,8 +156,8 @@ catch_postcondition is
 
   for c in tries.indices do
     h : handle_post (option String) is
-      try option String  => tries[c].call
-      catch(s String) option String => say "*** failed: $s ***"; nil
+      redef try option String  => tries[c].call
+      redef catch(s String) option String => say "*** failed: $s ***"; nil
     r := h.res
   until r??
     say r

--- a/tests/catch_postcondition/catch_postcondition.fz.expected_err
+++ b/tests/catch_postcondition/catch_postcondition.fz.expected_err
@@ -462,9 +462,9 @@ catch_postcondition.test#1 i16: --CURDIR--/catch_postcondition.fz:43:5:
 catch_postcondition.#fun11.call#0: --CURDIR--/catch_postcondition.fz:141:56:
   tries array ()->String := [ (() -> test i32), (() -> test i16), (() -> test i64) ]
 -------------------------------------------------------^^^^
-catch_postcondition.#loop1#2.h.try#0: --CURDIR--/catch_postcondition.fz:159:38:
-      try option String  => tries[c].call
--------------------------------------^^^^
+catch_postcondition.#loop1#2.h.try#0: --CURDIR--/catch_postcondition.fz:159:44:
+      redef try option String  => tries[c].call
+-------------------------------------------^^^^
 catch_postcondition.#loop1#2.h.#fun0.call#0.#fun1.call#0: --CURDIR--/catch_postcondition.fz:108:15:
         ).run try (()->catch m.get.get)
 --------------^^^
@@ -510,9 +510,9 @@ catch_postcondition.test#1 i32: --CURDIR--/catch_postcondition.fz:43:5:
 catch_postcondition.#fun10.call#0: --CURDIR--/catch_postcondition.fz:141:38:
   tries array ()->String := [ (() -> test i32), (() -> test i16), (() -> test i64) ]
 -------------------------------------^^^^
-catch_postcondition.#loop1#2.h.try#0: --CURDIR--/catch_postcondition.fz:159:38:
-      try option String  => tries[c].call
--------------------------------------^^^^
+catch_postcondition.#loop1#2.h.try#0: --CURDIR--/catch_postcondition.fz:159:44:
+      redef try option String  => tries[c].call
+-------------------------------------------^^^^
 catch_postcondition.#loop1#2.h.#fun0.call#0.#fun1.call#0: --CURDIR--/catch_postcondition.fz:108:15:
         ).run try (()->catch m.get.get)
 --------------^^^

--- a/tests/reg_issue1247/src/b.fz
+++ b/tests/reg_issue1247/src/b.fz
@@ -6,4 +6,4 @@ module b : a is
     else
       "positive"
 
-  fixed type.identity b => b
+  fixed redef type.identity b => b

--- a/tests/reg_issue874ff/issue874.fz
+++ b/tests/reg_issue874ff/issue874.fz
@@ -183,7 +183,7 @@ test_cov2 is
     redef as_string => "{f}"
 
   i(is_zero bool) : n is
-    fixed p(other i) => other
+    fixed redef p(other i) => other
 
 s := (test_cov2.i false).as_string
 say s
@@ -202,7 +202,7 @@ test_cov2a0 is
       y := x.p n.this
 
   i(is_zero bool) : n is
-    fixed p(other i) => other
+    fixed redef p(other i) => other
 
 _ := (test_cov2a0.i false).f
 

--- a/tests/sockets/sockets_test.fz
+++ b/tests/sockets/sockets_test.fz
@@ -40,7 +40,7 @@ sockets_test is
 
       rh : net.Request_Handler unit is
 
-        handle_request unit =>
+        redef handle_request unit =>
 
           chan => net.channel.env
 
@@ -86,7 +86,7 @@ sockets_test is
 
     rh : net.Request_Handler String is
 
-      handle_request =>
+      redef handle_request =>
 
         chan => net.channel.env
 

--- a/tests/tailrecursion/test_tailrecursion.fz
+++ b/tests/tailrecursion/test_tailrecursion.fz
@@ -55,7 +55,7 @@ test_tailrecursion =>
       fixed hehe =>
         m <- trick
         trick : Trick is
-          get_a => a
+          redef get_a => a
 
       if a %  11 = 3 then hehe
       if a < 200     then f a+1
@@ -80,7 +80,7 @@ test_tailrecursion =>
       get_a i32 => abstract
 
     trick(a) : Trick is
-      get_a => a
+      redef get_a => a
 
     f(a i32) =>
 

--- a/tests/this_type/test_this_type.fz
+++ b/tests/this_type/test_this_type.fz
@@ -77,7 +77,7 @@ simple_test_for_this_type_value =>
       b4 rq := b1
       b5 rq := b2
 
-    print => yak "q"
+    redef print => yak "q"
 
   r : q is
     redef print => yak "r"
@@ -133,12 +133,12 @@ test_redef_using_fixed =>
 
     # redefine abstract feature with co-variant argument and result
     #
-    op_abstract(v b.this) b.this => abstract
+    redef op_abstract(v b.this) b.this => abstract
 
     # redefine abstract with concrete type, must be fixed since this is
     # not a legal redefinition in a sub-type
     #
-    fixed op(v b) b => if debug then b "debug" /* b.this */ else b "non-debug"
+    fixed redef op(v b) b => if debug then b "debug" /* b.this */ else b "non-debug"
 
     # An implemented feature that will be redefined only by b, not by c
     #
@@ -151,11 +151,11 @@ test_redef_using_fixed =>
 
     # redefine abstract feature with co-variant argument and result
     #
-    op_abstract(v c.this) c.this => abstract
+    redef op_abstract(v c.this) c.this => abstract
 
     # redefine abstract that was implemented as fixed by parent b:
     #
-    fixed op(v c) c => if debug then c.this else c
+    fixed redef op(v c) c => if debug then c.this else c
 
   b1 := b "1"
   b2 := b "2"

--- a/tests/type_feature/test_type_feature.fz
+++ b/tests/type_feature/test_type_feature.fz
@@ -27,12 +27,12 @@ hasTypeArg is
   type.showTypeArgs String => abstract
 
 ex(T, U type) : hasTypeArg, property.equatable is
-  type.showTypeArgs => "T:$T U:$U"
-  fixed type.equality(a, b ex T U) bool => false
+  redef type.showTypeArgs => "T:$T U:$U"
+  fixed redef type.equality(a, b ex T U) bool => false
 
 ex2(T, U type: property.equatable, a, b T, c U) : hasTypeArg, property.equatable is
-  type.showTypeArgs => "T:$T U:$U"
-  fixed type.equality(a, b ex2 T U) bool =>
+  redef type.showTypeArgs => "T:$T U:$U"
+  fixed redef type.equality(a, b ex2 T U) bool =>
     (a.a = b.a &&
      a.b = b.b &&
      a.c = b.c   )

--- a/tests/valWithDynOuter/valWithDynOuter.fz
+++ b/tests/valWithDynOuter/valWithDynOuter.fz
@@ -89,7 +89,7 @@ valWithDynOuter is
 
   v (redef f String) : ref_v f is
     a => "v"
-    x => "$f-$a:v.x"
+    redef x => "$f-$a:v.x"
 
   w : v "w" is
     redef a => "w"

--- a/tests/visibility_modules_negative/main.fz
+++ b/tests/visibility_modules_negative/main.fz
@@ -79,7 +79,7 @@ public m =>
   redef_test_0 : redef_test is
     module redef b unit => // should flag an error Redefinition must not have more restrictive visibility.
       unit
-    module e unit => // should flag an error Redefinition must not have more restrictive visibility.
+    module redef e unit => // should flag an error Redefinition must not have more restrictive visibility.
       unit
 
 

--- a/tests/visibility_modules_negative/main.fz.expected_err
+++ b/tests/visibility_modules_negative/main.fz.expected_err
@@ -98,8 +98,8 @@ To solve this, increase the visibility of 'm.redef_test_0.b' to at least 'public
 
 
 --CURDIR--/main.fz:82:12: error 16: Redefinition must not have more restrictive visibility.
-    module e unit => // should flag an error Redefinition must not have more restrictive visibility.
------------^
+    module redef e unit => // should flag an error Redefinition must not have more restrictive visibility.
+-----------------^
 To solve this, increase the visibility of 'm.redef_test_0.e' to at least 'public'
 
 


### PR DESCRIPTION
resolves #3022