### PR TITLE
ast: add error on more restrive type-visibility of outer

### DIFF
--- a/lib/fuzion/sys.fz
+++ b/lib/fuzion/sys.fz
@@ -25,7 +25,7 @@
 
 # fuzion.sys -- unit type to group low-level system APIs
 #
-module sys is
+module:public sys is
 
 
   # Create a 0-terminated internal array of bytes from

--- a/src/dev/flang/ast/AstErrors.java
+++ b/src/dev/flang/ast/AstErrors.java
@@ -2159,6 +2159,14 @@ public class AstErrors extends ANY
           "To solve this, use a regular feature by removing the " + skw("type.") + " or move the feature definition inside of a feature.");
   }
 
+  public static void illegalTypeVisibility(Feature f)
+  {
+    error(f.pos(),
+          "Visibility of outer features type is more restrictive than features type.",
+          "Parent feature is here: " + f.outer().pos().show() + System.lineSeparator() +
+          "To solve this, either decrease the type visibility of this feature or increase the visibility of the type of the outer feature.");
+  }
+
 
 }
 

--- a/src/dev/flang/fe/SourceModule.java
+++ b/src/dev/flang/fe/SourceModule.java
@@ -1765,6 +1765,10 @@ A feature that is a constructor, choice or a type parameter may not redefine an 
       {
         AstErrors.illegalTypeVisibilityModifier(f);
       }
+    else if(f.definesType() && f.outer() != null && f.outer().visibility().typeVisibility().ordinal() < f.visibility().typeVisibility().ordinal())
+      {
+        AstErrors.illegalTypeVisibility(f);
+      }
   }
 
 


### PR DESCRIPTION
`Pointer` is `private:public` so `fuzion.sys` type should also be public.

