### PR TITLE
ast: cache result of `ResolvedNormalType.isRef()`

### DIFF
--- a/src/dev/flang/ast/ResolvedNormalType.java
+++ b/src/dev/flang/ast/ResolvedNormalType.java
@@ -91,6 +91,13 @@ public class ResolvedNormalType extends ResolvedType
   AbstractFeature _feature;
 
 
+  /**
+   * Cached result of isRef(). Even though this function looks harmless, it is
+   * suprisinging performance critical.
+   */
+  Boolean _isRef;
+
+
   /*--------------------------  constructors  ---------------------------*/
 
 
@@ -460,13 +467,19 @@ public class ResolvedNormalType extends ResolvedType
    */
   public boolean isRef()
   {
-    return switch (this._refOrVal)
+    var r = _isRef;
+    if (r == null)
       {
-      case Boxed                -> true;
-      case Value                -> false;
-      case LikeUnderlyingFeature-> feature().isThisRef();
-      case ThisType             -> false;
-      };
+        r = switch (this._refOrVal)
+          {
+          case Boxed                -> true;
+          case Value                -> false;
+          case LikeUnderlyingFeature-> feature().isThisRef();
+          case ThisType             -> false;
+          };
+        this._isRef = r;
+      }
+    return r;
   }
 
 

--- a/src/dev/flang/ast/ResolvedNormalType.java
+++ b/src/dev/flang/ast/ResolvedNormalType.java
@@ -93,7 +93,7 @@ public class ResolvedNormalType extends ResolvedType
 
   /**
    * Cached result of isRef(). Even though this function looks harmless, it is
-   * suprisinging performance critical.
+   * surprisingly performance critical.
    */
   Boolean _isRef;
 


### PR DESCRIPTION
This reduces the time to run

    > time ./build/bin/fz tests/catch_postcondition/catch_postcondition.fz

by about 1s or 4% on my machine (24.517s instead of 25.472s).
