### PR TITLE
be/c: add fzE_memcpy, fzE_memset

### DIFF
--- a/include/fz.h
+++ b/include/fz.h
@@ -34,6 +34,10 @@ Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
 
 void * fzE_malloc_safe(size_t size);
 
+void fzE_memset(void *dest, int ch, size_t sz);
+
+void fzE_memcpy(void *restrict dest, const void *restrict src, size_t sz);
+
 // make directory, return zero on success
 int fzE_mkdir(const char *pathname);
 

--- a/include/posix.c
+++ b/include/posix.c
@@ -95,7 +95,7 @@ char * fzE_readdir(intptr_t * dir) {
   {
     size_t len = strlen(d->d_name);
     char *dup = (char *) fzE_malloc_safe(len + 1);
-    strcpy(dup, d->d_name);
+    fzE_memcpy(dup, d->d_name, len + 1);
     return dup;
   }
 }
@@ -205,7 +205,7 @@ int fzE_socket(int family, int type, int protocol){
 int fzE_getaddrinfo(int family, int socktype, int protocol, int flags, char * host, char * port, struct addrinfo ** result){
   struct addrinfo hints;
 
-  memset(&hints, 0, sizeof hints);
+  fzE_memset(&hints, 0, sizeof hints);
 
   hints.ai_family = get_family(family);
   hints.ai_socktype = get_socket_type(socktype);
@@ -301,14 +301,14 @@ int fzE_get_peer_address(int sockfd, void * buf) {
   // sockaddr_storage: A structure at least as large
   // as any other sockaddr_* address structures.
   struct sockaddr_storage peeraddr;
-  memset(&peeraddr, 0, sizeof(peeraddr));
+  fzE_memset(&peeraddr, 0, sizeof(peeraddr));
   socklen_t peeraddrlen = sizeof(peeraddr);
   if (getpeername(sockfd, (struct sockaddr *)&peeraddr, &peeraddrlen) == 0) {
     if (peeraddr.ss_family == AF_INET) {
-      memcpy(buf, &(((struct sockaddr_in *)&peeraddr)->sin_addr.s_addr), 4);
+      fzE_memcpy(buf, &(((struct sockaddr_in *)&peeraddr)->sin_addr.s_addr), 4);
       return 4;
     } else if (peeraddr.ss_family == AF_INET6) {
-      memcpy(buf, &(((struct sockaddr_in6 *)&peeraddr)->sin6_addr.s6_addr), 16);
+      fzE_memcpy(buf, &(((struct sockaddr_in6 *)&peeraddr)->sin6_addr.s6_addr), 16);
       return 16;
     }
   }
@@ -323,7 +323,7 @@ unsigned short fzE_get_peer_port(int sockfd) {
   // sockaddr_storage: A structure at least as large
   // as any other sockaddr_* address structures.
   struct sockaddr_storage peeraddr;
-  memset(&peeraddr, 0, sizeof(peeraddr));
+  fzE_memset(&peeraddr, 0, sizeof(peeraddr));
   socklen_t peeraddrlen = sizeof(peeraddr);
   if (getpeername(sockfd, (struct sockaddr *)&peeraddr, &peeraddrlen) == 0) {
     if (peeraddr.ss_family == AF_INET) {
@@ -504,7 +504,7 @@ void fzE_init()
 {
 #ifdef FUZION_ENABLE_THREADS
   pthread_mutexattr_t attr;
-  memset(&fzE_global_mutex, 0, sizeof(fzE_global_mutex));
+  fzE_memset(&fzE_global_mutex, 0, sizeof(fzE_global_mutex));
   bool res = pthread_mutexattr_init(&attr) == 0 &&
             pthread_mutexattr_setprotocol(&attr, PTHREAD_PRIO_INHERIT) == 0 &&
             pthread_mutex_init(&fzE_global_mutex, &attr) == 0;

--- a/include/shared.c
+++ b/include/shared.c
@@ -94,6 +94,16 @@ void * fzE_malloc_safe(size_t size) {
   return p;
 }
 
+void fzE_memset(void *dest, int ch, size_t sz){
+  // NYI: UNDER DEVELOPMENT: use bounds checked version, e.g. memset_s
+  memset(dest, ch, sz);
+}
+
+void fzE_memcpy(void *restrict dest, const void *restrict src, size_t sz){
+  // NYI: UNDER DEVELOPMENT: use bounds checked version, e.g. memcpy_s
+  memcpy(dest, src, sz);
+}
+
 
 #ifdef FUZION_LINK_JVM
 
@@ -256,8 +266,9 @@ void fzE_destroy_jvm()
 // helper function to replace char `find`
 // by `replace` in string `str`.
 char* fzE_replace_char(const char* str, char find, char replace){
-    char * result = fzE_malloc_safe(strlen(str));
-    strcpy(result, str);
+    size_t len = strlen(str)
+    char * result = fzE_malloc_safe(len+1);
+    fzE_memcpy(result, str, len+1);
     char *pos = strchr(result,find);
     while (pos) {
         *pos = replace;
@@ -279,7 +290,7 @@ const char * fzE_java_string_to_utf8_bytes(jstring jstr)
   jbyte * bytes = (*getJNIEnv())->GetByteArrayElements(getJNIEnv(), arr, NULL);
   const jsize length = (*getJNIEnv())->GetArrayLength(getJNIEnv(), arr);
   char * result = fzE_malloc_safe(length);
-  memcpy(result, bytes, length);
+  fzE_memcpy(result, bytes, length);
 
   (*getJNIEnv())->ReleaseByteArrayElements(getJNIEnv(), arr, bytes, JNI_ABORT);
   (*getJNIEnv())->DeleteLocalRef(getJNIEnv(), arr);
@@ -294,7 +305,7 @@ const char * fzE_java_string_to_modified_utf8(jstring jstr)
   const char * str = (*getJNIEnv())->GetStringUTFChars(getJNIEnv(), jstr, JNI_FALSE);
   jsize sz = (*getJNIEnv())->GetStringUTFLength(getJNIEnv(), jstr);
   char * result = fzE_malloc_safe(sz);
-  memcpy(result, str, sz+1);
+  fzE_memcpy(result, str, sz+1);
   (*getJNIEnv())->ReleaseStringUTFChars(getJNIEnv(), jstr, str);
   return result;
 }

--- a/include/win.c
+++ b/include/win.c
@@ -117,7 +117,7 @@ char * fzE_readdir(intptr_t * dir) {
   fzE_dir_struct *d = (fzE_dir_struct *)dir;
   size_t len = strlen(d->findData.cFileName);
   char *dup = (char *) fzE_malloc_safe(len + 1);
-  strcpy(dup, d->findData.cFileName);
+  fzE_memcpy(dup, d->findData.cFileName, len + 1);
   return dup;
 }
 
@@ -320,10 +320,10 @@ int fzE_get_peer_address(int sockfd, void * buf) {
   socklen_t peeraddrlen = sizeof(peeraddr);
   int res = getpeername(sockfd, (struct sockaddr *)&peeraddr, &peeraddrlen);
   if (peeraddr.ss_family == AF_INET) {
-    memcpy(buf, &(((struct sockaddr_in *)&peeraddr)->sin_addr.s_addr), 4);
+    fzE_memcpy(buf, &(((struct sockaddr_in *)&peeraddr)->sin_addr.s_addr), 4);
     return 4;
   } else if (peeraddr.ss_family == AF_INET6) {
-    memcpy(buf, &(((struct sockaddr_in6 *)&peeraddr)->sin6_addr.s6_addr), 16);
+    fzE_memcpy(buf, &(((struct sockaddr_in6 *)&peeraddr)->sin6_addr.s6_addr), 16);
     return 16;
   } else {
     return -1;
@@ -556,7 +556,7 @@ void fzE_init()
 
 #ifdef FUZION_ENABLE_THREADS
   pthread_mutexattr_t attr;
-  memset(&fzE_global_mutex, 0, sizeof(fzE_global_mutex));
+  fzE_memset(&fzE_global_mutex, 0, sizeof(fzE_global_mutex));
   bool res = pthread_mutexattr_init(&attr) == 0 &&
             // NYI #1646 setprotocol returns EINVAL on windows.
             // pthread_mutexattr_setprotocol(&attr, PTHREAD_PRIO_INHERIT) == 0 &&

--- a/src/dev/flang/be/c/C.java
+++ b/src/dev/flang/be/c/C.java
@@ -1088,7 +1088,7 @@ public class C extends ANY
                            new List<>("void *", "size_t"),
                            new List<>(o, s),
                            CStmnt.seq(new List<>(CStmnt.decl(null, "void *", r, CExpr.call(malloc(), new List<>(s))),
-                                                 CExpr.call("memcpy", new List<>(r, o, s)),
+                                                 CExpr.call("fzE_memcpy", new List<>(r, o, s)),
                                                  r.ret()))));
     var ordered = _types.inOrder();
 
@@ -1191,7 +1191,7 @@ public class C extends ANY
     var tmp = new CIdent("tmp0");
     return CStmnt.seq(
       CStmnt.decl("struct " + CNames.fzThreadEffectsEnvironment.code(), tmp),
-      CExpr.call("memset", new List<>(tmp.adrOf(), CExpr.int32const(0), CExpr.sizeOfType("struct " + CNames.fzThreadEffectsEnvironment.code()))),
+      CExpr.call("fzE_memset", new List<>(tmp.adrOf(), CExpr.int32const(0), CExpr.sizeOfType("struct " + CNames.fzThreadEffectsEnvironment.code()))),
       CNames.fzThreadEffectsEnvironment.assign(tmp.adrOf())
     );
   }
@@ -1844,7 +1844,7 @@ public class C extends ANY
           CStmnt.lineComment("cur does not escape, alloc on stack"),
           CStmnt.decl(_names.struct(cl), CNames.CURRENT),
           // this fixes "variable 'fzCur' is uninitialized when used here" in e.g. reg_issue1188
-          CExpr.call("memset", new List<>(CNames.CURRENT.adrOf(), CExpr.int32const(0), CNames.CURRENT.sizeOfExpr())));
+          CExpr.call("fzE_memset", new List<>(CNames.CURRENT.adrOf(), CExpr.int32const(0), CNames.CURRENT.sizeOfExpr())));
       case Unknown   -> CStmnt.seq(CStmnt.lineComment("cur may escape, so use malloc"      ), declareAllocAndInitClazzId(cl, CNames.CURRENT));
       case Undefined -> CExpr.dummy("undefined life time");
       };


### PR DESCRIPTION
these should eventually use _secure_ versions of memset, memcpy that the compiler may not optimize away like it is allowed for e.g. `memset`
