### PR TITLE
ast: When checking actual type par against constraints, do not walk through inh chain of choice Fix #3362

### DIFF
--- a/src/dev/flang/ast/AbstractType.java
+++ b/src/dev/flang/ast/AbstractType.java
@@ -488,15 +488,12 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
                   {
                     result = true;
                   }
-                else if (!actual.isChoice())
+                for (var p: actual.feature().inherits())
                   {
-                    for (var p: actual.feature().inherits())
+                    var pt = p.type().applyTypePars(actual);
+                    if (!p.calledFeature().isChoice() && constraintAssignableFrom(pt))
                       {
-                        var pt = p.type().applyTypePars(actual);
-                        if (constraintAssignableFrom(pt))
-                          {
-                            result = true;
-                          }
+                        result = true;
                       }
                   }
               }

--- a/src/dev/flang/ast/AbstractType.java
+++ b/src/dev/flang/ast/AbstractType.java
@@ -483,18 +483,12 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
               (actual.feature() != null || Errors.any());
             if (actual.feature() != null)
               {
-                if (actual.feature() == feature() &&
-                    genericsAssignable(actual)) // NYI: Check: What about open generics?
-                  {
-                    result = true;
-                  }
+                result = actual.feature() == feature() &&
+                         genericsAssignable(actual); // NYI: Check: What about open generics?
                 for (var p: actual.feature().inherits())
                   {
-                    var pt = p.type().applyTypePars(actual);
-                    if (!p.calledFeature().isChoice() && constraintAssignableFrom(pt))
-                      {
-                        result = true;
-                      }
+                    result |= !p.calledFeature().isChoice() &&
+                      constraintAssignableFrom(p.type().applyTypePars(actual));
                   }
               }
           }

--- a/src/dev/flang/ast/AbstractType.java
+++ b/src/dev/flang/ast/AbstractType.java
@@ -469,6 +469,7 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
     var result = containsError()                   ||
       actual.containsError()                       ||
       this  .compareTo(actual               ) == 0 ||
+      this  .compareTo(Types.resolved.t_Any ) == 0 ||
       actual.isVoid();
     if (!result && !isGenericArgument())
       {
@@ -482,14 +483,12 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
               (actual.feature() != null || Errors.any());
             if (actual.feature() != null)
               {
-                if (actual.feature() == feature())
+                if (actual.feature() == feature() &&
+                    genericsAssignable(actual)) // NYI: Check: What about open generics?
                   {
-                    if (genericsAssignable(actual)) // NYI: Check: What about open generics?
-                      {
-                        result = true;
-                      }
+                    result = true;
                   }
-                if (!result)
+                else if (!actual.isChoice())
                   {
                     for (var p: actual.feature().inherits())
                       {

--- a/tests/reg_issue3362/Makefile
+++ b/tests/reg_issue3362/Makefile
@@ -1,0 +1,25 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test Makefile
+#
+# -----------------------------------------------------------------------
+
+override NAME = reg_issue3362
+include ../simple_and_negative.mk

--- a/tests/reg_issue3362/reg_issue3362.fz
+++ b/tests/reg_issue3362/reg_issue3362.fz
@@ -1,0 +1,65 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test
+#
+# -----------------------------------------------------------------------
+
+# Test choice type used as actual type parameter without matching the contstraing
+#
+reg_issue3362 is
+
+
+  # original example form issue #3362
+  #
+  base32_test is
+  my_c : choice String (array u8) is
+  mk_choice(x my_c) => x
+
+  # RFC 4618 test vectors
+  base32_test_vectors array (tuple my_c String) :=
+    [(mk_choice "fo", "MZXQ===="),
+     (mk_choice "foo", "MZXW6===")]
+
+  dummy_decode(arr array u8) outcome (array u8) => [0,0,0]
+
+  dec_test =>
+    for tup in base32_test_vectors do
+      (plain_expected, code) := tup
+      out :=
+        match dummy_decode code.utf8.as_array
+          arr array u8 =>
+            plain_actual := String.type.from_bytes arr
+            if plain_actual != plain_expected     # 1. should flag an error: `choice String (array u8)` is not assignable to property.equatable
+              error "decoding $code produced '$plain_actual' but should have been '$plain_expected'"
+            else
+              outcome "ok"
+          e error => error "error in test data"
+    until !out.ok
+      out.err.as_string
+    else
+      "RFC 4648 test vectors are decoded correctly"
+  say dec_test
+
+
+  # minimalistic-example
+  #
+  c : choice i32 unit is
+  a c := 0
+  _ := 0 = a   # 2. should flag an error: `choice i32 unit` is not assignable to property.equatable

--- a/tests/reg_issue3362/reg_issue3362.fz
+++ b/tests/reg_issue3362/reg_issue3362.fz
@@ -21,12 +21,12 @@
 #
 # -----------------------------------------------------------------------
 
-# Test choice type used as actual type parameter without matching the contstraing
+# Test choice type used as actual type parameter without matching the contstraint
 #
 reg_issue3362 is
 
 
-  # original example form issue #3362
+  # original example from issue #3362
   #
   base32_test is
   my_c : choice String (array u8) is
@@ -46,7 +46,7 @@ reg_issue3362 is
         match dummy_decode code.utf8.as_array
           arr array u8 =>
             plain_actual := String.type.from_bytes arr
-            if plain_actual != plain_expected     # 1. should flag an error: `choice String (array u8)` is not assignable to property.equatable
+            if plain_actual != plain_expected     # 1. should flag an error: `choice String (array u8)` is not assignable to `property.equatable`
               error "decoding $code produced '$plain_actual' but should have been '$plain_expected'"
             else
               outcome "ok"
@@ -62,4 +62,4 @@ reg_issue3362 is
   #
   c : choice i32 unit is
   a c := 0
-  _ := 0 = a   # 2. should flag an error: `choice i32 unit` is not assignable to property.equatable
+  _ := 0 = a   # 2. should flag an error: `choice i32 unit` is not assignable to `property.equatable`

--- a/tests/reg_issue3362/reg_issue3362.fz.expected_err
+++ b/tests/reg_issue3362/reg_issue3362.fz.expected_err
@@ -1,0 +1,15 @@
+
+--CURDIR--/reg_issue3362.fz:65:10: error 1: Incompatible type parameter
+  _ := 0 = a   # 2. should flag an error: `choice i32 unit` is not assignable to property.equatable
+---------^
+formal type parameter 'T' with constraint 'property.equatable'
+actual type parameter 'reg_issue3362.this.c'
+
+
+--CURDIR--/reg_issue3362.fz:49:29: error 2: Incompatible type parameter
+            if plain_actual != plain_expected     # 1. should flag an error: `choice String (array u8)` is not assignable to property.equatable
+----------------------------^^
+formal type parameter 'T' with constraint 'property.equatable'
+actual type parameter 'reg_issue3362.this.my_c'
+
+2 errors.

--- a/tests/reg_issue3362/reg_issue3362.fz.expected_err
+++ b/tests/reg_issue3362/reg_issue3362.fz.expected_err
@@ -1,13 +1,13 @@
 
 --CURDIR--/reg_issue3362.fz:65:10: error 1: Incompatible type parameter
-  _ := 0 = a   # 2. should flag an error: `choice i32 unit` is not assignable to property.equatable
+  _ := 0 = a   # 2. should flag an error: `choice i32 unit` is not assignable to `property.equatable`
 ---------^
 formal type parameter 'T' with constraint 'property.equatable'
 actual type parameter 'reg_issue3362.this.c'
 
 
 --CURDIR--/reg_issue3362.fz:49:29: error 2: Incompatible type parameter
-            if plain_actual != plain_expected     # 1. should flag an error: `choice String (array u8)` is not assignable to property.equatable
+            if plain_actual != plain_expected     # 1. should flag an error: `choice String (array u8)` is not assignable to `property.equatable`
 ----------------------------^^
 formal type parameter 'T' with constraint 'property.equatable'
 actual type parameter 'reg_issue3362.this.my_c'


### PR DESCRIPTION
Since choice types cannot be called, the result of a call to `choice X Y Z` is `void`, which lead to choice types that inherit from choice to be accepted to match any constraint. This patch fixes this by not walking through the parents if the actual type parameter is a choice.

This also adds a regression test with the original code from #3362 and a minimalistic example.
