### PR TITLE
docs: improve representation of type features

### DIFF
--- a/src/dev/flang/ast/FeatureName.java
+++ b/src/dev/flang/ast/FeatureName.java
@@ -272,7 +272,7 @@ public class FeatureName extends ANY implements Comparable<FeatureName>
       n.startsWith(FuzionConstants.PREANDCALLCONDITION_FEATURE_PREFIX) ? n.replaceFirst(FuzionConstants.PREANDCALLCONDITION_FEATURE_PREFIX + "[0-9]+_", "precall ") :
       n.startsWith(FuzionConstants.PRECONDITION_FEATURE_PREFIX       ) ? n.replaceFirst(FuzionConstants.PRECONDITION_FEATURE_PREFIX        + "[0-9]+_", "pre "    ) :
       n.startsWith(FuzionConstants.POSTCONDITION_FEATURE_PREFIX      ) ? n.replaceFirst(FuzionConstants.POSTCONDITION_FEATURE_PREFIX       + "[0-9]+_", "post "   ) :
-      n.endsWith(FuzionConstants.TYPE_NAME)                            ? n.replace("."+FuzionConstants.TYPE_NAME, "") :
+      n.endsWith(FuzionConstants.TYPE_NAME)                            ? n.replace("." + FuzionConstants.TYPE_NAME, "") :
       n.startsWith(FuzionConstants.ITER_ARG_PREFIX_INIT)               ? n.replace(FuzionConstants.ITER_ARG_PREFIX_INIT, "") :
       n.startsWith(FuzionConstants.ITER_ARG_PREFIX_NEXT)               ? n.replace(FuzionConstants.ITER_ARG_PREFIX_NEXT, "") :
       n;

--- a/src/dev/flang/ast/FeatureName.java
+++ b/src/dev/flang/ast/FeatureName.java
@@ -272,7 +272,7 @@ public class FeatureName extends ANY implements Comparable<FeatureName>
       n.startsWith(FuzionConstants.PREANDCALLCONDITION_FEATURE_PREFIX) ? n.replaceFirst(FuzionConstants.PREANDCALLCONDITION_FEATURE_PREFIX + "[0-9]+_", "precall ") :
       n.startsWith(FuzionConstants.PRECONDITION_FEATURE_PREFIX       ) ? n.replaceFirst(FuzionConstants.PRECONDITION_FEATURE_PREFIX        + "[0-9]+_", "pre "    ) :
       n.startsWith(FuzionConstants.POSTCONDITION_FEATURE_PREFIX      ) ? n.replaceFirst(FuzionConstants.POSTCONDITION_FEATURE_PREFIX       + "[0-9]+_", "post "   ) :
-      n.endsWith(FuzionConstants.TYPE_NAME)                            ? n.replace(FuzionConstants.TYPE_NAME, "type") :
+      n.endsWith(FuzionConstants.TYPE_NAME)                            ? n.replace("."+FuzionConstants.TYPE_NAME, "") :
       n.startsWith(FuzionConstants.ITER_ARG_PREFIX_INIT)               ? n.replace(FuzionConstants.ITER_ARG_PREFIX_INIT, "") :
       n.startsWith(FuzionConstants.ITER_ARG_PREFIX_NEXT)               ? n.replace(FuzionConstants.ITER_ARG_PREFIX_NEXT, "") :
       n;

--- a/src/dev/flang/tools/docs/Html.java
+++ b/src/dev/flang/tools/docs/Html.java
@@ -140,8 +140,19 @@ public class Html extends ANY
         return Stream.empty();
       }
     return Stream.concat(anchorTags0(f.outer()),
-      Stream.of("<a class='fd-feature font-weight-600' href='$2'>$1</a>".replace("$1", htmlEncodedBasename(f))
+      Stream.of(typePrfx(f) + "<a class='fd-feature font-weight-600' href='$2'>$1</a>".replace("$1", htmlEncodedBasename(f))
         .replace("$2", featureAbsoluteURL(f))));
+  }
+
+
+  /**
+   * Return "type." prefix if af is a type feature.
+   * @param af the feature to be checked
+   * @return html for "type." prefix if type feature, empty string otherwise
+   */
+  private String typePrfx(AbstractFeature af)
+  {
+    return af.outer() != null && af.outer().isTypeFeature() && !af.isTypeFeature() ? "<span class=\"fd-keyword\">type</span>." : "";
   }
 
 
@@ -182,9 +193,10 @@ public class Html extends ANY
 
 
   private String anchor(AbstractFeature af) {
-    return "<a class='fd-feature font-weight-600' href='" + featureAbsoluteURL(af) + "'>"
+    return "<span class='font-weight-600'>" + typePrfx(af)
+            + "<a class='fd-feature' href='" + featureAbsoluteURL(af) + "'>"
             + htmlEncodedBasename(af)
-            + "</a>";
+            + "</a></span>";
   }
 
 
@@ -310,9 +322,7 @@ public class Html extends ANY
    */
   private String htmlEncodedBasename(AbstractFeature af)
   {
-    var n = (af.outer() != null && af.outer().isTypeFeature() ? "type." : "") + af.featureName().baseNameHuman();
-
-    return htmlEncodeNbsp(n);
+    return htmlEncodeNbsp(af.featureName().baseNameHuman());
   }
 
 

--- a/src/dev/flang/tools/docs/Html.java
+++ b/src/dev/flang/tools/docs/Html.java
@@ -193,10 +193,10 @@ public class Html extends ANY
 
 
   private String anchor(AbstractFeature af) {
-    return "<span class='font-weight-600'>" + typePrfx(af)
+    return "<div class='font-weight-600'>" + typePrfx(af)
             + "<a class='fd-feature' href='" + featureAbsoluteURL(af) + "'>"
             + htmlEncodedBasename(af)
-            + "</a></span>";
+            + "</a></div>";
   }
 
 


### PR DESCRIPTION
The "type." prefix for type features is now rendered as a keyword. It appears only in front of features which are actual type features from user perspective.

Fixes issue of type appearing twice.

previously
> lock_free.#type.type.map.#type.type.empty

now
> lock_free.map.type.empty