### PR TITLE
docs: sort features names in api docs case insensitively

### DIFF
--- a/src/dev/flang/tools/docs/Html.java
+++ b/src/dev/flang/tools/docs/Html.java
@@ -238,6 +238,7 @@ public class Html extends ANY
   {
     return set
       .stream()
+      .sorted((af1, af2) -> af1.featureName().baseName().compareToIgnoreCase(af2.featureName().baseName()))
       .map(af -> {
         // NYI summary tag must not contain div
         return "<details id='" + htmlID(af)


### PR DESCRIPTION
I'll have to get used to `String` and `Sequence` not being at the top of the list, but generally it's easier to find a name without having to think about capitalization.