### PR TITLE
parser: remove rule for `dotTypeSuffix`

### DIFF
--- a/src/dev/flang/parser/Parser.java
+++ b/src/dev/flang/parser/Parser.java
@@ -3145,21 +3145,6 @@ anonymous   : "ref"
 
 
   /**
-   * Parse dotTypeSuffx
-   *
-dotTypeSuffx: dot "type"
-            ;
-   */
-  Expr dotTypeSuffx(AbstractType t)
-  {
-    var p = tokenSourcePos();
-    matchOperator(".", "dotTypeSuffx");
-    match(Token.t_type, "dotTypeSuffx");
-    return new DotType(p, t);
-  }
-
-
-  /**
    * Parse contract
    *
    * @param forkAtFormArgs in case the feature this contract belongs to has a


### PR DESCRIPTION
And remove `type_of_lazy`, which is no longer needed.
