### PR TITLE
ast: Re-resolve Current if used as partial function, improve #3308

### DIFF
--- a/src/dev/flang/ast/AbstractCurrent.java
+++ b/src/dev/flang/ast/AbstractCurrent.java
@@ -88,10 +88,33 @@ public abstract class AbstractCurrent extends Expr
    *
    * @return this.
    */
-  public AbstractCurrent visit(FeatureVisitor v, AbstractFeature outer)
+  public Expr visit(FeatureVisitor v, AbstractFeature outer)
   {
     _type = _type.visit(v, outer);
-    return this;
+    return v.action(this, outer);
+  }
+
+
+  /**
+   * In case this Current() was moved to a new feature, e.g., since it was used
+   * in a lambda, a lazy argument or a partial call, the types will be resolved
+   * again for a new outer feature that will be an artificial feature added as
+   * an inner feature to the original outer feature.
+   *
+   * @param res the resolution instance
+   *
+   * @param the outer feature this should be resolved for
+   *
+   * @return this in case outer is what it was when this was created, or a new
+   * Expr `Current.outer_ref. .. .outer_ref` to access the same current instance
+   * from within a new, nested outer feature.
+   */
+  public Expr resolveTypes(Resolution res, AbstractFeature outer)
+  {
+    var of = _type.feature();
+    return of == Types.f_ERROR || of == outer
+      ? this
+      : new This(pos(), outer, of).resolveTypes(res, outer);
   }
 
 

--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -1851,7 +1851,7 @@ public class Call extends AbstractCall
       {
         if (frml instanceof Feature f)
           {
-            f.impl().addInitialCall(this, outer);
+            f.impl().addInitialCall(this);
           }
       }
   }
@@ -2168,6 +2168,20 @@ public class Call extends AbstractCall
 
 
   /**
+   * Has this call been resolved and if so, for which outer feature?
+   *
+   * @return the outer feature this has been resolved for or null if this has
+   * not been resolved yet.  Note that the result may change due to repeated
+   * resolution when this is moved to a different feature as a result of partial
+   * application, lazy evaluation or is part of a lamba expression.
+   */
+  public AbstractFeature resolvedFor()
+  {
+    return _resolvedFor;
+  }
+
+
+  /**
    * try resolving this call as dot-type-call
    *
    * On success _calledFeature and _target will be set.
@@ -2273,7 +2287,6 @@ public class Call extends AbstractCall
       {
         _generics = FormalGenerics.resolve(res, _generics, outer);
         _generics = _generics.map(g -> g.resolve(res, _calledFeature.outer()));
-
 
         propagateForPartial(res, outer);
         if (needsToInferTypeParametersFromArgs())

--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -2004,7 +2004,7 @@ public class Call extends AbstractCall
               {
                 if (p instanceof Call pc)
                   {
-                    pc.resolveTypes(res, outer);
+                    pc.resolveTypes(res, aft);
                   }
                 var pt = p.type();
                 if (pt != Types.t_ERROR)

--- a/src/dev/flang/ast/Feature.java
+++ b/src/dev/flang/ast/Feature.java
@@ -1370,19 +1370,20 @@ public class Feature extends AbstractFeature
       {
         res = r;
       }
-    public void         action      (AbstractAssign a, AbstractFeature outer) {        a.resolveTypes   (res,   outer); }
-    public void         actionBefore(Call           c, AbstractFeature outer) {        c.tryResolveTypeCall(res,   outer); }
-    public Call         action      (Call           c, AbstractFeature outer) { return c.resolveTypes   (res,   outer); }
-    public Expr         action      (DotType        d, AbstractFeature outer) { return d.resolveTypes   (res,   outer); }
-    public Expr         action      (Destructure    d, AbstractFeature outer) { return d.resolveTypes   (res,   outer); }
-    public Expr         action      (Feature        f, AbstractFeature outer) { /* use f.outer() since qualified feature name may result in different outer! */
-                                                                                return f.resolveTypes   (res, f.outer() ); }
-    public Function     action      (Function       f, AbstractFeature outer) {        f.resolveTypes   (res,   outer); return f; }
-    public void         action      (Match          m, AbstractFeature outer) {        m.resolveTypes   (res,   outer); }
-    public Expr         action      (This           t, AbstractFeature outer) { return t.resolveTypes   (res,   outer); }
-    public AbstractType action      (AbstractType   t, AbstractFeature outer) { return t.resolve        (res,   outer); }
+    @Override public void         action      (AbstractAssign  a, AbstractFeature outer) {        a.resolveTypes   (res,   outer); }
+    @Override public void         actionBefore(Call            c, AbstractFeature outer) {        c.tryResolveTypeCall(res,   outer); }
+    @Override public Call         action      (Call            c, AbstractFeature outer) { return c.resolveTypes   (res,   outer); }
+    @Override public Expr         action      (DotType         d, AbstractFeature outer) { return d.resolveTypes   (res,   outer); }
+    @Override public Expr         action      (Destructure     d, AbstractFeature outer) { return d.resolveTypes   (res,   outer); }
+    @Override public Expr         action      (Feature         f, AbstractFeature outer) { /* use f.outer() since qualified feature name may result in different outer! */
+                                                                                           return f.resolveTypes   (res, f.outer() ); }
+    @Override public Function     action      (Function        f, AbstractFeature outer) {        f.resolveTypes   (res,   outer); return f; }
+    @Override public void         action      (Match           m, AbstractFeature outer) {        m.resolveTypes   (res,   outer); }
+    @Override public Expr         action      (This            t, AbstractFeature outer) { return t.resolveTypes   (res,   outer); }
+    @Override public AbstractType action      (AbstractType    t, AbstractFeature outer) { return t.resolve        (res,   outer); }
+    @Override public Expr         action      (AbstractCurrent c, AbstractFeature outer) { return c.resolveTypes(res, outer); }
 
-    public boolean doVisitActuals() { return false; }
+    @Override public boolean doVisitActuals() { return false; }
   }
 
 

--- a/src/dev/flang/ast/FeatureVisitor.java
+++ b/src/dev/flang/ast/FeatureVisitor.java
@@ -65,6 +65,7 @@ public abstract class FeatureVisitor extends ANY
   public void         actionBefore(AbstractCase     c                       ) { }
   public void         actionAfter (AbstractCase     c                       ) { }
   public void         action      (Cond             c, AbstractFeature outer) { }
+  public Expr         action      (AbstractCurrent  c, AbstractFeature outer) { return c; }
   public Expr         action      (Destructure      d, AbstractFeature outer) { return d; }
   public Expr         action      (Feature          f, AbstractFeature outer) { return f; }
   public Expr         action      (Function         f, AbstractFeature outer) { return f; }

--- a/src/dev/flang/ast/Impl.java
+++ b/src/dev/flang/ast/Impl.java
@@ -92,13 +92,6 @@ public class Impl extends ANY
   final List<Call> _initialCalls;
 
 
-  /**
-   * For FieldActual: The outer features for all the actual calls that were
-   * found for this argument field.
-   */
-  private final List<AbstractFeature> _outerOfInitialCalls;
-
-
   public enum Kind
   {
     FieldInit,    // a field with initialization syntactic sugar
@@ -165,8 +158,7 @@ public class Impl extends ANY
     this._expr = e;
     this.pos = pos;
     this._kind = kind;
-    this._initialCalls         = kind == Kind.FieldActual ? new List<>() : null;
-    this._outerOfInitialCalls  = kind == Kind.FieldActual ? new List<>() : null;
+    this._initialCalls = kind == Kind.FieldActual ? new List<>() : null;
   }
 
 
@@ -467,18 +459,22 @@ public class Impl extends ANY
 
   /**
    * For an actual value passed to an argument field with this Impl, record the
-   * actual and its outer feature for type inference
+   * actual call for type inference for argument types. This is used for code like
+   *
+   *   f(a,b) => a+b
+   *
+   *   x := f 3 4
+   *
+   * where the argument types for `a` and `b` are inferred from the actual
+   * arguments `3` and `4`.
    *
    * @param call an actual argument expression
-   *
-   * @param outer the feature containing the actl expression
    */
-  void addInitialCall(Call call, AbstractFeature outer)
+  void addInitialCall(Call call)
   {
     if (_kind == Impl.Kind.FieldActual)
       {
         _initialCalls.add(call);
-        _outerOfInitialCalls.add(outer);
       }
   }
 
@@ -496,8 +492,7 @@ public class Impl extends ANY
   private Expr initialValueFromCall(int i, Resolution res)
   {
     Expr result = null;
-    var ic = _initialCalls       .get(i);
-    var io = _outerOfInitialCalls.get(i);
+    var ic = _initialCalls.get(i);
     var aargs = ic._actuals.listIterator();
     for (var frml : ic.calledFeature().valueArguments())
       {
@@ -509,7 +504,7 @@ public class Impl extends ANY
                 if (res != null && !_infiniteRecursionInResolveTypes)
                   {
                     _infiniteRecursionInResolveTypes = true;
-                    actl = actl.visit(res.resolveTypesFully, io);
+                    actl = actl.visit(res.resolveTypesFully, ic.resolvedFor());
                     aargs.set(actl);
                     _infiniteRecursionInResolveTypes = false;
                   }
@@ -566,7 +561,6 @@ public class Impl extends ANY
             for (var i = 0; i < _initialCalls.size(); i++)
               {
                 var iv = initialValueFromCall(i, null);
-                var io = _outerOfInitialCalls.get(i);
                 var t = iv.typeForInferencing();
                 if (t != null)
                   {

--- a/tests/reg_issue3308/Makefile
+++ b/tests/reg_issue3308/Makefile
@@ -1,0 +1,25 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test Makefile
+#
+# -----------------------------------------------------------------------
+
+override NAME = reg_issue3308
+include ../simple.mk

--- a/tests/reg_issue3308/reg_issue3308.fz
+++ b/tests/reg_issue3308/reg_issue3308.fz
@@ -1,0 +1,48 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test
+#
+# -----------------------------------------------------------------------
+
+# Test partial application that refers to `a.this`
+#
+reg_issue3308 is
+
+  f(x ()->unit) =>
+
+  t is
+    a is
+
+      # first, a.this is part of the target of the partial call
+      q =>
+      say (f a.this.q)
+
+      # second, a.this is part of the arguments of the partial call
+      r(x _) =>
+      say (f (r a.this))
+
+      # third, a.this is part of the arguments of the partial call and
+      # boxed to Any
+      s(x Any) =>
+      # NYI: this still crashes `fz`:
+      #
+      # say (f (s a.this))
+
+  _ := t.a

--- a/tests/reg_issue3308/reg_issue3308.fz.expected_out
+++ b/tests/reg_issue3308/reg_issue3308.fz.expected_out
@@ -1,0 +1,2 @@
+unit
+unit


### PR DESCRIPTION
A `Current` that was created for `a.this` before partial application moved the code into a new artifical feature would return the wrong instance, so we need to resolve it again.

Note that the second commit which changes the `outer` argument in call to `p.resolveType` from `outer` to `aft` is actually another bug fix that happened to be necessary to get the test to run: the outer feature in an inherits call must be the inheriting feature, not some random feature that happens to use the type of the inheriting feature in as an argument type.

Also note that the fourth commit fixes an issue with formal argument types inferred from actual argument values since the original code might use the wrong (original) outer class for resolving the actual arguments. 

This still contains an commented-out test case that I have to check if it is part of #3308 or a different bug. Until this is understood, I would not close #3308.