### PR TITLE
lib: Add default implementation of numeric operator preconditions

### DIFF
--- a/lib/numeric.fz
+++ b/lib/numeric.fz
@@ -81,19 +81,21 @@ module:public numeric : property.hashable, property.orderable is
 
 
   # preconditions for basic operations: true if the operation's result is
-  # representable for the given values
+  # representable and defined for the given values
   #
-  # This does not check if the operation is defined (i.e, it
-  # returns true for '3/!0' or '0**!0'.)
+  # default implementations all return `true` such that children have to
+  # redefine these only for partial operations such as those resulting in
+  # an overflow or that are undefined like a division by zero for most
+  # types.
   #
   public prefix +! bool => true
-  public prefix -! bool => abstract
-  public infix +! (other numeric.this) bool => abstract
-  public infix -! (other numeric.this) bool => abstract
-  public infix *! (other numeric.this) bool => abstract
-  public infix /! (other numeric.this) bool => abstract
-  public infix %! (other numeric.this) bool => abstract
-  public infix **!(other numeric.this) bool => abstract
+  public prefix -! bool => true
+  public infix +! (other numeric.this) bool => true
+  public infix -! (other numeric.this) bool => true
+  public infix *! (other numeric.this) bool => true
+  public infix /! (other numeric.this) bool => true
+  public infix %! (other numeric.this) bool => true
+  public infix **!(other numeric.this) bool => true
 
 
   # overflow checking operations


### PR DESCRIPTION
Since preconditions are inherited now implementations of these are needed by all children of numeric. These implementations are missing, e.g., in fraction.

To avoid requiring adding all of these, this patch provides default implementations that are just `true`, so children are supposed to implement operations that are complete and redefine these for partial operations.

This fixes the abstract feature error produces by examples using fractions.
