### PR TITLE
util/tools: Move handling of properties to FuzionOptions, add env var support

### DIFF
--- a/src/dev/flang/be/jvm/JVM.java
+++ b/src/dev/flang/be/jvm/JVM.java
@@ -43,6 +43,7 @@ import dev.flang.be.jvm.runtime.Runtime;
 
 import dev.flang.util.ANY;
 import dev.flang.util.Errors;
+import dev.flang.util.FuzionOptions;
 import dev.flang.util.List;
 import dev.flang.util.Pair;
 import dev.flang.util.QuietThreadTermination;
@@ -377,11 +378,10 @@ should be avoided as much as possible.
    *
    * To enable tracing, use fz with
    *
-   *   FUZION_JAVA_OPTIONS=-Ddev.flang.be.jvm.JVM.TRACE=true
+   *   dev_flang_be_jvm_JVM_TRACE=true
    */
   static final boolean TRACE =
-    System.getProperty("dev.flang.be.jvm.JVM.TRACE",
-                       "false").equals("true");
+    FuzionOptions.boolPropertyOrEnv("dev.flang.be.jvm.JVM.TRACE");
 
 
   /**
@@ -390,11 +390,10 @@ should be avoided as much as possible.
    *
    * To enable tracing returns, use fz with
    *
-   *   FUZION_JAVA_OPTIONS=-Ddev.flang.be.jvm.JVM.TRACE_RETURN=true
+   *   dev_flang_be_jvm_JVM_TRACE_RETURN=true
    */
   static final boolean TRACE_RETURN =
-    System.getProperty("dev.flang.be.jvm.JVM.TRACE_RETURN",
-                       "false").equals("true");
+    FuzionOptions.boolPropertyOrEnv("dev.flang.be.jvm.JVM.TRACE_RETURN");
 
 
   /**
@@ -404,11 +403,10 @@ should be avoided as much as possible.
    *
    * To enable comments, use fz with
    *
-   *   FUZION_JAVA_OPTIONS=-Ddev.flang.be.jvm.JVM.CODE_COMMENTS=true
+   *   dev_flang_be_jvm_JVM_CODE_COMMENTS=true
    */
   static final boolean CODE_COMMENTS =
-    System.getProperty("dev.flang.be.jvm.JVM.CODE_COMMENTS",
-                       "false").equals("true");
+    FuzionOptions.boolPropertyOrEnv("dev.flang.be.jvm.JVM.CODE_COMMENTS");
   static
   {
     Expr.ENABLE_COMMENTS = CODE_COMMENTS;

--- a/src/dev/flang/fuir/analysis/AbstractInterpreter.java
+++ b/src/dev/flang/fuir/analysis/AbstractInterpreter.java
@@ -34,6 +34,7 @@ import static dev.flang.ir.IR.NO_SITE;
 
 import dev.flang.util.ANY;
 import dev.flang.util.Errors;
+import dev.flang.util.FuzionOptions;
 import dev.flang.util.List;
 import dev.flang.util.Pair;
 
@@ -255,26 +256,27 @@ public class AbstractInterpreter<VALUE, RESULT> extends ANY
 
 
   /**
-   * property-controlled flag to enable debug output.
+   * property- or env-var-controlled flag to enable debug output.
    *
    * To enable debugging, use fz with
    *
-   *   FUZION_JAVA_OPTIONS=-Ddev.flang.fuir.analysis.AbstractInterpreter.DEBUG=true
+   *   dev_flang_fuir_analysis_AbstractInterpreter_DEBUG=true
    *
    * or
    *
-   *   FUZION_JAVA_OPTIONS=-Ddev.flang.fuir.analysis.AbstractInterpreter.DEBUG=".*install_default"
-   *
+   *   dev_flang_fuir_analysis_AbstractInterpreter_DEBUG=".*install_default"
    */
   static final String DEBUG;
   static {
-    var debug = System.getProperty("dev.flang.fuir.analysis.AbstractInterpreter.DEBUG");
+    var prop = "dev.flang.fuir.analysis.AbstractInterpreter.DEBUG";
+    var debug = FuzionOptions.propertyOrEnv(prop);
     DEBUG =
       debug == null ||
       debug.equals("false") ? null :
       debug.equals("true" ) ? ".*"
                             : debug;
   }
+
 
   /*-------------------------  static methods  --------------------------*/
 

--- a/src/dev/flang/tools/Fuzion.java
+++ b/src/dev/flang/tools/Fuzion.java
@@ -586,7 +586,7 @@ public class Fuzion extends Tool
   /**
    * Default result of safety:
    */
-  boolean _safety = Boolean.valueOf(System.getProperty(FuzionConstants.FUZION_SAFETY_PROPERTY, "true"));
+  boolean _safety = FuzionOptions.boolPropertyOrEnv(FuzionConstants.FUZION_SAFETY_PROPERTY);
 
 
   /**

--- a/src/dev/flang/tools/FuzionHome.java
+++ b/src/dev/flang/tools/FuzionHome.java
@@ -28,6 +28,7 @@ package dev.flang.tools;
 
 import dev.flang.util.ANY;
 import dev.flang.util.FuzionConstants;
+import dev.flang.util.FuzionOptions;
 
 import java.nio.file.Path;
 
@@ -50,7 +51,7 @@ public class FuzionHome extends ANY
    * Value of property with name FUZION_HOME_PROPERTY.  Used only to initialize
    * _fuzionHome.
    */
-  private String _fuzionHomeProperty = System.getProperty(FuzionConstants.FUZION_HOME_PROPERTY);
+  private String _fuzionHomeProperty = FuzionOptions.propertyOrEnv(FuzionConstants.FUZION_HOME_PROPERTY);
 
 
   /**

--- a/src/dev/flang/tools/Tool.java
+++ b/src/dev/flang/tools/Tool.java
@@ -35,6 +35,7 @@ import dev.flang.parser.Parser;
 
 import dev.flang.util.ANY;
 import dev.flang.util.Errors;
+import dev.flang.util.FuzionOptions;
 import dev.flang.util.List;
 import dev.flang.util.Profiler;
 import dev.flang.util.Version;
@@ -105,7 +106,7 @@ public abstract class Tool extends ANY
   protected Tool(String name, String[] args)
   {
     _rawCmd = name;
-    _cmd = System.getProperty(FUZION_COMMAND_PROPERTY, name);
+    _cmd = FuzionOptions.propertyOrEnv(FUZION_COMMAND_PROPERTY, name);
     _args = args;
   }
 

--- a/src/dev/flang/util/FuzionOptions.java
+++ b/src/dev/flang/util/FuzionOptions.java
@@ -42,6 +42,67 @@ public class FuzionOptions extends ANY
 {
 
 
+  /*-------------------------  static methods  --------------------------*/
+
+
+  /**
+   * Get the value of a Java property (set via -D<name>=...)  or env variable.
+   *
+   * @param name property or env variable name.  Should usually be a fully
+   * qualified class name such as "dev.flang.optimizer.Warp.enable".  Since `.`
+   * is not permitted in env var, `.` will be replaced by `_` when checking env
+   * variables.
+   *
+   * @return the value of the property, if found. Otherwise, the value of the
+   * env var if found. null otherwise.
+   */
+  public static String propertyOrEnv(String name)
+  {
+    return propertyOrEnv(name, null);
+  }
+
+
+  /**
+   * Get the value of a Java property (set via -D<name>=...)  or env variable.
+   *
+   * @param name property or env variable name.  Should usually be a fully
+   * qualified class name such as "dev.flang.optimizer.Warp.enable".  Since `.`
+   * is not permitted in env var, `.` will be replaced by `_` when checking env
+   * variables.
+   *
+   * @param defawlt value to return in case propery / env var is not set.
+   *
+   * @return the value of the property, if found. Otherwise, the value of the
+   * env var if found. defawlt otherwise.
+   */
+  public static String propertyOrEnv(String name, String defawlt)
+  {
+    var result = System.getProperty(name);
+    if (result == null)
+      {
+        result = System.getenv(name.replace(".","_"));
+      }
+    return result != null ? result : defawlt;
+  }
+
+
+  /**
+   * Get the value of boolean a Java property (set via -D<name>=...)  or env
+   * variable.
+   *
+   * @param name property or env variable name.  Should usually be a fully
+   * qualified class name such as "dev.flang.optimizer.Warp.enable".  Since `.`
+   * is not permitted in env var, `.` will be replaced by `_` when checking env
+   * variables.
+   *
+   * @return true iff the property is set and equals to "true", false otherwise.
+   */
+  public static boolean boolPropertyOrEnv(String name)
+  {
+    return propertyOrEnv(name, "false").equals("true");
+  }
+
+
   /*----------------------------  variables  ----------------------------*/
 
 

--- a/src/dev/flang/util/Terminal.java
+++ b/src/dev/flang/util/Terminal.java
@@ -58,8 +58,7 @@ public class Terminal extends ANY
    * does not work, this remains set if stdout/stderr is piped into a file.
    */
   public static final boolean ENABLED =
-    !"true".equals(System.getProperty("FUZION_DISABLE_ANSI_ESCAPES")) &&
-    !"true".equals(System.getenv     ("FUZION_DISABLE_ANSI_ESCAPES")) &&
+    FuzionOptions.boolPropertyOrEnv("FUZION_DISABLE_ANSI_ESCAPES") &&
     System.getenv().get("TERM") != null;
 
   public static final String RESET                     = ENABLED ? "\033[0m" : "";


### PR DESCRIPTION

Special internal settings such as debugging output can now be enabled via env vars in addition to Java properties (using `_` instead of `.` since `.` is not permitted in env vars).

Remaining calls to System.getProperty for `user.dir`, `java.home`, `os.name` have not been changed.
