### PR TITLE
lib: add base16 (hex) encoding

### DIFF
--- a/lib/encodings/base16.fz
+++ b/lib/encodings/base16.fz
@@ -33,7 +33,7 @@ public base16 is
   four_bits(n u8) =>
     if 48 <= n <= 57        # case 0-9
       n.as_u8 - 48
-    else #if 65 <= n <= 70  # case A-F
+    else   # 65 <= n <= 70  # case A-F
       n.as_u8 - 55
 
   # checks if a character is valid in the encoding
@@ -43,7 +43,7 @@ public base16 is
   # Encodes a given byte sequence in base16
   # returns a sequence of ascii values
   public encode(data array u8) =>
-    data.flat_map u8 (b->[alphabet[(b>>(u8 4)).as_i32], alphabet[(b&(u8 15)).as_i32]])
+    data.flat_map u8 (b->[alphabet[(b>>4).as_i32], alphabet[(b&15).as_i32]])
 
   # Encodes a given byte sequence in base16
   # returns a string
@@ -95,7 +95,7 @@ public base16 is
 
       byte := if bits_0_3.ok && bits_4_7.ok
                 [(bits_0_3.val << 4) | bits_4_7.val]
-              else [(u8 0)]            # decoding result not used in error case
+              else [u8 0]              # decoding result not used in error case
 
     until bits_0_3.is_error || bits_4_7.is_error
       if bits_0_3.is_error then bits_0_3.err

--- a/lib/encodings/base16.fz
+++ b/lib/encodings/base16.fz
@@ -90,8 +90,8 @@ public base16 is
       nxt := 0, nxt + 2
     while nxt < data.length
     do
-      bits_0_3 := dec_char_at(nxt)
-      bits_4_7 := dec_char_at(nxt+1)
+      bits_0_3 := dec_char_at nxt
+      bits_4_7 := dec_char_at nxt+1
 
       byte := if bits_0_3.ok && bits_4_7.ok
                 [(bits_0_3.val << 4) | bits_4_7.val]

--- a/lib/encodings/base16.fz
+++ b/lib/encodings/base16.fz
@@ -31,14 +31,14 @@ public base16 is
 
   # decode a valid base16 character to 4 bits
   four_bits(n u8) =>
-    if n >= 48 && n <= 57        # case 0-9
+    if 48 <= n <= 57        # case 0-9
       n.as_u8 - 48
-    else #if n >= 65 && n <= 70  # case A-F
+    else #if 65 <= n <= 70  # case A-F
       n.as_u8 - 55
 
   # checks if a character is valid in the encoding
   is_valid(c u8) =>
-    (c >= 48 && c <= 57) || (c >= 65 && c <= 70)
+    (48 <= c <= 57) || (65 <= c <= 70)
 
   # Encodes a given byte sequence in base16
   # returns a sequence of ascii values

--- a/lib/encodings/base16.fz
+++ b/lib/encodings/base16.fz
@@ -1,0 +1,104 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion standard library feature base16
+#
+# -----------------------------------------------------------------------
+
+# base16 encoding and decoding as defined in RFC 4648
+# https://datatracker.ietf.org/doc/html/rfc4648#section-8
+#
+public base16 is
+
+  alphabet array u8:= [48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 65, 66, 67, 68, 69, 70] #0123456789ABCDEF
+  encoding_name => "base16"
+
+  # decode a valid base16 character to 4 bits
+  four_bits(n u8) =>
+    if n >= 48 && n <= 57        # case 0-9
+      n.as_u8 - 48
+    else #if n >= 65 && n <= 70  # case A-F
+      n.as_u8 - 55
+
+  # checks if a character is valid in the encoding
+  is_valid(c u8) =>
+    (c >= 48 && c <= 57) || (c >= 65 && c <= 70)
+
+  # Encodes a given byte sequence in base16
+  # returns a sequence of ascii values
+  public encode(data array u8) =>
+    data.flat_map u8 (b->[alphabet[(b>>(u8 4)).as_i32], alphabet[(b&(u8 15)).as_i32]])
+
+  # Encodes a given byte sequence in base16
+  # returns a string
+  public encode_to_string(data array u8) =>
+    String.type.from_bytes (encode data)
+
+
+  # decodes a base16 string, decoding is strict as required by RFC 4648
+  # lowercase letters, non alphabet characters, line breaks, uneven length cause errors
+  public decode_str(data String) =>
+    decode data.utf8.as_array
+
+
+  # decodes a sequence of ASCII characters, decoding is strict as required by RFC 4648
+  # lowercase letters, non alphabet characters, line breaks, uneven length cause errors
+  public decode(data array u8) =>
+
+    dec_char_at(i) =>
+
+      if i >= data.length
+        error "unexpected end of input, i.e. not of even length"
+      else
+        c := data[i]
+
+        # base16 alphabet character
+        if (is_valid c)
+          outcome (four_bits c)
+
+        # line break
+        else if c = 10 || c = 13
+          error """
+                line breaks are not allowed within encoded data, as required by RFC464, found \
+                {if c=10 then "LF" else "CR"} at position $i"""
+
+        # other non alphabet character
+        else
+          inv_char := String.type.from_bytes (data.slice i (i+4 > data.length ? data.length : i+4))
+                            .substring_codepoint 0 1
+
+          error "invalid $encoding_name input at byte position $i, decoding to unicode character '$inv_char'"
+
+    for
+      res list u8 := nil, res ++ byte  # contains the decoded data at the end
+      nxt := 0, nxt + 2
+    while nxt < data.length
+    do
+      bits_0_3 := dec_char_at(nxt)
+      bits_4_7 := dec_char_at(nxt+1)
+
+      byte := if bits_0_3.ok && bits_4_7.ok
+                [(bits_0_3.val << 4) | bits_4_7.val]
+              else [(u8 0)]            # decoding result not used in error case
+
+    until bits_0_3.is_error || bits_4_7.is_error
+      if bits_0_3.is_error then bits_0_3.err
+      else                  bits_4_7.err
+    else
+      outcome (res.as_array)

--- a/tests/base16/Makefile
+++ b/tests/base16/Makefile
@@ -1,0 +1,25 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test Makefile
+#
+# -----------------------------------------------------------------------
+
+override NAME = base16_test
+include ../simple.mk

--- a/tests/base16/base16_test.fz
+++ b/tests/base16/base16_test.fz
@@ -1,0 +1,155 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test base16
+#
+# -----------------------------------------------------------------------
+
+base16_test is
+
+  my_c : choice String (array u8) is
+  mk_choice(x my_c) => x
+
+  # RFC 4618 test vectors
+  base16_test_vectors array (tuple my_c String) :=
+    [(mk_choice $"", ""),
+     (mk_choice $"f", "66"),
+     (mk_choice "fo", "666F"),
+     (mk_choice "foo", "666F6F"),
+     (mk_choice "foob", "666F6F62"),
+     (mk_choice "fooba", "666F6F6261"),
+     (mk_choice "foobar", "666F6F626172")]
+
+  # Additional test vectors
+  own_test_vectors array (tuple my_c String) :=
+    [(mk_choice [(u8 15), 170, 85, 255, 0],    "0FAA55FF00"),
+     (mk_choice "123890ABCXYZabcxyz_:;>~<%&\$§!", "31323338393041424358595A61626378797A5F3A3B3E7E3C252624C2A721"),
+     (mk_choice
+     """
+     Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidun\
+     t ut labore et dolore magna aliquyam erat, sed dia voluptua.
+
+     At vero eos et accusam et justo duo dolores et ea rebum.""",
+     """
+     4C6F72656D20697073756D20646F6C6F722073697420616D65742C20636F6E73657465747572207361646970736369\
+     6E6720656C6974722C20736564206469616D206E6F6E756D79206569726D6F642074656D706F7220696E766964756E\
+     74207574206C61626F726520657420646F6C6F7265206D61676E6120616C69717579616D20657261742C2073656420\
+     64696120766F6C75707475612E0A0A4174207665726F20656F73206574206163637573616D206574206A7573746F20\
+     64756F20646F6C6F72657320657420656120726562756D2E""")]
+
+
+
+  # ENCODING
+
+  say """
+      Testing base16 encoding..."""
+
+  enc_test(test_vectors array (tuple my_c String), name String) =>
+    for results list (outcome String) := nil, results.concat (out:nil)
+        tup in test_vectors
+    do
+      (plain, code_expected) := tup
+      code_actual := match plain
+                        str String   => encodings.base16.encode_to_string str.utf8.as_array
+                        arr array u8 => encodings.base16.encode_to_string arr
+      out :=
+        if code_actual = code_expected
+          outcome "ok"
+        else
+          plain_str := match plain
+                         str String   => str
+                         arr array u8 => $arr
+          error "encode '$plain_str' produced '$code_actual' but should have been '$code_expected'"
+    else
+      if results ∀ (.ok)
+        say "$name test vectors are encoded correctly"
+      else
+        say "Failed encoding $name test vectors:"
+        results.filter (.is_error)
+              .map (.err.as_string)
+              .map ("  "+)
+              .for_each say
+        say ""
+  enc_test base16_test_vectors "RFC 4648"
+  enc_test own_test_vectors "Additional"
+
+
+
+  # DECODING
+
+  say """
+      \n
+      Testing base16 decoding..."""
+  dec_test(test_vectors array (tuple my_c String), name String) =>
+    for results list (outcome String) := nil, results.concat (out:nil)
+        tup in test_vectors
+    do
+      (plain_exp, code) := tup
+      out :=
+        match encodings.base16.decode code.utf8.as_array
+          actual array u8 =>
+            match plain_exp
+              str String   =>
+                if str = String.from_bytes actual
+                  outcome "ok"
+                else
+                  error "decoding $code produced '{String.from_bytes actual}' but should have been '$str'"
+              arr array u8 =>
+                if arr.length=actual.length && ((arr.zip actual (a,b->a=b)) ∀ x->x)
+                  outcome "ok"
+                else
+                  error "decoding $code produced '$actual' but should have been '$arr'"
+          e error => error "decoding failed when it should not have: {e.msg}"
+    else
+      if results ∀ (.ok)
+        say "$name test vectors are decoded correctly"
+      else
+        say "Failed decoding $name test vectors:"
+        results.filter (.is_error)
+              .map (.err.as_string)
+              .map ("  "+)
+              .for_each say
+        say ""
+  dec_test base16_test_vectors "RFC 4648"
+  dec_test own_test_vectors "Additional"
+
+
+
+  # ERROR MESSAGES
+
+  say """
+      \n
+      Test error messages when decoding broken base16...
+      """
+
+  broken_enc := ["66\r6F6F",   # carriage return
+                 "6\n66F6F",   # line break
+                 "666F6",      # invalid length
+                 "GHIJK",      # non alphabet character
+                 "abcde",      # non alphabet character
+                 "666F 6F",    # space
+                 "66;6F6F",    # non alphabet ascii character
+                 "666🌍F6"]    # non alphabet multi byte unicode character
+
+  for t in broken_enc do
+    yak "$t: "
+    say (match encodings.base16.decode_str t
+        arr array u8 => String.type.from_bytes arr
+        e error => e.as_string)
+  say ""

--- a/tests/base16/base16_test.fz.expected_out
+++ b/tests/base16/base16_test.fz.expected_out
@@ -1,0 +1,22 @@
+Testing base16 encoding...
+RFC 4648 test vectors are encoded correctly
+Additional test vectors are encoded correctly
+
+
+Testing base16 decoding...
+RFC 4648 test vectors are decoded correctly
+Additional test vectors are decoded correctly
+
+
+Test error messages when decoding broken base16...
+
+666F6F: error: line breaks are not allowed within encoded data, as required by RFC464, found CR at position 2
+6
+66F6F: error: line breaks are not allowed within encoded data, as required by RFC464, found LF at position 1
+666F6: error: unexpected end of input, i.e. not of even length
+GHIJK: error: invalid base16 input at byte position 0, decoding to unicode character 'G'
+abcde: error: invalid base16 input at byte position 0, decoding to unicode character 'a'
+666F 6F: error: invalid base16 input at byte position 4, decoding to unicode character ' '
+66;6F6F: error: invalid base16 input at byte position 2, decoding to unicode character ';'
+666🌍F6: error: invalid base16 input at byte position 3, decoding to unicode character '🌍'
+


### PR DESCRIPTION
base16 (hexadecimal) as defined in [RFC 4648](https://datatracker.ietf.org/doc/html/rfc4648#section-8)