### PR TITLE
fe: inScope, remove useIsBeforeDefinition

### DIFF
--- a/lib/uint.fz
+++ b/lib/uint.fz
@@ -88,8 +88,8 @@ is
       (l,carry_over) := data
         .reverse
         .reduce ((list u32).empty, u32 0) (r,t ->
-          (res, carry_over) := r
-          next := t<<shift | carry_over
+          (res, co) := r
+          next := t<<shift | co
           ([next] ++ res, t >> ((u32 32)-shift))
         )
       uint ([carry_over] ++ l) unit
@@ -165,18 +165,18 @@ is
   =>
     two_pow_32 := ((u64 1)<<32)
     (b1, b2) := equalize other
-    (r, _) := b1
+    b3 := b1
       .zip b2 (x, y -> (x,y))
       .reverse_list
-      .reduce ((list u32).empty, u64 0) (r,t ->
+      .reduce ((list u32).empty, u64 0) r,t->
         (minuend, subtrahend) := t
         (res, carry_over) := r
 
         difference := two_pow_32 + minuend.as_u64 - subtrahend.as_u64 - carry_over
 
         ([difference.low32bits] ++ res, if difference ≥ two_pow_32 then u64 0 else u64 1)
-      )
-    uint r unit
+      .values.0
+    uint b3 unit
 
 
   # return an array of length n
@@ -191,18 +191,16 @@ is
     data
       .reverse_list
       .indexed
-      .map ((x) ->
+      .map x->
         (i, v) := x
         other
           .data
           .reverse
           .indexed
-          .map (ox ->
+          .map ox->
             (oi,ov) := ox
             tmp := v.as_u64 * ov.as_u64
             uint ([(tmp>>32).low32bits , tmp.low32bits] ++ zeros i+oi) unit
-          )
-        )
       .flat_map uint (x -> x)
       .fold uint.sum
 

--- a/modules/nom/src/nom/multi.fz
+++ b/modules/nom/src/nom/multi.fz
@@ -32,7 +32,7 @@ module multi is
 
   # apply parser at least once, return results as sequence
   public many1 (I, O type, p Parser I I O) Parser I I (Sequence O) =>
-    parser I I (Sequence O) (input)->
+    parser I I (Sequence O) input->
       match p.call input
         s1 success I O => (many0 p).call input
         e error => e
@@ -43,20 +43,21 @@ module multi is
   pre m<=n
       n>0
   =>
-    parser I I (Sequence O) (input ->
-      (rest, acc) := (1..n)
-        .reduce (input, (list O).type.empty) (r, t ->
-          (rest, acc) := r
-          match p.call rest
+    parser I I (Sequence O) input->
+
+      (rest0, acc0) := (1..n)
+        .reduce (input, (list O).type.empty) r,t->
+          (rest1, acc1) := r
+          match p.call rest1
             s success =>
-              (s.rest, acc ++ [s.out])
+              (s.rest, acc1 ++ [s.out])
             error =>
-              abort (rest, acc)
-        )
-      if acc.count < m
-        error "matched only {acc.count} times"
+              abort (rest1, acc1)
+
+      if acc0.count < m
+        error "matched only {acc0.count} times"
       else
-        success rest acc.as_seq)
+        success rest0 acc0.as_seq
 
 
   # parse a separated list of values, zero or more values

--- a/modules/nom/src/nom/parsers/json.fz
+++ b/modules/nom/src/nom/parsers/json.fz
@@ -50,9 +50,9 @@ public json =>
 
     parser_hex_unicode =>
       preceded (Sequence codepoint) (Sequence codepoint) (Sequence codepoint) (tag "\\") (take_while_m_n codepoint 4 4 (c -> is_hex_digit c))
-        .map (Sequence codepoint) (d ->
-          (c,_) := d.reduce (u32 0, u32 4) (r, c -> (val, exp) := r; (c.parse_u32_hex.val * 10**exp, exp-1))
-          [(codepoint c)])
+        .map (Sequence codepoint) d->
+          t := d.reduce (u32 0, u32 4) (r, c -> (val, exp) := r; (c.parse_u32_hex.val * 10**exp, exp-1))
+          [(codepoint t.0)]
 
     parse_and_map(t, r String) Parser (Sequence codepoint) (Sequence codepoint) (Sequence codepoint) =>
       (tag t).map (Sequence codepoint) (_ -> r.as_codepoints)


### PR DESCRIPTION
In general this needs to be detected by DFA, so I think it was wrong in the first place to do this during feature lookup.