### PR TITLE
air: Clazz.toString created equal strings for a feature and its cotype

### DIFF
--- a/src/dev/flang/air/Clazz.java
+++ b/src/dev/flang/air/Clazz.java
@@ -1387,6 +1387,7 @@ public class Clazz extends ANY implements Comparable<Clazz>
             : ""
             )
          + feature().featureName().baseNameHuman()
+         + (feature().isTypeFeature() ? ".type" : "")
          + g.toString(" ", " ", "", t -> t.asStringWrapped(true))
          );
   }


### PR DESCRIPTION
This confused me during debugging.
