### PR TITLE
fix implementation of safety

### DIFF
--- a/src/dev/flang/be/jvm/Intrinsix.java
+++ b/src/dev/flang/be/jvm/Intrinsix.java
@@ -770,7 +770,7 @@ public class Intrinsix extends ANY implements ClassFileConstants
     put("safety",
         (jvm, si, cc, tvalue, args) ->
         {
-          return new Pair<>(Expr.UNIT, Expr.iconst(jvm._options.fuzionSafety() ? 1 : 0));
+          return new Pair<>(Expr.iconst(jvm._options.fuzionSafety() ? 1 : 0), Expr.UNIT);
         });
 
     put("fuzion.sys.fileio.read_dir", (jvm, si, cc, tvalue, args) -> {

--- a/src/dev/flang/tools/Fuzion.java
+++ b/src/dev/flang/tools/Fuzion.java
@@ -586,7 +586,7 @@ public class Fuzion extends Tool
   /**
    * Default result of safety:
    */
-  boolean _safety = FuzionOptions.boolPropertyOrEnv(FuzionConstants.FUZION_SAFETY_PROPERTY);
+  boolean _safety = FuzionOptions.boolPropertyOrEnv(FuzionConstants.FUZION_SAFETY_PROPERTY, true);
 
 
   /**


### PR DESCRIPTION
be/jvm: side effect and result was switched around
tool: boolPropertyOrEnv lacked correct default value


