### PR TITLE
be/int: improve thread safety

### DIFF
--- a/src/dev/flang/be/interpreter/Interpreter.java
+++ b/src/dev/flang/be/interpreter/Interpreter.java
@@ -57,6 +57,12 @@ public class Interpreter extends FUIRContext
         {
           return super.matchCaseTags(s, cix);
         };
+        // NYI: BUG: fuir should be thread safe #2760
+        @Override
+        public synchronized int[] accessedClazzes(int s)
+        {
+          return super.accessedClazzes(s);
+        }
       };
     FUIRContext.set_fuir(fuir);
     var processor = new Executor(_fuir, _options_);


### PR DESCRIPTION
exception was:
```
> Exception in thread "Thread-1" java.lang.NullPointerException: Cannot read field "left" because "r" is null
> 	at java.base/java.util.TreeMap.rotateLeft(TreeMap.java:2578)
> 	at java.base/java.util.TreeMap.fixAfterInsertion(TreeMap.java:2645)
> 	at java.base/java.util.TreeMap.addEntry(TreeMap.java:805)
> 	at java.base/java.util.TreeMap.put(TreeMap.java:863)
> 	at java.base/java.util.TreeMap.put(TreeMap.java:569)
> 	at dev.flang.fuir.FUIR.accessedClazzesDynamic(FUIR.java:1760)
> 	at dev.flang.fuir.FUIR.accessedClazzes(FUIR.java:1786)
> 	at dev.flang.be.interpreter.Executor.ttcc(Executor.java:290)
> 	at dev.flang.be.interpreter.Executor.call(Executor.java:225)
> 	at dev.flang.be.interpreter.Executor.call(Executor.java:49)
> 	at dev.flang.fuir.analysis.AbstractInterpreter.process(AbstractInterpreter.java:641)
> 	at dev.flang.fuir.analysis.AbstractInterpreter.process(AbstractInterpreter.java:514)
```
