### PR TITLE
air: reduce verbosity level of `GLOBAL CLAZZ` output

### DIFF
--- a/src/dev/flang/air/Clazzes.java
+++ b/src/dev/flang/air/Clazzes.java
@@ -345,9 +345,9 @@ public class Clazzes extends ANY
             clazzesToBeVisited.add(result);
           }
         result.registerAsHeir();
-        if (_options_.verbose(3))
+        if (_options_.verbose(5))
           {
-            _options_.verbosePrintln(3, "GLOBAL CLAZZ: " + result);
+            _options_.verbosePrintln(5, "GLOBAL CLAZZ: " + result);
             if (_options_.verbose(10))
               {
                 Thread.dumpStack();


### PR DESCRIPTION
This was annoying when debugging DFA with `-verbose=3`, maybe this output should be removed comnpletely.
