### PR TITLE
fe: fix accessing field of other instance in field init

### DIFF
--- a/src/dev/flang/fe/SourceModule.java
+++ b/src/dev/flang/fe/SourceModule.java
@@ -1212,6 +1212,9 @@ A post-condition of a feature that does not redefine an inherited feature must s
    * @param v
    * @return
    */
+  @SuppressWarnings({
+    "rawtypes", "unchecked"
+  })
   private boolean inScope(Expr use, AbstractFeature v)
   {
     // we only need to do this evaluation for:
@@ -1307,7 +1310,12 @@ A post-condition of a feature that does not redefine an inherited feature must s
 
         if (f.isField())
           {
-            if (useIsBeforeDefinition[0])
+            /**
+              * cases like this are okay:
+              *   ring(r ring) is
+              *      last ring := r.last
+              */
+            if (useIsBeforeDefinition[0] && !(use instanceof AbstractCall ac && ac.target() instanceof AbstractCall))
               {
                 return false;
               }

--- a/tests/visibility/visibility.fz
+++ b/tests/visibility/visibility.fz
@@ -331,4 +331,10 @@ visibility is
     r2 := red magenta; say "red magenta is $r2"
   visiB
 
+
+  # accessing field of other instance
+  # in field initializer
+  ring(r ring) is
+    last ring := r.last
+
   exit


### PR DESCRIPTION
this example was broken previous to this PR
```
  ring(r ring) is
    last ring := r.last
```

