### PR TITLE
doc: use svg instead of png image for reference manual

### DIFF
--- a/doc/ref_manual/fuzion_reference_manual.adoc
+++ b/doc/ref_manual/fuzion_reference_manual.adoc
@@ -28,7 +28,7 @@
 = Fuzion Reference Manual [DRAFT]
 The Fuzion Team <info@tokiwa.software>
 include::../../version.txt[]
-:title-logo-image: image:../../assets/logo.png[top=5%,align=center,pdfwidth=1.5cm]
+:title-logo-image: image:../../assets/logo.svg[top=5%,align=center,pdfwidth=1.5cm]
 :doctype: book
 :description: Fuzion Language Reference Manual
 :sectanchors:


### PR DESCRIPTION
The png just happened to be present in my clone of the fuzion repo, which is why I did not see any errors.
