### PR TITLE
be/jvm: fix intrinsic `ensure_not_frozen`

### DIFF
--- a/src/dev/flang/be/jvm/Intrinsix.java
+++ b/src/dev/flang/be/jvm/Intrinsix.java
@@ -679,12 +679,15 @@ public class Intrinsix extends ANY implements ClassFileConstants
           if (CHECKS)
             {
               var data = jvm._fuir.lookup_fuzion_sys_internal_array_data(at);
-              code = tvalue
-                .andThen(jvm.getfield(data))
-                .andThen(Expr.invokeStatic(Names.RUNTIME_CLASS,
-                                           in.replace("fuzion.sys.internal_array.",""),
-                                           "(" + (JAVA_LANG_OBJECT.descriptor()) + ")V",
-                                           ClassFileConstants.PrimitiveType.type_void));
+              if (jvm.fieldExists(data))
+                {
+                  code = tvalue
+                    .andThen(jvm.getfield(data))
+                    .andThen(Expr.invokeStatic(Names.RUNTIME_CLASS,
+                                               in.replace("fuzion.sys.internal_array.",""),
+                                               "(" + (JAVA_LANG_OBJECT.descriptor()) + ")V",
+                                               ClassFileConstants.PrimitiveType.type_void));
+                }
             }
           return new Pair<>(val, code);
         });

--- a/tests/reg_issue3527/Makefile
+++ b/tests/reg_issue3527/Makefile
@@ -1,0 +1,25 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test Makefile
+#
+# -----------------------------------------------------------------------
+
+override NAME = reg_issue3527
+include ../simple.mk

--- a/tests/reg_issue3527/reg_issue3527.fz
+++ b/tests/reg_issue3527/reg_issue3527.fz
@@ -1,0 +1,34 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test reg_issue3527
+#
+# -----------------------------------------------------------------------
+
+reg_issue3527 =>
+
+  cache0 := sieve_cache String 3
+
+  sieve_cache(T type : property.hashable, capacity u64) is
+
+    Node(val T) ref is
+      next concur.atomic (option Node) := concur.atomic (option Node) nil
+
+    cache := (lock_free.map T Node).type.empty
+    head  := concur.atomic (option Node) nil


### PR DESCRIPTION
Code was generated even though data field of internal array did not exist.

fixes #3527
