### PR TITLE
air: Remove FeatureAndActuals._preconditionsClazz

### DIFF
--- a/src/dev/flang/air/Clazz.java
+++ b/src/dev/flang/air/Clazz.java
@@ -1087,7 +1087,7 @@ public class Clazz extends ANY implements Comparable<Clazz>
       (f != null,
        !this.isVoidType());
 
-    return lookup(new FeatureAndActuals(f, AbstractCall.NO_GENERICS, false), -1, p, false);
+    return lookup(new FeatureAndActuals(f, AbstractCall.NO_GENERICS), -1, p, false);
   }
 
 
@@ -1316,7 +1316,7 @@ public class Clazz extends ANY implements Comparable<Clazz>
 
  */
 
-            var outerUnboxed = isBoxed() && !f.isConstructor() && !fa._preconditionClazz ? asValue() : this;
+            var outerUnboxed = isBoxed() && !f.isConstructor() ? asValue() : this;
             innerClazz = Clazzes.clazzWithSpecificOuter(t, select, outerUnboxed);
             if (select < 0)
               {

--- a/src/dev/flang/air/Clazzes.java
+++ b/src/dev/flang/air/Clazzes.java
@@ -503,7 +503,7 @@ public class Clazzes extends ANY
    */
   static Set<FeatureAndActuals> calledDynamicallyWithTypePars(AbstractFeature f)
   {
-    var fmin = new FeatureAndActuals(f);
+    var fmin = new FeatureAndActuals(f, false);
     var fmax = new FeatureAndActuals(f, true);
     return _calledDynamically_.subSet(fmin, fmax);
   }

--- a/src/dev/flang/air/Clazzes.java
+++ b/src/dev/flang/air/Clazzes.java
@@ -471,7 +471,7 @@ public class Clazzes extends ANY
                                                 * in types differently.
                                                 */);
 
-    var ft = new FeatureAndActuals(f, tp, false);
+    var ft = new FeatureAndActuals(f, tp);
     var added = _calledDynamically_.add(ft);
     if (added)
       {
@@ -503,7 +503,7 @@ public class Clazzes extends ANY
    */
   static Set<FeatureAndActuals> calledDynamicallyWithTypePars(AbstractFeature f)
   {
-    var fmin = new FeatureAndActuals(f, false);
+    var fmin = new FeatureAndActuals(f);
     var fmax = new FeatureAndActuals(f, true);
     return _calledDynamically_.subSet(fmin, fmax);
   }
@@ -751,8 +751,7 @@ public class Clazzes extends ANY
             calledDynamically(cf, typePars);
           }
 
-        var innerClazz        = tclazz.lookup(new FeatureAndActuals(cf, typePars, false), c.select(), c, c.isInheritanceCall());
-        var preconditionClazz = tclazz.lookup(new FeatureAndActuals(cf, typePars, true ), c.select(), c, c.isInheritanceCall());
+        var innerClazz        = tclazz.lookup(new FeatureAndActuals(cf, typePars), c.select(), c, c.isInheritanceCall());
         if (outerClazz.hasActualClazzes(c, outer))
           {
             // NYI: #2412: Check why this is done repeatedly and avoid redundant work!
@@ -760,7 +759,7 @@ public class Clazzes extends ANY
           }
         else
           {
-            outerClazz.saveActualClazzes(c, outer, new Clazz[] {innerClazz, tclazz, preconditionClazz});
+            outerClazz.saveActualClazzes(c, outer, new Clazz[] {innerClazz, tclazz});
           }
 
         var afs = innerClazz.argumentFields();
@@ -946,8 +945,7 @@ public class Clazzes extends ANY
           {
             var at = outerClazz.handDownThroughInheritsCalls(c.actualTypeParameters(), inh);
             var inner = tclazz.lookup(new FeatureAndActuals(c.calledFeature(),
-                                                            outerClazz.actualGenerics(at),
-                                                            false),
+                                                            outerClazz.actualGenerics(at)),
                                       c.select(),
                                       c,
                                       false);

--- a/src/dev/flang/fuir/FUIR.java
+++ b/src/dev/flang/fuir/FUIR.java
@@ -912,7 +912,7 @@ public class FUIR extends IR
       {
         var pf = p.calledFeature();
         var of = pf.outerRef();
-        var or = (of == null) ? null : (Clazz) cc._inner.get(new FeatureAndActuals(of, new List<>(), false));  // NYI: ugly cast
+        var or = (of == null) ? null : (Clazz) cc._inner.get(new FeatureAndActuals(of, new List<>()));  // NYI: ugly cast
         var needsOuterRef = (or != null && !or.resultClazz().isUnitType());
         toStack(code, p.target(), !needsOuterRef /* dump result if not needed */);
         if (needsOuterRef)
@@ -1507,7 +1507,7 @@ public class FUIR extends IR
           }
         var found = new TreeSet<Integer>();
         var result = new List<Integer>();
-        var fa = new FeatureAndActuals(f, typePars, false);
+        var fa = new FeatureAndActuals(f, typePars);
         for (var clz : tclazz.heirs())
           {
             if (CHECKS) check


### PR DESCRIPTION
This cleanup was forgotten in #3260.  This is no longer needed since we do not have explicit handling of preconditions any longer.
