### PR TITLE
be/c: implement dir traverse for win.c

### DIFF
--- a/include/posix.c
+++ b/include/posix.c
@@ -530,7 +530,7 @@ int64_t fzE_thread_create(void *(*code)(void *),
     fprintf(stderr,"*** pthread_create failed with return code %d\012",res);
     exit(EXIT_FAILURE);
   }
-  // NYI free pt
+  // NYI: BUG: free pt
   return (int64_t)pt;
 #else
   printf("You discovered a severe bug. (fzE_thread_join)");


### PR DESCRIPTION
This is only a first minimal implementation.
There are some details that need to be changed in the future. I'm aware of the following limitations:
- path length, see comment in fzE_opendir
- unicode support (this also needs to be tested for posix platforms)
- malloc/free of the struct that is passed around while traversing
