### PR TITLE
lexer: raise error if num literal is followed by letters.

### DIFF
--- a/src/dev/flang/parser/Lexer.java
+++ b/src/dev/flang/parser/Lexer.java
@@ -1790,8 +1790,16 @@ PLUSMINUS   : "+"
             yield new Literal();
           }
       }
-      default -> new Literal(m);
-      };
+      default ->
+      {
+        if (kind(p) == K_LETTER)
+        {
+          Errors.error(sourcePos(),
+                       "Broken numeric literal, expected anything but a letter following a numeric literal.",
+                       null);
+        }
+        yield new Literal(m);
+      }};
   }
 
 

--- a/tests/reg_issue2386/Makefile
+++ b/tests/reg_issue2386/Makefile
@@ -1,0 +1,25 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test Makefile
+#
+# -----------------------------------------------------------------------
+
+override NAME = reg_issue2386
+include ../simple.mk

--- a/tests/reg_issue2386/reg_issue2386.fz
+++ b/tests/reg_issue2386/reg_issue2386.fz
@@ -1,0 +1,24 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test
+#
+# -----------------------------------------------------------------------
+
+say 4abc

--- a/tests/reg_issue2386/reg_issue2386.fz.expected_err
+++ b/tests/reg_issue2386/reg_issue2386.fz.expected_err
@@ -1,0 +1,17 @@
+
+--CURDIR--/reg_issue2386.fz:24:6: error 1: Broken numeric literal, expected anything but a letter following a numeric literal.
+say 4abc
+-----^
+
+
+--CURDIR--/reg_issue2386.fz:24:1: error 2: Different count of arguments needed when calling feature
+say 4abc
+^^^
+Feature not found: 'say' (2 arguments)
+Target feature: 'universe'
+In call: 'say 4abc'
+To solve this, you might change the actual number of arguments to match the feature 'say' (one argument) at $MODULE/say.fz:31:8:
+public say(s Any) => io.out.println s
+-------^^^
+
+2 errors.


### PR DESCRIPTION
#2386 is actually two issues. This fixes only the first one.
