### PR TITLE
be/jvm: fix VerifyError when adding qualifier

### DIFF
--- a/lib/concur/atomic.fz
+++ b/lib/concur/atomic.fz
@@ -55,7 +55,7 @@ is
   #
   public racy_read ! racy_access
   pre
-    racy_accesses_supported # NYI: add qualifier once #3423 is resolved
+    debug: racy_accesses_supported
   =>
     racy_access_env.replace
     v
@@ -68,7 +68,7 @@ is
   #
   public racy_write(new_value T) ! racy_access
   pre
-    racy_accesses_supported # NYI: add qualifier once #3423 is resolved
+    debug: racy_accesses_supported
   =>
     racy_access_env.replace
     set v := new_value

--- a/src/dev/flang/be/jvm/Intrinsix.java
+++ b/src/dev/flang/be/jvm/Intrinsix.java
@@ -140,7 +140,7 @@ public class Intrinsix extends ANY implements ClassFileConstants
             jvm._fuir.clazzIs(rc, FUIR.SpecialClazzes.c_f32 ) ||
             jvm._fuir.clazzIs(rc, FUIR.SpecialClazzes.c_bool) ||
             jvm._fuir.clazzIs(rc, FUIR.SpecialClazzes.c_unit);
-          return new Pair<>(Expr.UNIT, Expr.iconst(r ? 1 : 0));
+          return new Pair<>(Expr.iconst(r ? 1 : 0), Expr.UNIT);
         });
 
     put("concur.util.loadFence",
@@ -228,13 +228,13 @@ public class Intrinsix extends ANY implements ClassFileConstants
     put("debug",
         (jvm, si, cc, tvalue, args) ->
         {
-          return new Pair<>(Expr.UNIT, Expr.iconst(jvm._options.fuzionDebug() ? 1 : 0));
+          return new Pair<>(Expr.iconst(jvm._options.fuzionDebug() ? 1 : 0), Expr.UNIT);
         });
 
     put("debug_level",
         (jvm, si, cc, tvalue, args) ->
         {
-          return new Pair<>(Expr.UNIT, Expr.iconst(jvm._options.fuzionDebugLevel()));
+          return new Pair<>(Expr.iconst(jvm._options.fuzionDebugLevel()), Expr.UNIT);
         });
 
     put("fuzion.java.Java_Object.is_null0",

--- a/src/dev/flang/be/jvm/JVM.java
+++ b/src/dev/flang/be/jvm/JVM.java
@@ -1744,7 +1744,8 @@ should be avoided as much as possible.
   Expr assignField(int s, Expr tvalue, int f, Expr value, int rt)
   {
     if (CHECKS) check
-      (tvalue != null || !_fuir.hasData(rt) || _fuir.clazzOuterClazz(f) == _fuir.clazzUniverse());
+      (tvalue != null || !_fuir.hasData(rt) || _fuir.clazzOuterClazz(f) == _fuir.clazzUniverse(),
+       value != Expr.UNIT || _fuir.clazzIsVoidType(rt) || !fieldExists(f));
 
     var occ   = _fuir.clazzOuterClazz(f);
     Expr res;


### PR DESCRIPTION
In some intrinsics definition value and side effect where switched around. Not sure how this ever worked?


