### PR TITLE
lsp: initial infrastructure for language server

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1342,3 +1342,62 @@ lint/javadoc:
 remove_unused_imports:
 	wget -O /tmp/google-java-format-1.21.0-all-deps.jar https://github.com/google/google-java-format/releases/download/v1.21.0/google-java-format-1.21.0-all-deps.jar
 	java -jar /tmp/google-java-format-1.21.0-all-deps.jar -r --fix-imports-only  --skip-sorting-imports `find src/`
+
+
+########
+# Begin : Fuzion Language Server
+########
+
+CLASSES_DIR_LSP = $(BUILD_DIR)/classes_lsp
+JAVA_FILES_LSP               = $(shell find $(SRC)/dev/flang/lsp -name '*.java' )
+CLASS_FILES_LSP               = $(CLASSES_DIR_LSP)/dev/flang/lsp/__marker_for_make__
+
+LSP_LSP4J_URL            = https://repo1.maven.org/maven2/org/eclipse/lsp4j/org.eclipse.lsp4j/0.23.1/org.eclipse.lsp4j-0.23.1.jar
+LSP_LSP4J_GENERATOR_URL  = https://repo1.maven.org/maven2/org/eclipse/lsp4j/org.eclipse.lsp4j.generator/0.23.1/org.eclipse.lsp4j.generator-0.23.1.jar
+LSP_LSP4J_JSONRPC_URL    = https://repo1.maven.org/maven2/org/eclipse/lsp4j/org.eclipse.lsp4j.jsonrpc/0.23.1/org.eclipse.lsp4j.jsonrpc-0.23.1.jar
+LSP_GSON_URL             = https://repo1.maven.org/maven2/com/google/code/gson/gson/2.11.0/gson-2.11.0.jar
+JARS_LSP_LSP4J           = $(BUILD_DIR)/jars/org.eclipse.lsp4j-0.23.1.jar
+JARS_LSP_LSP4J_GENERATOR = $(BUILD_DIR)/jars/org.eclipse.lsp4j.generator-0.23.1.jar
+JARS_LSP_LSP4J_JSONRPC   = $(BUILD_DIR)/jars/org.eclipse.lsp4j.jsonrpc-0.23.1.jar
+JARS_LSP_GSON            = $(BUILD_DIR)/jars/gson-2.11.0.jar
+
+$(JARS_LSP_LSP4J):
+	mkdir -p $(@D)
+	curl $(LSP_LSP4J_URL) --output $@
+
+$(JARS_LSP_LSP4J_GENERATOR):
+	mkdir -p $(@D)
+	curl $(LSP_LSP4J_GENERATOR_URL) --output $@
+
+$(JARS_LSP_LSP4J_JSONRPC):
+	mkdir -p $(@D)
+	curl $(LSP_LSP4J_JSONRPC_URL) --output $@
+
+$(JARS_LSP_GSON):
+	mkdir -p $(@D)
+	curl $(LSP_GSON_URL) --output $@
+
+JARS_LSP: $(JARS_LSP_LSP4J) $(JARS_LSP_LSP4J_GENERATOR) $(JARS_LSP_LSP4J_JSONRPC) $(JARS_LSP_GSON)
+	echo "b16bbc6232a3946e03d537bb9be74e18489dbc6a8b8c5ab6cb7980854df8440f $(BUILD_DIR)/jars/org.eclipse.lsp4j-0.23.1.jar" > $(BUILD_DIR)/jars/lsp.sha256
+	echo "1adaeb34550ebec21636a45afe76ff8b60188a056966feb3c7e562450ba911be $(BUILD_DIR)/jars/org.eclipse.lsp4j.generator-0.23.1.jar" >> $(BUILD_DIR)/jars/lsp.sha256
+	echo "4e1aa77474de1791d96dc55932fb46efdf53233548f38f62ba7376f8b0bc6650 $(BUILD_DIR)/jars/org.eclipse.lsp4j.jsonrpc-0.23.1.jar" >> $(BUILD_DIR)/jars/lsp.sha256
+	echo "57928d6e5a6edeb2abd3770a8f95ba44dce45f3b23b7a9dc2b309c581552a78b $(BUILD_DIR)/jars/gson-2.11.0.jar" >> $(BUILD_DIR)/jars/lsp.sha256
+	sha256sum --status -c $(BUILD_DIR)/jars/lsp.sha256
+
+$(CLASS_FILES_LSP): JARS_LSP
+	mkdir -p $(CLASSES_DIR_LSP)
+	$(JAVAC) -cp $(CLASSES_DIR):$(JARS_LSP_LSP4J):$(JARS_LSP_LSP4J_GENERATOR):$(JARS_LSP_LSP4J_JSONRPC):$(JARS_LSP_GSON) -d $(CLASSES_DIR_LSP) $(JAVA_FILES_LSP)
+	touch $@
+
+lsp/compile: $(FUZION_BASE) $(CLASS_FILES_LSP)
+
+LSP_FUZION_HOME = fuzion/build
+LSP_JAVA_STACKSIZE=16
+LSP_DEBUGGER_SUSPENDED = -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=127.0.0.1:8000
+LSP_JAVA_ARGS = -Dfuzion.home=$(LSP_FUZION_HOME) -Dfile.encoding=UTF-8 -Xss$(LSP_JAVA_STACKSIZE)m
+lsp/debug/stdio: lsp/compile
+	java $(LSP_DEBUGGER_SUSPENDED) -cp  $(CLASSES_DIR):$(JARS_LSP_LSP4J):$(JARS_LSP_LSP4J_GENERATOR):$(JARS_LSP_LSP4J_JSONRPC):$(JARS_LSP_GSON):$(CLASSES_DIR_LSP) $(LSP_JAVA_ARGS) dev.flang.lsp.server.Main -stdio
+
+########
+# End : Fuzion Language Server
+########

--- a/src/dev/flang/lsp/FuzionLanguageServer.java
+++ b/src/dev/flang/lsp/FuzionLanguageServer.java
@@ -1,0 +1,97 @@
+/*
+
+This file is part of the Fuzion language server protocol implementation.
+
+The Fuzion language server protocol implementation is free software: you can redistribute it
+and/or modify it under the terms of the GNU General Public License as published
+by the Free Software Foundation, version 3 of the License.
+
+The Fuzion language server protocol implementation is distributed in the hope that it will be
+useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+License for more details.
+
+You should have received a copy of the GNU General Public License along with The
+Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+*/
+
+/*-----------------------------------------------------------------------
+ *
+ * Tokiwa Software GmbH, Germany
+ *
+ * Source of class FuzionLanguageServer
+ *
+ *---------------------------------------------------------------------*/
+
+package dev.flang.lsp;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import org.eclipse.lsp4j.CodeLensOptions;
+import org.eclipse.lsp4j.CompletionOptions;
+import org.eclipse.lsp4j.ConfigurationItem;
+import org.eclipse.lsp4j.ConfigurationParams;
+import org.eclipse.lsp4j.ExecuteCommandOptions;
+import org.eclipse.lsp4j.HoverOptions;
+import org.eclipse.lsp4j.InitializeParams;
+import org.eclipse.lsp4j.InitializeResult;
+import org.eclipse.lsp4j.InitializedParams;
+import org.eclipse.lsp4j.Registration;
+import org.eclipse.lsp4j.RegistrationParams;
+import org.eclipse.lsp4j.RenameOptions;
+import org.eclipse.lsp4j.SemanticTokensServerFull;
+import org.eclipse.lsp4j.SemanticTokensWithRegistrationOptions;
+import org.eclipse.lsp4j.ServerCapabilities;
+import org.eclipse.lsp4j.SetTraceParams;
+import org.eclipse.lsp4j.SignatureHelpOptions;
+import org.eclipse.lsp4j.TextDocumentSyncKind;
+import org.eclipse.lsp4j.WorkDoneProgressCancelParams;
+import org.eclipse.lsp4j.services.LanguageServer;
+import org.eclipse.lsp4j.services.NotebookDocumentService;
+import org.eclipse.lsp4j.services.TextDocumentService;
+import org.eclipse.lsp4j.services.WorkspaceService;
+
+/**
+ * Implementation of the language server
+ */
+public class FuzionLanguageServer implements LanguageServer
+{
+  @Override
+  public WorkspaceService getWorkspaceService()
+  {
+    return new FuzionWorkspaceService();
+  }
+
+  @Override
+  public TextDocumentService getTextDocumentService()
+  {
+    return new FuzionTextDocumentService();
+  }
+
+  @Override
+  public void exit()
+  {
+    System.exit(0);
+  }
+
+  @Override
+  public CompletableFuture<Object> shutdown()
+  {
+    return CompletableFuture.supplyAsync(() -> Boolean.TRUE);
+  }
+
+  @Override
+  public CompletableFuture<InitializeResult> initialize(InitializeParams params)
+  {
+    var capabilities = new ServerCapabilities();
+    var res = new InitializeResult(capabilities);
+    return CompletableFuture.supplyAsync(() -> res);
+  }
+
+
+}

--- a/src/dev/flang/lsp/FuzionTextDocumentService.java
+++ b/src/dev/flang/lsp/FuzionTextDocumentService.java
@@ -1,0 +1,100 @@
+/*
+
+This file is part of the Fuzion language server protocol implementation.
+
+The Fuzion language server protocol implementation is free software: you can redistribute it
+and/or modify it under the terms of the GNU General Public License as published
+by the Free Software Foundation, version 3 of the License.
+
+The Fuzion language server protocol implementation is distributed in the hope that it will be
+useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+License for more details.
+
+You should have received a copy of the GNU General Public License along with The
+Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+*/
+
+/*-----------------------------------------------------------------------
+ *
+ * Tokiwa Software GmbH, Germany
+ *
+ * Source of class FuzionTextDocumentService
+ *
+ *---------------------------------------------------------------------*/
+
+package dev.flang.lsp;
+
+import java.net.URI;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import org.eclipse.lsp4j.CodeAction;
+import org.eclipse.lsp4j.CodeActionParams;
+import org.eclipse.lsp4j.CodeLens;
+import org.eclipse.lsp4j.CodeLensParams;
+import org.eclipse.lsp4j.Command;
+import org.eclipse.lsp4j.CompletionItem;
+import org.eclipse.lsp4j.CompletionList;
+import org.eclipse.lsp4j.CompletionParams;
+import org.eclipse.lsp4j.DefinitionParams;
+import org.eclipse.lsp4j.DidChangeTextDocumentParams;
+import org.eclipse.lsp4j.DidCloseTextDocumentParams;
+import org.eclipse.lsp4j.DidOpenTextDocumentParams;
+import org.eclipse.lsp4j.DidSaveTextDocumentParams;
+import org.eclipse.lsp4j.DocumentHighlight;
+import org.eclipse.lsp4j.DocumentHighlightParams;
+import org.eclipse.lsp4j.DocumentSymbol;
+import org.eclipse.lsp4j.DocumentSymbolParams;
+import org.eclipse.lsp4j.Hover;
+import org.eclipse.lsp4j.HoverParams;
+import org.eclipse.lsp4j.InlayHint;
+import org.eclipse.lsp4j.InlayHintParams;
+import org.eclipse.lsp4j.Location;
+import org.eclipse.lsp4j.LocationLink;
+import org.eclipse.lsp4j.PrepareRenameDefaultBehavior;
+import org.eclipse.lsp4j.PrepareRenameParams;
+import org.eclipse.lsp4j.PrepareRenameResult;
+import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.ReferenceParams;
+import org.eclipse.lsp4j.RenameParams;
+import org.eclipse.lsp4j.SemanticTokens;
+import org.eclipse.lsp4j.SemanticTokensParams;
+import org.eclipse.lsp4j.SignatureHelp;
+import org.eclipse.lsp4j.SignatureHelpParams;
+import org.eclipse.lsp4j.SymbolInformation;
+import org.eclipse.lsp4j.WorkspaceEdit;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
+import org.eclipse.lsp4j.jsonrpc.messages.Either3;
+import org.eclipse.lsp4j.services.TextDocumentService;
+
+
+public class FuzionTextDocumentService implements TextDocumentService
+{
+  @Override
+  public void didSave(DidSaveTextDocumentParams params)
+  {
+    // NYI: UNDER DEVELOPMENT:
+  }
+
+    @Override
+  public void didClose(DidCloseTextDocumentParams params)
+  {
+    // NYI: UNDER DEVELOPMENT:
+  }
+
+    @Override
+  public void didOpen(DidOpenTextDocumentParams params)
+  {
+    // NYI: UNDER DEVELOPMENT:
+  }
+
+  @Override
+  public void didChange(DidChangeTextDocumentParams params)
+  {
+    // NYI: UNDER DEVELOPMENT:
+  }
+}

--- a/src/dev/flang/lsp/FuzionWorkspaceService.java
+++ b/src/dev/flang/lsp/FuzionWorkspaceService.java
@@ -1,0 +1,52 @@
+/*
+
+This file is part of the Fuzion language server protocol implementation.
+
+The Fuzion language server protocol implementation is free software: you can redistribute it
+and/or modify it under the terms of the GNU General Public License as published
+by the Free Software Foundation, version 3 of the License.
+
+The Fuzion language server protocol implementation is distributed in the hope that it will be
+useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+License for more details.
+
+You should have received a copy of the GNU General Public License along with The
+Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+*/
+
+/*-----------------------------------------------------------------------
+ *
+ * Tokiwa Software GmbH, Germany
+ *
+ * Source of class FuzionWorkspaceService
+ *
+ *---------------------------------------------------------------------*/
+
+package dev.flang.lsp;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.eclipse.lsp4j.DidChangeConfigurationParams;
+import org.eclipse.lsp4j.DidChangeWatchedFilesParams;
+import org.eclipse.lsp4j.DidSaveTextDocumentParams;
+import org.eclipse.lsp4j.ExecuteCommandParams;
+import org.eclipse.lsp4j.services.WorkspaceService;
+
+public class FuzionWorkspaceService implements WorkspaceService
+{
+
+  @Override
+  public void didChangeWatchedFiles(DidChangeWatchedFilesParams params)
+  {
+
+  }
+
+  @Override
+  public void didChangeConfiguration(DidChangeConfigurationParams params)
+  {
+
+  }
+
+}

--- a/src/dev/flang/lsp/IO.java
+++ b/src/dev/flang/lsp/IO.java
@@ -1,0 +1,44 @@
+/*
+
+This file is part of the Fuzion language server protocol implementation.
+
+The Fuzion language server protocol implementation is free software: you can redistribute it
+and/or modify it under the terms of the GNU General Public License as published
+by the Free Software Foundation, version 3 of the License.
+
+The Fuzion language server protocol implementation is distributed in the hope that it will be
+useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+License for more details.
+
+You should have received a copy of the GNU General Public License along with The
+Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+*/
+
+/*-----------------------------------------------------------------------
+ *
+ * Tokiwa Software GmbH, Germany
+ *
+ * Source of class IO
+ *
+ *---------------------------------------------------------------------*/
+
+package dev.flang.lsp;
+
+import java.io.InputStream;
+import java.io.PrintStream;
+
+public class IO
+{
+  // To be able to suppress the output of the
+  // fuzion compiler we need to override
+  // System.out etc.
+  // In case of transport=stdio
+  // will use these fields to write to stdout.
+  //
+  public static final PrintStream SYS_OUT = System.out;
+  public static final PrintStream SYS_ERR = System.err;
+  public static final InputStream SYS_IN  = System.in;
+
+}

--- a/src/dev/flang/lsp/Main.java
+++ b/src/dev/flang/lsp/Main.java
@@ -1,0 +1,180 @@
+/*
+
+This file is part of the Fuzion language server protocol implementation.
+
+The Fuzion language server protocol implementation is free software: you can redistribute it
+and/or modify it under the terms of the GNU General Public License as published
+by the Free Software Foundation, version 3 of the License.
+
+The Fuzion language server protocol implementation is distributed in the hope that it will be
+useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+License for more details.
+
+You should have received a copy of the GNU General Public License along with The
+Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+*/
+
+/*-----------------------------------------------------------------------
+ *
+ * Tokiwa Software GmbH, Germany
+ *
+ * Source of class Main
+ *
+ *---------------------------------------------------------------------*/
+
+package dev.flang.lsp;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.lang.Thread.UncaughtExceptionHandler;
+import java.net.ServerSocket;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+
+import org.eclipse.lsp4j.MessageParams;
+import org.eclipse.lsp4j.MessageType;
+import org.eclipse.lsp4j.jsonrpc.Launcher;
+import org.eclipse.lsp4j.services.LanguageClient;
+
+import dev.flang.lsp.enums.Transport;
+import dev.flang.util.ANY;
+import dev.flang.util.Errors;
+
+/**
+ * Main class of Fuzion LSP responsible for starting the language server.
+ */
+public class Main extends ANY
+{
+
+
+  /**
+   * In case of wrong arguments this is called to
+   * print usage information and exit with a none zero
+   * exit code.
+   */
+  private static void printUsageAndExit()
+  {
+    IO.SYS_ERR.println("usage: [-stdio | -socket=<port>]");
+    System.exit(1);
+  }
+
+
+  /**
+   * Is the str contained in args?
+   */
+  private static boolean hasArg(String[] args, String str)
+  {
+    return Arrays.stream(args).map(arg -> arg.trim()).anyMatch(arg -> arg.startsWith(str));
+  }
+
+
+  /**
+   * For an arg like -socket=8080 extract the value (8080)
+   */
+  private static Optional<String> getArg(String[] args, String str)
+  {
+    return Arrays.stream(args)
+      .map(arg -> arg.trim())
+      .filter(arg -> arg.startsWith(str))
+      .findAny()
+      .map(x -> x.split("=")[1]);
+  }
+
+  /**
+   * get launcher for language server for given parameters
+   */
+  private static Launcher<LanguageClient> launcher(Transport t, int port) throws InterruptedException, ExecutionException, IOException
+  {
+    var server = new FuzionLanguageServer();
+    switch (t)
+      {
+      case stdio :
+        return buildLauncher(server, IO.SYS_IN, IO.SYS_OUT);
+      case socket :
+        try (var serverSocket = new ServerSocket(port))
+          {
+            IO.SYS_OUT.println("Property os.name: " + System.getProperty("os.name"));
+            IO.SYS_OUT.println("socket opened on port: " + serverSocket.getLocalPort());
+            var socket = serverSocket.accept();
+            return buildLauncher(server, socket.getInputStream(), socket.getOutputStream());
+          }
+      default:
+        Errors.fatal("Language server transport not yet implemented.");
+        return null;
+      }
+  }
+
+  /**
+   * build launcher for language server for given parameters
+   */
+  private static Launcher<LanguageClient> buildLauncher(FuzionLanguageServer server, InputStream in, OutputStream out)
+    throws IOException
+  {
+    return new Launcher.Builder<LanguageClient>()
+      .setLocalService(server)
+      .setRemoteInterface(LanguageClient.class)
+      .setInput(in)
+      .setOutput(out)
+      // NYI: .setExecutorService(Concurrency.MainExecutor)
+      .create();
+  }
+
+
+  public static void main(String[] args) throws Exception
+  {
+    System.setProperty("FUZION_DISABLE_ANSI_ESCAPES", "true");
+    Errors.MAX_ERROR_MESSAGES = Integer.MAX_VALUE;
+
+    /*
+    Servers usually support different communication channels (e.g. stdio, pipes, …).
+    To ease the usage of servers in different clients it is highly recommended that a server implementation
+    supports the following command line arguments to pick the communication channel:
+
+    stdio: uses stdio as the communication channel.
+    pipe: use pipes (Windows) or socket files (Linux, Mac) as the communication channel.
+          The pipe / socket file name is passed as the next arg or with --pipe=.
+    socket: uses a socket as the communication channel. The port is passed as next arg or with --port=.
+    node-ipc: use node IPC communication between the client and the server. This is only support if both client and server run under node.
+
+    https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#implementationConsiderations
+     */
+
+    Transport transport = Transport.stdio;
+    int port = -1;
+
+    if (hasArg(args, "-stdio"))
+      {
+        transport = Transport.stdio;
+      }
+    else if (hasArg(args, "-pipe"))
+      {
+        // NYI: UNDER DEVELOPMENT:
+        printUsageAndExit();
+      }
+    else if (hasArg(args, "-socket="))
+      {
+        transport = Transport.socket;
+        var p = getArg(args, "-socket");
+        if (p.isEmpty())
+          {
+            printUsageAndExit();
+            return;
+          }
+        port = Integer.parseInt(p.get());
+      }
+    else
+      {
+        printUsageAndExit();
+      }
+
+    var launcher = launcher(transport, port);
+    launcher.startListening();
+    var languageClient = launcher.getRemoteProxy();
+  }
+
+
+}

--- a/src/dev/flang/lsp/enums/Transport.java
+++ b/src/dev/flang/lsp/enums/Transport.java
@@ -1,0 +1,40 @@
+/*
+
+This file is part of the Fuzion language server protocol implementation.
+
+The Fuzion language server protocol implementation is free software: you can redistribute it
+and/or modify it under the terms of the GNU General Public License as published
+by the Free Software Foundation, version 3 of the License.
+
+The Fuzion language server protocol implementation is distributed in the hope that it will be
+useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+License for more details.
+
+You should have received a copy of the GNU General Public License along with The
+Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+*/
+
+/*-----------------------------------------------------------------------
+ *
+ * Tokiwa Software GmbH, Germany
+ *
+ * Source of class Transport
+ *
+ *---------------------------------------------------------------------*/
+
+package dev.flang.lsp.enums;
+
+/**
+ * Possible transport options for the language server.
+ *
+ * Essentially how the server communicates with the IDE / text editor.
+ */
+public enum Transport
+{
+  stdio,   // stdout/stdin/stderr
+  pipe,    // named pipe
+  socket,  // tcp socket
+  nodeIpc  // node inter process
+}


### PR DESCRIPTION
Does nothing useful at the moment, functionality will be added in further PRs.

`make lsp/compile` compiles the language server code.
`make lsp/debug/stdio` starts the language server in debug mode with transport mode stdio
