### PR TITLE
docs: make type in summary list clickable

### DIFF
--- a/src/dev/flang/tools/docs/Html.java
+++ b/src/dev/flang/tools/docs/Html.java
@@ -192,9 +192,9 @@ public class Html extends ANY
 
 
   private String anchor(AbstractFeature af) {
-    return "<div class='font-weight-600'>" + typePrfx(af)
+    return "<div class='font-weight-600'>"
             + "<a class='fd-feature' href='" + featureAbsoluteURL(af) + "'>"
-            + htmlEncodedBasename(af)
+            + typePrfx(af) + htmlEncodedBasename(af)
             + "</a></div>";
   }
 


### PR DESCRIPTION
Include the prefix/keyword "type." in the link. Even though the type is not part of the feature name, I think from a user perspective it is weird that clicking it does not open the feature page. The different colors should be a good indicator already.
![Screenshot_20240726_123659](https://github.com/user-attachments/assets/d4bf6b68-5da5-43f7-ac40-6ed6b3238d2b)



I can also remove the bold formatting from "type" if that is preffered
![Screenshot_20240726_125057](https://github.com/user-attachments/assets/4bdd4d45-976c-4df6-aa2a-db83ac8dcd0e)

