### PR TITLE
fuir: abstract interpreter, in case alwaysResultsInVoid add comments

### DIFF
--- a/src/dev/flang/fuir/analysis/AbstractInterpreter.java
+++ b/src/dev/flang/fuir/analysis/AbstractInterpreter.java
@@ -509,6 +509,16 @@ public class AbstractInterpreter<VALUE, RESULT> extends ANY
     var v = containsVoid(stack) ? null
                                 : _processor.unitValue();
 
+    if (last_s > 0 &&_fuir.alwaysResultsInVoid(last_s))
+      {
+        l.add(_processor.comment(_fuir.codeAtAsString(last_s) + " always results in void, stopping here."));
+
+        for (var s = last_s + _fuir.codeSizeAt(last_s); _fuir.withinCode(s); s = s + _fuir.codeSizeAt(s))
+          {
+            l.add(_processor.comment(_fuir.codeAtAsString(s) + " eliminated."));
+          }
+      }
+
     if (!containsVoid(stack) && stack.size() > 0)
       { // NYI: #1875: Manual stack cleanup.  This should not be needed since the
         // FUIR has the (so far undocumented) invariant that the stack must be


### PR DESCRIPTION
example c-code (last four lines):
```
        // 805306686: Current
        // 805306687: Call m.type.get_if_installed.#^effect.type.get_if_installed(outer m.type.get_if_installed) m.type
        // access to Call m.type.get_if_installed.#^effect.type.get_if_installed(outer m.type.get_if_installed) m.type eliminated
        // 805306688: Call m.type.unsafe_get(outer m.type) m
        fzT_m fzM_1;
        fzM_1 = fzC_m_oHtype_w_m__unsafe_u_get();
        // Call m.type.unsafe_get(outer m.type) m always results in void, stopping here.
        // Tag eliminated.
        // Current eliminated.
        // Assign to m.type.get_if_installed.#exprResult979 eliminated.
```