### PR TITLE
tests: check simple examples strip trailing CR

### DIFF
--- a/tests/_diff_err.sh
+++ b/tests/_diff_err.sh
@@ -39,7 +39,7 @@ tmp2="$(mktemp)"
 "$STRIP_ERR" <"$1" >"$tmp1"
 "$STRIP_ERR" <"$2" >"$tmp2"
 
-diff "$tmp1" "$tmp2"; rc=$?
+diff --strip-trailing-cr "$tmp1" "$tmp2"; rc=$?
 
 rm "$tmp1" "$tmp2"
 exit $rc

--- a/tests/check_simple_example_c.sh
+++ b/tests/check_simple_example_c.sh
@@ -92,8 +92,8 @@ else
     fi
 
     # show diff in stdout unless an unexpected output occurred to stderr
-    ($DIFFERR "$experr" tmp_err.txt && diff "$expout" tmp_out.txt) || echo -e "\033[31;1m*** FAILED\033[0m out on $2"
-    diff "$expout" tmp_out.txt >/dev/null && $DIFFERR "$experr" tmp_err.txt >/dev/null && echo -e "\033[32;1mPASSED\033[0m."
+    ($DIFFERR "$experr" tmp_err.txt && diff --strip-trailing-cr "$expout" tmp_out.txt) || echo -e "\033[31;1m*** FAILED\033[0m out on $2"
+    diff --strip-trailing-cr "$expout" tmp_out.txt >/dev/null && $DIFFERR "$experr" tmp_err.txt >/dev/null && echo -e "\033[32;1mPASSED\033[0m."
     RC=$?
     if [ -f testbin ]; then
         echo " (binary)"

--- a/tests/check_simple_example_int.sh
+++ b/tests/check_simple_example_int.sh
@@ -82,8 +82,8 @@ else
     fi
 
     # show diff in stdout unless an unexpected output occurred to stderr:
-    ($DIFFERR "$experr" tmp_err.txt && diff "$expout" tmp_out.txt) || echo -e "\033[31;1m*** FAILED\033[0m out on $2"
-    diff "$expout" tmp_out.txt >/dev/null && $DIFFERR "$experr" tmp_err.txt >/dev/null && echo -e "\033[32;1mPASSED\033[0m."
+    ($DIFFERR "$experr" tmp_err.txt && diff --strip-trailing-cr "$expout" tmp_out.txt) || echo -e "\033[31;1m*** FAILED\033[0m out on $2"
+    diff --strip-trailing-cr "$expout" tmp_out.txt >/dev/null && $DIFFERR "$experr" tmp_err.txt >/dev/null && echo -e "\033[32;1mPASSED\033[0m."
     RC=$?
     rm tmp_out.txt tmp_err.txt
 fi

--- a/tests/check_simple_example_jvm.sh
+++ b/tests/check_simple_example_jvm.sh
@@ -81,8 +81,8 @@ else
     fi
 
     # show diff in stdout unless an unexpected output occurred to stderr:
-    ($DIFFERR "$experr" tmp_err.txt && diff "$expout" tmp_out.txt) || echo -e "\033[31;1m*** FAILED\033[0m out on $2"
-    diff "$expout" tmp_out.txt >/dev/null && $DIFFERR "$experr" tmp_err.txt >/dev/null && echo -e "\033[32;1mPASSED\033[0m."
+    ($DIFFERR "$experr" tmp_err.txt && diff --strip-trailing-cr "$expout" tmp_out.txt) || echo -e "\033[31;1m*** FAILED\033[0m out on $2"
+    diff --strip-trailing-cr "$expout" tmp_out.txt >/dev/null && $DIFFERR "$experr" tmp_err.txt >/dev/null && echo -e "\033[32;1mPASSED\033[0m."
     RC=$?
     rm tmp_out.txt tmp_err.txt
 fi


### PR DESCRIPTION
this fixes test output diff on windows
