### PR TITLE
tests: fix two problems in check_example scripts

### DIFF
--- a/tests/check_simple_example_c.sh
+++ b/tests/check_simple_example_c.sh
@@ -45,7 +45,7 @@ RC=0
 if [ -f "$2".skip ]; then
     echo "SKIP $2"
 else
-    printf "RUN $2 "
+    printf 'RUN %s ' "$2"
     unset OPT
     head -n 1 "$2" | grep -q -E "# fuzion.debugLevel=.*$"     && export OPT=-Dfuzion.debugLevel=10
     head -n 1 "$2" | grep -q -E "# fuzion.debugLevel=9( .*)$" && export OPT=-Dfuzion.debugLevel=9
@@ -89,14 +89,10 @@ else
 
     # NYI: workaround for #2586
     if [ "${OS-default}" = "Windows_NT" ]; then
-        iconv --unicode-subst="?" -f utf-8 -t ascii "$experr" > tmp_conv.txt
-        cp tmp_conv.txt "$experr"
-        iconv --unicode-subst="?" -f utf-8 -t ascii "$expout" > tmp_conv.txt
-        cp tmp_conv.txt "$expout"
-        iconv --unicode-subst="?" -f utf-8 -t ascii tmp_err.txt > tmp_conv.txt
-        cp tmp_conv.txt tmp_err.txt
-        iconv --unicode-subst="?" -f utf-8 -t ascii tmp_out.txt > tmp_conv.txt
-        cp tmp_conv.txt tmp_out.txt
+        iconv --unicode-subst="?" -f utf-8 -t ascii "$experr" > tmp_conv.txt || false && cp tmp_conv.txt "$experr"
+        iconv --unicode-subst="?" -f utf-8 -t ascii "$expout" > tmp_conv.txt || false && cp tmp_conv.txt "$expout"
+        iconv --unicode-subst="?" -f utf-8 -t ascii tmp_err.txt > tmp_conv.txt || false && cp tmp_conv.txt tmp_err.txt
+        iconv --unicode-subst="?" -f utf-8 -t ascii tmp_out.txt > tmp_conv.txt || false && cp tmp_conv.txt tmp_out.txt
     fi
 
     # show diff in stdout unless an unexpected output occurred to stderr

--- a/tests/check_simple_example_int.sh
+++ b/tests/check_simple_example_int.sh
@@ -45,7 +45,7 @@ RC=0
 if [ -f "$2".skip ]; then
     echo "SKIP $2"
 else
-    printf "RUN $2 "
+    printf 'RUN %s ' "$2"
     unset OPT
     head -n 1 "$2" | grep -q -E "# fuzion.debugLevel=.*$"     && export OPT=-Dfuzion.debugLevel=10
     head -n 1 "$2" | grep -q -E "# fuzion.debugLevel=9( .*)$" && export OPT=-Dfuzion.debugLevel=9
@@ -78,14 +78,10 @@ else
 
     # NYI: workaround for #2586
     if [ "${OS-default}" = "Windows_NT" ]; then
-        iconv --unicode-subst="?" -f utf-8 -t ascii "$experr" > tmp_conv.txt
-        cp tmp_conv.txt "$experr"
-        iconv --unicode-subst="?" -f utf-8 -t ascii "$expout" > tmp_conv.txt
-        cp tmp_conv.txt "$expout"
-        iconv --unicode-subst="?" -f utf-8 -t ascii tmp_err.txt > tmp_conv.txt
-        cp tmp_conv.txt tmp_err.txt
-        iconv --unicode-subst="?" -f utf-8 -t ascii tmp_out.txt > tmp_conv.txt
-        cp tmp_conv.txt tmp_out.txt
+        iconv --unicode-subst="?" -f utf-8 -t ascii "$experr" > tmp_conv.txt || false && cp tmp_conv.txt "$experr"
+        iconv --unicode-subst="?" -f utf-8 -t ascii "$expout" > tmp_conv.txt || false && cp tmp_conv.txt "$expout"
+        iconv --unicode-subst="?" -f utf-8 -t ascii tmp_err.txt > tmp_conv.txt || false && cp tmp_conv.txt tmp_err.txt
+        iconv --unicode-subst="?" -f utf-8 -t ascii tmp_out.txt > tmp_conv.txt || false && cp tmp_conv.txt tmp_out.txt
     fi
 
     # show diff in stdout unless an unexpected output occurred to stderr:

--- a/tests/check_simple_example_jvm.sh
+++ b/tests/check_simple_example_jvm.sh
@@ -44,7 +44,7 @@ RC=0
 if [ -f "$2".skip ]; then
     echo "SKIP $2"
 else
-    printf "RUN $2 "
+    printf 'RUN %s ' "$2"
     unset OPT
     head -n 1 "$2" | grep -q -E "# fuzion.debugLevel=.*$"     && export OPT=-Dfuzion.debugLevel=10
     head -n 1 "$2" | grep -q -E "# fuzion.debugLevel=9( .*)$" && export OPT=-Dfuzion.debugLevel=9
@@ -77,14 +77,10 @@ else
 
     # NYI: workaround for #2586
     if [ "${OS-default}" = "Windows_NT" ]; then
-        iconv --unicode-subst="?" -f utf-8 -t ascii "$experr" > tmp_conv.txt
-        cp tmp_conv.txt "$experr"
-        iconv --unicode-subst="?" -f utf-8 -t ascii "$expout" > tmp_conv.txt
-        cp tmp_conv.txt "$expout"
-        iconv --unicode-subst="?" -f utf-8 -t ascii tmp_err.txt > tmp_conv.txt
-        cp tmp_conv.txt tmp_err.txt
-        iconv --unicode-subst="?" -f utf-8 -t ascii tmp_out.txt > tmp_conv.txt
-        cp tmp_conv.txt tmp_out.txt
+        iconv --unicode-subst="?" -f utf-8 -t ascii "$experr" > tmp_conv.txt || false && cp tmp_conv.txt "$experr"
+        iconv --unicode-subst="?" -f utf-8 -t ascii "$expout" > tmp_conv.txt || false && cp tmp_conv.txt "$expout"
+        iconv --unicode-subst="?" -f utf-8 -t ascii tmp_err.txt > tmp_conv.txt || false && cp tmp_conv.txt tmp_err.txt
+        iconv --unicode-subst="?" -f utf-8 -t ascii tmp_out.txt > tmp_conv.txt || false && cp tmp_conv.txt tmp_out.txt
     fi
 
     # show diff in stdout unless an unexpected output occurred to stderr:


### PR DESCRIPTION
First problem is the reason that linux tests are not running currently. Shellcheck complains about printf with direct variable substitution.
```
In tests/check_simple_example_jvm.sh line 47:
    printf "RUN $2 "
           ^-------^ SC2059 (info): Don't use variables in the printf format string. Use printf '..%s..' "$foo".
```

Second problem is the reason that windows tests are not running currently. NULL-characters and similar make windows-workaround using iconv fail:
```
 RUN base64url_test.fz make[1]: Leaving directory '/d/a/fuzion/fuzion/build/tests/base64url'
iconv: base64url_test.fz.expected_out:27:0: cannot convert
```

