### PR TITLE
ast: fix example pythagorean_triple

### DIFF
--- a/src/dev/flang/ast/Loop.java
+++ b/src/dev/flang/ast/Loop.java
@@ -563,7 +563,7 @@ public class Loop extends ANY
       @Override
       public Expr action(Call c, AbstractFeature outer)
       {
-        if (names.contains(c._name))
+        if (c._target == null && names.contains(c._name))
           {
             c._name = prefix + c._name;
           }


### PR DESCRIPTION
error was:
```

/home/not_synced/fuzion/examples/complex/pythagorean_triple.fz:51:15: error 1: Could not find called feature
      b := v².imag / f

Feature not found: 'imag' (no arguments)
Target feature: 'num.complex'
In call: 'v².imag'

/home/not_synced/fuzion/examples/complex/pythagorean_triple.fz:49:27: error 2: Could not find called feature
      f := v².real.gcd v².imag  # 1 or 2 (if real+imag is even)

Feature not found: 'imag' (no arguments)
Target feature: 'num.complex'
In call: 'v².imag'

2 errors.
```
Problem was that call to `imag` was prefixed for the loop even though the called had a target.
