### PR TITLE
makefile: use javac option `--release` as suggested by warning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@
 
 JAVA = java
 JAVA_VERSION = 21
-JAVAC = javac -encoding UTF8 -source $(JAVA_VERSION)
+JAVAC = javac -encoding UTF8 --release $(JAVA_VERSION)
 FZ_SRC = $(patsubst %/,%,$(dir $(lastword $(MAKEFILE_LIST))))
 SRC = $(FZ_SRC)/src
 BUILD_DIR = ./build


### PR DESCRIPTION
It is suggested to use `--release` instead of `-source`. Is there anything against it?

```
> make base-only
mkdir -p ./build/classes
javac -encoding UTF8 -source 21 -g -cp ./build/classes -d ./build/classes ./src/dev/flang/fuir/FUIR.java
warning: [options] location of system modules is not set in conjunction with -source 21
  not setting the location of system modules may lead to class files that cannot run on JDK 21
    --release 21 is recommended instead of -source 21 because it sets the location of system modules automatically
1 warning
.
.
.
```