### PR TITLE
tests: fixed `*** FAILED on err/out on <test_name>` output

### DIFF
--- a/tests/check_simple_example_c.sh
+++ b/tests/check_simple_example_c.sh
@@ -41,7 +41,6 @@ CURDIR=$("$SCRIPTPATH"/_cur_dir.sh)
 DIFFERR="$SCRIPTPATH"/_diff_err.sh
 
 
-RC=0
 if [ -f "$2".skip ]; then
     echo "SKIP $2"
 else
@@ -95,15 +94,16 @@ else
         iconv --unicode-subst="?" -f utf-8 -t ascii tmp_out.txt > tmp_conv.txt || false && cp tmp_conv.txt tmp_out.txt
     fi
 
-    # show diff in stdout unless an unexpected output occurred to stderr
-    ($DIFFERR "$experr" tmp_err.txt && diff --strip-trailing-cr "$expout" tmp_out.txt) || echo -e "\033[31;1m*** FAILED\033[0m out on $2"
-    diff --strip-trailing-cr "$expout" tmp_out.txt >/dev/null && $DIFFERR "$experr" tmp_err.txt >/dev/null && echo -e "\033[32;1mPASSED\033[0m."
-    RC=$?
-    if [ -f testbin ]; then
-        echo " (binary)"
-    else
-        echo " (no binary)"
+    FAILED="none" # "out" or "err" or "none"
+    $DIFFERR "$experr" tmp_err.txt || FAILED="err"; true
+    if [ "$FAILED" = "none" ]; then
+        diff --strip-trailing-cr "$expout" tmp_out.txt || FAILED="out"; true
     fi
     rm -f tmp_out.txt tmp_err.txt tmp_exp_out.txt testbin
+    if [ "$FAILED" = "none" ]; then
+        echo -e "\033[32;1mPASSED\033[0m."
+    else
+        echo -e "\033[31;1m*** FAILED\033[0m $FAILED on $2"
+        exit 1
+    fi
 fi
-exit $RC

--- a/tests/check_simple_example_int.sh
+++ b/tests/check_simple_example_int.sh
@@ -41,7 +41,6 @@ CURDIR=$("$SCRIPTPATH"/_cur_dir.sh)
 DIFFERR="$SCRIPTPATH"/_diff_err.sh
 
 
-RC=0
 if [ -f "$2".skip ]; then
     echo "SKIP $2"
 else
@@ -84,10 +83,16 @@ else
         iconv --unicode-subst="?" -f utf-8 -t ascii tmp_out.txt > tmp_conv.txt || false && cp tmp_conv.txt tmp_out.txt
     fi
 
-    # show diff in stdout unless an unexpected output occurred to stderr:
-    ($DIFFERR "$experr" tmp_err.txt && diff --strip-trailing-cr "$expout" tmp_out.txt) || echo -e "\033[31;1m*** FAILED\033[0m out on $2"
-    diff --strip-trailing-cr "$expout" tmp_out.txt >/dev/null && $DIFFERR "$experr" tmp_err.txt >/dev/null && echo -e "\033[32;1mPASSED\033[0m."
-    RC=$?
+    FAILED="none" # "out" or "err" or "none"
+    $DIFFERR "$experr" tmp_err.txt || FAILED="err"; true
+    if [ "$FAILED" = "none" ]; then
+        diff --strip-trailing-cr "$expout" tmp_out.txt || FAILED="out"; true
+    fi
     rm tmp_out.txt tmp_err.txt
+    if [ "$FAILED" = "none" ]; then
+        echo -e "\033[32;1mPASSED\033[0m."
+    else
+        echo -e "\033[31;1m*** FAILED\033[0m $FAILED on $2"
+        exit 1
+    fi
 fi
-exit $RC

--- a/tests/check_simple_example_jvm.sh
+++ b/tests/check_simple_example_jvm.sh
@@ -40,7 +40,6 @@ SCRIPTPATH="$(dirname "$(readlink -f "$0")")"
 CURDIR=$("$SCRIPTPATH"/_cur_dir.sh)
 DIFFERR="$SCRIPTPATH"/_diff_err.sh
 
-RC=0
 if [ -f "$2".skip ]; then
     echo "SKIP $2"
 else
@@ -83,10 +82,16 @@ else
         iconv --unicode-subst="?" -f utf-8 -t ascii tmp_out.txt > tmp_conv.txt || false && cp tmp_conv.txt tmp_out.txt
     fi
 
-    # show diff in stdout unless an unexpected output occurred to stderr:
-    ($DIFFERR "$experr" tmp_err.txt && diff --strip-trailing-cr "$expout" tmp_out.txt) || echo -e "\033[31;1m*** FAILED\033[0m out on $2"
-    diff --strip-trailing-cr "$expout" tmp_out.txt >/dev/null && $DIFFERR "$experr" tmp_err.txt >/dev/null && echo -e "\033[32;1mPASSED\033[0m."
-    RC=$?
+    FAILED="none" # "out" or "err" or "none"
+    $DIFFERR "$experr" tmp_err.txt || FAILED="err"; true
+    if [ "$FAILED" = "none" ]; then
+        diff --strip-trailing-cr "$expout" tmp_out.txt || FAILED="out"; true
+    fi
     rm tmp_out.txt tmp_err.txt
+    if [ "$FAILED" = "none" ]; then
+        echo -e "\033[32;1mPASSED\033[0m."
+    else
+        echo -e "\033[31;1m*** FAILED\033[0m $FAILED on $2"
+        exit 1
+    fi
 fi
-exit $RC


### PR DESCRIPTION
The original scripts always showed `*** FAILED on out on <test_name>?` which confused me.

Also removed the `(binary)` vs. `(no binary)` output for C backend tests, I needed this a long time ago when implementing the C backend to see what tests actually used the backend.

