### PR TITLE
ast: cleanup loop code

### DIFF
--- a/src/dev/flang/ast/Loop.java
+++ b/src/dev/flang/ast/Loop.java
@@ -31,6 +31,7 @@ import java.util.Iterator;
 import dev.flang.util.ANY;
 import dev.flang.util.FuzionConstants;
 import dev.flang.util.List;
+import dev.flang.util.Pair;
 import dev.flang.util.SourcePosition;
 
 
@@ -152,7 +153,7 @@ public class Loop extends ANY
   static private final boolean FUZION_DEBUG_LOOPS = "true".equals(System.getenv("FUZION_DEBUG_LOOPS"));
 
 
-  /*----------------------------  variables  ----------------------------*/
+  /*----------------------------  constants  ----------------------------*/
 
 
   /**
@@ -169,19 +170,24 @@ public class Loop extends ANY
 
 
   /**
-   * Loop prolog: Code block that initializes the index variables with their
-   * initial values. May be null if none.
+   * The block containing the implementation of the loop.
    */
-  private final Block _prolog;
-  private List<Expr> _prologSuccessBlock;
+  private final Block _impl;
 
 
   /**
-   * Code to be executed to update index variables after _untilCond was checked
-   * to be false.
+   * The name of this loop's tail recursive routine, used as prefix for internal names
    */
-  private Expr _nextIteration = null;
-  private List<Expr> _nextItSuccessBlock = null;
+  private final String _rawLoopName;
+
+
+  /**
+   * Position of the "else" keyword if present, or something close to it if not
+   */
+  private final SourcePosition _elsePos;
+
+
+  /*----------------------------  variables  ----------------------------*/
 
 
   /**
@@ -199,21 +205,10 @@ public class Loop extends ANY
 
 
   /**
-   * Position of the "else" keyword if present, or something close to it if not
-   */
-  private SourcePosition _elsePos;
-
-  /**
    * In case the else-clause has to be put into a routine, these are two
    * routines, the first for the prolog, the other for the rest of the loop.
    */
   private Feature[] _loopElse;
-
-
-  /**
-   * The name of this loop's tail recursive routine, used as prefix for internal names
-   */
-  private final String _rawLoopName;
 
 
   /*--------------------------  constructors  ---------------------------*/
@@ -289,39 +284,29 @@ public class Loop extends ANY
         _elseBlock0 = new Block(new List<>(_loopElse[1], callLoopElse(1)));
       }
 
-    _prologSuccessBlock = new List<>();
-    _prolog             = new Block(_prologSuccessBlock, hasImplicitResult);
-    _prolog._newScope = true;
-    if (!_indexVars.isEmpty())
-      {
-        _nextItSuccessBlock = new List<>();
-        _nextIteration = new Block(_nextItSuccessBlock, hasImplicitResult);
-        addIterators();
-      }
+    var prologBlock = new List<Expr>();
+    var nextItBlock = new List<Expr>();
+
+    var r = addIterators(prologBlock, nextItBlock);
+    var prologSuccessBlock = r.v0();
+    var nextItSuccessBlock = r.v1();
 
     var formalArguments = new List<AbstractFeature>();
     var initialActuals = new List<Expr>();
     var nextActuals = new List<Expr>();
     initialArguments(formalArguments, initialActuals, nextActuals);
-    var initialCall       = new Call(pos, null, loopName, initialActuals);
-    var tailRecursiveCall = new Call(pos, null, loopName, nextActuals   );
-    if (_nextIteration == null)
-      {
-        _nextIteration = tailRecursiveCall;
-      }
-    else
-      {
-        _nextItSuccessBlock.add(tailRecursiveCall);
-      }
 
-    if (untilCond != null)
-      {
-        _nextIteration = new If(untilCond.pos(),
-                                untilCond,
-                                Block.newIfNull(_successBlock),
-                                _nextIteration);
-      }
-    block._expressions.add(_nextIteration);
+    var tailRecursiveCall = new Call(pos, null, loopName, nextActuals);
+    nextItSuccessBlock.add(tailRecursiveCall);
+
+    Expr nextIteration = untilCond == null
+      ? new Block(nextItBlock, hasImplicitResult)
+      : new If(untilCond.pos(),
+               untilCond,
+               Block.newIfNull(_successBlock),
+               new Block(nextItBlock, hasImplicitResult));
+
+    block._expressions.add(nextIteration);
     if (whileCond != null)
       {
         block = Block.fromExpr(new If(whileCond.pos(), whileCond, block, _elseBlock0));
@@ -336,8 +321,12 @@ public class Loop extends ANY
                                Function.NO_CALLS,
                                Contract.EMPTY_CONTRACT,
                                new Impl(p, block, Impl.Kind.RoutineDef));
-    _prologSuccessBlock.add(loop);
-    _prologSuccessBlock.add(initialCall);
+
+    var initialCall = new Call(pos, null, loopName, initialActuals);
+    prologSuccessBlock.add(initialCall);
+
+    _impl           = new Block(new List<>(loop, prologBlock), hasImplicitResult);
+    _impl._newScope = true;
   }
 
 
@@ -351,9 +340,9 @@ public class Loop extends ANY
   {
     if (FUZION_DEBUG_LOOPS)
       {
-        say(_prolog);
+        say(_impl);
       }
-    return _prolog;
+    return _impl;
   }
 
 
@@ -559,10 +548,10 @@ public class Loop extends ANY
 
 
   /**
-   * Helper routine to add code to _prologSuccessBlock and _nextItSuccessBlock
-   * for index vars.
+   * Helper routine to add code to prologBlock and nextItBlock for index vars,
+   * and return the corresponding success blocks.
    */
-  private void addIterators()
+  private Pair<List<Expr>,List<Expr>> addIterators(List<Expr> prologBlock, List<Expr> nextItBlock)
   {
     boolean mustDeclareLoopElse = _loopElse != null;
     int iteratorCount = 0;
@@ -577,8 +566,8 @@ public class Loop extends ANY
             if (mustDeclareLoopElse)
               { // we declare loopElse function after all non-iterating index
                 // vars such that the else clause can access these vars.
-                _prologSuccessBlock.add(_loopElse[0]);
-                _nextItSuccessBlock.add(_loopElse[2]);
+                prologBlock.add(_loopElse[0]);
+                nextItBlock.add(_loopElse[2]);
                 mustDeclareLoopElse = false;
               }
             var listName = _rawLoopName + "list" + (iteratorCount++);
@@ -594,7 +583,7 @@ public class Loop extends ANY
                                          /* contract */    null,
                                          /* impl */        new Impl(p, asList, Impl.Kind.FieldDef));
             list._isIndexVarUpdatedByLoop = true;  // hack to prevent error AstErrors.initialValueNotAllowed(this)
-            _prologSuccessBlock.add(list);
+            prologBlock.add(list);
             ParsedType nilType = new ParsedType(p, "nil", new List<>(), null);
             ParsedType consType = new ParsedType(p, "Cons", new List<>(), null);
             Call next1    = new Call(p, new Call(p, listName + "cons"), "head");
@@ -607,10 +596,10 @@ public class Loop extends ANY
             Case match2c = new Case(p, consType, listName + "cons", new Block(nextIt2));
             Case match2n = new Case(p, nilType, listName + "nil", (_loopElse != null) ? Block.fromExpr(callLoopElse(2)) : Block.newIfNull(null));
             Match match2 = new Match(p, new Call(p, listName + "arg"), new List<AbstractCase>(match2c, match2n));
-            _prologSuccessBlock.add(match1);
-            _nextItSuccessBlock.add(match2);
-            _prologSuccessBlock = prolog2;
-            _nextItSuccessBlock = nextIt2;
+            prologBlock.add(match1);
+            nextItBlock.add(match2);
+            prologBlock = prolog2;
+            nextItBlock = nextIt2;
             f.setImpl(new Impl(f.impl().pos, next1, Impl.Kind.FieldDef));
             n.setImpl(new Impl(n.impl().pos, next2, Impl.Kind.FieldDef));
             f._isLoopIterator = true;
@@ -618,11 +607,12 @@ public class Loop extends ANY
             n._isLoopIterator = true;
             n._loopIteratorListName = listName;
           }
-        _prologSuccessBlock.add(f);
-        _nextItSuccessBlock.add(n);
+        prologBlock.add(f);
+        nextItBlock.add(n);
         f._isIndexVarUpdatedByLoop = true;
         n._isIndexVarUpdatedByLoop = true;
       }
+    return new Pair<>(prologBlock, nextItBlock);
   }
 
 }


### PR DESCRIPTION
Moved the actual tail recursive loop feature to the impl-block, was in prologSuccessBlock. This should in theory reduce variable shadowing.

Also renamed some fields and made some fields final in an attempt to improve readability.
