### PR TITLE
air: For a missing implementation of an abstract feature, show call chain

### DIFF
--- a/src/dev/flang/air/AirErrors.java
+++ b/src/dev/flang/air/AirErrors.java
@@ -74,7 +74,8 @@ public class AirErrors extends AstErrors
 
   public static void abstractFeatureNotImplemented(AbstractFeature featureThatDoesNotImplementAbstract,
                                                    Set<AbstractFeature> abstractFeature,
-                                                   HasSourcePosition instantiatedAt)
+                                                   HasSourcePosition instantiatedAt,
+                                                   String context)
   {
     var abs = new StringBuilder();
     var abstracts = new StringBuilder();
@@ -104,7 +105,8 @@ public class AirErrors extends AstErrors
           "Used " + kind + " " + (abstractFeature.size() > 1 ? "features " + abs + " are" : "feature " + abs + " is") + " not implemented by "+s(featureThatDoesNotImplementAbstract),
           "Feature " + s(featureThatDoesNotImplementAbstract) + " " +
           "instantiated at " + instantiatedAt.pos().show() + "\n" +
-          abstracts);
+          abstracts + "\n" +
+          "Callchain that lead to this point:\n\n" + context);
   }
 
 }

--- a/src/dev/flang/fuir/FUIR.java
+++ b/src/dev/flang/fuir/FUIR.java
@@ -2624,7 +2624,8 @@ public class FUIR extends IR
    */
   record AbsMissing(Clazz clazz,
                     TreeSet<AbstractFeature> called,
-                    SourcePosition instantiationPos)
+                    SourcePosition instantiationPos,
+                    String context)
   {
   };
 
@@ -2649,11 +2650,11 @@ public class FUIR extends IR
    * @param instantiationPos if known, the site where `cl` was instantiated,
    * `NO_SITE` if unknown.
    */
-  public void recordAbstractMissing(int cl, int f, int instantiationSite)
+  public void recordAbstractMissing(int cl, int f, int instantiationSite, String context)
   {
     var cc = clazz(cl);
     var cf = clazz(f);
-    var r = _abstractMissing.computeIfAbsent(cc, ccc -> new AbsMissing(ccc, new TreeSet<>(), sitePos(instantiationSite)));
+    var r = _abstractMissing.computeIfAbsent(cc, ccc -> new AbsMissing(ccc, new TreeSet<>(), sitePos(instantiationSite), context));
     r.called.add(cf.feature());
   }
 
@@ -2670,7 +2671,8 @@ public class FUIR extends IR
       .stream()
       .forEach(r -> AirErrors.abstractFeatureNotImplemented(r.clazz.feature(),
                                                             r.called,
-                                                            r.instantiationPos));
+                                                            r.instantiationPos,
+                                                            r.context));
   }
 
 

--- a/src/dev/flang/fuir/analysis/dfa/DFA.java
+++ b/src/dev/flang/fuir/analysis/dfa/DFA.java
@@ -344,7 +344,7 @@ public class DFA extends ANY
             .map(c -> c._site)
             .findAny()
             .orElse(NO_SITE);
-          _fuir.recordAbstractMissing(t_cl, _fuir.accessedClazz(s), instantiatedAt);
+          _fuir.recordAbstractMissing(t_cl, _fuir.accessedClazz(s), instantiatedAt, _call.contextString());
         }
       return res;
     }

--- a/tests/reg_issue3359/reg_issue3359.fz.expected_err
+++ b/tests/reg_issue3359/reg_issue3359.fz.expected_err
@@ -19,6 +19,14 @@ which is called at --CURDIR--/reg_issue3359.fz:97:41:
 ----------------------------------------^
 without providing an implementation
 
+Callchain that lead to this point:
+
+call 'reg_issue3359.u#1 reg_issue3359.i' at --CURDIR--/reg_issue3359.fz:103:3:
+  u i
+--^
+call 'reg_issue3359'
+program entry point
+
 
 --CURDIR--/reg_issue3359.fz:84:3: error 2: Used abstract features 'reg_issue3359.i.q', 'reg_issue3359.i.r' are not implemented by 'reg_issue3359.j'
   j : i is
@@ -40,6 +48,14 @@ which is called at --CURDIR--/reg_issue3359.fz:97:41:
 ----------------------------------------^
 without providing an implementation
 
+Callchain that lead to this point:
+
+call 'reg_issue3359.u#1 reg_issue3359.j' at --CURDIR--/reg_issue3359.fz:106:3:
+  u j
+--^
+call 'reg_issue3359'
+program entry point
+
 
 --CURDIR--/reg_issue3359.fz:89:3: error 3: Used abstract feature 'reg_issue3359.i.r' is not implemented by 'reg_issue3359.k'
   k : j is
@@ -54,6 +70,14 @@ which is called at --CURDIR--/reg_issue3359.fz:97:41:
     else if envir.args.count = 1 then v.r
 ----------------------------------------^
 without providing an implementation
+
+Callchain that lead to this point:
+
+call 'reg_issue3359.u#1 reg_issue3359.k' at --CURDIR--/reg_issue3359.fz:109:3:
+  u k
+--^
+call 'reg_issue3359'
+program entry point
 
 
 --CURDIR--/reg_issue3359.fz:34:3: error 4: Used abstract features 'reg_issue3359.f.type.n', 'reg_issue3359.f.type.o' are not implemented by 'reg_issue3359.f.type'
@@ -75,6 +99,14 @@ which is called at --CURDIR--/reg_issue3359.fz:55:41:
 ----------------------------------------^
 without providing an implementation
 
+Callchain that lead to this point:
+
+call 'reg_issue3359.t#1 reg_issue3359.f' at --CURDIR--/reg_issue3359.fz:61:3:
+  t f
+--^
+call 'reg_issue3359'
+program entry point
+
 
 --CURDIR--/reg_issue3359.fz:42:3: error 5: Used abstract features 'reg_issue3359.f.type.n', 'reg_issue3359.f.type.o' are not implemented by 'reg_issue3359.g.type'
   g : f is
@@ -95,6 +127,14 @@ which is called at --CURDIR--/reg_issue3359.fz:55:41:
 ----------------------------------------^
 without providing an implementation
 
+Callchain that lead to this point:
+
+call 'reg_issue3359.t#1 reg_issue3359.g' at --CURDIR--/reg_issue3359.fz:64:3:
+  t g
+--^
+call 'reg_issue3359'
+program entry point
+
 
 --CURDIR--/reg_issue3359.fz:47:3: error 6: Used abstract feature 'reg_issue3359.f.type.o' is not implemented by 'reg_issue3359.h.type'
   h : g is
@@ -108,5 +148,13 @@ which is called at --CURDIR--/reg_issue3359.fz:55:41:
     else if envir.args.count = 1 then T.o
 ----------------------------------------^
 without providing an implementation
+
+Callchain that lead to this point:
+
+call 'reg_issue3359.t#1 reg_issue3359.h' at --CURDIR--/reg_issue3359.fz:67:3:
+  t h
+--^
+call 'reg_issue3359'
+program entry point
 
 6 errors.


### PR DESCRIPTION
This can help to understand why the DFA things this call was required. 

This was useful for me working on #3480, but extracted this into this separate PR.
