### PR TITLE
lexer: fix source range for case unexpected end of file

### DIFF
--- a/src/dev/flang/parser/Lexer.java
+++ b/src/dev/flang/parser/Lexer.java
@@ -1207,15 +1207,15 @@ public class Lexer extends SourceFile
    * Obtain the given range pos..lastTokenEndPos() as a SourceRange object.
    *
    * @param pos a byte position within this file, must be smaller than
-   * lastTokenEndPos().
+   * lastTokenEndPos(), unless there were previous errors
    */
   public SourceRange sourceRange(int pos)
   {
     if (PRECONDITIONS) require
       (0 <= pos,
        Errors.any() || pos < lastTokenEndPos());
-
-    var endPos = Math.max(pos+1, lastTokenEndPos());
+    // in error case lastTokenEnd() < pos is possible
+    var endPos = Math.max(Math.min(pos+1, byteLength()), lastTokenEndPos());
     return sourceRange(pos, endPos);
   }
 

--- a/src/dev/flang/util/SourceFile.java
+++ b/src/dev/flang/util/SourceFile.java
@@ -1024,6 +1024,7 @@ The end of a source code line is marked by one of the code points LF 0x000a, VT 
   {
     if (PRECONDITIONS) require
       (0 <= pos,
+       pos <= endPos,
        endPos <= byteLength());
 
     return new SourceRange(this, pos, endPos);


### PR DESCRIPTION
this caused a precondition to fail when a syntax error 'unexpected end of file' happened