### PR TITLE
ast/tests: Do not turn ambiguous type into a free type, fix #3337

### DIFF
--- a/src/dev/flang/ast/SrcModule.java
+++ b/src/dev/flang/ast/SrcModule.java
@@ -72,7 +72,12 @@ public interface SrcModule
   List<FeatureAndOuter> lookup(AbstractFeature thiz, String name, Expr use, boolean traverseOuter, boolean hidden);
   AbstractFeature lookupOpenTypeParameterResult(AbstractFeature outer, Expr use);
   void checkTypes(Feature f);
-  FeatureAndOuter lookupType(SourcePosition pos, AbstractFeature outer, String name, boolean traverseOuter, boolean ignoreNotFound);
+  FeatureAndOuter lookupType(SourcePosition pos,
+                             AbstractFeature outer,
+                             String name,
+                             boolean traverseOuter,
+                             boolean ignoreAmbiguous,
+                             boolean ignoreNotFound);
 
   void addTypeFeature(AbstractFeature outerType,
                       Feature         innerType);

--- a/src/dev/flang/ast/UnresolvedType.java
+++ b/src/dev/flang/ast/UnresolvedType.java
@@ -573,13 +573,17 @@ public abstract class UnresolvedType extends AbstractType implements HasSourcePo
         if (_resolved == null)
           {
             var traverseOuter = ot == null && _name != FuzionConstants.TYPE_FEATURE_THIS_TYPE;
-            var fo = res._module.lookupType(pos(), of, _name, traverseOuter, mayBeFreeType || inTypeFeature);
+            var fo = res._module.lookupType(pos(), of, _name, traverseOuter,
+                                            false                           /* ignore ambiguos */,
+                                            mayBeFreeType || inTypeFeature  /* ignore not found */);
             if (_resolved == null && (fo == null || !fo._feature.isTypeParameter() && inTypeFeature))
               { // if we are in a type feature, type lookup happens in the
                 // original feature, except for type parameters that we just
                 // checked in the type feature (of).
                 of = originalOuterFeature(of);
-                fo = res._module.lookupType(pos(), of, _name, traverseOuter, mayBeFreeType);
+                fo = res._module.lookupType(pos(), of, _name, traverseOuter,
+                                            false          /* ignore ambiguos */,
+                                            mayBeFreeType  /* ignore not found */);
               }
             if (_resolved == null)
               {
@@ -682,13 +686,17 @@ public abstract class UnresolvedType extends AbstractType implements HasSourcePo
         if (_resolved == null)
           {
             var traverseOuter = ot == null && _name != FuzionConstants.TYPE_FEATURE_THIS_TYPE;
-            var fo = res._module.lookupType(pos(), of, _name, traverseOuter, true);
+            var fo = res._module.lookupType(pos(), of, _name, traverseOuter,
+                                            true /* ignore ambigous */ ,
+                                            true /* ignore not found */);
             if (_resolved == null && (fo == null || !fo._feature.isTypeParameter() && inTypeFeature))
               { // if we are in a type feature, type lookup happens in the
                 // original feature, except for type parameters that we just
                 // checked in the type feature (of).
                 of = originalOuterFeature(of);
-                fo = res._module.lookupType(pos(), of, _name, traverseOuter, true);
+                fo = res._module.lookupType(pos(), of, _name, traverseOuter,
+                                            true /* ignore ambigous */ ,
+                                            true /* ignore not found */);
               }
             if (_resolved == null)
               {

--- a/src/dev/flang/fe/SourceModule.java
+++ b/src/dev/flang/fe/SourceModule.java
@@ -256,7 +256,10 @@ public class SourceModule extends Module implements SrcModule, MirModule
         new Types.Resolved(this,
                            (name) ->
                              {
-                               return lookupType(SourcePosition.builtIn, _universe, name, false, false)
+                               return lookupType(SourcePosition.builtIn, _universe, name,
+                                                 false /* traverse outer   */,
+                                                 false /* ignore ambiguous */,
+                                                 false /* ignore not found */)
                                 ._feature
                                 .selfType();
                              },
@@ -528,7 +531,9 @@ part of the (((inner features))) declarations of the corresponding
          var q = inner._qname;
          var n = q.get(at);
          var o =
-           n != FuzionConstants.TYPE_NAME ? lookupType(inner.pos(), outer, n, at == 0, false)._feature
+           n != FuzionConstants.TYPE_NAME ? lookupType(inner.pos(), outer, n, at == 0,
+                                                       false /* ignore ambiguous */,
+                                                       false /* ignore not found */)._feature
                                           : outer.typeFeature(_res);
          if (at < q.size()-2)
            {
@@ -1353,7 +1358,11 @@ A post-condition of a feature that does not redefine an inherited feature must s
    * outer's outer (i.e., use is unqualified), false to search in outer only
    * (i.e., use is qualified with outer).
    *
-   * @param ignoreNotFound If true, no errors are produced but null might be returned
+   * @param ignoreAmbiguous If true, no errors are produced but null might be
+   * returned if type is ambiguous.
+   *
+   * @param ignoreNotFound If true, no errors are produced but null might be
+   * returned in case type was not found.
    *
    * @return FeatureAndOuter tuple of the found type's declaring feature,
    * FeatureAndOuter.ERROR in case of an error, null in case no type was found
@@ -1363,6 +1372,7 @@ A post-condition of a feature that does not redefine an inherited feature must s
                                     AbstractFeature outer,
                                     String name,
                                     boolean traverseOuter,
+                                    boolean ignoreAmbiguous,
                                     boolean ignoreNotFound)
   {
     if (PRECONDITIONS) require
@@ -1403,18 +1413,18 @@ A post-condition of a feature that does not redefine an inherited feature must s
                   }
               }
           }
-        if (type_fs.size() > 1)
+        if (type_fs.size() > 1 && !ignoreAmbiguous)
           {
             AstErrors.ambiguousType(pos, name, type_fs);
             result = FeatureAndOuter.ERROR;
           }
-        else if (type_fs.size() < 1 && ignoreNotFound)
-          {
-            result = null;
-          }
-        else if (type_fs.size() < 1)
+        else if (type_fs.size() < 1 && !ignoreNotFound)
           {
             AstErrors.typeNotFound(pos, name, outer, nontype_fs);
+          }
+        else if (type_fs.size() != 1)
+          {
+            result = null;
           }
       }
 

--- a/src/dev/flang/fe/SourceModule.java
+++ b/src/dev/flang/fe/SourceModule.java
@@ -1405,25 +1405,16 @@ A post-condition of a feature that does not redefine an inherited feature must s
           }
         if (type_fs.size() > 1)
           {
-            if (ignoreNotFound)
-              {
-                result = null;
-              }
-            else
-              {
-                AstErrors.ambiguousType(pos, name, type_fs);
-              }
+            AstErrors.ambiguousType(pos, name, type_fs);
+            result = FeatureAndOuter.ERROR;
+          }
+        else if (type_fs.size() < 1 && ignoreNotFound)
+          {
+            result = null;
           }
         else if (type_fs.size() < 1)
           {
-            if (ignoreNotFound)
-              {
-                result = null;
-              }
-            else
-              {
-                AstErrors.typeNotFound(pos, name, outer, nontype_fs);
-              }
+            AstErrors.typeNotFound(pos, name, outer, nontype_fs);
           }
       }
 

--- a/tests/reg_issue3337/Makefile
+++ b/tests/reg_issue3337/Makefile
@@ -22,4 +22,4 @@
 # -----------------------------------------------------------------------
 
 override NAME = reg_issue3337
-include ../simple.mk
+include ../simple_and_negative.mk

--- a/tests/reg_issue3337/Makefile
+++ b/tests/reg_issue3337/Makefile
@@ -1,0 +1,25 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test Makefile
+#
+# -----------------------------------------------------------------------
+
+override NAME = reg_issue3337
+include ../simple.mk

--- a/tests/reg_issue3337/reg_issue3337.fz
+++ b/tests/reg_issue3337/reg_issue3337.fz
@@ -1,0 +1,36 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test
+#
+# -----------------------------------------------------------------------
+
+# Test partial application that refers to `a.this`
+#
+reg_issue3337 is
+
+  test1(String type, h String) is
+  test2(String type, h String) =>
+  test3(String type, h type : list String) is
+  test4(String type, h type : list String) =>
+  test5(h type : list String, String type) is
+  test6(h type : list String, String type) =>
+  test7(String type) option String =>
+  test8(String type) is _ := option String nil
+  test9(String type) => _ := option String nil

--- a/tests/reg_issue3337/reg_issue3337.fz
+++ b/tests/reg_issue3337/reg_issue3337.fz
@@ -21,16 +21,17 @@
 #
 # -----------------------------------------------------------------------
 
-# Test partial application that refers to `a.this`
+# Test ambiguous types conflicting with type parameter in a signature
 #
 reg_issue3337 is
 
-  test1(String type, h String) is
-  test2(String type, h String) =>
-  test3(String type, h type : list String) is
-  test4(String type, h type : list String) =>
-  test5(h type : list String, String type) is
-  test6(h type : list String, String type) =>
-  test7(String type) option String =>
-  test8(String type) is _ := option String nil
-  test9(String type) => _ := option String nil
+  test1(String type, h String) is                #  1. should flag an error: `h String` ambiguous
+  test2(String type, h String) =>                #  2. should flag an error: `h String` ambiguous
+  test3(String type, h type : list String) is    #  3. should flag an error: `list  String` ambiguous
+  test4(String type, h type : list String) =>    #  4. should flag an error: `list String` ambiguous
+  test5(h type : list String, String type) is    #  5. should flag an error: `list String` ambiguous
+  test6(h type : list String, String type) =>    #  6. should flag an error: `list String` ambiguous
+  test7(String type) String =>                   #  7. should flag an error: `String` ambiguous
+  test8(String type) option String =>            #  8. should flag an error: `option String` ambiguous
+  test9(String type) is _ := option String nil   #  9. should flag an error: `option String` ambiguous
+  test10(String type) => _ := option String nil  # 10. should flag an error: `option String` ambiguous

--- a/tests/reg_issue3337/reg_issue3337.fz.expected_err
+++ b/tests/reg_issue3337/reg_issue3337.fz.expected_err
@@ -1,0 +1,145 @@
+
+--CURDIR--/reg_issue3337.fz:28:24: error 1: Ambiguous type
+  test1(String type, h String) is
+-----------------------^^^^^^
+For a type used in a declaration, overloading results in an ambiguity that cannot be resolved by the compiler.
+Type that is ambiguous: 'String'
+Possible features that match this type: 
+'reg_issue3337.test1.String' defined at --CURDIR--/reg_issue3337.fz:28:9:
+  test1(String type, h String) is
+--------^^^^^^
+and 'String' defined at $MODULE/String.fz:28:8:
+public String ref : property.equatable, property.hashable, property.orderable is
+-------^^^^^^
+
+To solve this, rename these features such that each one has a unique name.
+
+
+--CURDIR--/reg_issue3337.fz:29:24: error 2: Ambiguous type
+  test2(String type, h String) =>
+-----------------------^^^^^^
+For a type used in a declaration, overloading results in an ambiguity that cannot be resolved by the compiler.
+Type that is ambiguous: 'String'
+Possible features that match this type: 
+'reg_issue3337.test2.String' defined at --CURDIR--/reg_issue3337.fz:29:9:
+  test2(String type, h String) =>
+--------^^^^^^
+and 'String' defined at $MODULE/String.fz:28:8:
+public String ref : property.equatable, property.hashable, property.orderable is
+-------^^^^^^
+
+To solve this, rename these features such that each one has a unique name.
+
+
+--CURDIR--/reg_issue3337.fz:34:29: error 3: Ambiguous type
+  test7(String type) option String =>
+----------------------------^^^^^^
+For a type used in a declaration, overloading results in an ambiguity that cannot be resolved by the compiler.
+Type that is ambiguous: 'String'
+Possible features that match this type: 
+'reg_issue3337.test7.String' defined at --CURDIR--/reg_issue3337.fz:34:9:
+  test7(String type) option String =>
+--------^^^^^^
+and 'String' defined at $MODULE/String.fz:28:8:
+public String ref : property.equatable, property.hashable, property.orderable is
+-------^^^^^^
+
+To solve this, rename these features such that each one has a unique name.
+
+
+--CURDIR--/reg_issue3337.fz:30:36: error 4: Ambiguous type
+  test3(String type, h type : list String) is
+-----------------------------------^^^^^^
+For a type used in a declaration, overloading results in an ambiguity that cannot be resolved by the compiler.
+Type that is ambiguous: 'String'
+Possible features that match this type: 
+'reg_issue3337.test3.String' defined at --CURDIR--/reg_issue3337.fz:30:9:
+  test3(String type, h type : list String) is
+--------^^^^^^
+and 'String' defined at $MODULE/String.fz:28:8:
+public String ref : property.equatable, property.hashable, property.orderable is
+-------^^^^^^
+
+To solve this, rename these features such that each one has a unique name.
+
+
+--CURDIR--/reg_issue3337.fz:31:36: error 5: Ambiguous type
+  test4(String type, h type : list String) =>
+-----------------------------------^^^^^^
+For a type used in a declaration, overloading results in an ambiguity that cannot be resolved by the compiler.
+Type that is ambiguous: 'String'
+Possible features that match this type: 
+'reg_issue3337.test4.String' defined at --CURDIR--/reg_issue3337.fz:31:9:
+  test4(String type, h type : list String) =>
+--------^^^^^^
+and 'String' defined at $MODULE/String.fz:28:8:
+public String ref : property.equatable, property.hashable, property.orderable is
+-------^^^^^^
+
+To solve this, rename these features such that each one has a unique name.
+
+
+--CURDIR--/reg_issue3337.fz:32:23: error 6: Ambiguous type
+  test5(h type : list String, String type) is
+----------------------^^^^^^
+For a type used in a declaration, overloading results in an ambiguity that cannot be resolved by the compiler.
+Type that is ambiguous: 'String'
+Possible features that match this type: 
+'reg_issue3337.test5.String' defined at --CURDIR--/reg_issue3337.fz:32:31:
+  test5(h type : list String, String type) is
+------------------------------^^^^^^
+and 'String' defined at $MODULE/String.fz:28:8:
+public String ref : property.equatable, property.hashable, property.orderable is
+-------^^^^^^
+
+To solve this, rename these features such that each one has a unique name.
+
+
+--CURDIR--/reg_issue3337.fz:33:23: error 7: Ambiguous type
+  test6(h type : list String, String type) =>
+----------------------^^^^^^
+For a type used in a declaration, overloading results in an ambiguity that cannot be resolved by the compiler.
+Type that is ambiguous: 'String'
+Possible features that match this type: 
+'reg_issue3337.test6.String' defined at --CURDIR--/reg_issue3337.fz:33:31:
+  test6(h type : list String, String type) =>
+------------------------------^^^^^^
+and 'String' defined at $MODULE/String.fz:28:8:
+public String ref : property.equatable, property.hashable, property.orderable is
+-------^^^^^^
+
+To solve this, rename these features such that each one has a unique name.
+
+
+--CURDIR--/reg_issue3337.fz:35:37: error 8: Ambiguous type
+  test8(String type) is _ := option String nil
+------------------------------------^^^^^^
+For a type used in a declaration, overloading results in an ambiguity that cannot be resolved by the compiler.
+Type that is ambiguous: 'String'
+Possible features that match this type: 
+'reg_issue3337.test8.String' defined at --CURDIR--/reg_issue3337.fz:35:9:
+  test8(String type) is _ := option String nil
+--------^^^^^^
+and 'String' defined at $MODULE/String.fz:28:8:
+public String ref : property.equatable, property.hashable, property.orderable is
+-------^^^^^^
+
+To solve this, rename these features such that each one has a unique name.
+
+
+--CURDIR--/reg_issue3337.fz:36:37: error 9: Ambiguous type
+  test9(String type) => _ := option String nil
+------------------------------------^^^^^^
+For a type used in a declaration, overloading results in an ambiguity that cannot be resolved by the compiler.
+Type that is ambiguous: 'String'
+Possible features that match this type: 
+'reg_issue3337.test9.String' defined at --CURDIR--/reg_issue3337.fz:36:9:
+  test9(String type) => _ := option String nil
+--------^^^^^^
+and 'String' defined at $MODULE/String.fz:28:8:
+public String ref : property.equatable, property.hashable, property.orderable is
+-------^^^^^^
+
+To solve this, rename these features such that each one has a unique name.
+
+9 errors.

--- a/tests/reg_issue3337/reg_issue3337.fz.expected_err
+++ b/tests/reg_issue3337/reg_issue3337.fz.expected_err
@@ -1,12 +1,12 @@
 
 --CURDIR--/reg_issue3337.fz:28:24: error 1: Ambiguous type
-  test1(String type, h String) is
+  test1(String type, h String) is                #  1. should flag an error: `h String` ambiguous
 -----------------------^^^^^^
 For a type used in a declaration, overloading results in an ambiguity that cannot be resolved by the compiler.
 Type that is ambiguous: 'String'
 Possible features that match this type: 
 'reg_issue3337.test1.String' defined at --CURDIR--/reg_issue3337.fz:28:9:
-  test1(String type, h String) is
+  test1(String type, h String) is                #  1. should flag an error: `h String` ambiguous
 --------^^^^^^
 and 'String' defined at $MODULE/String.fz:28:8:
 public String ref : property.equatable, property.hashable, property.orderable is
@@ -16,13 +16,13 @@ To solve this, rename these features such that each one has a unique name.
 
 
 --CURDIR--/reg_issue3337.fz:29:24: error 2: Ambiguous type
-  test2(String type, h String) =>
+  test2(String type, h String) =>                #  2. should flag an error: `h String` ambiguous
 -----------------------^^^^^^
 For a type used in a declaration, overloading results in an ambiguity that cannot be resolved by the compiler.
 Type that is ambiguous: 'String'
 Possible features that match this type: 
 'reg_issue3337.test2.String' defined at --CURDIR--/reg_issue3337.fz:29:9:
-  test2(String type, h String) =>
+  test2(String type, h String) =>                #  2. should flag an error: `h String` ambiguous
 --------^^^^^^
 and 'String' defined at $MODULE/String.fz:28:8:
 public String ref : property.equatable, property.hashable, property.orderable is
@@ -31,14 +31,14 @@ public String ref : property.equatable, property.hashable, property.orderable is
 To solve this, rename these features such that each one has a unique name.
 
 
---CURDIR--/reg_issue3337.fz:34:29: error 3: Ambiguous type
-  test7(String type) option String =>
-----------------------------^^^^^^
+--CURDIR--/reg_issue3337.fz:34:22: error 3: Ambiguous type
+  test7(String type) String =>                   #  7. should flag an error: `String` ambiguous
+---------------------^^^^^^
 For a type used in a declaration, overloading results in an ambiguity that cannot be resolved by the compiler.
 Type that is ambiguous: 'String'
 Possible features that match this type: 
 'reg_issue3337.test7.String' defined at --CURDIR--/reg_issue3337.fz:34:9:
-  test7(String type) option String =>
+  test7(String type) String =>                   #  7. should flag an error: `String` ambiguous
 --------^^^^^^
 and 'String' defined at $MODULE/String.fz:28:8:
 public String ref : property.equatable, property.hashable, property.orderable is
@@ -47,14 +47,30 @@ public String ref : property.equatable, property.hashable, property.orderable is
 To solve this, rename these features such that each one has a unique name.
 
 
---CURDIR--/reg_issue3337.fz:30:36: error 4: Ambiguous type
-  test3(String type, h type : list String) is
+--CURDIR--/reg_issue3337.fz:35:29: error 4: Ambiguous type
+  test8(String type) option String =>            #  8. should flag an error: `option String` ambiguous
+----------------------------^^^^^^
+For a type used in a declaration, overloading results in an ambiguity that cannot be resolved by the compiler.
+Type that is ambiguous: 'String'
+Possible features that match this type: 
+'reg_issue3337.test8.String' defined at --CURDIR--/reg_issue3337.fz:35:9:
+  test8(String type) option String =>            #  8. should flag an error: `option String` ambiguous
+--------^^^^^^
+and 'String' defined at $MODULE/String.fz:28:8:
+public String ref : property.equatable, property.hashable, property.orderable is
+-------^^^^^^
+
+To solve this, rename these features such that each one has a unique name.
+
+
+--CURDIR--/reg_issue3337.fz:30:36: error 5: Ambiguous type
+  test3(String type, h type : list String) is    #  3. should flag an error: `list  String` ambiguous
 -----------------------------------^^^^^^
 For a type used in a declaration, overloading results in an ambiguity that cannot be resolved by the compiler.
 Type that is ambiguous: 'String'
 Possible features that match this type: 
 'reg_issue3337.test3.String' defined at --CURDIR--/reg_issue3337.fz:30:9:
-  test3(String type, h type : list String) is
+  test3(String type, h type : list String) is    #  3. should flag an error: `list  String` ambiguous
 --------^^^^^^
 and 'String' defined at $MODULE/String.fz:28:8:
 public String ref : property.equatable, property.hashable, property.orderable is
@@ -63,14 +79,14 @@ public String ref : property.equatable, property.hashable, property.orderable is
 To solve this, rename these features such that each one has a unique name.
 
 
---CURDIR--/reg_issue3337.fz:31:36: error 5: Ambiguous type
-  test4(String type, h type : list String) =>
+--CURDIR--/reg_issue3337.fz:31:36: error 6: Ambiguous type
+  test4(String type, h type : list String) =>    #  4. should flag an error: `list String` ambiguous
 -----------------------------------^^^^^^
 For a type used in a declaration, overloading results in an ambiguity that cannot be resolved by the compiler.
 Type that is ambiguous: 'String'
 Possible features that match this type: 
 'reg_issue3337.test4.String' defined at --CURDIR--/reg_issue3337.fz:31:9:
-  test4(String type, h type : list String) =>
+  test4(String type, h type : list String) =>    #  4. should flag an error: `list String` ambiguous
 --------^^^^^^
 and 'String' defined at $MODULE/String.fz:28:8:
 public String ref : property.equatable, property.hashable, property.orderable is
@@ -79,14 +95,14 @@ public String ref : property.equatable, property.hashable, property.orderable is
 To solve this, rename these features such that each one has a unique name.
 
 
---CURDIR--/reg_issue3337.fz:32:23: error 6: Ambiguous type
-  test5(h type : list String, String type) is
+--CURDIR--/reg_issue3337.fz:32:23: error 7: Ambiguous type
+  test5(h type : list String, String type) is    #  5. should flag an error: `list String` ambiguous
 ----------------------^^^^^^
 For a type used in a declaration, overloading results in an ambiguity that cannot be resolved by the compiler.
 Type that is ambiguous: 'String'
 Possible features that match this type: 
 'reg_issue3337.test5.String' defined at --CURDIR--/reg_issue3337.fz:32:31:
-  test5(h type : list String, String type) is
+  test5(h type : list String, String type) is    #  5. should flag an error: `list String` ambiguous
 ------------------------------^^^^^^
 and 'String' defined at $MODULE/String.fz:28:8:
 public String ref : property.equatable, property.hashable, property.orderable is
@@ -95,31 +111,15 @@ public String ref : property.equatable, property.hashable, property.orderable is
 To solve this, rename these features such that each one has a unique name.
 
 
---CURDIR--/reg_issue3337.fz:33:23: error 7: Ambiguous type
-  test6(h type : list String, String type) =>
+--CURDIR--/reg_issue3337.fz:33:23: error 8: Ambiguous type
+  test6(h type : list String, String type) =>    #  6. should flag an error: `list String` ambiguous
 ----------------------^^^^^^
 For a type used in a declaration, overloading results in an ambiguity that cannot be resolved by the compiler.
 Type that is ambiguous: 'String'
 Possible features that match this type: 
 'reg_issue3337.test6.String' defined at --CURDIR--/reg_issue3337.fz:33:31:
-  test6(h type : list String, String type) =>
+  test6(h type : list String, String type) =>    #  6. should flag an error: `list String` ambiguous
 ------------------------------^^^^^^
-and 'String' defined at $MODULE/String.fz:28:8:
-public String ref : property.equatable, property.hashable, property.orderable is
--------^^^^^^
-
-To solve this, rename these features such that each one has a unique name.
-
-
---CURDIR--/reg_issue3337.fz:35:37: error 8: Ambiguous type
-  test8(String type) is _ := option String nil
-------------------------------------^^^^^^
-For a type used in a declaration, overloading results in an ambiguity that cannot be resolved by the compiler.
-Type that is ambiguous: 'String'
-Possible features that match this type: 
-'reg_issue3337.test8.String' defined at --CURDIR--/reg_issue3337.fz:35:9:
-  test8(String type) is _ := option String nil
---------^^^^^^
 and 'String' defined at $MODULE/String.fz:28:8:
 public String ref : property.equatable, property.hashable, property.orderable is
 -------^^^^^^
@@ -128,13 +128,13 @@ To solve this, rename these features such that each one has a unique name.
 
 
 --CURDIR--/reg_issue3337.fz:36:37: error 9: Ambiguous type
-  test9(String type) => _ := option String nil
+  test9(String type) is _ := option String nil   #  9. should flag an error: `option String` ambiguous
 ------------------------------------^^^^^^
 For a type used in a declaration, overloading results in an ambiguity that cannot be resolved by the compiler.
 Type that is ambiguous: 'String'
 Possible features that match this type: 
 'reg_issue3337.test9.String' defined at --CURDIR--/reg_issue3337.fz:36:9:
-  test9(String type) => _ := option String nil
+  test9(String type) is _ := option String nil   #  9. should flag an error: `option String` ambiguous
 --------^^^^^^
 and 'String' defined at $MODULE/String.fz:28:8:
 public String ref : property.equatable, property.hashable, property.orderable is
@@ -142,4 +142,20 @@ public String ref : property.equatable, property.hashable, property.orderable is
 
 To solve this, rename these features such that each one has a unique name.
 
-9 errors.
+
+--CURDIR--/reg_issue3337.fz:37:38: error 10: Ambiguous type
+  test10(String type) => _ := option String nil  # 10. should flag an error: `option String` ambiguous
+-------------------------------------^^^^^^
+For a type used in a declaration, overloading results in an ambiguity that cannot be resolved by the compiler.
+Type that is ambiguous: 'String'
+Possible features that match this type: 
+'reg_issue3337.test10.String' defined at --CURDIR--/reg_issue3337.fz:37:10:
+  test10(String type) => _ := option String nil  # 10. should flag an error: `option String` ambiguous
+---------^^^^^^
+and 'String' defined at $MODULE/String.fz:28:8:
+public String ref : property.equatable, property.hashable, property.orderable is
+-------^^^^^^
+
+To solve this, rename these features such that each one has a unique name.
+
+10 errors.


### PR DESCRIPTION
An ambiguous type in a feature signature should be reported as a bug, and not turned silently into a free type.

Also added a test for different uses of ambiguous types due to type parameters.
