### PR TITLE
ast: numliteral, remove type inference to i64

### DIFF
--- a/src/dev/flang/ast/NumLiteral.java
+++ b/src/dev/flang/ast/NumLiteral.java
@@ -477,10 +477,9 @@ public class NumLiteral extends Constant
   AbstractType typeForCallTarget()
   {
     var i = hasDot() ? null : intValue(ConstantType.ct_i32);
-    return
-      i == null                      ? Types.resolved.t_f64 :
-      ConstantType.ct_i32.canHold(i) ? Types.resolved.t_i32
-                                     : Types.resolved.t_i64;
+    return i == null
+      ? Types.resolved.t_f64
+      : Types.resolved.t_i32;
   }
 
 

--- a/tests/reg_issue1158_type_of_type_parameters/test_type_of.fz
+++ b/tests/reg_issue1158_type_of_type_parameters/test_type_of.fz
@@ -65,7 +65,7 @@ test_type_of is
   chck_cmp $(type_of2 (type_of2 (option 42))) "Type of 'Type'"
   chck_cmp $(type_of2 (option i32).type     ) "Type of 'Type'"
 
-  type_of3 3140000000             "Type of 'i64' 3140000000"
+  type_of3 (i64 3140000000)       "Type of 'i64' 3140000000"
   type_of3 (option 42)            "Type of 'option i32' 42"
   type_of3 (type_of2 (option 42)) "Type of 'Type' Type of 'option i32'"
   type_of3 (option i32).type      "Type of 'Type' Type of 'option i32'"


### PR DESCRIPTION
If a numliteral did not have a dot and did not fit in i32, i64 was inferred as type. I think this magic does more harm than good. So this PR is proposing to remove this logic.


