### PR TITLE
tools: add_simple_test.fz, fix ambiguity error

### DIFF
--- a/bin/add_simple_test.fz
+++ b/bin/add_simple_test.fz
@@ -57,15 +57,15 @@ add_simple_test is
 
         """
 
-        makefile_body(test String) =>
+        makefile_body(name String) =>
           """
-          override NAME = {test}
+          override NAME = {name}
           include ../simple.mk
           """
 
-        test_body(test String) =>
+        test_body(name String) =>
           """
-          {test} is
+          {name} is
 
           """
 

--- a/bin/add_simple_test.fz
+++ b/bin/add_simple_test.fz
@@ -65,7 +65,7 @@ add_simple_test is
 
         test_body(name String) =>
           """
-          {name} is
+          {name} =>
 
           """
 


### PR DESCRIPTION
```
/home/not_synced/fuzion/bin/add_simple_test.fz:62:28: error 1: Ambiguous targets found for call to 'test'
          override NAME = {test}

Found several possible call targets within the current feature at different levels of outer features:
in 'add_simple_test.fun.call.makefile_body' found 'add_simple_test.fun.call.makefile_body.test' defined at /home/not_synced/fuzion/bin/add_simple_test.fz:60:23:
        makefile_body(test String) =>

and in 'add_simple_test.fun.call' found 'add_simple_test.fun.call.test' defined at /home/not_synced/fuzion/bin/add_simple_test.fz:32:7:
      test String =>

To solve this, you may qualify the feature using 'add_simple_test.fun.call.makefile_body.this.test' or 'add_simple_test.fun.call.this.test'.
...
```
