### PR TITLE
lib: ctrie, use different unique ids for new root and snapshot

### DIFF
--- a/modules/lock_free/src/lock_free/map.fz
+++ b/modules/lock_free/src/lock_free/map.fz
@@ -662,7 +662,7 @@ is
   public snapshot(read_only bool) map CTK CTV =>
     root := read_root
     expmain := gcas_read root
-    new_gen := unique_id
+    new_gen => unique_id
     descriptor := Rdcss_Descriptor root expmain (copy_to_gen root new_gen)
     if rdcss_root descriptor
       # new ctrie by changing generation of root

--- a/tests/ctrie_threads/ctrie_threads.fz
+++ b/tests/ctrie_threads/ctrie_threads.fz
@@ -155,7 +155,7 @@ ctrie_threads is
             nil => panic "$kt not found"
             i32 =>
           if ctrie[kt].exists
-            say "removed key $kt still present"
+            panic "removed key $kt still present"
           if k%5=0 && s2[kt].is_nil
             panic "removed key $kt from snapshot"
 


### PR DESCRIPTION
This is how reference implementation does it. Does not fix the bug with snaphotting though...