### PR TITLE
util: use double underline instead of dotted underline

### DIFF
--- a/src/dev/flang/util/SourcePosition.java
+++ b/src/dev/flang/util/SourcePosition.java
@@ -193,7 +193,7 @@ public class SourcePosition extends ANY implements Comparable<SourcePosition>, H
               /* not a SourceRange! */
               {
                 sb.append(_sourceFile.asString(_sourceFile.lineStartPos(l), p))
-                  .append(Terminal.DOTTED_UNDERLINE)
+                  .append(Terminal.DOUBLE_UNDERLINE)
                   .append(Terminal.UNDERLINE_LINE_RED)
                   .append(_sourceFile.asString(p, p + 1))
                   .append(Terminal.UNDERLINE_OFF)
@@ -207,7 +207,7 @@ public class SourcePosition extends ANY implements Comparable<SourcePosition>, H
                 var leadingWhiteSpace = countLeadingWhiteSpace(str);
                 sb.append(_sourceFile.asString(_sourceFile.lineStartPos(l), p))
                   .append(str.subSequence(0, leadingWhiteSpace))
-                  .append(Terminal.DOTTED_UNDERLINE)
+                  .append(Terminal.DOUBLE_UNDERLINE)
                   .append(Terminal.UNDERLINE_LINE_RED)
                   .append(str.subSequence(leadingWhiteSpace, str.length()))
                   .append(Terminal.UNDERLINE_OFF)

--- a/src/dev/flang/util/SourcePosition.java
+++ b/src/dev/flang/util/SourcePosition.java
@@ -193,7 +193,7 @@ public class SourcePosition extends ANY implements Comparable<SourcePosition>, H
               /* not a SourceRange! */
               {
                 sb.append(_sourceFile.asString(_sourceFile.lineStartPos(l), p))
-                  .append(Terminal.DOUBLE_UNDERLINE)
+                  .append(Terminal.CURLY_UNDERLINE)
                   .append(Terminal.UNDERLINE_LINE_RED)
                   .append(_sourceFile.asString(p, p + 1))
                   .append(Terminal.UNDERLINE_OFF)
@@ -207,7 +207,7 @@ public class SourcePosition extends ANY implements Comparable<SourcePosition>, H
                 var leadingWhiteSpace = countLeadingWhiteSpace(str);
                 sb.append(_sourceFile.asString(_sourceFile.lineStartPos(l), p))
                   .append(str.subSequence(0, leadingWhiteSpace))
-                  .append(Terminal.DOUBLE_UNDERLINE)
+                  .append(Terminal.CURLY_UNDERLINE)
                   .append(Terminal.UNDERLINE_LINE_RED)
                   .append(str.subSequence(leadingWhiteSpace, str.length()))
                   .append(Terminal.UNDERLINE_OFF)

--- a/src/dev/flang/util/Terminal.java
+++ b/src/dev/flang/util/Terminal.java
@@ -70,6 +70,7 @@ public class Terminal extends ANY
   public static final String UNDERLINE                 = ENABLED ? "\033[4m" : "";   // also called underscore
   public static final String DOTTED_UNDERLINE          = ENABLED ? "\033[4:4m" : "";
   public static final String DOUBLE_UNDERLINE          = ENABLED ? "\033[21m" : "";
+  public static final String CURLY_UNDERLINE           = ENABLED ? "\033[4:3m" : "";
   public static final String UNDERLINE_OFF             = ENABLED ? "\033[24m" : "";
   public static final String BLINK                     = ENABLED ? "\033[5m" : "";
   public static final String BLINK_OFF                 = ENABLED ? "\033[25m" : "";

--- a/src/dev/flang/util/Terminal.java
+++ b/src/dev/flang/util/Terminal.java
@@ -69,6 +69,7 @@ public class Terminal extends ANY
   public static final String ITALICS_OFF               = ENABLED ? "\033[23m" : "";
   public static final String UNDERLINE                 = ENABLED ? "\033[4m" : "";   // also called underscore
   public static final String DOTTED_UNDERLINE          = ENABLED ? "\033[4:4m" : "";
+  public static final String DOUBLE_UNDERLINE          = ENABLED ? "\033[21m" : "";
   public static final String UNDERLINE_OFF             = ENABLED ? "\033[24m" : "";
   public static final String BLINK                     = ENABLED ? "\033[5m" : "";
   public static final String BLINK_OFF                 = ENABLED ? "\033[25m" : "";

--- a/src/dev/flang/util/Terminal.java
+++ b/src/dev/flang/util/Terminal.java
@@ -69,7 +69,6 @@ public class Terminal extends ANY
   public static final String ITALICS_OFF               = ENABLED ? "\033[23m" : "";
   public static final String UNDERLINE                 = ENABLED ? "\033[4m" : "";   // also called underscore
   public static final String DOTTED_UNDERLINE          = ENABLED ? "\033[4:4m" : "";
-  public static final String DOUBLE_UNDERLINE          = ENABLED ? "\033[21m" : "";
   public static final String CURLY_UNDERLINE           = ENABLED ? "\033[4:3m" : "";
   public static final String UNDERLINE_OFF             = ENABLED ? "\033[24m" : "";
   public static final String BLINK                     = ENABLED ? "\033[5m" : "";


### PR DESCRIPTION
Could barely see the underline in my terminal:
![2024-07-11_16-29](https://github.com/tokiwa-software/fuzion/assets/88769212/dc113478-c51b-4927-98ee-6653af0cb13b)
with this patch:
![2024-07-11_16-30](https://github.com/tokiwa-software/fuzion/assets/88769212/e4581606-949f-4338-891f-dd8e7180c34d)









