### PR TITLE
docs: underline all links in api docs on mouseover

### DIFF
--- a/assets/docs/style.css
+++ b/assets/docs/style.css
@@ -182,7 +182,6 @@ Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
   font-size: x-small;
 }
 
-a.fd-type:hover,
-a.fd-inherited:hover{
+.fd a:hover{
   text-decoration: underline;
 }


### PR DESCRIPTION
This will underline all links in the API documentation on mouseover. E.g. this would illustrate that there are several links in the title of a feature:
```
lock_free.map.type.empty
_________ ___      _____
```
Links for types and parent features in the feature signature are currently underlined (see  #3398), which I think helps a lot to see where a link leads.

I don't have an opinion for the other cases, for consistency it'd probably be good to underline all links, on the other hand I think it's good to avoid unnecessary visual effects. Any thoughts @tokiwa-software/developers?