### PR TITLE
tests: portable nproc

### DIFF
--- a/.github/workflows/apple.yml
+++ b/.github/workflows/apple.yml
@@ -68,4 +68,4 @@ jobs:
         run: |
           export CPATH=/opt/homebrew/include
           export LIBRARY_PATH=/opt/homebrew/lib
-          make run_tests
+          make run_tests_parallel

--- a/.github/workflows/apple_c.yml
+++ b/.github/workflows/apple_c.yml
@@ -65,4 +65,4 @@ jobs:
         run: |
           export CPATH=/opt/homebrew/include
           export LIBRARY_PATH=/opt/homebrew/lib
-          make run_tests_c
+          make run_tests_c_parallel

--- a/.github/workflows/apple_int.yml
+++ b/.github/workflows/apple_int.yml
@@ -62,4 +62,4 @@ jobs:
         run: make no-java
 
       - name: run tests
-        run: make run_tests_int
+        run: make run_tests_int_parallel

--- a/.github/workflows/apple_jvm.yml
+++ b/.github/workflows/apple_jvm.yml
@@ -62,4 +62,4 @@ jobs:
         run: make no-java
 
       - name: run tests
-        run: make run_tests_jvm
+        run: make run_tests_jvm_parallel


### PR DESCRIPTION
also changed apple to workflows to use run_tests_parallel
