### PR TITLE
ai: add method `reportErrorInCode`

### DIFF
--- a/src/dev/flang/be/c/C.java
+++ b/src/dev/flang/be/c/C.java
@@ -482,7 +482,7 @@ public class C extends ANY
       if (rcases.size() >= 2)
         { // more than two reference cases: we have to create separate switch of clazzIds for refs
           var id = refEntry.deref().field(CNames.CLAZZ_ID);
-          var notFound = reportErrorInCode("unexpected reference type %d found in match", id);
+          var notFound = reportErrorInCode0("unexpected reference type %d found in match", id);
           tdefault = CStmnt.suitch(id, rcases, notFound);
         }
       return new Pair<>(CExpr.UNIT, CStmnt.seq(getRef, CStmnt.suitch(tag, tcases, tdefault)));
@@ -544,6 +544,17 @@ public class C extends ANY
                                                         CExpr.string(_fuir.clazzAsString(ecl))),
                                     CExpr.exit(1)));
       return new Pair<>(res, o);
+    }
+
+    /**
+     * Generate code to terminate the execution immediately.
+     *
+     * @param msg a message explaining the illegal state
+     */
+    @Override
+    public CStmnt reportErrorInCode(String msg)
+    {
+      return reportErrorInCode0("%s", CExpr.string(msg));
     }
 
   }
@@ -1225,7 +1236,7 @@ public class C extends ANY
    *
    * @return the C statement to report the error and exit(1).
    */
-  CStmnt reportErrorInCode(String msg, CExpr... args)
+  CStmnt reportErrorInCode0(String msg, CExpr... args)
   {
     var msg2 = "*** %s:%d: " + msg + "\n";
     var args2 = new List<CExpr>(CIdent.FILE, CIdent.LINE);
@@ -1264,9 +1275,9 @@ public class C extends ANY
       {
         if (isCall && (_fuir.hasData(rt) || _fuir.clazzIsVoidType(rt)))
           {
-            ol.add(reportErrorInCode("no targets for access of %s within %s",
-                                     CExpr.string(_fuir.clazzAsString(cc0)),
-                                     CExpr.string(_fuir.siteAsString(s))));
+            ol.add(reportErrorInCode0("no targets for access of %s within %s",
+                                      CExpr.string(_fuir.clazzAsString(cc0)),
+                                      CExpr.string(_fuir.siteAsString(s))));
             res = null;
           }
         else
@@ -1347,10 +1358,10 @@ public class C extends ANY
           {
             var id = tvalue.deref().field(CNames.CLAZZ_ID);
             acc = CStmnt.suitch(id, cazes,
-                                reportErrorInCode("unhandled dynamic target %d in access of %s within %s",
-                                                  id,
-                                                  CExpr.string(_fuir.clazzAsString(cc0)),
-                                                  CExpr.string(_fuir.siteAsString(s))));
+                                reportErrorInCode0("unhandled dynamic target %d in access of %s within %s",
+                                                   id,
+                                                   CExpr.string(_fuir.clazzAsString(cc0)),
+                                                   CExpr.string(_fuir.siteAsString(s))));
           }
         ol.add(acc);
         res = _fuir.clazzIsVoidType(rt)

--- a/src/dev/flang/be/c/Intrinsics.java
+++ b/src/dev/flang/be/c/Intrinsics.java
@@ -1472,7 +1472,7 @@ public class Intrinsics extends ANY
 
     if (c._fuir.clazzIsVoidType(rt))
       {
-        result = c.reportErrorInCode("Unexpected comparison of void values. This is a bug in the compiler.");
+        result = c.reportErrorInCode0("Unexpected comparison of void values. This is a bug in the compiler.");
       }
     else if (c._fuir.clazzIsUnitType(rt))
       { // unit-type values are always equal:

--- a/src/dev/flang/be/interpreter/Executor.java
+++ b/src/dev/flang/be/interpreter/Executor.java
@@ -528,6 +528,20 @@ public class Executor extends ProcessExpression<Value, Object>
 
 
   /**
+   * Generate code to terminate the execution immediately.
+   *
+   * @param msg a message explaining the illegal state
+   */
+  @Override
+  public Object reportErrorInCode(String msg)
+  {
+    say_err(msg);
+    System.exit(1);
+    return null;
+  }
+
+
+  /**
    * callOnInstance assigns the arguments to the argument fields of a newly
    * created instance, calls the parents and then this feature.
    *

--- a/src/dev/flang/be/jvm/CodeGen.java
+++ b/src/dev/flang/be/jvm/CodeGen.java
@@ -986,6 +986,18 @@ class CodeGen
     return new Pair<>(res, Expr.UNIT);
   }
 
+  /**
+   * Generate code to terminate the execution immediately.
+   *
+   * @param msg a message explaining the illegal state
+   */
+  // NYI: BUG: #3178 reportErrorInCode may currently not be called repeatedly
+  //           triggers error: Expecting a stack map frame
+  // @Override
+  // public Expr reportErrorInCode(String msg)
+  // {
+  //   return this._jvm.reportErrorInCode(msg);
+  // }
 
 }
 

--- a/src/dev/flang/fuir/analysis/AbstractInterpreter.java
+++ b/src/dev/flang/fuir/analysis/AbstractInterpreter.java
@@ -246,6 +246,13 @@ public class AbstractInterpreter<VALUE, RESULT> extends ANY
      */
     public abstract Pair<VALUE, RESULT> env(int s, int ecl);
 
+    /**
+     * Generate code to terminate the execution immediately.
+     *
+     * @param msg a message explaining the illegal state
+     */
+    public RESULT reportErrorInCode(String msg) { return comment(msg); }
+
   }
 
 
@@ -508,6 +515,11 @@ public class AbstractInterpreter<VALUE, RESULT> extends ANY
 
     var v = containsVoid(stack) ? null
                                 : _processor.unitValue();
+
+    if (last_s > 0 && _fuir.alwaysResultsInVoid(last_s))
+      {
+        l.add(_processor.reportErrorInCode("Severe compiler bug! This code should be unreachable."));
+      }
 
     if (!containsVoid(stack) && stack.size() > 0)
       { // NYI: #1875: Manual stack cleanup.  This should not be needed since the

--- a/src/dev/flang/fuir/analysis/dfa/DFA.java
+++ b/src/dev/flang/fuir/analysis/dfa/DFA.java
@@ -717,6 +717,19 @@ public class DFA extends ANY
       return new Pair<>(_call.getEffectForce(s, ecl), _unit_);
     }
 
+
+    /**
+     * Generate code to terminate the execution immediately.
+     *
+     * @param msg a message explaining the illegal state
+     */
+    @Override
+    public Unit reportErrorInCode(String msg)
+    {
+      // In the DFA, ignore these errors
+      return _unit_;
+    }
+
   }
 
 


### PR DESCRIPTION
reportErrorInCode is for generating code - or executing in the interpreters case - that stops execution immediately because an illegal state has been reached. Reaching these illegal states should only be possible in case of a bug in the compiler or if safety has been turned off.