### PR TITLE
ast: On failure of a pre- / post-condition, show the full failing expression

### DIFF
--- a/src/dev/flang/ast/Contract.java
+++ b/src/dev/flang/ast/Contract.java
@@ -629,7 +629,7 @@ public class Contract extends ANY
     for (var c : dc)
       {
         var cond = c.cond;
-        var p = cond.pos();
+        var p = cond.sourceRange();
         if (preBool)
           {
             cc = cc == null ? cond
@@ -1035,7 +1035,7 @@ all of their redefinition to `true`. +
         var l = new List<Expr>();
         for (var c : fc._declared_postconditions)
           {
-            var p = c.cond.pos();
+            var p = c.cond.sourceRange();
             l.add(new If(p,
                          c.cond,
                          new Block(),

--- a/tests/contracts_negative/SquareRoot.fz.expected_err
+++ b/tests/contracts_negative/SquareRoot.fz.expected_err
@@ -1,5 +1,5 @@
 
-error 1: FATAL FAULT `precondition`: ≥
+error 1: FATAL FAULT `precondition`: a ≥ 0
 Call stack:
 fuzion.type.runtime.type.fault.type.install_default#0.#fun264.call#1: $MODULE/fuzion/runtime/fault.fz:38:18:
       fuzion.sys.fatal_fault kind msg
@@ -16,9 +16,9 @@ fuzion.runtime.pre_fault.cause#1: $MODULE/eff/fallible.fz:35:6:
 fuzion.runtime.precondition_fault#1: $MODULE/fuzion/runtime/pre_fault.fz:58:52:
 public precondition_fault(msg String) => pre_fault.cause msg
 ---------------------------------------------------^^^^^
-SquareRoot.#pre1_sqrt#1: --CURDIR--/SquareRoot.fz:30:9:
+SquareRoot.#pre1_sqrt#1: --CURDIR--/SquareRoot.fz:30:7:
       a ≥ 0
---------^^^
+------^^^^^^^
 SquareRoot.#preandcall2_sqrt#1: --CURDIR--/SquareRoot.fz:29:5:
     pre
 ----^^^

--- a/tests/contracts_negative/SquareRoot.fz.expected_err_c
+++ b/tests/contracts_negative/SquareRoot.fz.expected_err_c
@@ -1,1 +1,1 @@
-*** failed precondition: `≥`
+*** failed precondition: `a ≥ 0`

--- a/tests/contracts_negative/SquareRoot.fz.expected_err_jvm
+++ b/tests/contracts_negative/SquareRoot.fz.expected_err_jvm
@@ -1,5 +1,5 @@
 
-error 1: FATAL FAULT `precondition`: ≥
+error 1: FATAL FAULT `precondition`: a ≥ 0
 Call stack:
 fuzion__sys__2fatal_fault
 fuzion_INT__t__install_default__INTERN_fun264__1call


### PR DESCRIPTION
The expression shown was often reduced to something like `:` or `<`, now the whole expression is shown, unless that expression comes from a fum file that currently does not have the full information.
