### PR TITLE
util: Fix handling of env var `FUZION_DISABLE_ANSI_ESCAPSE`

### DIFF
--- a/src/dev/flang/util/Terminal.java
+++ b/src/dev/flang/util/Terminal.java
@@ -58,7 +58,7 @@ public class Terminal extends ANY
    * does not work, this remains set if stdout/stderr is piped into a file.
    */
   public static final boolean ENABLED =
-    FuzionOptions.boolPropertyOrEnv("FUZION_DISABLE_ANSI_ESCAPES") &&
+    !FuzionOptions.boolPropertyOrEnv("FUZION_DISABLE_ANSI_ESCAPES") &&
     System.getenv().get("TERM") != null;
 
   public static final String RESET                     = ENABLED ? "\033[0m" : "";


### PR DESCRIPTION
This was set the wrong way around.

