### PR TITLE
parser: improve syntax error on wrong `set` usage.

### DIFF
--- a/src/dev/flang/parser/Parser.java
+++ b/src/dev/flang/parser/Parser.java
@@ -705,7 +705,14 @@ name        : IDENT                            // all parts of name must be in s
                 }
               else if (!ignoreError)
                 {
-                  syntaxError(pos, "'[ ]' or identifier after 'set'", "name");
+                  if (ENABLE_SET_KEYWORD)
+                    {
+                      syntaxError(pos, "'[ ]' or identifier after 'set'", "name");
+                    }
+                  else
+                    {
+                      syntaxError(pos, "'[ ]' after 'set'", "name");
+                    }
                 }
               break;
             }

--- a/src/dev/flang/parser/Parser.java
+++ b/src/dev/flang/parser/Parser.java
@@ -1424,6 +1424,10 @@ actuals     : actualArgs
         var l = actualArgs();
         result = new ParsedCall(target, n, l);
       }
+
+    // replace calls with erroneous name by ParsedCall.ERROR.
+    result = n == ParsedName.ERROR_NAME ? ParsedCall.ERROR : result;
+
     return pure ? pureCallTail(skippedDot, result)
                 : callTail(    skippedDot, result);
   }

--- a/tests/reg_issue627/Makefile
+++ b/tests/reg_issue627/Makefile
@@ -1,0 +1,25 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test Makefile
+#
+# -----------------------------------------------------------------------
+
+override NAME = reg_issue627
+include ../simple.mk

--- a/tests/reg_issue627/reg_issue627.fz
+++ b/tests/reg_issue627/reg_issue627.fz
@@ -1,0 +1,25 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test
+#
+# -----------------------------------------------------------------------
+
+reg_issue627 is
+  set(a string) unit is

--- a/tests/reg_issue627/reg_issue627.fz.expected_err
+++ b/tests/reg_issue627/reg_issue627.fz.expected_err
@@ -1,0 +1,19 @@
+
+--CURDIR--/reg_issue627.fz:25:3: error 1: Syntax error: expected '[ ]' after 'set', found left parenthesis '('
+  set(a string) unit is
+--^
+While parsing: name, parse stack: name (2 times), call (2 times), callOrFeatOrThis, term, opTail, opExpr, operatorExpr, expr, exprs, block, implRout, implFldOrRout, routOrField, feature, expr, exprs, block, unit
+
+
+--CURDIR--/reg_issue627.fz:25:17: error 2: Syntax error: expected semicolon ';', found identifier 'unit'
+  set(a string) unit is
+----------------^
+While parsing: semicolon or flat line break, parse stack: semiOrFlatLF, exprs, block, implRout, implFldOrRout, routOrField, feature, expr, exprs, block, unit
+
+
+<built-in>: error 3: Could not find called feature
+Feature not found: '**error**' (one argument)
+Target feature: 'reg_issue627'
+In call: 'set(a string)'
+
+3 errors.

--- a/tests/reg_issue627/reg_issue627.fz.expected_err
+++ b/tests/reg_issue627/reg_issue627.fz.expected_err
@@ -10,10 +10,4 @@ While parsing: name, parse stack: name (2 times), call (2 times), callOrFeatOrTh
 ----------------^
 While parsing: semicolon or flat line break, parse stack: semiOrFlatLF, exprs, block, implRout, implFldOrRout, routOrField, feature, expr, exprs, block, unit
 
-
-<built-in>: error 3: Could not find called feature
-Feature not found: '**error**' (one argument)
-Target feature: 'reg_issue627'
-In call: 'set(a string)'
-
-3 errors.
+2 errors.


### PR DESCRIPTION
fixes #627

we can not remove/replace `set` as a keyword since it used in `set [] :=` as well as `set identifier := ...`