### PR TITLE
examples: fix webserver examples

### DIFF
--- a/examples/webserver/webserver_java.fz
+++ b/examples/webserver/webserver_java.fz
@@ -100,17 +100,6 @@ webserver_java is
                    match s.getOutputStream
                      e error => e
                      o Java.java.io.OutputStream =>
-                       output := jio.DataOutputStream.new o
-
-                       req := read
-                       say "got request ({req.byte_length} bytes): $req"
-                       if req.starts_with "GET "
-                         send200 "<html>Hello Fuzion $n!</html>"
-
-                       # close streams
-                       _ := input.close
-                       _ := output.close
-
                        # helper to read request
                        #
                        read String =>
@@ -139,3 +128,17 @@ webserver_java is
                          if ok!!
                            say "#### "+ok.err
 
+
+                       output := jio.DataOutputStream.new o
+
+                       req := read
+                       say "got request ({req.byte_length} bytes): $req"
+                       if req.starts_with "GET "
+                         send200 "<html>Hello Fuzion $n!</html>"
+
+                       # close streams
+                       _ := input.close
+                       _ := output.close
+
+                       # NYI: BUG: #3253 explicit unit` should not be necessary.
+                       unit

--- a/examples/webserver/webserver_native.fz
+++ b/examples/webserver/webserver_native.fz
@@ -49,7 +49,7 @@ webserver_native is
   #
   rh(n i32) : net.Request_Handler unit is
 
-    handle_request unit =>
+    redef handle_request unit =>
       say "accepted connection:"
 
       match io.buffered.read_line


### PR DESCRIPTION
This is due to recent changes, that a each expression in a block must result in `unit` and also redef is now always required even when implementing an abstract method.