### PR TITLE
lib: Remove `Types`, move `Types.get` to `type_as_value`, fix #3431

### DIFF
--- a/lib/Any.fz
+++ b/lib/Any.fz
@@ -44,7 +44,7 @@ public Any ref is
 
 
   # Get the dynamic type of this instance.  For value instances `x`, this is
-  # equal to `type_of x`, but for `x` with a  `ref` type `x.dynamic_type` gives
+  # equal to `type_of x`, but for `x` with a `ref` type `x.dynamic_type` gives
   # the actual runtime type, while `type_of x` results in the static
   # compile-time type.
   #
@@ -53,3 +53,14 @@ public Any ref is
   # to just return Type.type.
   #
   public dynamic_type => Any.this.type
+
+
+  # Get a type as a value.
+  #
+  # This is a feature with the effect equivalent to Fuzion's `expr.type` call tail.
+  # It is recommended to use `expr.type` and not `expr.type_value`.
+  #
+  # `type_value` is here to show how this can be implemented and to illustrate the
+  # difference to `dynamic_type`.
+  #
+  public type.type_value => Any.this.type

--- a/lib/Type.fz
+++ b/lib/Type.fz
@@ -53,18 +53,15 @@ module:public Type ref is
   public redef dynamic_type => Type.type
 
 
-# Types -- features related to Type but not requiring an instance of Type
+# Get the Type instance corresponding to a given type
 #
-public Types is
-
-  # Get the Type instance corresponding to a given type
-  #
-  # The result of 'Types.get x' is the same as 'x.type'.
-  #
-  # Internally, Fuzion's front end implements 'x.type' using
-  # 'Types.get x'.
-  #
-  public get(T type) => T
+# The result of `type_as_value x` is the same as `x.type`.
+#
+# Internally, Fuzion's front end implements `x.type` using
+# `type_as_value x`. The middle end then replaces calls to
+# `type_as_value` by `T`'s type clazz.
+#
+public type_as_value(T type) => T
 
 
 # universe feature to determine the compile-time type of an expression.

--- a/src/dev/flang/air/Clazz.java
+++ b/src/dev/flang/air/Clazz.java
@@ -2243,10 +2243,10 @@ public class Clazz extends ANY implements Comparable<Clazz>
       {
         result = typeParameterActualType().typeClazz();
       }
-    else if (f  == Types.resolved.f_Types_get                          ||
-             of == Types.resolved.f_Types_get && f == of.resultField()   )
+    else if (f  == Types.resolved.f_type_as_value                     ||
+             of == Types.resolved.f_type_as_value && f == of.resultField()   )
       {
-        var ag = (f == Types.resolved.f_Types_get ? this : _outer).actualGenerics();
+        var ag = (f == Types.resolved.f_type_as_value ? this : _outer).actualGenerics();
         result = ag[0].typeClazz();
       }
     else
@@ -2342,13 +2342,13 @@ public class Clazz extends ANY implements Comparable<Clazz>
             var gi = gs.get(i);
             if (gi.isThisType())
               {
-                // Only calls to Types.get may have generic parameters gi with
-                // gi.isThisType().  Calls to Types.get will essentially become
+                // Only calls to type_as_value may have generic parameters gi with
+                // gi.isThisType().  Calls to type_as_value will essentially become
                 // NOPs anyway. Here we replace the this.types by their
                 // underlying type to avoid problems creating clazzes form
                 // this.types.
                 if (CHECKS) check
-                  (Errors.any() || feature() == Types.resolved.f_Types_get);
+                  (Errors.any() || feature() == Types.resolved.f_type_as_value);
 
                 gi = gi.feature().isThisRef() ? gi.asRef() : gi.asValue();
               }

--- a/src/dev/flang/ast/AbstractFeature.java
+++ b/src/dev/flang/ast/AbstractFeature.java
@@ -915,7 +915,7 @@ public abstract class AbstractFeature extends Expr implements Comparable<Abstrac
               {
                 inh.add(new Call(pos(), "Type"));
               }
-            _typeFeature = existingOrNewTypeFeature(res, name, typeArgs, inh);
+            existingOrNewTypeFeature(res, name, typeArgs, inh);
           }
       }
     return _typeFeature;
@@ -988,33 +988,42 @@ public abstract class AbstractFeature extends Expr implements Comparable<Abstrac
    * Helper method for typeFeature to create a new feature with given name and
    * inherits clause iff no such feature exists in outer().typeFeature().
    *
+   * The new type feature will be stored in _typeFeature.
+   *
    * @param res Resolution instance used to resolve this for types.
    *
    * @param name the name of the type feature to be created
    *
+   * @param typeArgs arguments of the type feature.
+   * NYI: OPTIMIZATION: typeArgs should be determined within this method and
+   * only when needed.
+   *
    * @param inh the inheritance clause of the new type feature.
    */
-  private AbstractFeature existingOrNewTypeFeature(Resolution res, String name, List<AbstractFeature> typeArgs, List<AbstractCall> inh)
+  private void existingOrNewTypeFeature(Resolution res, String name, List<AbstractFeature> typeArgs, List<AbstractCall> inh)
   {
     if (PRECONDITIONS) require
       (!isUniverse());
     var outerType = outer().isUniverse()    ? universe() :
                     outer().isTypeFeature() ? outer()
                                             : outer().typeFeature(res);
-    var result = res._module.declaredOrInheritedFeatures(outerType,
-                                                         FeatureName.get(name, 0)).getFirstOrNull();
-    if (result == null)
+    _typeFeature = res._module.declaredOrInheritedFeatures(outerType,
+                                                           FeatureName.get(name, 0)).getFirstOrNull();
+    if (_typeFeature == null)
       {
         var p = pos();
         var typeFeature = new Feature(p, visibility().typeVisibility(), 0, NoType.INSTANCE, new List<>(name), typeArgs,
                                       inh,
                                       Contract.EMPTY_CONTRACT,
                                       new Impl(p, new Block(new List<>()), Impl.Kind.Routine));
+
+        // we need to set _TypeFeature early to avoid endless recursion during
+        // res._module.addTypeFeature for `Any.type`:
+        _typeFeature = typeFeature;
+
         typeFeature._typeFeatureOrigin = this;
         res._module.addTypeFeature(outerType, typeFeature);
-        result = typeFeature;
       }
-    return result;
   }
 
 

--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -1573,7 +1573,7 @@ public class Call extends AbstractCall
             t = tf.selfType().applyTypePars(tf, tg);
           }
       }
-    else if (_calledFeature == Types.resolved.f_Types_get)
+    else if (_calledFeature == Types.resolved.f_type_as_value)
       {
         t = _generics.get(0);
         // we are using `.this.type` inside a type feature, see #2295

--- a/src/dev/flang/ast/DotType.java
+++ b/src/dev/flang/ast/DotType.java
@@ -115,11 +115,9 @@ public class DotType extends ExprWithPos
    */
   public Call resolveTypes(Resolution res, AbstractFeature outer)
   {
-    var tc = new Call(pos(), new Universe(), "Types");
-    tc.resolveTypes(res, outer);
     return new Call(pos(),
-                    tc,
-                    "get",
+                    new Universe(),
+                    "type_as_value",
                     -1,
                     new List<>(_lhs),
                     new List<>(),

--- a/src/dev/flang/ast/Impl.java
+++ b/src/dev/flang/ast/Impl.java
@@ -624,7 +624,7 @@ public class Impl extends ANY
 
     return result != null &&
            result.isTypeType() &&
-           !(_expr instanceof Call c && c.calledFeature() == Types.resolved.f_Types_get)
+           !(_expr instanceof Call c && c.calledFeature() == Types.resolved.f_type_as_value)
       ? Types.resolved.f_Type.selfType()
       : result;
   }

--- a/src/dev/flang/ast/Types.java
+++ b/src/dev/flang/ast/Types.java
@@ -174,8 +174,7 @@ public class Types extends ANY
     public final AbstractFeature f_concur_atomic;
     public final AbstractFeature f_concur_atomic_v;
     public final AbstractFeature f_Type;
-    public final AbstractFeature f_Types;
-    public final AbstractFeature f_Types_get;
+    public final AbstractFeature f_type_as_value;
     public final AbstractFeature f_Lazy;
     public final AbstractFeature f_Unary;
     public final AbstractFeature f_auto_unwrap;
@@ -237,8 +236,7 @@ public class Types extends ANY
       f_concur_atomic              = f_concur.get(mod, "atomic");
       f_concur_atomic_v            = f_concur_atomic.get(mod, "v");
       f_Type                       = universe.get(mod, "Type");
-      f_Types                      = universe.get(mod, "Types");
-      f_Types_get                  = f_Types.get(mod, "get");
+      f_type_as_value              = universe.get(mod, "type_as_value");
       f_Lazy                       = universe.get(mod, LAZY_NAME);
       f_Unary                      = universe.get(mod, UNARY_NAME);
       f_auto_unwrap                = universe.get(mod, "auto_unwrap");

--- a/tests/modules/src/test_modules.fz
+++ b/tests/modules/src/test_modules.fz
@@ -41,8 +41,8 @@ test_modules is
 
   # test type features for types from base.fum that are used in a.fum
   #
-  say (Types.get fuzion.java)
-  say (Types.get fuzion.java.Java_Object)
-  say (Types.get fuzion.java.Java_String)
-  say (Types.get (fuzion.java.Array bool))
-  say (Types.get (fuzion.java.Array u8))
+  say fuzion.java.type
+  say fuzion.java.Java_Object.type
+  say fuzion.java.Java_String.type
+  say (fuzion.java.Array bool).type
+  say (fuzion.java.Array u8).type

--- a/tests/modules/src_a/a.fz
+++ b/tests/modules/src_a/a.fz
@@ -27,8 +27,8 @@ public a is
   # make sure a.fum references type features derived from types from base.fum
   #
   q =>
-    say (Types.get fuzion.java)
-    say (Types.get fuzion.java.Java_Object)
-    say (Types.get fuzion.java.Java_String)
-    say (Types.get (fuzion.java.Array bool))
-    say (Types.get (fuzion.java.Array i32))
+    say fuzion.java.type
+    say fuzion.java.Java_Object.type
+    say fuzion.java.Java_String.type
+    say (fuzion.java.Array bool).type
+    say (fuzion.java.Array i32).type

--- a/tests/reg_issue1158_type_of_type_parameters/test_type_of.fz
+++ b/tests/reg_issue1158_type_of_type_parameters/test_type_of.fz
@@ -70,8 +70,14 @@ test_type_of is
   type_of3 (type_of2 (option 42)) "Type of 'Type' Type of 'option i32'"
   type_of3 (option i32).type      "Type of 'Type' Type of 'option i32'"
 
-  chck_cmp $(Types.get f64         ) "Type of 'f64'"
-  chck_cmp $(Types.get (option i32)) "Type of 'option i32'"
+  chck_cmp $f64.type          "Type of 'f64'"
+  chck_cmp $(option i32).type "Type of 'option i32'"
+
+  chck_cmp $f64.type_value          "Type of 'f64'"
+  chck_cmp $(option i32).type_value "Type of 'option i32'"
+
+  chck_cmp $(type_as_value f64         ) "Type of 'f64'"
+  chck_cmp $(type_as_value (option i32)) "Type of 'option i32'"
 
   t(T type) => T
   chck_cmp $(t f64         ) "Type of 'f64'"


### PR DESCRIPTION
This removes the old-style type-feature `Types`.  The only inner feature. `get`, unfortunately cannot be moved to `Type.type.get` or any other type feature, see #3431 for details. Instead, `get` gets moved to `universe.type_as_value`.

Also added `Any.type_value` as an alternative. This would be a much better place for `type_as_value`, but it cannot be within a type feature.

In any case, the following three expressions are equivalent

   abc.type
   type_as_value abc
   abc.type_value

the preferred version is the first.

Note that this patch also contains a fix in
`AbstractFeature.existingOrNewTypeFeature` that was triggered by adding a type feature to `Any.fz`.
