### PR TITLE
tests: In scripts for simple C tests, handle PIPE_FAIL (141)

### DIFF
--- a/tests/record_simple_example_c.sh
+++ b/tests/record_simple_example_c.sh
@@ -43,7 +43,7 @@ CURDIR=$("$SCRIPTPATH"/_cur_dir.sh)
 if [ -f "$2".skip ]; then
     echo "SKIPPED $2"
 else
-    ( (FUZION_DISABLE_ANSI_ESCAPES=true $1 -c "$2" -o=testbin && ./testbin) 2>"$2".expected_err_c | head -n 100) >"$2".expected_out_c || true # tail my result in 141
+    ( (FUZION_DISABLE_ANSI_ESCAPES=true $1 -c "$2" -o=testbin && ./testbin) 2>"$2".expected_err_c | head -n 100) >"$2".expected_out_c || true # tail may result in 141
     sed -i "s|${CURDIR//\\//}/|--CURDIR--/|g" "$2".expected_err_c
     rm -rf testbin
     echo "RECORDED $2"


### PR DESCRIPTION
Also compare 10000 lines, not just 100 of output.
