### PR TITLE
be: remove precondition handling code

### DIFF
--- a/src/dev/flang/be/c/C.java
+++ b/src/dev/flang/be/c/C.java
@@ -177,12 +177,9 @@ public class C extends ANY
       var cc0 = _fuir.accessedClazz            (s);
       var ol = new List<CStmnt>();
       var res = CExpr.UNIT;
-      if (!_fuir.callPreconditionOnly(s))
-        {
-          var r = access(s, tvalue, args);
-          ol.add(r.v1());
-          res = r.v0();
-        }
+      var r = access(s, tvalue, args);
+      ol.add(r.v1());
+      res = r.v0();
       return new Pair<>(res, CStmnt.seq(ol));
     }
 

--- a/src/dev/flang/be/c/C.java
+++ b/src/dev/flang/be/c/C.java
@@ -1752,9 +1752,8 @@ public class C extends ANY
   private CStmnt cFunctionDecl(int cl, CStmnt body)
   {
     var res = _fuir.clazzResultClazz(cl);
-    var resultType = !_fuir.hasData(res)
-      ? "void"
-      : _types.clazz(res);
+    var resultType = _fuir.hasData(res) ? _types.clazz(res)
+                                        : "void";
     var argts = new List<String>();
     var argns = new List<CIdent>();
     var or = _fuir.clazzOuterRef(cl);

--- a/src/dev/flang/be/c/CNames.java
+++ b/src/dev/flang/be/c/CNames.java
@@ -52,12 +52,6 @@ public class CNames extends ANY
 
 
   /**
-   * Prefix for C functions created for Fuzion preconditions
-   */
-  private static final String C_PRECONDITION_PREFIX = "fzP_";
-
-
-  /**
    * Prefix for types declared for clazz instances
    */
   private static final String TYPE_PREFIX = "fzT_";
@@ -238,12 +232,6 @@ public class CNames extends ANY
    * Mapping from clazz ids to C function names
    */
   private final CClazzNames _functionNames = new CClazzNames(C_FUNCTION_PREFIX);
-
-
-  /**
-   * Mapping from clazz ids to C function names
-   */
-  private final CClazzNames _preConditionNames = new CClazzNames(C_PRECONDITION_PREFIX);
 
 
   /**
@@ -471,15 +459,10 @@ public class CNames extends ANY
    * Name of the C function of the given clazz.
    *
    * @param cl clazz id
-   *
-   * @param pre true iff we want to get the precondition, not the function
-   * itself.
    */
-  String function(int cl, boolean pre)
+  String function(int cl)
   {
-    return (pre
-            ? _preConditionNames
-            : _functionNames    ).get(cl);
+    return _functionNames.get(cl);
   }
 
 

--- a/src/dev/flang/be/c/CTypes.java
+++ b/src/dev/flang/be/c/CTypes.java
@@ -146,7 +146,6 @@ public class CTypes extends ANY
     return switch (_fuir.clazzKind(cl))
       {
       case Choice, Routine -> true;
-      case Intrinsic, Abstract -> _fuir.hasPrecondition(cl);
       default              -> false;
       };
 

--- a/src/dev/flang/be/c/Intrinsics.java
+++ b/src/dev/flang/be/c/Intrinsics.java
@@ -833,7 +833,7 @@ public class Intrinsics extends ANY
 
                                 arg.assign(CExpr.call(c.malloc(), new List<>(CExpr.sizeOfType("struct " + CNames.fzThreadStartRoutineArg.code())))),
 
-                                arg.deref().field(CNames.fzThreadStartRoutineArgFun).assign(CExpr.ident(c._names.function(call, false)).adrOf().castTo("void *")),
+                                arg.deref().field(CNames.fzThreadStartRoutineArgFun).assign(CExpr.ident(c._names.function(call)).adrOf().castTo("void *")),
                                 arg.deref().field(CNames.fzThreadStartRoutineArgArg).assign(A0.castTo("void *")),
 
                                 CExpr.call("fzE_thread_create", new List<>(CNames.fzThreadStartRoutine.adrOf(), arg)).ret());
@@ -962,7 +962,7 @@ public class Intrinsics extends ANY
                                        evi.assign(CIdent.TRUE ),
                                        evj.assign(jmpbuf.adrOf()),
                                        CStmnt.iff(CExpr.call("setjmp",new List<>(jmpbuf)).eq(CExpr.int32const(0)),
-                                                  CExpr.call(c._names.function(call, false), new List<>(A0))),
+                                                  CExpr.call(c._names.function(call), new List<>(A0))),
                                        /* NYI: this is a bit radical: we copy back the value from env to the outer instance, i.e.,
                                         * the outer instance is no longer immutable and we might run into difficulties if
                                         * the outer instance is used otherwise.

--- a/src/dev/flang/be/interpreter/Executor.java
+++ b/src/dev/flang/be/interpreter/Executor.java
@@ -32,7 +32,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
 import dev.flang.fuir.FUIR;
-import dev.flang.fuir.FUIR.ContractKind;
 import dev.flang.fuir.analysis.AbstractInterpreter;
 import dev.flang.fuir.analysis.AbstractInterpreter.ProcessExpression;
 
@@ -240,8 +239,7 @@ public class Executor extends ProcessExpression<Value, Object>
         // NYI change call to pass in ai as in match expression?
         var cur = new Instance(cc);
 
-        callOnInstance(s, cc, cur, tvalue, args, true);
-        callOnInstance(s, cc, cur, tvalue, args, false);
+        callOnInstance(s, cc, cur, tvalue, args);
 
         Value rres = cur;
         var resf = _fuir.clazzResultField(cc);
@@ -459,7 +457,7 @@ public class Executor extends ProcessExpression<Value, Object>
             _cur,
             tagAndChoiceElement.v1());
       }
-    return ai.process(_fuir.matchCaseCode(s, cix));
+    return ai.processCode(_fuir.matchCaseCode(s, cix));
   }
 
 
@@ -528,19 +526,6 @@ public class Executor extends ProcessExpression<Value, Object>
     return pair(result);
   }
 
-  @Override
-  public Object contract(int s, ContractKind ck, Value cc)
-  {
-    if (!cc.boolValue())
-      {
-        var cl = _fuir.clazzAt(s);
-        Errors.runTime(_fuir.sitePos(s),
-                       (ck == ContractKind.Pre ? "Precondition" : "Postcondition") + " does not hold",
-                       (ck == ContractKind.Pre ? "For" : "After") + " call to " + _fuir.clazzAsStringNew(cl) + "\n" + callStack(fuir()));
-      }
-    return null;
-  }
-
 
   /**
    * callOnInstance assigns the arguments to the argument fields of a newly
@@ -556,17 +541,15 @@ public class Executor extends ProcessExpression<Value, Object>
    *
    * @param args the arguments to be passed to this call.
    *
-   * @param pre
-   *
    * @return
    */
-  Value callOnInstance(int s, int cc, Instance cur, Value outer, List<Value> args, boolean pre)
+  Value callOnInstance(int s, int cc, Instance cur, Value outer, List<Value> args)
   {
     FuzionThread.current()._callStackFrames.push(cc);
     FuzionThread.current()._callStack.push(s);
 
     new AbstractInterpreter<>(_fuir, new Executor(cur, outer, args))
-      .process(cc, pre);
+      .processClazz(cc);
 
     FuzionThread.current()._callStack.pop();
     FuzionThread.current()._callStackFrames.pop();

--- a/src/dev/flang/be/interpreter/Interpreter.java
+++ b/src/dev/flang/be/interpreter/Interpreter.java
@@ -83,8 +83,7 @@ public class Interpreter extends FUIRContext
     try
       {
         FuzionThread.current()._callStackFrames.push(_fuir.mainClazzId());
-        _ai.process(_fuir.mainClazzId(), true);
-        _ai.process(_fuir.mainClazzId(), false);
+        _ai.processClazz(_fuir.mainClazzId());
       }
     catch (FatalError e)
       {

--- a/src/dev/flang/be/interpreter/Intrinsics.java
+++ b/src/dev/flang/be/interpreter/Intrinsics.java
@@ -911,7 +911,7 @@ public class Intrinsics extends ANY
         {
           var oc   = executor.fuir().clazzArgClazz(innerClazz, 0);
           var call = executor.fuir().lookupCall(oc);
-          var t = new Thread(() -> executor.callOnInstance(NO_SITE, call, new Instance(call), args.get(1), new List<>(), false));
+          var t = new Thread(() -> executor.callOnInstance(NO_SITE, call, new Instance(call), args.get(1), new List<>()));
           t.setDaemon(true);
           t.start();
           return new i64Value(_startedThreads_.add(t));
@@ -1524,7 +1524,7 @@ public class Intrinsics extends ANY
               var oc   = executor.fuir().clazzActualGeneric(innerClazz, 0);
               var call = executor.fuir().lookupCall(oc);
               try {
-                var ignore = executor.callOnInstance(NO_SITE, call, new Instance(call), args.get(1), new List<>(), false);
+                var ignore = executor.callOnInstance(NO_SITE, call, new Instance(call), args.get(1), new List<>());
                 return new boolValue(true);
               } catch (Abort a) {
                 if (a._effect == cl)

--- a/src/dev/flang/be/jvm/Choices.java
+++ b/src/dev/flang/be/jvm/Choices.java
@@ -463,7 +463,7 @@ public class Choices extends ANY implements ClassFileConstants
                     {
                       if (CHECKS) check
                         (code == null);  // if there are several non-voids, we would have at least boollike kind
-                      code = Expr.UNIT.andThen(ai.process(_fuir.matchCaseCode(s, mc)));
+                      code = Expr.UNIT.andThen(ai.processCode(_fuir.matchCaseCode(s, mc)));
                     }
                 }
             }
@@ -484,8 +484,8 @@ public class Choices extends ANY implements ClassFileConstants
                   var t = intValueForTagNum(subjClazz, tagNum);
                   switch (t)
                     {
-                    case 0: neg = Expr.UNIT.andThen(ai.process(_fuir.matchCaseCode(s, mc))); break;
-                    case 1: pos = Expr.UNIT.andThen(ai.process(_fuir.matchCaseCode(s, mc))); break;
+                    case 0: neg = Expr.UNIT.andThen(ai.processCode(_fuir.matchCaseCode(s, mc))); break;
+                    case 1: pos = Expr.UNIT.andThen(ai.processCode(_fuir.matchCaseCode(s, mc))); break;
                     case -1: break; //  void type
                     default: throw new Error("JVM backend match found unexpected tag number " + t + " when compiling " + _fuir.siteAsString(s));
                   }
@@ -516,7 +516,7 @@ public class Choices extends ANY implements ClassFileConstants
                         .andThen(Expr.iconst(tagNum))                               //          tag, tag, tagNum
                         .andThen(Expr.branch(ClassFileConstants.O_if_icmpeq,        //          tag
                                              Expr.POP                               //          -
-                                               .andThen(ai.process(_fuir.matchCaseCode(s, mc)))
+                                               .andThen(ai.processCode(_fuir.matchCaseCode(s, mc)))
                                                .andThen(Expr.gotoLabel(lEnd))));
                     }
                 }
@@ -553,12 +553,12 @@ public class Choices extends ANY implements ClassFileConstants
                         {                                                       //          sub
                           pos = Expr.POP;                                       //          -
                         }
-                      pos = pos.andThen(ai.process(_fuir.matchCaseCode(s, mc)));
+                      pos = pos.andThen(ai.processCode(_fuir.matchCaseCode(s, mc)));
                     }
                   else if (_fuir.clazzIsUnitType(tc))
                     {
                       neg = Expr.POP                                            //          -
-                        .andThen(ai.process(_fuir.matchCaseCode(s, mc)));
+                        .andThen(ai.processCode(_fuir.matchCaseCode(s, mc)));
                     }
                 }
             }
@@ -610,7 +610,7 @@ public class Choices extends ANY implements ClassFileConstants
                             .andThen(Expr.POP)                                  //          sub
                             .andThen(Expr.POP);                                 //          -
                         }
-                      pos = pos.andThen(ai.process(_fuir.matchCaseCode(s, mc)))
+                      pos = pos.andThen(ai.processCode(_fuir.matchCaseCode(s, mc)))
                         .andThen(Expr.gotoLabel(lEnd));
                       code = code.andThen(Expr.DUP)                             //          sub, tag, tag
                         .andThen(Expr.iconst(tagNum))                           //          sub, tag, tag, tagNum
@@ -668,7 +668,7 @@ public class Choices extends ANY implements ClassFileConstants
                             .andThen(Expr.POP);                                     //          -
                         }
                       pos = pos
-                        .andThen(ai.process(_fuir.matchCaseCode(s, mc)))
+                        .andThen(ai.processCode(_fuir.matchCaseCode(s, mc)))
                         .andThen(Expr.gotoLabel(lEnd));
                       code = code.andThen(Expr.DUP)                                 //          sub, tag, tag
                         .andThen(Expr.iconst(tagNum))                               //          sub, tag, tag, tagNum

--- a/src/dev/flang/be/jvm/CodeGen.java
+++ b/src/dev/flang/be/jvm/CodeGen.java
@@ -261,36 +261,6 @@ class CodeGen
 
 
   /**
-   * If e might have some side effect, evaluate e and store the result in a new
-   * local variable.
-   *
-   * This is used in case e's value is needed repeatedly as in passing it to a
-   * precondition check before it is passed to the actual call.
-   *
-   * @param si site of the expr requiring this
-   *
-   * @param e expression to evaluation and store in a local, null for void value
-   *
-   * @return a pair of a new expression that loads the value of e and an
-   * expression that evaluates e and stores it in a local variable.
-   */
-  Pair<Expr,Expr> storeInLocal(int si, Expr e)
-  {
-    if (e == null)
-      {
-        return new Pair<>(null, Expr.UNIT);
-      }
-    else
-      {
-        var t = e.type();
-        var l = _jvm.allocLocal(si, t.stackSlots());
-        return new Pair<>(t.load(l),
-                          e.andThen(t.store(l)));
-      }
-  }
-
-
-  /**
    * Perform a call of a feature with target instance tvalue with given
    * arguments.  The type of tvalue might be dynamic (a reference). See
    * FUIR.access*().

--- a/src/dev/flang/be/jvm/Intrinsix.java
+++ b/src/dev/flang/be/jvm/Intrinsix.java
@@ -846,7 +846,7 @@ public class Intrinsix extends ANY implements ClassFileConstants
       },
         (jvm, si, cc, tvalue, args) ->
         {
-          var name = jvm._names.function(cc, false);
+          var name = jvm._names.function(cc);
           var in = jvm._fuir.clazzOriginalName(cc);
           var msg = "missing implementation of JVM backend intrinsic '" +
             in + "', need '" + Intrinsics.class.getName() + "." + name + "' or inline code in " +
@@ -946,7 +946,7 @@ public class Intrinsix extends ANY implements ClassFileConstants
   static Pair<Expr, Expr> inlineCode(JVM jvm, int si, int cc, Expr tvalue, List<Expr> args)
   {
     Pair<Expr, Expr> result = null;
-    var name = jvm._names.function(cc, false);
+    var name = jvm._names.function(cc);
     if (!_availableIntrinsics.contains(name))
       {
         var in = jvm._fuir.clazzOriginalName(cc);
@@ -978,7 +978,7 @@ public class Intrinsix extends ANY implements ClassFileConstants
    */
   static boolean inRuntime(JVM jvm, int cc)
   {
-    return _availableIntrinsics.contains( jvm._names.function(cc, false));
+    return _availableIntrinsics.contains( jvm._names.function(cc));
   }
 
 

--- a/src/dev/flang/be/jvm/JVM.java
+++ b/src/dev/flang/be/jvm/JVM.java
@@ -740,7 +740,7 @@ should be avoided as much as possible.
    * For each routine with clazz id cl, this holds the number
    * of local var slots for the created method at index _fuir.clazzId2num(cl).
    */
-  final int[] _numLocalsForCode;
+  final int[] _numLocals;
 
 
   /**
@@ -782,8 +782,8 @@ should be avoided as much as possible.
     _tailCall = new TailCall(fuir);
     _ai = new AbstractInterpreter<>(fuir, new CodeGen(this));
     var cnt = _fuir.clazzId2num(_fuir.lastClazz())+1;
-    _numLocalsForCode         = new int[cnt];
-    _startLabels              = new Label[cnt];
+    _numLocals   = new int[cnt];
+    _startLabels = new Label[cnt];
 
     Errors.showAndExit();
   }
@@ -1150,7 +1150,7 @@ should be avoided as much as possible.
    */
   int numLocals(int cl)
   {
-    return _numLocalsForCode[_fuir.clazzId2num(cl)];
+    return _numLocals[_fuir.clazzId2num(cl)];
   }
 
 
@@ -1163,7 +1163,7 @@ should be avoided as much as possible.
    */
   void setNumLocals(int cl, int n)
   {
-    _numLocalsForCode[_fuir.clazzId2num(cl)] = n;
+    _numLocals[_fuir.clazzId2num(cl)] = n;
   }
 
 

--- a/src/dev/flang/be/jvm/JVM.java
+++ b/src/dev/flang/be/jvm/JVM.java
@@ -737,10 +737,10 @@ should be avoided as much as possible.
 
 
   /**
-   * For each routine and precondition with clazz id cl, this holds the number
+   * For each routine with clazz id cl, this holds the number
    * of local var slots for the created method at index _fuir.clazzId2num(cl).
    */
-  final int[] _numLocalsForCode, _numLocalsForPrecondition;
+  final int[] _numLocalsForCode;
 
 
   /**
@@ -783,7 +783,6 @@ should be avoided as much as possible.
     _ai = new AbstractInterpreter<>(fuir, new CodeGen(this));
     var cnt = _fuir.clazzId2num(_fuir.lastClazz())+1;
     _numLocalsForCode         = new int[cnt];
-    _numLocalsForPrecondition = new int[cnt];
     _startLabels              = new Label[cnt];
 
     Errors.showAndExit();
@@ -940,12 +939,8 @@ should be avoided as much as possible.
           case Routine:
           case Intrinsic:
             {
-              codeForRoutine(cl, false);
+              codeForRoutine(cl);
             }
-          }
-        if (_fuir.hasPrecondition(cl))
-          {
-            codeForRoutine(cl, true);
           }
       }
   }
@@ -985,12 +980,9 @@ should be avoided as much as possible.
    *
    * @param cl is of clazz to compile
    *
-   * @param pre true to create code for cl's precondition, false to create code
-   * for cl itself.
-   *
    * @return the prolog code.
    */
-  Expr prolog(int cl, boolean pre)
+  Expr prolog(int cl)
   {
     var result = Expr.UNIT;
     if (!_types.isScalar(cl))  // not calls like `u8 0x20` or `f32 3.14`.
@@ -1042,11 +1034,11 @@ should be avoided as much as possible.
         return Expr.UNIT;
       }
   }
-  Expr traceReturn(int cl, boolean pre)
+  Expr traceReturn(int cl)
   {
     if (TRACE_RETURN)
       {
-        var msg = "return from "+_fuir.clazzAsString(cl)+(pre ? " PRECONDITION" : "");
+        var msg = "return from " + _fuir.clazzAsString(cl);
         return callRuntimeTrace(msg);
       }
     else
@@ -1056,28 +1048,28 @@ should be avoided as much as possible.
   }
 
 
-  Expr epilog(int cl, boolean pre)
+  Expr epilog(int cl)
   {
     var cf = _types.classFile(cl);
     var r = _fuir.clazzResultField(cl);
     var t = _fuir.clazzResultClazz(cl);
-    if (pre || !_fuir.clazzIsRef(t) /* NYI: UNDER DEVELOPMENT: needed? */ && _fuir.clazzIsUnitType(t))
+    if (!_fuir.clazzIsRef(t) /* NYI: UNDER DEVELOPMENT: needed? */ && _fuir.clazzIsUnitType(t))
       {
-        return traceReturn(cl, pre)
+        return traceReturn(cl)
           .andThen(Expr.RETURN);
       }
     else if (r == -1)   // a constructor
       {
         var jt = _types.javaType(t);
         return
-          traceReturn(cl, pre)
+          traceReturn(cl)
           .andThen(jt.load(current_index(cl)))
           .andThen(jt.return0());
       }
     else
       {
         var ft = _types.resultType(t);
-        var tr =  traceReturn(cl, pre);
+        var tr =  traceReturn(cl);
 
         return fieldExists(r)
           ? tr
@@ -1150,19 +1142,15 @@ should be avoided as much as possible.
 
 
   /**
-   * Get the number of local var slots for the given routine or precondition.
+   * Get the number of local var slots for the given routine
    *
    * @param cl id of clazz to generate code for
    *
-   * @param pre true to create code for cl's precondition, false to create code
-   * for cl itself.
-   *
    * @return the number of slotes used for local vars
    */
-  int numLocals(int cl, boolean pre)
+  int numLocals(int cl)
   {
-    return (pre ? _numLocalsForPrecondition
-                : _numLocalsForCode        )[_fuir.clazzId2num(cl)];
+    return _numLocalsForCode[_fuir.clazzId2num(cl)];
   }
 
 
@@ -1171,15 +1159,11 @@ should be avoided as much as possible.
    *
    * @param cl id of clazz to generate code for
    *
-   * @param pre true to create code for cl's precondition, false to create code
-   * for cl itself.
-   *
    * @param n the number of slots needed for local vars
    */
-  void setNumLocals(int cl, boolean pre, int n)
+  void setNumLocals(int cl, int n)
   {
-    (pre ? _numLocalsForPrecondition
-         : _numLocalsForCode        )[_fuir.clazzId2num(cl)] = n;
+    _numLocalsForCode[_fuir.clazzId2num(cl)] = n;
   }
 
 
@@ -1206,9 +1190,6 @@ should be avoided as much as possible.
    *
    * @param cl id of clazz to generate code for
    *
-   * @param pre true to create code for cl's precondition, false to create code
-   * for cl itself.
-   *
    * @param numSlots the number of slots to be alloced
    *
    * @return the local var index of the allocated slots
@@ -1216,9 +1197,8 @@ should be avoided as much as possible.
   int allocLocal(int si, int numSlots)
   {
     var cl = _fuir.clazzAt(si);
-    var pre = _fuir.isPreconditionAt(si);
-    var res = numLocals(cl, pre);
-    setNumLocals(cl, pre, res + numSlots);
+    var res = numLocals(cl);
+    setNumLocals(cl, res + numSlots);
     return res;
   }
 
@@ -1226,34 +1206,30 @@ should be avoided as much as possible.
    * Create code for given clazz cl.
    *
    * @param cl id of clazz to generate code for
-   *
-   * @param pre true to create code for cl's precondition, false to create code
-   * for cl itself.
    */
-  void codeForRoutine(int cl, boolean pre)
+  void codeForRoutine(int cl)
   {
     if (PRECONDITIONS) require
       (_fuir.clazzKind(cl) == FUIR.FeatureKind.Routine ||
-       _fuir.clazzKind(cl) == FUIR.FeatureKind.Intrinsic || pre);
+       _fuir.clazzKind(cl) == FUIR.FeatureKind.Intrinsic);
 
     var cf = _types.classFile(cl);
     if (cf == null) return;
     var prolog = Expr.UNIT;
     var epilog = Expr.UNIT;
     Expr code;
-    var name = _names.function(cl, pre);
+    var name = _names.function(cl);
 
     // for an intrinsic that is not type type parameter, we do not generate code:
-    if (pre ||
-        _fuir.clazzKind(cl) == FUIR.FeatureKind.Routine ||
+    if (_fuir.clazzKind(cl) == FUIR.FeatureKind.Routine ||
         _fuir.clazzTypeParameterActualType(cl) >= 0)
       {
-        if (pre || _fuir.clazzKind(cl) == FUIR.FeatureKind.Routine)
+        if (_fuir.clazzKind(cl) == FUIR.FeatureKind.Routine)
           {
-            setNumLocals(cl, pre, current_index(cl) + Math.max(1, _types.javaType(cl).stackSlots()));
-            prolog = prolog(cl, pre);
-            code = _ai.process(cl, pre).v1();
-            epilog = epilog(cl, pre);
+            setNumLocals(cl, current_index(cl) + Math.max(1, _types.javaType(cl).stackSlots()));
+            prolog = prolog(cl);
+            code = _ai.processClazz(cl).v1();
+            epilog = epilog(cl);
           }
         else // intrinsic is a type parameter, type instances are unit types, so nothing to be done:
           {
@@ -1264,7 +1240,7 @@ should be avoided as much as possible.
         check
           (cf != null);
 
-        var sl = pre ? null : _startLabels[_fuir.clazzId2num(cl)];
+        var sl = _startLabels[_fuir.clazzId2num(cl)];
         var bc_cl = prolog
           .andThen(sl != null ? sl : Expr.UNIT)
           .andThen(code)
@@ -1272,49 +1248,12 @@ should be avoided as much as possible.
 
         var locals = initialLocals(cl);
 
-        var code_cl = cf.codeAttribute((pre ? "precondition of " : "") + _fuir.clazzAsString(cl),
+        var code_cl = cf.codeAttribute(_fuir.clazzAsString(cl),
                                        bc_cl,
                                        new List<>(), new List<>(), ClassFile.StackMapTable.fromCode(cf, locals, bc_cl));
 
-        cf.method(ClassFileConstants.ACC_STATIC | ClassFileConstants.ACC_PUBLIC, name, _types.descriptor(cl, pre), new List<>(code_cl));
+        cf.method(ClassFileConstants.ACC_STATIC | ClassFileConstants.ACC_PUBLIC, name, _types.descriptor(cl), new List<>(code_cl));
 
-        // If both precondition and routine exists, create a helper that calls both combined
-        if (!pre && _fuir.hasPrecondition(cl))
-          {
-            var bc_combined = Expr.UNIT;
-            var jt = _types.resultType(_fuir.clazzResultClazz(cl));
-
-            // In a loop, generate two calls, one for the precondition (preCond
-            // == true), then for the actual routine (preCond == false):
-            var preCond = true;
-            do
-              {
-                bc_combined = bc_combined
-                  .andThen(javaTypeOfTarget(cl).load(0));
-                for(var i = 0; i<_fuir.clazzArgCount(cl); i++)
-                  {
-                    var at = _fuir.clazzArgClazz(cl, i);
-                    var jti = _types.resultType(at);
-                    bc_combined = bc_combined
-                      .andThen(jti.load(argSlot(cl, i)));
-                  }
-                bc_combined = bc_combined
-                  .andThen(Expr.invokeStatic(_names.javaClass(cl),
-                                             _names.function(cl, preCond),
-                                             _types.descriptor(cl, preCond),
-                                             preCond ? PrimitiveType.type_void : jt));
-                preCond = !preCond;
-              }
-            while (!preCond);
-
-            bc_combined = bc_combined
-              .andThen(jt.return0());
-
-            var code_comb = cf.codeAttribute("combined precondition and code of " + _fuir.clazzAsString(cl),
-                                             bc_combined,
-                                             new List<>(), new List<>(), ClassFile.StackMapTable.fromCode(cf, locals, bc_combined));
-            cf.method(ClassFileConstants.ACC_STATIC | ClassFileConstants.ACC_PUBLIC, Names.COMBINED_NAME, _types.descriptor(cl, false), new List<>(code_comb));
-          }
       }
   }
 

--- a/src/dev/flang/be/jvm/JVM.java
+++ b/src/dev/flang/be/jvm/JVM.java
@@ -974,9 +974,9 @@ should be avoided as much as possible.
 
 
   /**
-   * Create prolog for code of given routine or precondition.  The prolog
-   * creates a new instance of cl and stores a reference to that instance into
-   * local var at slot current_index().
+   * Create prolog for code of given routine.  The prolog creates a new instance
+   * of cl and stores a reference to that instance into local var at slot
+   * current_index().
    *
    * @param cl is of clazz to compile
    *
@@ -1155,7 +1155,7 @@ should be avoided as much as possible.
 
 
   /**
-   * Set the number of local var slots for the given routine or precondition.
+   * Set the number of local var slots for the given routine.
    *
    * @param cl id of clazz to generate code for
    *
@@ -1168,9 +1168,11 @@ should be avoided as much as possible.
 
 
   /**
-   * Set the number of local var slots for the given routine or precondition.
+   * Create and get the label at the beginning of the code for routine cl.
    *
    * @param cl id of clazz
+   *
+   * @return the existing or newly created label.
    */
   Label startLabel(int cl)
   {
@@ -1186,7 +1188,7 @@ should be avoided as much as possible.
 
 
   /**
-   * Alloc local var slots for the given routine or precondition.
+   * Alloc local var slots for the given routine.
    *
    * @param cl id of clazz to generate code for
    *

--- a/src/dev/flang/be/jvm/Names.java
+++ b/src/dev/flang/be/jvm/Names.java
@@ -130,13 +130,6 @@ public class Names extends ANY implements ClassFileConstants
 
 
   /**
-   * Name and signature of Runtime.precondition_fail()
-   */
-  static final String RUNTIME_CONTRACT_FAIL     = "contract_fail";
-  static final String RUNTIME_CONTRACT_FAIL_SIG = "(Ljava/lang/String;)V";
-
-
-  /**
    * Name of Runtime.LOCK_FOR_ATOMIC
    */
   static final String RUNTIME_LOCK_FOR_ATOMIC   = "LOCK_FOR_ATOMIC";
@@ -150,7 +143,6 @@ public class Names extends ANY implements ClassFileConstants
   private static final String DYNAMIC_FUNCTION_PREFIX = "fzD_";
 
   static final String ROUTINE_NAME      = "fzRoutine";                // method with code for the routine
-  static final String COMBINED_NAME     = "fzPreconditionAndRoutine"; // method that calls precondition followed by routine, to reduce code size
   static final String NAME_ID           = "_L";
   static
   {

--- a/src/dev/flang/be/jvm/Names.java
+++ b/src/dev/flang/be/jvm/Names.java
@@ -149,15 +149,13 @@ public class Names extends ANY implements ClassFileConstants
   private static final String INTERFACE_PREFIX = "fzI_";
   private static final String DYNAMIC_FUNCTION_PREFIX = "fzD_";
 
-  static final String PRECONDITION_NAME = "fzPrecondition";           // method with code for the precondition
   static final String ROUTINE_NAME      = "fzRoutine";                // method with code for the routine
   static final String COMBINED_NAME     = "fzPreconditionAndRoutine"; // method that calls precondition followed by routine, to reduce code size
   static final String NAME_ID           = "_L";
   static
   {
     if (CHECKS) check
-      (PRECONDITION_NAME.equals(Runtime.PRECONDITION_NAME),
-       ROUTINE_NAME.equals(Runtime.ROUTINE_NAME),
+      (ROUTINE_NAME.equals(Runtime.ROUTINE_NAME),
        CLASS_PREFIX.equals(Runtime.CLASS_PREFIX),
        (CLASS_PREFIX + NAME_ID).equals(Runtime.CLASS_PREFIX_WITH_ID));
   }
@@ -553,13 +551,11 @@ public class Names extends ANY implements ClassFileConstants
    *
    * @param cl clazz id
    *
-   * @param pre true iff we want to get the precondition, not the function
-   * itself.
+   * @return the Java name
    */
-  String function(int cl, boolean pre)
+  String function(int cl)
   {
-    return pre                                               ? PRECONDITION_NAME :
-           _fuir.clazzKind(cl) != FUIR.FeatureKind.Intrinsic ? ROUTINE_NAME
+    return _fuir.clazzKind(cl) != FUIR.FeatureKind.Intrinsic ? ROUTINE_NAME
                                                              : mangle(_fuir.clazzOriginalName(cl));
   }
 

--- a/src/dev/flang/be/jvm/Types.java
+++ b/src/dev/flang/be/jvm/Types.java
@@ -486,7 +486,7 @@ public class Types extends ANY implements ClassFileConstants
 
 
   /**
-   * Get the signature descriptor string for calling cl or its precondition
+   * Get the signature descriptor string for calling cl
    *
    * @param explicitOuter true if the target instance is required (for Java
    * dynamic binding) even if the called clazz does not need it.
@@ -524,7 +524,7 @@ public class Types extends ANY implements ClassFileConstants
 
 
   /**
-   * Get the signature descriptor string for calling cl or its precondition
+   * Get the signature descriptor string for calling cl
    *
    * @param cl the called clazz
    */

--- a/src/dev/flang/be/jvm/Types.java
+++ b/src/dev/flang/be/jvm/Types.java
@@ -254,26 +254,6 @@ public class Types extends ANY implements ClassFileConstants
   }
 
 
-  int numUnitTypesInChoiceOfOnlyRefs(int cl)
-  {
-    if (PRECONDITIONS) require
-      (_fuir.clazzIsChoiceOfOnlyRefs(cl));
-
-    int numUnitTypes = 0;
-    for (var i = 0; i < _fuir.clazzNumChoices(cl); i++)
-      {
-        var tc = _fuir.clazzChoice(cl, i);
-        if (!_fuir.clazzIsVoidType(tc) && !_fuir.clazzIsRef(tc))
-          {
-            if (CHECKS) check
-              (_fuir.clazzIsUnitType(tc));
-            numUnitTypes++;
-          }
-      }
-    return numUnitTypes;
-  }
-
-
   boolean clazzNeedsCode(int cl)
   {
     return _fuir.clazzNeedsCode(cl) ||
@@ -284,25 +264,6 @@ public class Types extends ANY implements ClassFileConstants
       cl == _fuir.clazz_fuzionSysArray_u8_length() ||
       cl == _fuir.clazz_fuzionJavaObject() ||
       cl == _fuir.clazz_fuzionJavaObject_Ref();
-  }
-
-
-  boolean isChoiceOfOneRefAndOneUnitType(int cl)
-  {
-    var result = false;
-    if (_fuir.clazzIsChoice(cl))
-      {
-        if (_fuir.clazzIsChoiceOfOnlyRefs(cl))
-          {
-            var nc = _fuir.clazzNumChoices(cl);
-            var nu = numUnitTypesInChoiceOfOnlyRefs(cl);
-            var nr = nc - nu; // num refs
-            if (CHECKS) check
-              (nr > 0);
-            result = nu == 1 && nr == 1;
-          }
-      }
-    return result;
   }
 
 

--- a/src/dev/flang/be/jvm/Types.java
+++ b/src/dev/flang/be/jvm/Types.java
@@ -230,7 +230,7 @@ public class Types extends ANY implements ClassFileConstants
     return Expr.invokeStatic(cls,
                              fname,
                              descriptor(cc),
-                             resultType(cc),
+                             resultType(_fuir.clazzResultClazz(cc)),
                              line);
   }
 
@@ -486,19 +486,6 @@ public class Types extends ANY implements ClassFileConstants
 
 
   /**
-   * Get the result type of a call to clazz cl or its precondition
-   *
-   * @param cl the called clazz
-   */
-  JavaType resultType2(int cl)
-  {
-    var rt = _fuir.clazzResultClazz(cl);
-    return resultType(rt);
-
-  }
-
-
-  /**
    * Get the signature descriptor string for calling cl or its precondition
    *
    * @param explicitOuter true if the target instance is required (for Java
@@ -530,7 +517,7 @@ public class Types extends ANY implements ClassFileConstants
           }
       }
     as.append(")")
-      .append(resultType(cl).descriptor());
+      .append(resultType(_fuir.clazzResultClazz(cl)).descriptor());
 
     return as.toString();
   }

--- a/src/dev/flang/be/jvm/runtime/Runtime.java
+++ b/src/dev/flang/be/jvm/runtime/Runtime.java
@@ -660,17 +660,6 @@ public class Runtime extends ANY
 
 
   /**
-   * Called after a precondition/postcondition check failed
-   *
-   * @param msg a detail message explaining what failed
-   */
-  public static void contract_fail(String msg)
-  {
-    Errors.fatal("CONTRACT FAILED: " + msg, stackTrace());
-  }
-
-
-  /**
    * Get the message of last exception thrown in the current thread.
    */
   public static String getException()

--- a/src/dev/flang/be/jvm/runtime/Runtime.java
+++ b/src/dev/flang/be/jvm/runtime/Runtime.java
@@ -103,7 +103,6 @@ public class Runtime extends ANY
    * that package.  We do not want to bundle the backend classes with a
    * stand-alone application that needs the runtime classes, so this is copied.
    */
-  public static final String PRECONDITION_NAME = "fzPrecondition";
   public static final String ROUTINE_NAME      = "fzRoutine";
   public static final String CLASS_PREFIX      = "fzC_";
   public static final String CLASS_PREFIX_WITH_ID = "fzC__L";
@@ -711,15 +710,14 @@ public class Runtime extends ANY
     for (var s : t.getStackTrace())
       {
         var m = s.getMethodName();
-        var r = switch (m)
+        var show = switch (m)
           {
           case "main",
-               ROUTINE_NAME      -> "";
-          case PRECONDITION_NAME -> "precondition of ";
-          default -> null;
+               ROUTINE_NAME -> true;
+          default           -> false;
           };
         var cl = s.getClassName();
-        if (r != null && cl.startsWith(CLASS_PREFIX))
+        if (show && cl.startsWith(CLASS_PREFIX))
           {
             int start;
             if (cl.startsWith(CLASS_PREFIX_WITH_ID))
@@ -731,8 +729,7 @@ public class Runtime extends ANY
               {
                 start = CLASS_PREFIX.length();
               }
-            cl = cl.substring(start);
-            var str = r + cl;
+            var str = cl.substring(start);
             if (str.equals(last))
               {
                 count++;

--- a/src/dev/flang/fuir/FUIR.java
+++ b/src/dev/flang/fuir/FUIR.java
@@ -1638,32 +1638,6 @@ hw25 is
 
 
   /**
-   * Is this call only to check preconditions.
-   *
-   * This is a bit of a hack for calls to parent features in inherits clauses:
-   * These calls are inlined, so the backend does not need to take care.  Only
-   * the precondition must be executed explicitly, so there remains a call to
-   * the parent feature with callPreconditionOnly() returning true.
-   *
-   * The result of a the call in this case is unit.
-   *
-   * @param s site of the call
-   *
-   * @return true if only the precondition should be executed.
-   */
-  public boolean callPreconditionOnly(int s)
-  {
-    if (PRECONDITIONS) require
-      (s >= SITE_BASE,
-       withinCode(s),
-       codeAt(s) == ExprKind.Call);
-
-    var call = (AbstractCall) getExpr(s);
-    return call.isInheritanceCall();
-  }
-
-
-  /**
    * Get the target (outer) clazz of a feature access
    *
    * @param cl index of clazz containing the access

--- a/src/dev/flang/fuir/FUIR.java
+++ b/src/dev/flang/fuir/FUIR.java
@@ -916,29 +916,6 @@ public class FUIR extends IR
   {
     for (var p: ff.inherits())
       {
-        /*
-NYI: Any side-effects in p.target() or p.actuals() will be executed twice, once for
-     the precondition and once for the inlined call! See this example:
-
-hw25 is
-  A (a i32)
-    pre
-      a < 100
-  is
-    say "in A: $a"
-
-  B : A x is
-
-  count := 0
-
-  x =>
-    set count := count + 1
-    count
-
-  B; B; B
-  if (count == 3) say "PASS" else say "FAIL"
-        */
-
         var pf = p.calledFeature();
         var of = pf.outerRef();
         var or = (of == null) ? null : (Clazz) cc._inner.get(new FeatureAndActuals(of, new List<>(), false));  // NYI: ugly cast
@@ -969,21 +946,18 @@ hw25 is
 
   /**
    * This has to be called after `super.addCode(List)` was called to record the
-   * clazz and whether the code belongs to a precondition for all sites of the
-   * newly added code.
+   * clazz for all sites of the newly added code.
    *
    * @param cl the clazz id of the clazz that contains the new code
-   *
-   * @param pre true iff the new code was part of a precondition.
    */
-  private void recordClazzAndPreForSitesOfRecentlyAddedCode(int cl)
+  private void recordClazzForSitesOfRecentlyAddedCode(int cl)
   {
     if (PRECONDITIONS) require
       (_siteClazzes.size() < _allCode.size());
 
     while (_siteClazzes.size() < _allCode.size())
       {
-        _siteClazzes       .add(cl);
+        _siteClazzes.add(cl);
       }
   }
 
@@ -1018,7 +992,7 @@ hw25 is
             addCode(cc, code, ff);
           }
         res = addCode(code);
-        recordClazzAndPreForSitesOfRecentlyAddedCode(cl);
+        recordClazzForSitesOfRecentlyAddedCode(cl);
         _clazzCode.put(cl, res);
       }
     return res;

--- a/src/dev/flang/fuir/analysis/AbstractInterpreter.java
+++ b/src/dev/flang/fuir/analysis/AbstractInterpreter.java
@@ -245,12 +245,6 @@ public class AbstractInterpreter<VALUE, RESULT> extends ANY
      */
     public abstract Pair<VALUE, RESULT> env(int s, int ecl);
 
-    /**
-     * Process a contract of kind ck of clazz cl that results in bool value cc
-     * (i.e., the contract fails if !cc).
-     */
-    public abstract RESULT contract(int s, FUIR.ContractKind ck, VALUE cc);
-
   }
 
 
@@ -470,24 +464,19 @@ public class AbstractInterpreter<VALUE, RESULT> extends ANY
    *
    * @param cl clazz id
    *
-   * @param pre true to process cl's precondition, false to process cl's code
-   * followed by its postcondition.
-   *
    * @return A Pair consisting of a VALUE that is either
    * _processor().unitValue() or null (in case cl diverges) and the result of
    * the abstract interpretation, e.g., the generated code.
    */
-  public Pair<VALUE,RESULT> process(int cl, boolean pre)
+  public Pair<VALUE,RESULT> processClazz(int cl)
   {
     var l = new List<RESULT>();
-    var s = pre ? _fuir.clazzContract(cl, FUIR.ContractKind.Pre, 0)
-                : _fuir.clazzCode(cl);
+    var s = _fuir.clazzCode(cl);
     if (s != NO_SITE)
       {
         assignOuterAndArgFields(l, s);
       }
-    var p = pre ? processContract(cl, FUIR.ContractKind.Pre)
-                : process(s);
+    var p = processCode(s);
     l.add(p.v1());
     var res = p.v0();
     return new Pair<>(res, _processor.sequence(l));
@@ -503,7 +492,7 @@ public class AbstractInterpreter<VALUE, RESULT> extends ANY
    * _processor().unitValue() or null (in case cl diverges) and the result of
    * the abstract interpretation, e.g., the generated code.
    */
-  public Pair<VALUE,RESULT> process(int s0)
+  public Pair<VALUE,RESULT> processCode(int s0)
   {
     var stack = new Stack<VALUE>();
     var l = new List<RESULT>();
@@ -540,40 +529,6 @@ public class AbstractInterpreter<VALUE, RESULT> extends ANY
       }
 
     return new Pair<>(v, _processor.sequence(l));
-  }
-
-
-  /**
-   * Perform abstract interpretation on given code
-   *
-   * @param cl clazz id
-   *
-   * @param ck the contracts kind
-   *
-   * @return the result of the abstract interpretation, e.g., the generated
-   * code.
-   */
-  Pair<VALUE,RESULT> processContract(int cl, FUIR.ContractKind ck)
-  {
-    var l = new List<RESULT>();
-    for (var ci = 0;
-         _fuir.clazzContract(cl, ck, ci) != NO_SITE;
-         ci++)
-      {
-        var s = _fuir.clazzContract(cl, ck, ci);
-        var stack = new Stack<VALUE>();
-        for (var si = s; !containsVoid(stack) && _fuir.withinCode(si); si = si + _fuir.codeSizeAt(si))
-          {
-            s = si; // when exiting this loop, s will be the site of the last expression, while si will not be within the code
-            l.add(_processor.expressionHeader(s));
-            l.add(process(s, stack));
-          }
-        if (!containsVoid(stack))
-          {
-            l.add(_processor.contract(s, ck, stack.pop()));
-          }
-      }
-    return new Pair<>(_processor.unitValue(), _processor.sequence(l));
   }
 
 

--- a/src/dev/flang/fuir/analysis/dfa/Call.java
+++ b/src/dev/flang/fuir/analysis/dfa/Call.java
@@ -70,12 +70,6 @@ public class Call extends ANY implements Comparable<Call>, Context
 
 
   /**
-   * Is this a call to _cc's precondition?
-   */
-  final boolean _pre;
-
-
-  /**
    * If available, _site gives the call site of this Call as used in the IR.
    * Calls with different call sites are analysed separately, even if the
    * context and environment of the call is the same.
@@ -139,8 +133,6 @@ public class Call extends ANY implements Comparable<Call>, Context
    *
    * @param cc called clazz
    *
-   * @param pre true if calling precondition
-   *
    * @param site the call site, -1 if unknown (from intrinsic or program entry
    * point)
    *
@@ -151,11 +143,10 @@ public class Call extends ANY implements Comparable<Call>, Context
    * @param context for debugging: Reason that causes this call to be part of
    * the analysis.
    */
-  public Call(DFA dfa, int cc, boolean pre, int site, Value target, List<Val> args, Env env, Context context)
+  public Call(DFA dfa, int cc, int site, Value target, List<Val> args, Env env, Context context)
   {
     _dfa = dfa;
     _cc = cc;
-    _pre = pre;
     _site = site;
     _target = target;
     _args = args;
@@ -163,15 +154,15 @@ public class Call extends ANY implements Comparable<Call>, Context
     _context = context;
     _instance = dfa.newInstance(cc, site, this);
 
-    if (!pre && dfa._fuir.clazzResultField(cc)==-1) /* <==> _fuir.isConstructor(cl) */
+    if (dfa._fuir.clazzResultField(cc)==-1) /* <==> _fuir.isConstructor(cl) */
       {
         /* a constructor call returns current as result, so it always escapes together with all outer references! */
-        dfa.escapes(cc, pre);
+        dfa.escapes(cc);
         var or = dfa._fuir.clazzOuterRef(cc);
         while (or != -1)
           {
             var orr = dfa._fuir.clazzResultClazz(or);
-            dfa.escapes(orr,false);
+            dfa.escapes(orr);
             or = dfa._fuir.clazzOuterRef(orr);
           }
       }
@@ -191,9 +182,7 @@ public class Call extends ANY implements Comparable<Call>, Context
       _cc   <   other._cc  ? -1 :
       _cc   >   other._cc  ? +1 :
       _site <   other._site? -1 :
-      _site >   other._site? +1 :
-      _pre  && !other._pre ? -1 :
-      !_pre &&  other._pre ? +1 : Value.compare(_target, other._target);
+      _site >   other._site? +1 : Value.compare(_target, other._target);
     for (var i = 0; r == 0 && i < _args.size(); i++)
       {
         r = Value.compare(      _args.get(i).value(),
@@ -281,11 +270,7 @@ public class Call extends ANY implements Comparable<Call>, Context
     else if (_returns)
       {
         var rf = _dfa._fuir.clazzResultField(_cc);
-        if (_pre)
-          {
-            result = Value.UNIT;
-          }
-        else if (rf == -1)
+        if (rf == -1)
           {
             result = _instance;
           }
@@ -312,8 +297,7 @@ public class Call extends ANY implements Comparable<Call>, Context
   public String toString()
   {
     var sb = new StringBuilder();
-    sb.append(_pre ? "precondition of " : "")
-      .append(_dfa._fuir.clazzAsString(_cc));
+    sb.append(_dfa._fuir.clazzAsString(_cc));
     if (_target != Value.UNIT)
       {
         sb.append(" target=")
@@ -351,7 +335,7 @@ public class Call extends ANY implements Comparable<Call>, Context
          Errors.effe(Env.envAsString(_env)) +
          " for call to "
        : "call ")+
-      Errors.sqn((_pre ? "precondition of " : "") + _dfa._fuir.clazzAsString(_cc)) +
+      Errors.sqn(_dfa._fuir.clazzAsString(_cc)) +
       (pos != null ? " at " + pos.pos().show() : "");
   }
 
@@ -476,11 +460,11 @@ public class Call extends ANY implements Comparable<Call>, Context
     if (!_escapes)
       {
         _escapes = true;
-        // we currently store for _cc/_pre, so we accumulate different call
+        // we currently store for _cc, so we accumulate different call
         // contexts to the same clazz. We might make this more detailed and
         // record this local to the call or use part of the call's context like
         // the target value to be more accurate.
-        _dfa.escapes(_cc, _pre);
+        _dfa.escapes(_cc);
       }
   }
 

--- a/src/dev/flang/fuir/analysis/dfa/DFA.java
+++ b/src/dev/flang/fuir/analysis/dfa/DFA.java
@@ -171,8 +171,6 @@ public class DFA extends ANY
      *
      * @param s site of the expression causing this assignment
      *
-     * @param pre true iff interpreting cl's precondition, false for cl itself.
-     *
      * @param tc clazz id of the target instance
      *
      * @param f clazz id of the assigned field
@@ -243,13 +241,8 @@ public class DFA extends ANY
     @Override
     public Pair<Val, Unit> call(int s, Val tvalue, List<Val> args)
     {
-      var ccP = _fuir.accessedPreconditionClazz(s);
       var cc0 = _fuir.accessedClazz            (s);
       Val res = Value.UNIT;
-      if (ccP != -1)
-        {
-          res = call0(s, tvalue, args, ccP, true, tvalue);
-        }
       if (res != null && !_fuir.callPreconditionOnly(s))
         {
           res = access(s, tvalue, args);
@@ -335,7 +328,7 @@ public class DFA extends ANY
       Val r;
       if (isCall)
         {
-          r = call0(s, tvalue, args, cc, false, original_tvalue);
+          r = call0(s, tvalue, args, cc, original_tvalue);
         }
       else
         {
@@ -357,7 +350,7 @@ public class DFA extends ANY
 
 
     /**
-     * Helper for call to handle non-dynamic call to cc (or cc's precondition)
+     * Helper for call to handle non-dynamic call to cc
      *
      * @param s site of call
      *
@@ -367,16 +360,14 @@ public class DFA extends ANY
      *
      * @param cc clazz that is called
      *
-     * @param preCalled true to call the precondition of cl instead of cl.
-     *
      * @return result values of the call
      */
-    Val call0(int s, Val tvalue, List<Val> args, int cc, boolean preCalled, Val original_tvalue)
+    Val call0(int s, Val tvalue, List<Val> args, int cc, Val original_tvalue)
     {
       // in case we access the value in a boxed target, unbox it first:
       tvalue = unboxTarget(tvalue, _fuir.accessTargetClazz(s), cc);
       Val res = null;
-      switch (preCalled ? FUIR.FeatureKind.Routine : _fuir.clazzKind(cc))
+      switch (_fuir.clazzKind(cc))
         {
         case Abstract :
           Errors.error("Call to abstract feature encountered.",
@@ -387,7 +378,7 @@ public class DFA extends ANY
           {
             if (_fuir.clazzNeedsCode(cc))
               {
-                var ca = newCall(cc, preCalled, s, tvalue.value(), args, _call._env, _call);
+                var ca = newCall(cc, s, tvalue.value(), args, _call._env, _call);
                 res = ca.result();
                 if (res != null && res != Value.UNIT && !_fuir.clazzIsRef(_fuir.clazzResultClazz(cc)))
                   {
@@ -396,10 +387,9 @@ public class DFA extends ANY
                 // check if target value of new call ca causes current _call's instance to escape.
                 var or = _fuir.clazzOuterRef(cc);
                 if (original_tvalue instanceof EmbeddedValue ev && ev._instance == _call._instance &&
-                    (ca._pre ? _escapesPre : _escapes).contains(ca._cc) &&
+                    _escapes.contains(ca._cc) &&
                     (or != -1) &&
-                    _fuir.clazzFieldIsAdrOfValue(or) &&   // outer ref is adr, otherwise target is passed by value (primitive type like u32)
-                    !_fuir.isPreconditionAt(s)            // NYI: BUG: #2695: precondition instance should never escape
+                    _fuir.clazzFieldIsAdrOfValue(or)    // outer ref is adr, otherwise target is passed by value (primitive type like u32)
                     )
                   {
                     _call.escapes();
@@ -539,11 +529,7 @@ public class DFA extends ANY
 
       // register calls for constant creation even though
       // not every backend actually performs these calls.
-      if (_fuir.hasPrecondition(constCl))
-        {
-          newCall(constCl, true, NO_SITE, _universe, args, null /* new environment */, context);
-        }
-      newCall(constCl, false, NO_SITE, _universe, args, null /* new environment */, context);
+      newCall(constCl, NO_SITE, _universe, args, null /* new environment */, context);
 
       return result;
     }
@@ -638,7 +624,7 @@ public class DFA extends ANY
 
           if (taken)
             {
-              var resv = ai.process(_fuir.matchCaseCode(s, mc));
+              var resv = ai.processCode(_fuir.matchCaseCode(s, mc));
               if (resv.v0() != null)
                 { // if at least one case returns (i.e., result is not null), this match returns.
                   r = Value.UNIT;
@@ -668,23 +654,6 @@ public class DFA extends ANY
     public Pair<Val, Unit> env(int s, int ecl)
     {
       return new Pair<>(_call.getEffectForce(s, ecl), _unit_);
-    }
-
-
-    /**
-     * Process a contract of kind ck of clazz cl that results in bool value cc
-     * (i.e., the contract fails if !cc).
-     */
-    @Override
-    public Unit contract(int s, FUIR.ContractKind ck, Val cc)
-    {
-      return _unit_;
-      /*
-      return Unit.iff(cc.field(_names.TAG_NAME).not(),
-                        Unit.seq(Value.fprintfstderr("*** failed " + ck + " on call to '%s'\n",
-                                                       Value.string(_fuir.clazzAsString(cl))),
-                                   Value.exit(1)));
-      */
     }
 
   }
@@ -949,20 +918,17 @@ public class DFA extends ANY
          *
          * @param cl a clazz id of any kind
          *
-         * @param pre true to analyse the instance created for cl's precondition,
-         * false to analyse the instance created for a call to cl
-         *
          * @return A conservative estimate of the lifespan of cl's instance.
          * Undefined if a call to cl does not create an instance, Call if it is
          * guaranteed that the instance is inaccessible after the call returned.
          */
-        public LifeTime lifeTime(int cl, boolean pre)
+        public LifeTime lifeTime(int cl)
         {
           return
-            pre || (clazzKind(cl) != FeatureKind.Routine)
-                ? super.lifeTime(cl, pre)
-                : currentEscapes(cl, pre) ? LifeTime.Unknown :
-                                            LifeTime.Call;
+            (clazzKind(cl) != FeatureKind.Routine)
+                ? super.lifeTime(cl)
+                : currentEscapes(cl) ? LifeTime.Unknown :
+                                       LifeTime.Call;
         }
 
 
@@ -972,14 +938,12 @@ public class DFA extends ANY
          *
          * @param cl a call's inner clazz
          *
-         * @param pre true iff precondition is called.
-         *
          * @return true iff the instance of the call must be allocated on the
          * heap.
          */
-        private boolean currentEscapes(int cl, boolean pre)
+        private boolean currentEscapes(int cl)
         {
-          return (pre ? _escapesPre : _escapes).contains(cl);
+          return _escapes.contains(cl);
         }
 
 
@@ -1053,19 +1017,7 @@ public class DFA extends ANY
   {
     var cl = _fuir.mainClazzId();
 
-    if (_fuir.hasPrecondition(cl))
-      {
-        newCall(cl,
-                true,
-                NO_SITE,
-                Value.UNIT,
-                new List<>(),
-                null /* env */,
-                Context._MAIN_ENTRY_POINT_);
-      }
-
     newCall(cl,
-            false,
             NO_SITE,
             Value.UNIT,
             new List<>(),
@@ -1173,7 +1125,7 @@ public class DFA extends ANY
    */
   void analyze(Call c)
   {
-    if (_fuir.clazzKind(c._cc) == FUIR.FeatureKind.Routine || c._pre)
+    if (_fuir.clazzKind(c._cc) == FUIR.FeatureKind.Routine)
       {
         var i = c._instance;
         check
@@ -1193,7 +1145,7 @@ public class DFA extends ANY
           }
 
         var ai = new AbstractInterpreter<Val,Unit>(_fuir, new Analyze(c));
-        var r = ai.process(c._cc, c._pre);
+        var r = ai.processClazz(c._cc);
         if (r.v0() != null)
           {
             c.returns();
@@ -1240,11 +1192,6 @@ public class DFA extends ANY
    */
   TreeSet<Integer> _escapes = new TreeSet<>();
 
-  /**
-   * Set of clazzes whose instance may escape the call to the clazz's
-   * precondition.
-   */
-  TreeSet<Integer> _escapesPre = new TreeSet<>();
 
   /**
    * Set of sites of calls whose result value may escape the caller's
@@ -1259,16 +1206,13 @@ public class DFA extends ANY
    * on the stack.
    *
    * @param cc the clazz to check
-   *
-   * @param pre true iff we need info on the precondition and not the routine
-   * cc.
    */
-  void escapes(int cc, boolean pre)
+  void escapes(int cc)
   {
-    var escapeSet = pre ? _escapesPre : _escapes;
+    var escapeSet = _escapes;
     if (escapeSet.add(cc))
       {
-        wasChanged(() -> "Escapes: " + (pre ? "precondition of " : "") + _fuir.clazzAsString(cc));
+        wasChanged(() -> "Escapes: " + _fuir.clazzAsString(cc));
       }
   }
 
@@ -1742,7 +1686,7 @@ public class DFA extends ANY
 
           // NYI: spawn0 needs to set up an environment representing the new
           // thread and perform thread-related checks (race-detection. etc.)!
-          var ncl = cl._dfa.newCall(call, false, NO_SITE, cl._args.get(0).value(), new List<>(), null /* new environment */, cl);
+          var ncl = cl._dfa.newCall(call, NO_SITE, cl._args.get(0).value(), new List<>(), null /* new environment */, cl);
           return new NumericValue(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc));
         });
     put("fuzion.sys.thread.join0"        , cl -> Value.UNIT);
@@ -1831,7 +1775,7 @@ public class DFA extends ANY
 
           var env = cl._env;
           var newEnv = cl._dfa.newEnv(cl, env, ecl, cl._target);
-          var ncl = cl._dfa.newCall(call, false, NO_SITE, cl._args.get(0).value(), new List<>(), newEnv, cl);
+          var ncl = cl._dfa.newCall(call, NO_SITE, cl._args.get(0).value(), new List<>(), newEnv, cl);
           // NYI: result must be null if result of ncl is null (ncl does not return) and effect.abort is not called
           return Value.UNIT;
         });
@@ -2137,8 +2081,6 @@ public class DFA extends ANY
    *
    * @param cl the called clazz
    *
-   * @param pre true iff precondition is called
-   *
    * @param site the call site, -1 if unknown (from intrinsic or program entry
    * point)
    *
@@ -2154,9 +2096,9 @@ public class DFA extends ANY
    * @return cl a new or existing call to cl (or its precondition) with the
    * given target, args and environment.
    */
-  Call newCall(int cl, boolean pre, int site, Value tvalue, List<Val> args, Env env, Context context)
+  Call newCall(int cl, int site, Value tvalue, List<Val> args, Env env, Context context)
   {
-    var r = new Call(this, cl, pre, site, tvalue, args, env, context);
+    var r = new Call(this, cl, site, tvalue, args, env, context);
     var e = _calls.get(r);
     if (e == null)
       {

--- a/src/dev/flang/fuir/analysis/dfa/DFA.java
+++ b/src/dev/flang/fuir/analysis/dfa/DFA.java
@@ -241,12 +241,8 @@ public class DFA extends ANY
     @Override
     public Pair<Val, Unit> call(int s, Val tvalue, List<Val> args)
     {
-      var cc0 = _fuir.accessedClazz            (s);
-      Val res = Value.UNIT;
-      if (res != null && !_fuir.callPreconditionOnly(s))
-        {
-          res = access(s, tvalue, args);
-        }
+      var cc0 = _fuir.accessedClazz(s);
+      var res = access(s, tvalue, args);
       DFA.this.site(s).recordResult(res == null);
       return new Pair<>(res, _unit_);
     }

--- a/src/dev/flang/fuir/analysis/dfa/DFA.java
+++ b/src/dev/flang/fuir/analysis/dfa/DFA.java
@@ -929,8 +929,7 @@ public class DFA extends ANY
 
 
         /**
-         * For a call to cl (or cl's precondition), does the instance of cl
-         * escape the call?
+         * For a call to cl, does the instance of cl escape the call?
          *
          * @param cl a call's inner clazz
          *
@@ -1197,9 +1196,8 @@ public class DFA extends ANY
 
 
   /**
-   * Record that the given clazz (or its precondition) escape the call to the
-   * routine (or precondition).  If it escapes. the instance cannot be allocated
-   * on the stack.
+   * Record that the given clazz escape the call to the routine.  If it
+   * does escape, the instance cannot be allocated on the stack.
    *
    * @param cc the clazz to check
    */
@@ -2089,8 +2087,8 @@ public class DFA extends ANY
    * @param context for debugging: Reason that causes this call to be part of
    * the analysis.
    *
-   * @return cl a new or existing call to cl (or its precondition) with the
-   * given target, args and environment.
+   * @return cl a new or existing call to cl with the given target, args and
+   * environment.
    */
   Call newCall(int cl, int site, Value tvalue, List<Val> args, Env env, Context context)
   {


### PR DESCRIPTION
Significant simplification of fuir, dfa and all the backends since contracts are pure syntax sugar now and do not need any backend support. 
