### PR TITLE
lib: remove NYI for `(infix /).this.s`

### DIFF
--- a/lib/String.fz
+++ b/lib/String.fz
@@ -229,7 +229,7 @@ public String ref : property.equatable, property.hashable, property.orderable is
         parse_error "invalid integer digit for base $base"
       else
         hi0 := hi *? base;
-        # NYI: can not qualify call in lambda
+        # NYI: #3298 can not qualify call in lambda
         v := if (neg) hi0 -? t
               else     hi0 +? t
         match s

--- a/lib/int.fz
+++ b/lib/int.fz
@@ -86,9 +86,8 @@ is
   # divide this int by other
   public fixed redef infix /  (other int) int
   =>
-    # NYI: infix /.this.s not working
-    s0 := result_sign_mul_div other
-    int s0 n/other.n
+    s := result_sign_mul_div other
+    int (infix /).this.s n/other.n
 
 
   # modulo, returns the remainder of the


### PR DESCRIPTION
also added link to bug on another related NYI

