### PR TITLE
lib: move `infix ∈` and `infix ∉` to `property.equatable`

### DIFF
--- a/lib/String.fz
+++ b/lib/String.fz
@@ -666,18 +666,6 @@ public String ref : property.equatable, property.hashable, property.orderable is
     p*l + String.this + p*r
 
 
-  # is this part of given set
-  #
-  element_of(s container.Set String) => s.contains String.this
-  public infix ∈ (s container.Set String) => String.this.element_of s
-
-
-  # is this not part of given set
-  #
-  not_element_of(s container.Set String) => !element_of s
-  public infix ∉ (s container.Set String) => String.this.not_element_of s
-
-
   # return string of at least length l by
   # padding codepoint s to start of string
   #

--- a/lib/numeric.fz
+++ b/lib/numeric.fz
@@ -190,22 +190,6 @@ module:public numeric : property.hashable, property.orderable is
     while numeric.this / b ≥ bs
 
 
-  # is this part of given set
-  #
-  # NYI: infix operators currently always use dynamic binding on the lhs and pass
-  # the rhs as an argument.  If we would support an 'rinfix ∈' that would use the
-  # rhs for dynamic binding and the lhs as argument, we could define '∈' in Set T
-  # and it would work for all set types.
-  #
-  public element_of(s container.Set numeric.this) => s.contains numeric.this
-  public infix ∈ (s container.Set numeric.this) => numeric.this.element_of s
-
-  # is this not part of given set
-  #
-  public not_element_of(s container.Set numeric.this) => !element_of s
-  public infix ∉ (s container.Set numeric.this) => numeric.this.not_element_of s
-
-
   # -----------------------------------------------------------------------
   #
   # type features:

--- a/lib/property/equatable.fz
+++ b/lib/property/equatable.fz
@@ -50,3 +50,25 @@ public equatable is
   # is this not part of given set
   #
   not_element_of(s container.Set equatable.this) => !(equatable.this.element_of s)
+
+
+  # is `this` contained in `Set` `s`?
+  #
+  # This should usually be called using type inference as in
+  #
+  #   my_set := set_of ["A","B","C"]
+  #   say ("B" ∈ my_set)
+  #   say ("D" ∈ my_set)
+  #
+  public infix ∈ (s container.Set equatable.this) => element_of s
+
+
+  # is `this` not contained in `Set` `s`?
+  #
+  # This should usually be called using type inference as in
+  #
+  #   my_set := set_of ["A","B","C"]
+  #   say ("B" ∉ my_set)
+  #   say ("D" ∉ my_set)
+  #
+  public infix ∉ (s container.Set  equatable.this) => not_element_of s

--- a/lib/property/equatable.fz
+++ b/lib/property/equatable.fz
@@ -40,3 +40,13 @@ public equatable is
   # as 'b'.
   #
   public type.equality(a, b equatable.this) bool => abstract
+
+
+  # is this part of given set
+  #
+  element_of(s container.Set equatable.this) => s.contains equatable.this
+
+
+  # is this not part of given set
+  #
+  not_element_of(s container.Set equatable.this) => !(equatable.this.element_of s)

--- a/lib/universe.fz
+++ b/lib/universe.fz
@@ -31,25 +31,3 @@
 #
 # `universe.this.say "hello"`
 #
-
-
-# is `e` contained in `Set` `s`?
-#
-# This should usually be called using type inference as in
-#
-#   my_set := set_of ["A","B","C"]
-#   say ("B" ∈ my_set)
-#   say ("D" ∈ my_set)
-#
-public infix ∈ (T type : property.equatable, e T, s container.Set T) => s.contains e
-
-
-# is `e` not contained in `Set` `s`?
-#
-# This should usually be called using type inference as in
-#
-#   my_set := set_of ["A","B","C"]
-#   say ("B" ∉ my_set)
-#   say ("D" ∉ my_set)
-#
-public infix ∉ (T type : property.equatable, e T, s container.Set T) => !(e ∈ s)

--- a/lib/universe.fz
+++ b/lib/universe.fz
@@ -31,3 +31,25 @@
 #
 # `universe.this.say "hello"`
 #
+
+
+# is `e` contained in `Set` `s`?
+#
+# This should usually be called using type inference as in
+#
+#   my_set := set_of ["A","B","C"]
+#   say ("B" ∈ my_set)
+#   say ("D" ∈ my_set)
+#
+public infix ∈ (T type : property.equatable, e T, s container.Set T) => s.contains e
+
+
+# is `e` not contained in `Set` `s`?
+#
+# This should usually be called using type inference as in
+#
+#   my_set := set_of ["A","B","C"]
+#   say ("B" ∉ my_set)
+#   say ("D" ∉ my_set)
+#
+public infix ∉ (T type : property.equatable, e T, s container.Set T) => !(e ∈ s)


### PR DESCRIPTION
Also move `element_of` and `not_element_of` from `String` and `numeric` to `property.equatable`.  This results in `a ∈ s` and `a ∉ s` to work for all `equatable` types, which is required for a `Set` anyway.

