### PR TITLE
generate type feature documentation inside origin feature

### DIFF
--- a/src/dev/flang/ast/AbstractFeature.java
+++ b/src/dev/flang/ast/AbstractFeature.java
@@ -1019,7 +1019,7 @@ public abstract class AbstractFeature extends Expr implements Comparable<Abstrac
    * For a type feature, this specifies the base feature the type feature was
    * created for.
    */
-  AbstractFeature typeFeatureOrigin()
+  public AbstractFeature typeFeatureOrigin()
   {
     if (CHECKS) check
       (isTypeFeature());

--- a/src/dev/flang/tools/docs/Docs.java
+++ b/src/dev/flang/tools/docs/Docs.java
@@ -122,7 +122,7 @@ public class Docs extends ANY
 
 
   /**
-   * do a breath first traversel of declared features,
+   * do a breath first traversal of declared features,
    * passing found features to consumer c.
    * @param c
    * @param start
@@ -256,11 +256,12 @@ public class Docs extends ANY
       {
         return "";
       }
-    String path = (featurePath(f.outer()) + f.featureName().toString());
+
+    String path = f.isTypeFeature() ? (featurePath(f.typeFeatureOrigin()) + "/" + "type.")
+                                    : (featurePath(f.outer()) + f.featureName().toString()) + "/";
 
     return path
-      .replace(" ", "+")
-      + "/";
+      .replace(" ", "+");
   }
 
 

--- a/src/dev/flang/tools/docs/Html.java
+++ b/src/dev/flang/tools/docs/Html.java
@@ -494,7 +494,13 @@ public class Html extends ANY
       {
         return "";
       }
-    return featureAbsoluteURL0(f.outer()) + "/" + urlEncode(f.featureName().toString());
+    if (f.isTypeFeature()) {
+      return featureAbsoluteURL0(f.typeFeatureOrigin());
+    } else
+    {
+      String prefix = f.outer().isTypeFeature() ? "type." : "";
+      return featureAbsoluteURL0(f.outer()) + "/" + prefix + urlEncode(f.featureName().toString());
+    }
   }
 
 


### PR DESCRIPTION
Directory structure now looks like this
```
String+(no+arguments)
├── as_codepoints+(no+arguments)
├── as_java_object+(no+arguments)
├── as_string+(no+arguments)
│ ...
├── type.a_char+(no+arguments)
├── type.cap_a_char+(no+arguments)
├── type.cap_z_char+(no+arguments)
│ ...
```

instead of this
```
String+(no+arguments)
├── as_codepoints+(no+arguments)
├── as_java_object+(no+arguments)
├── as_string+(no+arguments)
│ ...
```

```
String.type+(one+argument)
├── a_char+(no+arguments)
├── cap_a_char+(no+arguments)
├── cap_z_char+(no+arguments)
├── concat1+(one+argument)
│ ...
├── z_char+(no+arguments)
└── zero_char+(no+arguments)
```

I've made the method `typeFeatureOrigin()` public, I don't know if this could cause any problems.