### PR TITLE
underline 'type' and 'inherited' links in api docs on mouseover

### DIFF
--- a/assets/docs/style.css
+++ b/assets/docs/style.css
@@ -181,3 +181,8 @@ Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
   font-weight: 600;
   font-size: x-small;
 }
+
+a.fd-type:hover,
+a.fd-inherited:hover{
+  text-decoration: underline;
+}


### PR DESCRIPTION
This will just underline links for types and inherited features, but not the feature itself or the "[src]" button.
```
list(A type) => void : choice nil, Cons list.A (list list.A), Sequence list.A
                       _____________________________________  _______________
```

Would it be better to underline all links for a more consistent style?

