### PR TITLE
ast/tests: Repeat type resolution for arguments in lambda to fix #3315 and fix #3308

### DIFF
--- a/src/dev/flang/air/Clazz.java
+++ b/src/dev/flang/air/Clazz.java
@@ -980,7 +980,9 @@ public class Clazz extends ANY implements Comparable<Clazz>
 
     if (Clazzes.isCalledDynamically(f) &&
         isRef() &&
-        isInstantiated())
+        isInstantiated() &&
+        (/* on a routine, we can only call the outer ref: */
+         feature().isConstructor() || feature().isChoice() || f.isOuterRef()))
       {
         for (var ft : Clazzes.calledDynamicallyWithTypePars(f))
           {

--- a/src/dev/flang/air/Clazz.java
+++ b/src/dev/flang/air/Clazz.java
@@ -980,9 +980,7 @@ public class Clazz extends ANY implements Comparable<Clazz>
 
     if (Clazzes.isCalledDynamically(f) &&
         isRef() &&
-        isInstantiated() &&
-        (/* on a routine, we can only call the outer ref: */
-         feature().isConstructor() || feature().isChoice() || f.isOuterRef()))
+        isInstantiated())
       {
         for (var ft : Clazzes.calledDynamicallyWithTypePars(f))
           {

--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -917,7 +917,7 @@ public class Call extends AbstractCall
    * change its outer feature and resolution of actuals will have to be
    * repeated.
    */
-  private AbstractFeature _actualsResolvedFor;
+  protected AbstractFeature _actualsResolvedFor;
 
 
   /**

--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -998,7 +998,6 @@ public class Call extends AbstractCall
           {
             _calledFeature = foa._feature;
             _resolvedFormalArgumentTypes = null;
-            _actualsResolvedFor = null;
             _pendingError = null;
             var newActuals = new List<>(_target);
             newActuals.addAll(_actuals);
@@ -2252,7 +2251,6 @@ public class Call extends AbstractCall
                   // we found a feature that fits a dot-type-call.
                   _calledFeature = f;
                   _resolvedFormalArgumentTypes = null;
-                  _actualsResolvedFor = null;
                   _target = new DotType(_pos, _target.asParsedType()).resolveTypes(res, thiz);
                 }
             }

--- a/src/dev/flang/ast/Destructure.java
+++ b/src/dev/flang/ast/Destructure.java
@@ -268,10 +268,7 @@ public class Destructure extends ExprWithPos
                                   FuzionConstants.DESTRUCTURE_PREFIX + id++,
                                   outer);
         tmp.scheduleForResolution(res);
-        exprs.add(tmp.resolveTypes(res, outer));
-        Assign atmp = new Assign(res, pos(), tmp, _value, outer);
-        atmp.resolveTypes(res, outer);
-        exprs.add(atmp);
+        exprs.add(new Assign(res, pos(), tmp, _value, outer));
         var names = _names.iterator();
         var fields = _fields.iterator();
         List<String> fieldNames = new List<>();

--- a/src/dev/flang/ast/Feature.java
+++ b/src/dev/flang/ast/Feature.java
@@ -2077,9 +2077,7 @@ A ((Choice)) declaration must not contain a result type.
                 }
               };
             ass = ass.visit(res._resolveSyntaxSugar1, outer);
-            result = new Block
-              (new List<>
-               (this, ass));
+            result = new Block(new List<>(this, ass));
           }
       }
     return result;

--- a/src/dev/flang/ast/Feature.java
+++ b/src/dev/flang/ast/Feature.java
@@ -1375,8 +1375,6 @@ public class Feature extends AbstractFeature
     @Override public Call         action      (Call            c, AbstractFeature outer) { return c.resolveTypes   (res,   outer); }
     @Override public Expr         action      (DotType         d, AbstractFeature outer) { return d.resolveTypes   (res,   outer); }
     @Override public Expr         action      (Destructure     d, AbstractFeature outer) { return d.resolveTypes   (res,   outer); }
-    @Override public Expr         action      (Feature         f, AbstractFeature outer) { /* use f.outer() since qualified feature name may result in different outer! */
-                                                                                           return f.resolveTypes   (res, f.outer() ); }
     @Override public Function     action      (Function        f, AbstractFeature outer) {        f.resolveTypes   (res,   outer); return f; }
     @Override public void         action      (Match           m, AbstractFeature outer) {        m.resolveTypes   (res,   outer); }
     @Override public Expr         action      (This            t, AbstractFeature outer) { return t.resolveTypes   (res,   outer); }
@@ -1490,10 +1488,7 @@ public class Feature extends AbstractFeature
           {
             typeFeature(res);
           }
-        visit(new FeatureVisitor()
-          {
-            public Expr action(Call c, AbstractFeature outer) { return c.resolveSyntacticSugar(res, outer); }
-          });
+        visit(res._resolveSyntaxSugar1);
 
         _state = State.RESOLVED_SUGAR1;
         res.scheduleForTypeInference(this);
@@ -2015,62 +2010,77 @@ A ((Choice)) declaration must not contain a result type.
 
 
   /**
-   * determine the static type of all expressions and declared features in this feature
+   * resolve syntactic sugar of feature declaration, i.e., add assignment for the
+   * initial value of fields.
    *
-   * @param res this is called during type resolution, res gives the resolution
-   * instance.
+   * @param res the resolution instance.
    *
-   * @param outer the root feature that contains this expression.
+   * @param outer the root feature that contains this feature declaration.
    */
-  public Expr resolveTypes(Resolution res, AbstractFeature outer)
+  public Expr resolveSyntacticSugar1(Resolution res, AbstractFeature outer)
   {
     if (PRECONDITIONS) require
       (res != null,
+       outer.state() == State.RESOLVING_SUGAR1,
        isUniverse() || outer != null || Errors.any());
 
     Expr result = this;
 
     if (CHECKS) check
-      (this.outer() == outer,
-        Errors.any() ||
-        (_impl._kind != Impl.Kind.FieldDef    &&
-         _impl._kind != Impl.Kind.FieldActual)
-        || _returnType == NoType.INSTANCE);
+      (Errors.any() ||
+       (_impl._kind != Impl.Kind.FieldDef    &&
+        _impl._kind != Impl.Kind.FieldActual)
+       || _returnType == NoType.INSTANCE);
 
     if (_impl.hasInitialValue())
       {
-        /* add assignment of initial value: */
-        result = new Block
-          (new List<>
-           (this,
-            new Assign(res, _pos, this, _impl.expr(), outer)
-            {
-              public AbstractAssign visit(FeatureVisitor v, AbstractFeature outer)
+        // outer() != outer may be the case for fields declared in types
+        //
+        //   type.f := x
+        //
+        // or for qualified declarations
+        //
+        //   String.new_field := 3
+        //
+        // which should have caused errors already.
+        if (CHECKS) check
+          (Errors.any() || this.outer() == outer);
+
+        if (this.outer() == outer)
+          {
+            /* add assignment of initial value: */
+            AbstractAssign ass = new Assign(res, _pos, this, _impl.expr(), outer)
               {
-                /* During findFieldDefInScope, we check field uses in impl, but
-                 * we have to avoid doing this again in this assignment since a declaration
-                 *
-                 *   x := 3
-                 *   x := x + 1
-                 *
-                 * is converted into
-                 *
-                 *   Feature x with impl kind FieldDef, initialvalue 3
-                 *   x := 3
-                 *   Feature x with impl kind FieldDef, initialvalue x + 1
-                 *   x := x + 1
-                 *
-                 * so the second assignment would find the second x, which is
-                 * wrong.
-                 *
-                 * Alternatively, we could add this assignment in a later phase.
-                 */
-                return v.visitAssignFromFieldImpl()
-                  ? super.visit(v, outer)
-                  : this;
-              }
-            }
-            ));
+                public AbstractAssign visit(FeatureVisitor v, AbstractFeature outer)
+                {
+                  /* During findFieldDefInScope, we check field uses in impl, but
+                   * we have to avoid doing this again in this assignment since a declaration
+                   *
+                   *   x := 3
+                   *   x := x + 1
+                   *
+                   * is converted into
+                   *
+                   *   Feature x with impl kind FieldDef, initialvalue 3
+                   *   x := 3
+                   *   Feature x with impl kind FieldDef, initialvalue x + 1
+                   *   x := x + 1
+                   *
+                   * so the second assignment would find the second x, which is
+                   * wrong.
+                   *
+                   * Alternatively, we could add this assignment in a later phase.
+                   */
+                  return v.visitAssignFromFieldImpl()
+                    ? super.visit(v, outer)
+                    : this;
+                }
+              };
+            ass = ass.visit(res._resolveSyntaxSugar1, outer);
+            result = new Block
+              (new List<>
+               (this, ass));
+          }
       }
     return result;
   }

--- a/src/dev/flang/ast/Function.java
+++ b/src/dev/flang/ast/Function.java
@@ -304,7 +304,7 @@ public class Function extends AbstractLambda
             var inheritsName =
               (t.feature() == Types.resolved.f_Unary && gs.size() == 2) ? Types.UNARY_NAME :
               (t.feature() == Types.resolved.f_Lazy  && gs.size() == 1) ? Types.LAZY_NAME
-                                                                              : Types.FUNCTION_NAME;
+                                                                        : Types.FUNCTION_NAME;
 
             // inherits clause for wrapper feature: Function<R,A,B,C,...>
             _inheritsCall = new Call(pos(), null, inheritsName);

--- a/src/dev/flang/ast/Function.java
+++ b/src/dev/flang/ast/Function.java
@@ -323,7 +323,6 @@ public class Function extends AbstractLambda
             res._module.findDeclarations(_wrapper, outer);
             res.resolveDeclarations(_wrapper);
             res.resolveTypes(_feature);
-            var ignore = _feature.typeFeature(res);  // NYI: type feature is required for `tests/reg_issue3308`, check why this is the case
             if (inferResultType)
               {
                 result = _feature.resultType();

--- a/src/dev/flang/ast/Function.java
+++ b/src/dev/flang/ast/Function.java
@@ -321,10 +321,11 @@ public class Function extends AbstractLambda
                                    Contract.EMPTY_CONTRACT,
                                    new Impl(pos(), new Block(expressions), Impl.Kind.Routine));
             res._module.findDeclarations(_wrapper, outer);
+            res.resolveDeclarations(_wrapper);
+            res.resolveTypes(_feature);
+            var ignore = _feature.typeFeature(res);  // NYI: type feature is required for `tests/reg_issue3308`, check why this is the case
             if (inferResultType)
               {
-                res.resolveDeclarations(_wrapper);
-                res.resolveTypes(_feature);
                 result = _feature.resultType();
                 _inheritsCall._generics = gs.setOrClone(0, result);
               }

--- a/src/dev/flang/ast/ParsedCall.java
+++ b/src/dev/flang/ast/ParsedCall.java
@@ -283,6 +283,7 @@ public class ParsedCall extends Call
                             new Block(new List<Expr>(as, t1)));
             _actuals = new List<Expr>(result);
             _calledFeature = Types.resolved.f_bool_AND;
+            _resolvedFormalArgumentTypes  = null;
             _pendingError = null;
             _name = _calledFeature.featureName().baseName();
           }
@@ -502,6 +503,8 @@ public class ParsedCall extends Call
           {
             _name = nn;
             _calledFeature = null;
+            _resolvedFormalArgumentTypes  = null;
+            _actualsResolvedFor = null;
             _pendingError = null;
           }
         var fn = new Function(pos(),

--- a/src/dev/flang/ast/ParsedCall.java
+++ b/src/dev/flang/ast/ParsedCall.java
@@ -283,7 +283,7 @@ public class ParsedCall extends Call
                             new Block(new List<Expr>(as, t1)));
             _actuals = new List<Expr>(result);
             _calledFeature = Types.resolved.f_bool_AND;
-            _resolvedFormalArgumentTypes  = null;
+            _resolvedFormalArgumentTypes  = null;  // _calledFeature changed, so formal arg types must be resolved again
             _pendingError = null;
             _name = _calledFeature.featureName().baseName();
           }
@@ -503,10 +503,9 @@ public class ParsedCall extends Call
           {
             _name = nn;
             _calledFeature = null;
-            _resolvedFormalArgumentTypes  = null;
-            _actualsResolvedFor = null;
-            _pendingError = null;
           }
+        _resolvedFormalArgumentTypes  = null;
+        _pendingError = null;
         var fn = new Function(pos(),
                               pns,
                               this)

--- a/src/dev/flang/ast/Resolution.java
+++ b/src/dev/flang/ast/Resolution.java
@@ -152,6 +152,18 @@ public class Resolution extends ANY
   FeatureVisitor resolveTypesFully = new Feature.ResolveTypes(this);
 
 
+  /**
+   * FeatureVisitor to call resolveSyntacticSugar1() on Calls and Features.
+   *
+   * This is used during state RESOLVING_SUGAR1
+   */
+  FeatureVisitor _resolveSyntaxSugar1 = new FeatureVisitor()
+    {
+      public Expr action(Feature f, AbstractFeature outer) { return f.resolveSyntacticSugar1(Resolution.this, outer); }
+      public Expr action(Call    c, AbstractFeature outer) { return c.resolveSyntacticSugar1(Resolution.this, outer); }
+    };
+
+
   final FuzionOptions _options;
 
 

--- a/tests/reg_issue3308/reg_issue3308.fz
+++ b/tests/reg_issue3308/reg_issue3308.fz
@@ -39,10 +39,12 @@ reg_issue3308 is
       say (f (r a.this))
 
       # third, a.this is part of the arguments of the partial call and
-      # boxed to Any
+      # boxed to Any, see #3315
       s(x Any) =>
-      # NYI: this still crashes `fz`:
-      #
-      # say (f (s a.this))
+      say (f (s a.this))
+
+      # fouth, an even simpler version of #3315
+      t(_ unit) =>
+      _ := f (t unit)
 
   _ := t.a

--- a/tests/reg_issue3308/reg_issue3308.fz
+++ b/tests/reg_issue3308/reg_issue3308.fz
@@ -26,6 +26,7 @@
 reg_issue3308 is
 
   f(x ()->unit) =>
+  g(x ()->unit) => _ := x.call
 
   t is
     a is
@@ -47,4 +48,35 @@ reg_issue3308 is
       t(_ unit) =>
       _ := f (t unit)
 
+      # fifth: access outer ref in partial application and call `as_string`
+      redef as_string => "--a--"
+      u(x Any) => say x
+      say (g (u a.this))
+
+    # same thing using a function `b` instead of a constructor `a`:
+    b =>
+
+      # first, b.this is part of the target of the partial call
+      q =>
+      say (f b.this.q)
+
+      # second, b.this is part of the arguments of the partial call
+      r(x _) =>
+      say (f (r b.this))
+
+      # third, b.this is part of the arguments of the partial call and
+      # boxed to Any, see #3315
+      s(x Any) =>
+      say (f (s b.this))
+
+      # fouth, an even simpler version of #3315
+      t(_ unit) =>
+      _ := f (t unit)
+
+      # fifth: access outer ref in partial application and call `as_string`
+      redef as_string => "--b--"
+      u(x Any) => say x
+      # say (g (u b.this))       -- NYI: BUG #3324: does not work yet!
+
   _ := t.a
+  _ := t.b

--- a/tests/reg_issue3308/reg_issue3308.fz.expected_out
+++ b/tests/reg_issue3308/reg_issue3308.fz.expected_out
@@ -1,2 +1,3 @@
 unit
 unit
+unit

--- a/tests/reg_issue3308/reg_issue3308.fz.expected_out
+++ b/tests/reg_issue3308/reg_issue3308.fz.expected_out
@@ -1,3 +1,8 @@
 unit
 unit
 unit
+--a--
+unit
+unit
+unit
+unit


### PR DESCRIPTION
The type resolution has top be repeated for actual arguments in a lambda, lazy or partial call since the outer feature has changed. 

For this to work, the code that assigns the initial value to a field must be created later, i.e, not during `resolveTypes` but in phase `syntaxSugar1`. 

The issue from #3315 is no longer commented out in tests/reg_issue3308 and an even simpler example was added as well. This PR also adds new test cases with outer feature being a function and not a constructor. This includes a commented-out version of the example in #3324, which does not work yet. 
