### PR TITLE
lib: move `/!` and `%!` from `wrap_around` to `integer`

### DIFF
--- a/lib/int.fz
+++ b/lib/int.fz
@@ -107,13 +107,6 @@ is
         int s0 (n ** other.n)
 
 
-  # all operations are allowed for all ints
-  # except for division where we need to
-  # check for division by zero
-
-  public fixed redef infix /! (other int) bool => other != int.zero
-  public fixed redef infix %! (other int) bool => other != int.zero
-
   public fixed redef infix **!(other int) bool =>
     other ≥ int.zero  # 0 and 1 ** -other would be okay but we disallow nonetheless
 

--- a/lib/integer.fz
+++ b/lib/integer.fz
@@ -31,6 +31,13 @@
 #
 module:public integer : numeric is
 
+
+  # preconditions used in 'numeric' for basic operations: true if the
+  # operation is permitted for the given values
+  public redef infix /! (other integer.this) => other != integer.this.zero
+  public redef infix %! (other integer.this) => other != integer.this.zero
+
+
   # test divisibility by other
   public infix %% (other integer.this) bool
     pre

--- a/lib/num/wrap_around.fz
+++ b/lib/num/wrap_around.fz
@@ -56,8 +56,6 @@ module:public wrap_around : integer is
   public redef infix +! (other wrap_around.this) => !(overflow_on_add other) && !(underflow_on_add other)
   public redef infix -! (other wrap_around.this) => !(overflow_on_sub other) && !(underflow_on_sub other)
   public redef infix *! (other wrap_around.this) => !(overflow_on_mul other) && !(underflow_on_mul other)
-  public redef infix /! (other wrap_around.this) => other != wrap_around.this.zero
-  public redef infix %! (other wrap_around.this) => other != wrap_around.this.zero
   public redef infix **!(other wrap_around.this) => !(overflow_on_exp other)
 
   # neg, add, sub, mul with wrap-around semantics

--- a/lib/uint.fz
+++ b/lib/uint.fz
@@ -266,8 +266,6 @@ is
 
   public fixed redef prefix -! bool => uint.this = uint.zero
   public fixed redef infix -! (other uint) bool => uint.this ≥ other
-  public fixed redef infix /! (other uint) bool => other != uint.zero
-  public fixed redef infix %! (other uint) bool => other != uint.zero
 
   # exponentation always works, even though it might be
   # slow for large numbers


### PR DESCRIPTION
Maybe I'm missing something but I thought these two are better redefined in integer instead of wrap_around.
