### PR TITLE
dockerfile: use clang18 instead of clang14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM eclipse-temurin:21-alpine@sha256:511d5a9217ed753d9c099d3d753111d7f9e0e40550b860bceac042f4e55f715c as builder
 WORKDIR /fuzion
 COPY . .
-RUN apk add --no-cache bash clang14 git make && FUZION_REPRODUCIBLE_BUILD="true" PRECONDITIONS="true" POSTCONDITIONS="true" make
+RUN apk add --no-cache bash clang18 git make && FUZION_REPRODUCIBLE_BUILD="true" PRECONDITIONS="true" POSTCONDITIONS="true" make
 
 FROM eclipse-temurin:21-alpine@sha256:511d5a9217ed753d9c099d3d753111d7f9e0e40550b860bceac042f4e55f715c as runner
 COPY --from=builder /fuzion/build /fuzion
-RUN apk add --no-cache bash clang14 gc-dev
+RUN apk add --no-cache bash clang18 gc-dev
 ENV PATH="/fuzion/bin:${PATH}" PRECONDITIONS="true" POSTCONDITIONS="true"


### PR DESCRIPTION
alpine seems to have dropped clang version 14
