### PR TITLE
ast: fix `8 %% 5 = 3` does not cause an error

### DIFF
--- a/src/dev/flang/ast/ParsedCall.java
+++ b/src/dev/flang/ast/ParsedCall.java
@@ -310,15 +310,23 @@ public class ParsedCall extends Call
 
 
   /**
-   * Does this call a non-generic infix operator?
+   * Is this a call to an operator that may be
+   * considered valid in a chained boolean?
+   * I.e.: <,>,≤,≥,=,<=,>=,!=
    */
-  private boolean isInfixOperator()
+  private boolean isValidOperatorInChainedBoolean()
   {
     return
-      _name.startsWith("infix ") &&
-      (_actuals.size() == 1 /* normal infix operator 'a.infix + b' */                ||
-       _actuals.size() == 2 /* infix on different target 'X.Y.Z.this.infix + a b' */    ) &&
-      true; /* no check for _generics.size(), we allow infix operator to infer arbitrary number of type parameters */
+      _name.equals("infix <") ||
+      _name.equals("infix >") ||
+      _name.equals("infix ≤") ||
+      _name.equals("infix ≥") ||
+      _name.equals("infix <=") ||
+      _name.equals("infix >=") ||
+      _name.equals("infix =") ||
+      _name.equals("infix !=") ||
+      // && is used to chain the calls togehter.
+      _name.equals("infix &&");
   }
 
 
@@ -343,9 +351,9 @@ public class ParsedCall extends Call
     Call result = null;
     if (Types.resolved != null &&
         targetFeature(res, thiz) == Types.resolved.f_bool &&
-        isInfixOperator() &&
+        isValidOperatorInChainedBoolean() &&
         target() instanceof ParsedCall pc &&
-        pc.isInfixOperator() &&
+        pc.isValidOperatorInChainedBoolean() &&
         pc.isOperatorCall(false))
       {
         result = (pc._actuals.get(0) instanceof ParsedCall acc && acc.isChainedBoolRHS())

--- a/tests/reg_issue3036/Makefile
+++ b/tests/reg_issue3036/Makefile
@@ -1,0 +1,25 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test Makefile
+#
+# -----------------------------------------------------------------------
+
+override NAME = reg_issue3036
+include ../simple.mk

--- a/tests/reg_issue3036/reg_issue3036.fz
+++ b/tests/reg_issue3036/reg_issue3036.fz
@@ -1,0 +1,24 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test
+#
+# -----------------------------------------------------------------------
+
+say (8 %% 5 = 3)

--- a/tests/reg_issue3036/reg_issue3036.fz.expected_err
+++ b/tests/reg_issue3036/reg_issue3036.fz.expected_err
@@ -1,0 +1,13 @@
+
+--CURDIR--/reg_issue3036.fz:24:13: error 1: Incompatible types found during type inference for type parameters
+say (8 %% 5 = 3)
+------------^
+Types inferred for first type parameter 'T':
+'bool' found at --CURDIR--/reg_issue3036.fz:24:8:
+say (8 %% 5 = 3)
+-------^^
+'i32' found at --CURDIR--/reg_issue3036.fz:24:15:
+say (8 %% 5 = 3)
+--------------^
+
+one error.


### PR DESCRIPTION
Previously every infix feature with one or two args was considered valid as a chained boolean. This is now restricted to only these: <,>,≤,≥,=,<=,>=,!=

fixes #3036


