### PR TITLE
ast: improve error message when inheritance is used without `ref`

### DIFF
--- a/src/dev/flang/ast/AstErrors.java
+++ b/src/dev/flang/ast/AstErrors.java
@@ -424,7 +424,12 @@ public class AstErrors extends ANY
           }
         else
           {
-            remedy = "To solve this, you could change the type of the target " + ss(target) + " to " + s(actlT) + " or convert the type of the assigned value to " + s(frmlT) + ".\n";
+            remedy = !frmlT.isRef() && actlT.feature().inheritsFrom(frmlT.feature()) ?
+                        "To solve this you could:\n" + //
+                            "  • make  " + s(frmlT) + " a reference by adding the " + st("ref")+ " keyword, so all its heirs can be used in place of it\n" + //
+                            "  • change the type of the target " + ss(target) + " to " + s(actlT) + "\n" + //
+                            "  • convert the type of the assigned value to " + s(frmlT) + "."
+                        : "To solve this, you could change the type of the target " + ss(target) + " to " + s(actlT) + " or convert the type of the assigned value to " + s(frmlT) + ".\n";
           }
         actlFound   = "actual type found   : " + s(actlT);
         valAssigned = "for value assigned  : " + s(value) + "\n";

--- a/src/dev/flang/ast/AstErrors.java
+++ b/src/dev/flang/ast/AstErrors.java
@@ -424,7 +424,7 @@ public class AstErrors extends ANY
           }
         else
           {
-            remedy = !frmlT.isRef() && actlT.feature().inheritsFrom(frmlT.feature()) ?
+            remedy = !frmlT.isRef() && !actlT.isGenericArgument() && !frmlT.isGenericArgument() && actlT.feature().inheritsFrom(frmlT.feature()) ?
                         "To solve this you could:\n" + //
                             "  • make  " + s(frmlT) + " a reference by adding the " + st("ref")+ " keyword, so all its heirs can be used in place of it,\n" + //
                             "  • change the type of the target " + ss(target) + " to " + s(actlT) + ", or\n" + //

--- a/src/dev/flang/ast/AstErrors.java
+++ b/src/dev/flang/ast/AstErrors.java
@@ -426,8 +426,8 @@ public class AstErrors extends ANY
           {
             remedy = !frmlT.isRef() && actlT.feature().inheritsFrom(frmlT.feature()) ?
                         "To solve this you could:\n" + //
-                            "  • make  " + s(frmlT) + " a reference by adding the " + st("ref")+ " keyword, so all its heirs can be used in place of it\n" + //
-                            "  • change the type of the target " + ss(target) + " to " + s(actlT) + "\n" + //
+                            "  • make  " + s(frmlT) + " a reference by adding the " + st("ref")+ " keyword, so all its heirs can be used in place of it,\n" + //
+                            "  • change the type of the target " + ss(target) + " to " + s(actlT) + ", or\n" + //
                             "  • convert the type of the assigned value to " + s(frmlT) + "."
                         : "To solve this, you could change the type of the target " + ss(target) + " to " + s(actlT) + " or convert the type of the assigned value to " + s(frmlT) + ".\n";
           }


### PR DESCRIPTION
fix #3563

How it looks now
```
> cat /tmp/impr_err_msg.fz
parent is
  func String => abstract

child : parent is
  redef func => "not working because ref keyword missing"


main(x parent) =>
  say (x.func)

main child
> FUZION_DISABLE_ANSI_ESCAPES=true fz /tmp/impr_err_msg.fz

/tmp/impr_err_msg.fz:11:6: error 1: Incompatible types when passing argument in a call
main child
-----^^^^^
Actual type for argument #1 'x' does not match expected type.
In call to          : 'main'
expected formal type: 'parent'
actual type found   : 'child'
assignable to       : 'child'
for value assigned  : 'child'
To solve this you could:
  • make  'parent' a reference by adding the 'ref' keyword, so all its heirs can be used in place of it
  • change the type of the target 'x' to 'child'
  • convert the type of the assigned value to 'parent'.

one error.

```