### PR TITLE
lib: support `ref` effect types, make all effects simple, remove `effect_mode`

### DIFF
--- a/lib/cache.fz
+++ b/lib/cache.fz
@@ -71,8 +71,8 @@ public cache(T type, f () -> T) T =>
   # the use of `state` for type T
   cache_item(val T) is
 
-  if !(effect.is_installed (state unit cache_item))
-    _ := state unit cache_item unit (cache_item f()) effect_mode.default
+  if !(state unit cache_item).is_instated
+    (state unit cache_item unit (cache_item f()) unit).default
 
   state_get cache_item
     .val

--- a/lib/concur/atomic_access.fz
+++ b/lib/concur/atomic_access.fz
@@ -26,7 +26,7 @@
 # atomic_access -- an effect that permits reading and writing values in instances
 # of atomic
 #
-private:module atomic_access : simple_effect is
+private:module atomic_access : effect is
 
   # install default instance of mutate
   #

--- a/lib/concur/racy_access.fz
+++ b/lib/concur/racy_access.fz
@@ -26,7 +26,7 @@
 # racy_access -- an effect that permits reading and writing values in instances
 # of atomic using the racy access functions
 #
-private:module racy_access : simple_effect is
+private:module racy_access : effect is
 
   # install default instance of mutate
   #

--- a/lib/concur/sync.fz
+++ b/lib/concur/sync.fz
@@ -42,13 +42,13 @@ public sync is
 
   # NYI: documentation missing, waiting for JVM backend impl
 
-  private:public mutex(mtx fuzion.sys.Pointer) : simple_effect is
+  private:public mutex(mtx fuzion.sys.Pointer) : effect is
 
     public type.new(T type, code ()->T) outcome T =>
       match concur.sync.mtx_init
         e error => e
         mtx fuzion.sys.Pointer =>
-          res := (concur.sync.mutex mtx).go code
+          res := (concur.sync.mutex mtx).instate_self code
           concur.sync.mtx_destroy mtx
           res
 
@@ -62,12 +62,12 @@ public sync is
       match concur.sync.cnd_init mtx
         e error => e
         cnd fuzion.sys.Pointer =>
-          res := (concur.sync.condition cnd mtx).go code
+          res := (concur.sync.condition cnd mtx).instate_self code
           concur.sync.cnd_destroy cnd
           res
 
 
-  private:public condition(cnd fuzion.sys.Pointer, mtx fuzion.sys.Pointer) : simple_effect is
+  private:public condition(cnd fuzion.sys.Pointer, mtx fuzion.sys.Pointer) : effect is
 
     public signal => cnd_signal cnd
     public broadcast => cnd_broadcast cnd

--- a/lib/concur/thread.fz
+++ b/lib/concur/thread.fz
@@ -28,7 +28,7 @@
 public thread (
   # the handler this effect uses to spawn threads
   p Thread_Handler
-  ) : simple_effect
+  ) : effect
 is
 
   # type for a spawned thread

--- a/lib/container/hash_map.fz
+++ b/lib/container/hash_map.fz
@@ -61,7 +61,7 @@ is
 
   # the contents
   #
-  contents := mi.go ()->
+  contents := mi.instate_self ()->
     for
       mcontents := (mutate.array (option (tuple HK V))).new mi allocated_size.as_i64 nil, mcontents
       k in ks

--- a/lib/container/ps_map.fz
+++ b/lib/container/ps_map.fz
@@ -147,7 +147,7 @@ O(n log n).
 
     m : mutate is
 
-    m.go ()->
+    m.instate_self ()->
 
       nsize := size + 1
       ndata := m.env.new data

--- a/lib/container/sorted_array.fz
+++ b/lib/container/sorted_array.fz
@@ -85,7 +85,7 @@ is
     if heap_size ≥ a.length
       a
     else
-      m.go ()->
+      m.instate_self ()->
 
         # h1 is the mutable index within the current first heap, this is updated
         # by the function passed to the array constructor.

--- a/lib/eff/fallible.fz
+++ b/lib/eff/fallible.fz
@@ -26,7 +26,7 @@
 # Any effect that may signal a fault should inherit from fallible to permit
 # its use within type parameteric features such as `eff.try`
 #
-public fallible(ERROR type, h ERROR->void) : effect effect_mode.plain is
+public fallible(ERROR type, h ERROR->void) : effect is
 
 
   # cause fault with the given error
@@ -86,7 +86,7 @@ public fallible(ERROR type, h ERROR->void) : effect effect_mode.plain is
       # use local mutate to store error passed to `cause`
       lm : mutate.
 
-      lm.go ()->
+      lm.instate_self ()->
         m := lm.env.new (option ERROR nil)
         (fallible.this.new e->
           m <- e
@@ -113,7 +113,7 @@ handle(ERROR type, F type : fallible ERROR, T type) is
   # use local mutate to store msg passed to `cause`
   lm : mutate.
 
-  res => lm.go ()->
+  res => lm.instate_self ()->
       m := lm.env.new (option ERROR nil)
       (F.new e->
           m <- e

--- a/lib/effect.fz
+++ b/lib/effect.fz
@@ -29,98 +29,141 @@
 # of effect are installed in the current environment while their code is
 # executed.  The code may access the effect via <type>.env.
 #
-module:public effect (
-  # action to be performed, may include code to run while this effect is installed.
+public effect is
+
+
+  # --------------------  effect intrinsics  --------------------
+
+
+  # set default effect in the current context to this if none is
+  # installed
   #
-  r effect_mode.val
-  )
-is
-
-  match r
-    _ effect_mode.plain   =>
-    i effect_mode.inst    => run i.f ()->unit
-    _ effect_mode.repl    => replace
-    _ effect_mode.default => default
-    _ effect_mode.new     =>
-
-  public mode effect_mode.val =>
-    match r
-      effect_mode.plain => effect_mode.plain
-      effect_mode.inst, effect_mode.repl, effect_mode.default, effect_mode.new => effect_mode.repl
-
-  # replace effect in the current context by this
-  module replace unit => intrinsic
+  type.default0(e effect.this) unit => intrinsic
 
 
   # execute code provided in f.call while this effect is installed
   # in the current environment. Return immediately in case abort is
   # called.
+
+  # NYI: uses type parameter T only to simplify backends
   #
-  # NYI: uses type parameter T only to simplify C backend
-  #
-  abortable(T type : Function unit, f T) unit => intrinsic
+  type.instate0(T type : Function unit, e effect.this, f T) unit => intrinsic
 
 
-  # replace effect in the current context by this and abort current execution
-  public abort void
-  pre
-    safety: effect.is_installed effect.this
-    safety: abortable
-  =>
-    abort0
+  # replace existing effect of type `E` in the new effect value `e`
+  #
+  type.replace0(e effect.this) unit => intrinsic
+
 
   # Intrinsic version of abort.
   #
-  # NYI: precondition does not seem to work for an intrinsic yet, causes test failure e.g., in tests/local_mutate
-  # so we use cannot make `abort` intrinsic.
-  abort0 void
+  type.abort0(e effect.this) void => intrinsic
+
+
+  # has an effect of this type been instated?
+  #
+  type.is_instated0 bool => intrinsic
+
+
+  # --------------------  default effects  --------------------
+
+
+  # set default instance for effect type `effect.this` to `e`
+  #
+  # NYI: UNDER DEVELOPMENT: This is a manual work-around to automatically install
+  # default effects. It should be replaced by a effect configuration file that
+  # is defined locally to a fuzion project or globally to the fuzion installation
+  # the defines the default effects to be used. The DFA should then automatically
+  # determine the required effects and create code to  instate them at the beginning
+  # of an application.
+  #
+  public type.default(e effect.this) => default0 e
+
+
+  # --------------------  effect instation  --------------------
+
+
+  # execute 'code' in a context where the effect instance `e` has been
+  # installed for effect type `effect.this`.
+  #
+  # In case `f` returns normally, this will return `f`'s result.
+  #
+  # In case `f` aborts this effect, return `def()`.
+  #
+  public type.instate(# result type
+                      R type,
+
+                      # the effect value to instate
+                      e effect.this,
+
+                      # the code to execute with `e` instated.
+                      code () -> R,
+
+                      # the lazy default result to use if effect aborts
+                      def Lazy R
+                      ) R
   =>
-    intrinsic
-
-
-  # does this effect support abort?
-  #
-  # Redefining this to return `false` helps to detect unexptected calls to
-  # `abort` at runtime and ensure that the static analysis finds that the
-  # code executed with this effect will always return normally and produce
-  # a result. This is used, e.g, in `mutate` to avoid static analysis
-  # reporting `panic` as an effect of the use of a local mutate instance.
-  #
-  public abortable => true
-
-
-  # set default effect in the current context to this if none is installed
-  module default unit => intrinsic
-
-  # execute the code of 'f' in the context of this effect
-  #
-  public run(R type, f () -> R, def ()->R) R =>
-    cf := Effect_Call f
-    abortable cf
+    cf := e.Effect_Call code
+    instate0 e cf
     match cf.res
       nil => def()
       x R => x
 
 
-  # abort the current execution and return from the surrounding call to
-  # abortable with result == false.
+  # execute 'code' in a context where the effect instance `e` has been
+  # installed for effect type `effect.this`.
   #
-  public return void
-  pre
-    safety: abortable
+  # In case `f` returns normally, this will return `f`'s result.
+  #
+  # In case `f` aborts this effect, this will panic.
+  #
+  public type.instate(# result type
+                      R type,
+
+                      # the effect value to instate
+                      e effect.this,
+
+                      # the code to execute with `e` instated.
+                      code () -> R
+                      ) R
   =>
-    abort
+    instate R e code (panic "unexpected abort in {effect.this.type}")
+
+
+  # convenience version of `instate` for effect values whose type is
+  # exactly the effect type (i.e., the value type does not inherit
+  # from the effect type).
+  #
+  # Execute 'code' in a context where this effect instance has been
+  # installed for effect type `effect.this`.
+  #
+  # In case `f` returns normally, this will return `f`'s result.
+  #
+  # In case `f` aborts this effect, this will panic.
+  #
+  public instate_self(# result type
+                      R type,
+
+                      # the code to execute with `e` instated.
+                      code () -> R
+                      ) R
+  =>
+    effect.this.instate R effect.this code
+
+
+  # has an effect of this type been instated?
+  #
+  public type.is_instated bool => is_instated0
 
 
   # has an effect of the given type been installed?
-  public type.is_installed(E type) bool => intrinsic
-
-  # has an effect of the given type been installed?
-  public type.get_if_installed option effect.this =>
-    if is_installed effect.this
+  public type.get_if_installed option effect.this
+  =>
+    if effect.this.is_instated
       unsafe_get
     else
       nil
+
 
   # internal helper to perform `E.env` without producing an error
   # in case static analysis fails to verify that `effect.this` is
@@ -130,7 +173,7 @@ is
     effect.this.env
 
 
-  # helper instance for effect.abortable to wrap call to f() into a ()->unit
+  # helper instance for effect.instate to wrap call to f() into a ()->unit
   #
   # NOTE: Since all control flow to enter an environment goes through this it is
   # essential that static analysis works well.  `Effect_Call` must be an inner
@@ -154,29 +197,102 @@ is
       set res := f()
 
 
-# effect mode is an enum that determines how an instance of effect is used
-#
-public effect_mode is
-
-  public plain is             # a plain effect, not installed as 'env'
-  public repl is              # effect instance replaces previous one in 'env'
-  public default is           # install as default. NYI: remove and use 'new' instead, see io.stdin.fz
-  public new is               # a new effect to be installed
-  public inst(f ()->unit) is  # install and run 'f'. NYI: remove and use 'new' instead, see io.stdin.fz
-
-  public val : choice plain repl default new inst of
-
-
-public code_effect : effect (effect_mode.inst code)
-is
-
-  # the code to be executed within this effect.  This is typically
-  # redefined as an argument field of a sub-feature of effect.
+  # execute the code of 'f' in the context of this effect
   #
-  # NYI: Currently, there is no direct way to return a result value
-  # from the code.
+  # NYI: CLEANUP: REMOVE, use type.instate instead
   #
-  public code ()->unit => abstract
+  public run(R type, f () -> R, def ()->R) R =>
+    effect.this.instate R effect.this f def.call
+
+
+  # --------------------  replacing effect instances  --------------------
+
+
+  # replace existing effect for type `effect.this` by the new effect value `e`.
+  #
+  # For effects that model the outside world (e.g., i/o, time, sensors and actuators, etc.),
+  # the effect might be a unit type, so the replace is effectively a no-operation.  However,
+  # the call to `replace` is used ot model the change of the outside world and must be
+  # included for analysis tools to appreciate this.
+  #
+  # replace may only be called during the execution of an operation of a currently installed
+  # effect of the same effect type.
+  #
+  # NYI: BUG: It is currently not enforced that replace is only called during the execution
+  # of an operation of a currenlty installed effect of the same effect type.
+  #
+  public type.replace(e effect.this)
+  =>
+    replace0 e
+
+
+  # replace existing effect of type `effect.this` by the new effect value `effect.this`.
+  #
+  # This is a convenience feature for value type effects for which the type of
+  # the effect instance equals the effect type.  `ref` type effects typically have
+  # values that may be children of the effect type that are of a different type, so
+  # `effect_type.replace new_value` must be used.
+  #
+  # replace may only be called during the execution of an operation of a currently installed
+  # effect of the same effect type.
+  #
+  public replace
+  =>
+    effect.this.type.replace effect.this
+
+
+  # --------------------  aborting code execution  --------------------
+
+
+  # replace existing effect for type `effect.this` by the new effect value `e`
+  # and abort code execution to return to the point where the effect was instated.
+  #
+  public type.abort(e effect.this) void
+  pre
+    safety: effect.this.is_instated
+    safety: effect.this.env.abortable
+  =>
+    abort0 e
+
+
+  # replace existing effect of type `effect.this` by the new effect value `effect.this`.
+  # and abort code execution to return to the point where the effect was instated.
+  #
+  public abort void
+  pre
+    safety: effect.this.is_instated
+    safety: abortable
+  =>
+    effect.this.abort0 effect.this
+
+
+  # does this effect support abort?
+  #
+  # Redefining this to return `false` helps to detect unexptected calls to
+  # `abort` at runtime and ensure that the static analysis finds that the
+  # code executed with this effect will always return normally and produce
+  # a result. This is used, e.g, in `mutate` to avoid static analysis
+  # reporting `panic` as an effect of the use of a local mutate instance.
+  #
+  public abortable => true
+
+
+  # abort the current execution and return from the surrounding call to
+  # `instate`.
+  #
+  # NYI: CLEANUP: `return` is the same as `abort`. The term `return` seems
+  # common for algebraic effects, but is confusing since it is different to
+  # returning from a call. We need to decide to break with algebraic effect
+  # jargon (and remove `return`) or to stick with it (and rename `abort` as
+  # `return`).
+  #
+  public return void
+  pre
+    safety: abortable
+  =>
+    abort
+
+# --------------------  effect helper features  --------------------
 
 
 # simple_effect provides a simple means to define and use an effect
@@ -187,28 +303,29 @@ is
 # To install this effect to execute a function, simple_effect.use
 # can be called.
 #
-public simple_effect : effect effect_mode.plain
+# NYI: CLEANUP: REMOVE, use effect instead
+#
+public simple_effect : effect
 is
 
   # install this simple_effect and run code
   #
-  # In case of an `abort`, `use` returns silently (NYI: maybe this should better
-  # return an oucome with the abort wrapped in an error?).
+  # In case of an `abort`, `use` panics
+  #
+  # NYI: CLEANUP: REMOVE, use effect.instate instead
   #
   public use(code ()->unit) unit =>
-    cf := Effect_Call code
-    abortable cf
-    # ignore cf.res
+    simple_effect.this.instate simple_effect.this code
 
 
   # install this effect and run code that produces a result of
   # type T. panic in case abort is called.
   #
-  public go(T type, f ()->T) T =>
-    cf := Effect_Call f
-    abortable cf
-    match cf.res
-      nil => msg := "*** unexpected abort in {simple_effect.this.type}"
+  # NYI: CLEANUP: REMOVE, use effect.instate instead
+  #
+  public go(T type, code ()->T) T =>
+    simple_effect.this.instate T simple_effect.this code ()->
+             msg := "*** unexpected abort in {simple_effect.this.type}"
              if abortable
                panic msg
              else
@@ -216,4 +333,3 @@ is
                # not abortable cf can only return with a result. So we do a low-level
                # panic that does not show up as a used effect:
                fuzion.std.panic msg
-      x T => x

--- a/lib/effect.fz
+++ b/lib/effect.fz
@@ -80,6 +80,19 @@ public effect is
   public type.default(e effect.this) => default0 e
 
 
+  # convenience version of `type.default` for effect values whose type is
+  # exactly the effect type (i.e., the value type does not inherit
+  # from the effect type).
+  #
+  # set default instance for effect type `effect.this` to value `effect.this`.
+  #
+  # NYI: UNDER DEVELOPMENT: See type.default
+  #
+  public default unit
+  =>
+    effect.this.type.default effect.this
+
+
   # --------------------  effect instation  --------------------
 
 

--- a/lib/envir/args.fz
+++ b/lib/envir/args.fz
@@ -25,7 +25,7 @@
 
 # envir.args -- effect providing access to command line args
 #
-public args (all array String) : container.searchable_sequence String all.as_list, simple_effect is
+public args (all array String) : container.searchable_sequence String all.as_list, effect is
 
   # install default effect args using fuzion.sys.args
   #

--- a/lib/envir/vars.fz
+++ b/lib/envir/vars.fz
@@ -25,7 +25,7 @@
 
 # envir.vars -- effect providing access to environment variables
 #
-public vars (p Vars_Handler) : simple_effect is
+public vars (p Vars_Handler) : effect is
 
   # If set, get the environment variable corresponding to v.
   #

--- a/lib/exit.fz
+++ b/lib/exit.fz
@@ -30,10 +30,8 @@ private:public exit (
   # the handler this effect uses to exit
   p Exit_Handler,
 
-  r effect_mode.val,
-
-  _ unit
-  ) : effect r
+  _, _ unit
+  ) : effect
 is
 
   # exit with the given code
@@ -56,8 +54,8 @@ is
   # install default instance of exit
   #
   type.install_default unit =>
-    if !effect.is_installed exit
-      _ := exit default_exit_handler effect_mode.default unit
+    if !exit.is_instated
+      (exit default_exit_handler unit unit).default
 
 
   # default exit handler
@@ -124,7 +122,7 @@ pre debug: code ≤ 127
 # install given exit handler and run code with it.
 #
 public exit(handler Exit_Handler, code ()->unit) =>
-  _ := exit handler (effect_mode.inst code) unit
+  exit.instate (exit handler unit unit) code
 
 
 # Exit_Handler -- abstract exit

--- a/lib/handles.fz
+++ b/lib/handles.fz
@@ -65,11 +65,8 @@ private:public handles(
   # NYI: As soon as one-way monads are enforced, this array can be implemented
   # using marray, reducing the overhead of an update from O(count) to O(1)!
   #
-  ar array T,
-
-  # action to be taken: plain monad, install or replace?
-  r effect_mode.val
-  ) : oneway_monad X (handles T X) r
+  ar array T
+  ) : oneway_monad X (handles T X)
 is
 
   # number of handles created
@@ -88,7 +85,7 @@ is
     debug: result.has_last
   =>
     na := array T count+1 (i -> if (i < count) ar[i] else w)
-    handles T X v na mode
+    handles T X v na
 
 
   # has one element been created using 'new'?
@@ -136,7 +133,7 @@ is
     # the new value to be stored with 'h'
     w T)
   =>
-    handles T X v (ar.put h.x w) mode
+    handles T X v (ar.put h.x w)
 
 
   # create a new instance with the value refered to by a given handle read and
@@ -164,24 +161,24 @@ is
     f T->T
     )
   =>
-    _ := handles T X v (ar.put x (f ar[x])) mode
+    _ := handles T X v (ar.put x (f ar[x]))
 
 
   public redef infix >>= (f X -> handles T X) => bind X f
 
   public bind(B type, f X -> handles T B) handles T B =>
-    handles T B (f v).v ar effect_mode.plain
+    handles T B (f v).v ar
 
-  public return( B type, w B) => handles T B w ar effect_mode.plain
+  public return( B type, w B) => handles T B w ar
 
 # short-hand for creating and installing an empty set of handles of given type.
 #
 public handles(T type, rr ()->unit) =>
-  _ := handles T unit unit (array T 0 x->do) (effect_mode.inst rr)
+  (handles T unit).instate (handles T unit unit (array T 0 x->do)) rr
 
 # short-hand for creating an empty set of handles of given type.
 #
-public handles_(T type) => handles T unit unit (array T 0 x->do) effect_mode.plain
+public handles_(T type) => handles T unit unit (array T 0 x->do)
 
 
 # short-hand for accessing handles monad for given type in current environment
@@ -225,7 +222,7 @@ handles_type(T type) is
   # install default instance of handles
   #
   install_default unit =>
-    _ := handles T unit unit (array T 0 x->do) effect_mode.default
+    (handles T unit unit (array T 0 x->do)).default
 
 
 # initializes a new handle with the given initial value

--- a/lib/handles2.fz
+++ b/lib/handles2.fz
@@ -39,11 +39,8 @@ private:public handles2(
   # the inner value of this monad
   public v X,
 
-  last_opt option (handle2_0 T),
-
-  # action to be taken: plain monad, install or replace?
-  r effect_mode.val
-  ) : oneway_monad X (handles2 T X) r
+  last_opt option (handle2_0 T)
+  ) : oneway_monad X (handles2 T X)
 is
 
   # create a new instance with one additional handle
@@ -57,7 +54,7 @@ is
   post
     debug: result.has_last
   =>
-    handles2 T X v (handle2_0 w) mode
+    handles2 T X v (handle2_0 w)
 
 
   # has one element been created using 'new'?
@@ -104,15 +101,9 @@ is
 
     # the new value to be stored with 'h'
     w T)
-  pre
-    debug: match mode
-             effect_mode.plain   => false  # must be used as oneway_monad only
-             effect_mode.default => false
-             effect_mode.new     => false
-             effect_mode.inst, effect_mode.repl => true
   =>
     h.put w
-    handles2 T X v last_opt mode
+    handles2 T X v last_opt
 
 
   # create a new instance with the value referred to by a given handle read and
@@ -125,32 +116,26 @@ is
     # function calculating the new value from the old value
     f T->T
     )
-  pre
-    debug: match mode
-            effect_mode.plain   => false  # must be used as oneway_monad only
-            effect_mode.default => false
-            effect_mode.new     => false
-            effect_mode.inst, effect_mode.repl => true
   =>
     h.put (f h.get)
-    handles2 T X v last_opt mode
+    handles2 T X v last_opt
 
 
   public redef infix >>= (f X -> handles2 T X) => bind X f
 
   public bind(B type, f X -> handles2 T B) handles2 T B =>
-    handles2 T B (f v).v last_opt effect_mode.plain
+    handles2 T B (f v).v last_opt
 
-  public return(B type, w B) => handles2 T B w last_opt effect_mode.plain
+  public return(B type, w B) => handles2 T B w last_opt
 
 # short-hand for creating and installing an empty set of handles2 of given type.
 #
 handles2(T type, rr ()->unit) =>
-  _ := handles2 T unit unit nil (effect_mode.inst rr)
+  (handles2 T unit).instate (handles2 T unit unit nil) rr
 
 # short-hand for creating an empty set of handles2 of given type.
 #
-handles2_(T type) => handles2 T unit unit nil effect_mode.plain
+handles2_(T type) => handles2 T unit unit nil
 
 
 # short-hand for accessing handles monad for given type in current environment
@@ -191,7 +176,7 @@ handles2_type(T type) is
   # install default instance of handles2
   #
   install_default unit =>
-    _ := handles2 T unit unit nil effect_mode.default
+    (handles2 T unit unit nil).default
 
 
 # create a new handle2 using the handles2 instance from the current environment

--- a/lib/io/buffered/reader.fz
+++ b/lib/io/buffered/reader.fz
@@ -27,7 +27,7 @@
 #
 # note: anything in the buffer when effect is uninstalled will be discarded.
 #
-public reader(LM type : mutate, rp Read_Provider, buf_size i32) : effect effect_mode.plain is
+public reader(LM type : mutate, rp Read_Provider, buf_size i32) : effect is
 
 
   # circular buffer backing this reader

--- a/lib/io/buffered/writer.fz
+++ b/lib/io/buffered/writer.fz
@@ -27,7 +27,7 @@
 #
 # note: anything in the buffer when effect is uninstalled will be discarded.
 #
-public writer(LM type : mutate, wp Write_Provider, buf_size i32) : effect effect_mode.plain is
+public writer(LM type : mutate, wp Write_Provider, buf_size i32) : effect is
 
 
   # circular buffer backing this writer

--- a/lib/io/dir/make.fz
+++ b/lib/io/dir/make.fz
@@ -23,7 +23,7 @@
 
 # make -- effect providing make directory
 #
-public make(fwh Make_Dir_Handler, _ unit) : simple_effect is
+public make(fwh Make_Dir_Handler, _ unit) : effect is
 
   # makes a directory using the specified path
   # parent directories in the path should exist otherwise, no creation will take place and an error will be the outcome
@@ -49,7 +49,7 @@ public make(fwh Make_Dir_Handler, _ unit) : simple_effect is
 # install the effect and perform the operation.
 #
 public make(path String) =>
-  if !(effect.is_installed io.dir.make)
+  if !io.dir.make.is_instated
     (io.dir.make make.default_handler unit).default
   make.env.make_dir path
 

--- a/lib/io/dir/open.fz
+++ b/lib/io/dir/open.fz
@@ -27,7 +27,7 @@
 #
 module:public open(public T type,
                    fd i64,
-                   public path String) : simple_effect is
+                   public path String) : effect is
 
   # reads the next entry of this directory
   #

--- a/lib/io/dir/read.fz
+++ b/lib/io/dir/read.fz
@@ -23,7 +23,7 @@
 
 # read -- effect providing reading operations in directories
 #
-public read(ro Read_Handler) : simple_effect is
+public read(ro Read_Handler) : effect is
 
 
   # reads the next entry of this directory

--- a/lib/io/dir/use.fz
+++ b/lib/io/dir/use.fz
@@ -40,7 +40,7 @@ public use(T, R type, path String, code ()-> outcome R) outcome R =>
     fd i64 =>
       # install effect `open T` and run `code`
       r := open T fd path
-        .go code
+        .instate_self code
       # close file
       _ := fuzion.sys.fileio.close_dir fd
       # return result

--- a/lib/io/file/delete.fz
+++ b/lib/io/file/delete.fz
@@ -25,7 +25,7 @@
 
 # delete -- effect wrapping the file delete operation
 #
-public delete(dop Delete_Handler, _ unit) : simple_effect is
+public delete(dop Delete_Handler, _ unit) : effect is
 
   # deletes the file/dir found in the path
   # returns unit as outcome in case of successful deletion and error in case of failure

--- a/lib/io/file/move.fz
+++ b/lib/io/file/move.fz
@@ -25,7 +25,7 @@
 
 # move -- effect wrapping the file move operation
 #
-public move(mop Move_Handler) : simple_effect is
+public move(mop Move_Handler) : effect is
 
   # moves file/dir from an old path to a the new path
   # can rename the file/dir as well by changing the name of the old file/dir to a new name in the new_path

--- a/lib/io/file/open.fz
+++ b/lib/io/file/open.fz
@@ -27,7 +27,7 @@
 #
 module:public open(public T type,
                    fd i64,
-                   public file_name String) : simple_effect is
+                   public file_name String) : effect is
 
   # writes the content of an array of bytes to a file opened as fd
   #
@@ -36,7 +36,7 @@ module:public open(public T type,
   public write(content Sequence u8) =>
     # NYI we should probably not override existing effect in all cases..
     # also write effect would not show up if used like this.
-    (io.file.write (io.file.write.default_write_handler fd)).go ()->
+    (io.file.write (io.file.write.default_write_handler fd)).instate_self ()->
       io.file.write.write content.as_array
 
 

--- a/lib/io/file/read.fz
+++ b/lib/io/file/read.fz
@@ -25,7 +25,7 @@
 
 # read -- effect providing byte reading operations from files
 #
-public read(ro Read_Handler) : simple_effect is
+public read(ro Read_Handler) : effect is
 
 
   # how much of a file do we read at a time, in bytes

--- a/lib/io/file/seek.fz
+++ b/lib/io/file/seek.fz
@@ -25,7 +25,7 @@
 
 # seek -- effect providing stream seeking operations
 #
-public seek(ps Seek_Handler) : simple_effect is
+public seek(ps Seek_Handler) : effect is
 
   # seek offset in the stream represented by fd
   # returns an outcome i64 that represents the new offset

--- a/lib/io/file/stat.fz
+++ b/lib/io/file/stat.fz
@@ -37,7 +37,7 @@ private:public meta_data(
 
 # stat -- effect providing operations to retrieve file stats
 #
-public stat(ps Stat_Handler) : simple_effect is
+public stat(ps Stat_Handler) : effect is
 
   # returns stats of the file/dir passed in the pathname
   # in success it will return a meta_data outcome storing stats regarding the file/dir

--- a/lib/io/file/use.fz
+++ b/lib/io/file/use.fz
@@ -57,7 +57,7 @@ public use(T, R type, file_name String, m mode.val, code ()-> outcome R) outcome
     fd i64 =>
       # install effect `open T` and run `code`
       r := open T fd file_name
-        .go code
+        .instate_self code
       # close file
       _ := fuzion.sys.fileio.close fd
       # return result

--- a/lib/io/file/write.fz
+++ b/lib/io/file/write.fz
@@ -25,7 +25,7 @@
 
 # write -- effect providing writing operations for files
 #
-public write(fwh Write_Handler) : simple_effect is
+public write(fwh Write_Handler) : effect is
 
 
   # writes the content of an array of bytes to a file opened as fd

--- a/lib/io/print_effect.fz
+++ b/lib/io/print_effect.fz
@@ -27,7 +27,7 @@
 #
 # This is used as heir feature for effects such as io.out and io.err.
 #
-public print_effect (p Print_Handler) : simple_effect
+public print_effect (p Print_Handler) : effect
 is
 
   # print the given string followed be new line

--- a/lib/list.fz
+++ b/lib/list.fz
@@ -164,7 +164,7 @@ public list(public A type) : choice nil (Cons A (list A)), Sequence A is
   public redef as_array array A =>
     lm : mutate is
       redef mpanic(msg String) => fuzion.std.panic msg
-    lm.go ()->
+    lm.instate_self ()->
       e := lm.env.new list.this
       array A count _->
         res := e.get.first

--- a/lib/mutate.fz
+++ b/lib/mutate.fz
@@ -53,7 +53,7 @@
 #
 # is not supported yet.
 #
-public mutate : simple_effect is
+public mutate : effect is
 
 
   # does this effect support abort?

--- a/lib/mutate.fz
+++ b/lib/mutate.fz
@@ -108,13 +108,13 @@ public mutate : simple_effect is
 
     # is this element open, i.e., can it be mutated?
     #
-    public open => id != u64 0
+    public open => my_id != u64 0
 
 
     # stop any further mutations of this element
     #
     public close =>
-      set id := 0
+      set my_id := 0
 
 
   # create a new mutable value with the given initial value and update the

--- a/lib/net/channel.fz
+++ b/lib/net/channel.fz
@@ -35,7 +35,7 @@
 # 2) writing to a channel installed by `server.accept` will result in an error.
 # 3) reading from a channel installed by `client ...` will block indefinitely.
 #
-module:public channel(desc i64) : simple_effect
+module:public channel(desc i64) : effect
 is
 
 

--- a/lib/net/client.fz
+++ b/lib/net/client.fz
@@ -48,10 +48,10 @@ public client(T type, ch Connection_Handler T, f net.family.val, p net.protocol.
       # NYI: BUG: (try net.connection_handler).on ()->
 
       lm : mutate is
-      res := lm.go ()->
+      res := lm.instate_self ()->
         (io.buffered.reader lm (read_provider desc) 1024).with ()->
           (io.buffered.writer lm (write_provider desc) 1024).with ()->
-            (net.channel desc).go ()->
+            (net.channel desc).instate_self ()->
               ch.handle_connection lm
 
       _ := fuzion.sys.net.close desc

--- a/lib/net/server.fz
+++ b/lib/net/server.fz
@@ -34,10 +34,10 @@
 module:public server(
   state outcome i64,
   p protocol.val,
-  m effect_mode.val,
+  _ unit,  # NYI: CLEANUP: rename `server(f family.val, p protocol.val, addr String, port u16)` to avoid these 3xunit
   _ unit,
   _ unit
-) : effect m
+) : effect
 is
 
   # get the last error that occurred
@@ -52,11 +52,12 @@ is
   public close =>
     match state
       d i64 =>
-        _ := match fuzion.sys.net.close d
+        s := match fuzion.sys.net.close d
           unit =>
-            server (error "not initialized") nil effect_mode.repl unit unit
+            server (error "not initialized") nil unit unit unit
           error error =>
-            server error nil effect_mode.repl unit unit
+            server error nil unit unit unit
+        s.replace
       * =>
 
 
@@ -76,15 +77,15 @@ is
             # no_threads : concur.Thread_Handler is
             #   spawn(code ()->unit) concur.thread.spawned =>
             #     panic "may not spawn threads in connection handler"
-            # (concur.thread no_threads).go ()->
+            # (concur.thread no_threads).instate_self ()->
             #   _ := connection_handler.env.handle_connection (channel desc)
             #   fuzion.sys.net.close desc
 
             lm : mutate is
-            res := lm.go ()->
+            res := lm.instate_self ()->
               (io.buffered.reader lm (read_provider desc) 1024).with ()->
                 (io.buffered.writer lm (write_provider desc) 1024).with ()->
-                  (net.channel desc).go ()->
+                  (net.channel desc).instate_self ()->
                     ch.handle_connection lm
 
             _ := fuzion.sys.net.close desc
@@ -96,7 +97,7 @@ is
 
           e error =>
             # NYI we may not need to close server on every error...
-            _ := server e nil effect_mode.repl unit unit
+            (server e nil unit unit unit).replace
             e
       e error =>
         e
@@ -111,14 +112,14 @@ is
           desc i64 =>
             _ := concur.thread.spawn ()->
               lm : mutate is
-              _ := lm.go ()->
+              _ := lm.instate_self ()->
                 (io.buffered.reader lm (read_provider desc) 1024).with ()->
                   (io.buffered.writer lm (write_provider desc) 1024).with ()->
-                    (net.channel desc).go ()->
+                    (net.channel desc).instate_self ()->
                       ch.handle_connection lm
             unit
           e error =>
-            _ := server e nil effect_mode.repl unit unit
+            (server e nil unit unit unit).replace
             e
       e error => e
 
@@ -145,7 +146,7 @@ public server(f family.val, p protocol.val, addr String, port u16) outcome unit 
 
   match init_ip_server f p addr port
     desc i64 =>
-      _ := server desc p effect_mode.repl unit unit
+      (server desc p unit unit unit).replace
       unit
     e error =>
       e
@@ -153,8 +154,8 @@ public server(f family.val, p protocol.val, addr String, port u16) outcome unit 
 
 # get currently installed server from env
 public server =>
-  if !effect.is_installed server
-    _ := server (error "not initialized") nil effect_mode.default unit unit
+  if !server.is_instated
+    (server (error "not initialized") nil unit unit unit).default
   server.env
 
 

--- a/lib/oneway_monad.fz
+++ b/lib/oneway_monad.fz
@@ -33,10 +33,6 @@ public oneway_monad(
 
   A type,
 
-  OMA type : oneway_monad A OMA,
-
-  # action to be performed, may include code to run while this effect is installed.
-  #
-  r effect_mode.val
-  ) : monad A OMA, effect r
+  OMA type : oneway_monad A OMA
+  ) : monad A OMA, effect
 is

--- a/lib/process/env_vars.fz
+++ b/lib/process/env_vars.fz
@@ -25,7 +25,7 @@
 # the environment variables in this map are used
 # when spawning a new process.
 #
-public env_vars(get container.Map String String) : simple_effect
+public env_vars(get container.Map String String) : effect
 pre
   get.keys ∀ (x -> x.as_codepoints ∀ (y -> y.is_ascii))
   get.values ∀ (x -> x.as_codepoints ∀ (y -> y.is_ascii))

--- a/lib/random.fz
+++ b/lib/random.fz
@@ -28,10 +28,8 @@
 public random (
 
   # the handler this effect uses to create random numbers
-  p Random_Handler,
-
-  r effect_mode.val
-  ) : effect r
+  p Random_Handler
+  ) : effect
 is
 
 
@@ -39,7 +37,10 @@ is
   # environment to the next random value.  The the contents of the current
   # instance are left unchanged, 'random.env' will provide the new instance.
   #
-  next => random p.next mode
+  next =>
+    res := random p.next
+    res.replace
+    res
 
 
   # return next random number of type i32 in the range 0..max-1
@@ -98,8 +99,8 @@ is
   # install default instance of random
   #
   type.install_default =>
-    if !effect.is_installed random
-      _ := random simple_random_handler.default effect_mode.default
+    if !random.is_instated
+      (random simple_random_handler.default).default
 
 
 # random with no argument returns random.env, i.e., the currently installed
@@ -110,10 +111,10 @@ public random =>
   random.env
 
 public simple_random(seed u64, rr ()->unit) =>
-  _ := random (simple_random_handler seed seed) (effect_mode.inst rr)
+  random.instate (random (simple_random_handler seed seed)) rr
 
 public time_seeded_random(rr ()->unit) =>
-  _ := random simple_random_handler.time_seeded (effect_mode.inst rr)
+  random.instate (random simple_random_handler.time_seeded) rr
 
 
 # Random_Handler -- abstract source of random numbers
@@ -203,4 +204,4 @@ simple_random_handler(seed1 u64, seed2 u64) : Random_Handler is
   # random number generator.
   #
   type.time_seeded(rr ()->unit) =>
-    _ := random time_seeded (effect_mode.inst rr)
+    random.instate (random time_seeded) rr

--- a/lib/state.fz
+++ b/lib/state.fz
@@ -40,8 +40,8 @@ public state(
   # the current state
   get S,
 
-  r effect_mode.val
-  ) : oneway_monad T (state T S) r
+  _ unit
+  ) : oneway_monad T (state T S)
 is
 
   # monadic operator
@@ -59,23 +59,23 @@ is
 
   # return function
   #
-  public return (a T) => state a get mode
+  public return (a T) => state a get unit
 
 
   # map this using f
   #
   public map (B type, f T -> B) state B S =>
-    state (f val) get mode
+    state (f val) get unit
 
 
   # modify the state, leaving the contents unchanged
   #
-  public modify (f S -> S) => state val (f get) mode
+  public modify (f S -> S) => state val (f get) unit
 
 
   # set state to new, leaving the contents unchanged
   #
-  public put (new S) => state val new mode
+  public put (new S) => state val new unit
 
 
   # converts option to a string
@@ -90,7 +90,7 @@ is
 # state with 1 argument is short hand for a state containing unit and
 # initial_value
 #
-public state(S type, initial_value S) => state unit initial_value effect_mode.plain
+public state(S type, initial_value S) => state unit initial_value unit
 
 # install new state monad for type S and run r within that state monad
 #
@@ -98,7 +98,7 @@ public state(S type, initial_value S) => state unit initial_value effect_mode.pl
 #
 public state(S, R type, initial_value S, r ()->R) =>
   res option R := nil
-  _ := state unit S unit initial_value (effect_mode.inst (()->set res := r.call))
+  (state unit S).instate (state unit S unit initial_value unit) (()->set res := r.call)
   res.get
 
 

--- a/lib/time/nano.fz
+++ b/lib/time/nano.fz
@@ -34,7 +34,7 @@
 # not be the right source of time to, e.g., feed an alarm clock that should
 # wake you up at 6h30 every morning.
 #
-public nano (p Nano_Time_Handler) : simple_effect is
+public nano (p Nano_Time_Handler) : effect is
 
   # no guarantee can be given for precision nor resolution
   public read =>
@@ -66,7 +66,7 @@ public nano (p Nano_Time_Handler) : simple_effect is
 # short-hand for accessing time.nano effect in current environment
 #
 public nano =>
-  if !effect.is_installed nano
+  if !nano.is_instated
     nano.install_default
   nano.env
 

--- a/lib/time/now.fz
+++ b/lib/time/now.fz
@@ -24,7 +24,7 @@
 # -----------------------------------------------------------------------
 
 # effect for getting the current date_time
-public now (p () -> time.date_time) : simple_effect is
+public now (p () -> time.date_time) : effect is
 
   # get current date_time
   #

--- a/lib/unique_id.fz
+++ b/lib/unique_id.fz
@@ -23,7 +23,7 @@
 
 # unique_id -- effect that generates a unique id
 #
-public unique_id (p Unique_Id_Handler) : simple_effect
+public unique_id (p Unique_Id_Handler) : effect
 is
 
   public get => {replace; p.get}

--- a/src/dev/flang/be/c/Intrinsics.java
+++ b/src/dev/flang/be/c/Intrinsics.java
@@ -928,23 +928,28 @@ public class Intrinsics extends ANY
     )).ret());
 
 
-    put("effect.replace"       ,
-        "effect.default"       ,
-        "effect.abortable"     ,
-        "effect.abort0"        , (c,cl,outer,in) ->
+    put("effect.type.abort0"     ,
+        "effect.type.default0"   ,
+        "effect.type.instate0"   ,
+        "effect.type.is_instated0",
+        "effect.type.replace0"   , (c,cl,outer,in) ->
         {
-          var ecl = c._fuir.effectType(cl);
+          var ecl = c._fuir.effectTypeFromInstrinsic(cl);
           var ev  = CNames.fzThreadEffectsEnvironment.deref().field(c._names.env(ecl));
           var evi = CNames.fzThreadEffectsEnvironment.deref().field(c._names.envInstalled(ecl));
           var evj = CNames.fzThreadEffectsEnvironment.deref().field(c._names.envJmpBuf(ecl));
           var o   = CNames.OUTER;
-          var e   = c._fuir.clazzIsRef(ecl) ? o : o.deref();
+          var e   = A0;
           return
             switch (in)
               {
-              case "effect.replace"   ->                                  ev.assign(e)                            ;
-              case "effect.default"   -> CStmnt.iff(evi.not(), CStmnt.seq(ev.assign(e), evi.assign(CIdent.TRUE )));
-              case "effect.abortable" ->
+              case "effect.type.abort0"        ->
+                CStmnt.seq(CStmnt.iff(evi, CExpr.call("longjmp",new List<>(evj.deref(), CExpr.int32const(1)))),
+                           CExpr.fprintfstderr("*** C backend support for %s missing\n",
+                                               CExpr.string(c._fuir.clazzOriginalName(cl))),
+                           CExpr.exit(1));
+              case "effect.type.default0"     -> CStmnt.iff(evi.not(), CStmnt.seq(c._fuir.clazzIsUnitType(ecl) ? CExpr.UNIT : ev.assign(e), evi.assign(CIdent.TRUE )));
+              case "effect.type.instate0"     ->
                 {
                   var oc = c._fuir.clazzActualGeneric(cl, 0);
                   var call = c._fuir.lookupCall(oc);
@@ -958,11 +963,11 @@ public class Intrinsics extends ANY
                                        CStmnt.decl("bool"             , oldevi, evi),
                                        CStmnt.decl("jmp_buf*"         , oldevj, evj),
                                        CStmnt.decl("jmp_buf", jmpbuf),
-                                       ev.assign(e),
+                                       c._fuir.clazzIsUnitType(ecl) ? CExpr.UNIT : ev.assign(e),
                                        evi.assign(CIdent.TRUE ),
                                        evj.assign(jmpbuf.adrOf()),
                                        CStmnt.iff(CExpr.call("setjmp",new List<>(jmpbuf)).eq(CExpr.int32const(0)),
-                                                  CExpr.call(c._names.function(call), new List<>(A0))),
+                                                  CExpr.call(c._names.function(call), new List<>(A1))),
                                        /* NYI: this is a bit radical: we copy back the value from env to the outer instance, i.e.,
                                         * the outer instance is no longer immutable and we might run into difficulties if
                                         * the outer instance is used otherwise.
@@ -983,22 +988,10 @@ public class Intrinsics extends ANY
                                        CExpr.call("exit", new List<>(CExpr.int32const(1))));
                     }
                 }
-              case "effect.abort0"  ->
-                CStmnt.seq(CStmnt.iff(evi, CExpr.call("longjmp",new List<>(evj.deref(), CExpr.int32const(1)))),
-                           CExpr.fprintfstderr("*** C backend support for %s missing\n",
-                                               CExpr.string(c._fuir.clazzOriginalName(cl))),
-                           CExpr.exit(1));
+              case "effect.type.is_instated0" -> CStmnt.seq(CStmnt.iff(evi, c._names.FZ_TRUE.ret()), c._names.FZ_FALSE.ret());
+              case "effect.type.replace0"     -> c._fuir.clazzIsUnitType(ecl) ? CExpr.UNIT : ev.assign(e);
               default -> throw new Error("unexpected intrinsic '" + in + "'.");
               };
-        });
-    put("effect.type.is_installed"       , (c,cl,outer,in) ->
-        {
-          var ecl = c._fuir.clazzActualGeneric(cl, 0);
-          var evi = CNames.fzThreadEffectsEnvironment.deref().field(c._names.envInstalled(ecl));
-          // NYI: UNDER DEVELOPMENT: can this logic be moved to abstract interpreter?
-          return c._fuir.clazzNeedsCode(ecl)
-            ? CStmnt.seq(CStmnt.iff(evi, c._names.FZ_TRUE.ret()), c._names.FZ_FALSE.ret())
-            : c._names.FZ_FALSE.ret();
         });
 
     var noJava = CStmnt.seq(
@@ -1265,6 +1258,7 @@ public class Intrinsics extends ANY
   private static void put(String n1, String n2, IntrinsicCode c) { put(n1, c); put(n2, c); }
   private static void put(String n1, String n2, String n3, IntrinsicCode c) { put(n1, c); put(n2, c); put(n3, c); }
   private static void put(String n1, String n2, String n3, String n4, IntrinsicCode c) { put(n1, c); put(n2, c); put(n3, c); put(n4, c); }
+  private static void put(String n1, String n2, String n3, String n4, String n5, IntrinsicCode c) { put(n1, c); put(n2, c); put(n3, c); put(n4, c); put(n5, c); }
 
 
   /**

--- a/src/dev/flang/be/interpreter/Executor.java
+++ b/src/dev/flang/be/interpreter/Executor.java
@@ -521,7 +521,7 @@ public class Executor extends ProcessExpression<Value, Object>
       }
 
     if (POSTCONDITIONS) ensure
-      (result != unitValue());
+      (fuir().clazzIsUnitType(ecl) || result != unitValue());
 
     return pair(result);
   }

--- a/src/dev/flang/be/interpreter/Intrinsics.java
+++ b/src/dev/flang/be/interpreter/Intrinsics.java
@@ -191,6 +191,7 @@ public class Intrinsics extends ANY
   private static void putUnsafe(String n1, String n2, String n3, IntrinsicCode c) { putUnsafe(n1, c); putUnsafe(n2, c); putUnsafe(n3, c); }
   private static void put(String n1, String n2, String n3, String n4, IntrinsicCode c) { put(n1, c); put(n2, c); put(n3, c); put(n4, c); }
   private static void putUnsafe(String n1, String n2, String n3, String n4, IntrinsicCode c) { putUnsafe(n1, c); putUnsafe(n2, c); putUnsafe(n3, c); putUnsafe(n4, c); }
+  private static void put(String n1, String n2, String n3, String n4, String n5, IntrinsicCode c) { put(n1, c); put(n2, c); put(n3, c); put(n4, c); put(n5, c); }
 
 
   /**
@@ -1388,15 +1389,11 @@ public class Intrinsics extends ANY
         arg0[5] = calendar.get(Calendar.MILLISECOND) * 1000;
         return new Instance(executor.fuir().clazz(FUIR.SpecialClazzes.c_unit));
       });
-    put("effect.replace"  ,
-        "effect.default"  ,
-        "effect.abortable",
-        "effect.abort0"   , (executor, innerClazz) -> effect(executor, innerClazz));
-    put("effect.type.is_installed", (executor, innerClazz) -> args ->
-        {
-          int cl = executor.fuir().clazzActualGeneric(innerClazz, 0);
-          return new boolValue(FuzionThread.current()._effects.get(cl) != null /* NOTE not containsKey since cl may map to null! */ );
-        });
+    put("effect.type.abort0"      ,
+        "effect.type.default0"    ,
+        "effect.type.instate0"    ,
+        "effect.type.is_instated0",
+        "effect.type.replace0"    , (executor, innerClazz) -> effect(executor, innerClazz));
 
     putUnsafe("fuzion.sys.process.create"  , (executor, innerClazz) -> args -> {
       var process_and_args = Arrays
@@ -1524,35 +1521,43 @@ public class Intrinsics extends ANY
     return (args) ->
       {
         var m = args.get(0);
-        var cl = executor.fuir().clazzOuterClazz(innerClazz);
         String in = executor.fuir().clazzOriginalName(innerClazz);
+        int ecl = executor.fuir().effectTypeFromInstrinsic(innerClazz);
+        var ev = args.size() > 1 ? args.get(1) : null;
+        var effects = FuzionThread.current()._effects;
         switch (in)
           {
-          case "effect.replace": check(FuzionThread.current()._effects.get(cl) != null, m != Value.EMPTY_VALUE); FuzionThread.current()._effects.put(cl, m   );   break;
-          case "effect.default": if (FuzionThread.current()._effects.get(cl) == null) { check(m != Value.EMPTY_VALUE); FuzionThread.current()._effects.put(cl, m   ); } break;
-          case "effect.abortable" :
+          case "effect.type.abort0"    : throw new Abort(ecl);
+          case "effect.type.default0"  : if (effects.get(ecl) == null) { check(executor.fuir().clazzIsUnitType(ecl) || ev != Value.EMPTY_VALUE); effects.put(ecl, ev); } break;
+          case "effect.type.instate0"  :
             {
-              var prev = FuzionThread.current()._effects.get(cl);
-              FuzionThread.current()._effects.put(cl, m);
+              var prev = effects.get(ecl);
+              effects.put(ecl, ev);
               var oc   = executor.fuir().clazzActualGeneric(innerClazz, 0);
               var call = executor.fuir().lookupCall(oc);
-              try {
-                var ignore = executor.callOnInstance(NO_SITE, call, new Instance(call), args.get(1), new List<>());
-                return new boolValue(true);
-              } catch (Abort a) {
-                if (a._effect == cl)
-                  {
-                    return new boolValue(false);
-                  }
-                else
-                  {
-                    throw a;
-                  }
-              } finally {
-                FuzionThread.current()._effects.put(cl, prev);
-              }
+              try
+                {
+                  var ignore = executor.callOnInstance(NO_SITE, call, new Instance(call), args.get(2), new List<>());
+                  return new boolValue(true);
+                }
+              catch (Abort a)
+                {
+                  if (a._effect == ecl)
+                    {
+                      return new boolValue(false);
+                    }
+                  else
+                    {
+                      throw a;
+                    }
+                }
+              finally
+                {
+                  effects.put(ecl, prev);
+                }
             }
-          case "effect.abort0": throw new Abort(cl);
+          case "effect.type.is_instated0": return new boolValue(effects.get(ecl) != null /* NOTE not containsKey since ecl may map to null! */ );
+          case "effect.type.replace0"    : check(effects.get(ecl) != null, executor.fuir().clazzIsUnitType(ecl) || ev != Value.EMPTY_VALUE); effects.put(ecl, ev);   break;
           default: throw new Error("unexpected effect intrinsic '"+in+"'");
           }
         return Value.EMPTY_VALUE;

--- a/src/dev/flang/be/jvm/CodeGen.java
+++ b/src/dev/flang/be/jvm/CodeGen.java
@@ -982,7 +982,7 @@ class CodeGen
                                  Names.RUNTIME_EFFECT_GET,
                                  Names.RUNTIME_EFFECT_GET_SIG,
                                  Names.ANY_TYPE))
-      .andThen(Expr.checkcast(_types.javaType(ecl)));
+      .andThen(Expr.checkcast(_types.resultType(ecl)));
     return new Pair<>(res, Expr.UNIT);
   }
 

--- a/src/dev/flang/be/jvm/Intrinsix.java
+++ b/src/dev/flang/be/jvm/Intrinsix.java
@@ -692,11 +692,12 @@ public class Intrinsix extends ANY implements ClassFileConstants
           return new Pair<>(val, code);
         });
 
-    put("effect.abort0",
+    put("effect.type.abort0",
         (jvm, si, cc, tvalue, args) ->
         {
-          var ecl = jvm._fuir.effectType(cc);
+          var ecl = jvm._fuir.effectTypeFromInstrinsic(cc);
           var code = Expr.iconst(jvm._fuir.clazzId2num(ecl))
+            .andThen(args.get(0).drop())
             .andThen(Expr.invokeStatic(Names.RUNTIME_CLASS,
                                        "effect_abort",
                                        "(I)V",
@@ -704,23 +705,23 @@ public class Intrinsix extends ANY implements ClassFileConstants
           return new Pair<>(Expr.UNIT, code);
         });
 
-    put("effect.abortable",
+    put("effect.type.instate0",
         (jvm, si, cc, tvalue, args) ->
         {
-          var ecl = jvm._fuir.effectType(cc);
-          var oc = jvm._fuir.clazzActualGeneric(cc, 0);
+          var ecl = jvm._fuir.effectTypeFromInstrinsic(cc);
+          var oc  = jvm._fuir.clazzActualGeneric(cc, 0);
           var call = jvm._fuir.lookupCall(oc);
           var call_t = jvm._types.javaType(call);
           if (call_t instanceof ClassType call_ct)
             {
               var result = Expr.iconst(jvm._fuir.clazzId2num(ecl))
-                .andThen(tvalue)
                 .andThen(args.get(0))
+                .andThen(args.get(1))
                 .andThen(Expr.classconst(call_ct))
                 .andThen(Expr.invokeStatic(Names.RUNTIME_CLASS,
-                                           "effect_abortable",
+                                           "effect_instate",
                                            "(" + ("I" +
-                                                  Names.ANY_DESCR +
+                                                  Names.ANYI_DESCR +
                                                   Names.ANY_DESCR +
                                                   JAVA_LANG_CLASS.descriptor()) +
                                            ")V",
@@ -733,26 +734,37 @@ public class Intrinsix extends ANY implements ClassFileConstants
             }
         });
 
-    put("effect.default",
+    put("effect.type.default0",
         (jvm, si, cc, tvalue, args) ->
         {
-          var ecl = jvm._fuir.effectType(cc);
+          var ecl = jvm._fuir.effectTypeFromInstrinsic(cc);
+          var arg = args.get(0);
+          if (arg == Expr.UNIT)
+            {
+              arg = Expr.ACONST_NULL;
+            }
           var result = Expr.iconst(jvm._fuir.clazzId2num(ecl))
-            .andThen(tvalue)
+            .andThen(arg)
             .andThen(Expr.invokeStatic(Names.RUNTIME_CLASS,
                                        "effect_default",
                                        "(" + ("I" +
-                                              Names.ANY_DESCR) +
+                                              Names.ANYI_DESCR) +
                                        ")V",
                                        ClassFileConstants.PrimitiveType.type_void));
           return new Pair<>(Expr.UNIT, result);
         });
-    put("effect.replace",
+
+   put("effect.type.replace0",
         (jvm, si, cc, tvalue, args) ->
         {
-          var ecl = jvm._fuir.effectType(cc);
+          var ecl = jvm._fuir.effectTypeFromInstrinsic(cc);
+          var arg = args.get(0);
+          if (arg == Expr.UNIT)
+            {
+              arg = Expr.ACONST_NULL;
+            }
           var result = Expr.iconst(jvm._fuir.clazzId2num(ecl))
-            .andThen(tvalue)
+            .andThen(arg)
             .andThen(Expr.invokeStatic(Names.RUNTIME_CLASS,
                                        "effect_replace",
                                        "(" + ("I" +
@@ -761,13 +773,14 @@ public class Intrinsix extends ANY implements ClassFileConstants
                                        ClassFileConstants.PrimitiveType.type_void));
           return new Pair<>(Expr.UNIT, result);
         });
-    put("effect.type.is_installed",
+
+    put("effect.type.is_instated0",
         (jvm, si, cc, tvalue, args) ->
         {
-          var ecl = jvm._fuir.clazzActualGeneric(cc, 0);
+          var ecl = jvm._fuir.effectTypeFromInstrinsic(cc);
           var val = Expr.iconst(jvm._fuir.clazzId2num(ecl))
             .andThen(Expr.invokeStatic(Names.RUNTIME_CLASS,
-                                       "effect_is_installed",
+                                       "effect_is_instated",
                                        "(I)Z",
                                        ClassFileConstants.PrimitiveType.type_boolean));
           return new Pair<>(val, Expr.UNIT);

--- a/src/dev/flang/be/jvm/Names.java
+++ b/src/dev/flang/be/jvm/Names.java
@@ -126,7 +126,7 @@ public class Names extends ANY implements ClassFileConstants
    * Name and signature of Runtime.effect_get()
    */
   static final String RUNTIME_EFFECT_GET     = "effect_get";
-  static final String RUNTIME_EFFECT_GET_SIG = "(I)" + ANY_DESCR;
+  static final String RUNTIME_EFFECT_GET_SIG = "(I)" + ANYI_DESCR;
 
 
   /**

--- a/src/dev/flang/be/jvm/Runner.java
+++ b/src/dev/flang/be/jvm/Runner.java
@@ -107,7 +107,7 @@ public class Runner extends ClassLoader
     var cf = _classFiles.get(name);
     if (cf != null)
       {
-        var b =_classFiles.get(name).bytes();
+        var b = _classFiles.get(name).bytes();
         result = defineClass(name, b, 0, b.length);
       }
     return result;

--- a/src/dev/flang/be/jvm/runtime/FuzionThread.java
+++ b/src/dev/flang/be/jvm/runtime/FuzionThread.java
@@ -48,7 +48,7 @@ public class FuzionThread extends Thread
   /**
    * Currently installed effects for this thread.
    */
-  List<Any> _installedEffects = new List<>();
+  List<AnyI> _installedEffects = new List<>();
 
 
   /**
@@ -141,7 +141,7 @@ public class FuzionThread extends Thread
    *
    * @param id an effect id.
    */
-  Any effect_load(int id)
+  AnyI effect_load(int id)
   {
     ensure_effect_capacity(id);
     return _installedEffects.get(id);
@@ -153,7 +153,7 @@ public class FuzionThread extends Thread
    *
    * @param id an effect id.
    */
-  void effect_store(int id, Any instance)
+  void effect_store(int id, AnyI instance)
   {
     ensure_effect_capacity(id);
     _installedEffects.set(id, instance);

--- a/src/dev/flang/be/jvm/runtime/Runtime.java
+++ b/src/dev/flang/be/jvm/runtime/Runtime.java
@@ -501,7 +501,7 @@ public class Runtime extends ANY
   }
 
 
-  public static void effect_default(int id, Any instance)
+  public static void effect_default(int id, AnyI instance)
   {
     var t = currentThread();
     t.ensure_effect_capacity(id);
@@ -519,7 +519,7 @@ public class Runtime extends ANY
    *
    * @return true iff an effect with that id was installed.
    */
-  public static boolean effect_is_installed(int id)
+  public static boolean effect_is_instated(int id)
   {
     var t = currentThread();
 
@@ -585,7 +585,7 @@ public class Runtime extends ANY
 
 
   /**
-   * Helper method to implement effect.abortable.  Install an instance of effect
+   * Helper method to implement effect.type.instante0.  Install an instance of effect
    * type specified by id and run f.call while it is installed.  Helper to
    * implement intrinsic effect.abort.
    *
@@ -597,7 +597,7 @@ public class Runtime extends ANY
    *
    * @param call the Java clazz of the Unary instance to be executed.
    */
-  public static void effect_abortable(int id, Any instance, Any code, Class call)
+  public static void effect_instate(int id, AnyI instance, Any code, Class call)
   {
     var t = currentThread();
 
@@ -613,7 +613,7 @@ public class Runtime extends ANY
       }
     if (r == null)
       {
-        Errors.fatal("in effect.abortable, missing `" + ROUTINE_NAME + "` in class `" + call + "`");
+        Errors.fatal("in effect.type.instate0, missing `" + ROUTINE_NAME + "` in class `" + call + "`");
       }
     else
       {
@@ -623,7 +623,7 @@ public class Runtime extends ANY
           }
         catch (IllegalAccessException e)
           {
-            Errors.fatal("effect.abortable call caused `" + e + "` when calling `" + call + "`");
+            Errors.fatal("effect.type.instate0 call caused `" + e + "` when calling `" + call + "`");
           }
         catch (InvocationTargetException e)
           {
@@ -656,7 +656,7 @@ public class Runtime extends ANY
    *
    * @throws Error in case no instance was installed.
    */
-  public static Any effect_get(int id)
+  public static AnyI effect_get(int id)
   {
     var t = currentThread();
 

--- a/src/dev/flang/fuir/FUIR.java
+++ b/src/dev/flang/fuir/FUIR.java
@@ -2273,17 +2273,20 @@ public class FUIR extends IR
    *
    * @return true for effect.install and similar features.
    */
-  public boolean isEffect(int cl)
+  public boolean isEffectIntrinsic(int cl)
   {
     if (PRECONDITIONS) require
-      (clazzKind(cl) == FeatureKind.Intrinsic);
+      (cl != NO_CLAZZ);
 
-    return switch(clazzOriginalName(cl))
+    return
+      (clazzKind(cl) == FeatureKind.Intrinsic) &&
+      switch(clazzOriginalName(cl))
       {
-      case "effect.replace",
-           "effect.default",
-           "effect.abortable",
-           "effect.abort0" -> true;
+      case "effect.type.abort0"  ,
+           "effect.type.default0",
+           "effect.type.instate0",
+           "effect.type.is_instated0",
+           "effect.type.replace0" -> true;
       default -> false;
       };
   }
@@ -2299,13 +2302,12 @@ public class FUIR extends IR
    *
    * @return the type of the outer feature of cl
    */
-  public int effectType(int cl)
+  public int effectTypeFromInstrinsic(int cl)
   {
     if (PRECONDITIONS) require
-      (isEffect(cl));
+      (isEffectIntrinsic(cl));
 
-    var or = clazzOuterRef(cl);
-    return clazzResultClazz(or);
+    return clazzActualGeneric(clazzOuterClazz(cl), 0);
   }
 
 

--- a/src/dev/flang/fuir/analysis/dfa/Call.java
+++ b/src/dev/flang/fuir/analysis/dfa/Call.java
@@ -35,7 +35,7 @@ import dev.flang.ir.IR.FeatureKind;
 
 import dev.flang.util.ANY;
 import dev.flang.util.Errors;
-import static dev.flang.util.FuzionConstants.EFFECT_ABORTABLE_NAME;
+import static dev.flang.util.FuzionConstants.EFFECT_INSTATE_NAME;
 import dev.flang.util.HasSourcePosition;
 import dev.flang.util.List;
 import dev.flang.util.Terminal;
@@ -383,8 +383,8 @@ public class Call extends ANY implements Comparable<Call>, Context
     var pos = callSitePos();
     return
       (forEnv
-       ? (on.equals(EFFECT_ABORTABLE_NAME)
-          ? "install effect " + Errors.effe(_dfa._fuir.clazzAsStringHuman(_dfa._fuir.effectType(_cc))) + ", old environment was "
+       ? (on.equals(EFFECT_INSTATE_NAME)
+          ? "install effect " + Errors.effe(_dfa._fuir.clazzAsStringHuman(_dfa._fuir.effectTypeFromInstrinsic(_cc))) + ", old environment was "
           : "effect environment ") +
          Errors.effe(Env.envAsString(env())) +
          " for call to "

--- a/src/dev/flang/fuir/analysis/dfa/DFA.java
+++ b/src/dev/flang/fuir/analysis/dfa/DFA.java
@@ -45,7 +45,7 @@ import static dev.flang.ir.IR.NO_SITE;
 
 import dev.flang.util.ANY;
 import dev.flang.util.Errors;
-import static dev.flang.util.FuzionConstants.EFFECT_ABORTABLE_NAME;
+import static dev.flang.util.FuzionConstants.EFFECT_INSTATE_NAME;
 import dev.flang.util.FuzionOptions;
 import dev.flang.util.List;
 import dev.flang.util.IntMap;
@@ -2062,17 +2062,17 @@ public class DFA extends ANY
           return Value.UNIT;
         });
 
-    put("effect.replace"                 , cl ->
+    put("effect.type.replace0"              , cl ->
         {
-          var ecl = cl._dfa._fuir.effectType(cl._cc);
-          var new_e = cl._target;
+          var ecl = cl._dfa._fuir.effectTypeFromInstrinsic(cl._cc);
+          var new_e = cl._args.get(0).value();
           cl.replaceEffect(ecl, new_e);
           return Value.UNIT;
         });
-    put("effect.default"                 , cl ->
+    put("effect.type.default0"              , cl ->
         {
-          var ecl = cl._dfa._fuir.effectType(cl._cc);
-          var new_e = cl._target;
+          var ecl = cl._dfa._fuir.effectTypeFromInstrinsic(cl._cc);
+          var new_e = cl._args.get(0).value();
           var old_e = cl._dfa._defaultEffects.get(ecl);
           if (old_e != null)
             {
@@ -2086,32 +2086,32 @@ public class DFA extends ANY
             }
           return Value.UNIT;
         });
-    put(EFFECT_ABORTABLE_NAME            , cl ->
+    put(EFFECT_INSTATE_NAME                 , cl ->
         {
-          var ecl = cl._dfa._fuir.effectType(cl._cc);
-          var oc = cl._dfa._fuir.clazzActualGeneric(cl._cc, 0);
+          var ecl = cl._dfa._fuir.effectTypeFromInstrinsic(cl._cc);
+          var oc  = cl._dfa._fuir.clazzActualGeneric(cl._cc, 0);
           var call = cl._dfa._fuir.lookupCall(oc);
 
           if (CHECKS) check
             (cl._dfa._fuir.clazzNeedsCode(call));
 
           var env = cl._env;
-          var newEnv = cl._dfa.newEnv(env, ecl, cl._target);
-          var ncl = cl._dfa.newCall(call, NO_SITE, cl._args.get(0).value(), new List<>(), newEnv, cl);
+          var newEnv = cl._dfa.newEnv(env, ecl, cl._args.get(0).value());
+          var ncl = cl._dfa.newCall(call, NO_SITE, cl._args.get(1).value(), new List<>(), newEnv, cl);
           // NYI: result must be null if result of ncl is null (ncl does not return) and effect.abort is not called
           return Value.UNIT;
         });
-    put("effect.abort0"                  , cl ->
+    put("effect.type.abort0"                , cl ->
         {
-          var ecl = cl._dfa._fuir.effectType(cl._cc);
-          var new_e = cl._target;
+          var ecl = cl._dfa._fuir.effectTypeFromInstrinsic(cl._cc);
+          var new_e = cl._args.get(0).value();
           cl.replaceEffect(ecl, new_e);
           // NYI: we might have to do cl.returns() for 'cl' being the
           // corresponding call to 'effect.abortable' and make sure new_e is
           // used to create the value produced by the effect.
           return null;
         });
-    put("effect.type.is_installed"       , cl -> cl.getEffectCheck(cl._dfa._fuir.clazzActualGeneric(cl._cc, 0)) != null
+    put("effect.type.is_instated0"          , cl -> cl.getEffectCheck(cl._dfa._fuir.effectTypeFromInstrinsic(cl._cc)) != null
         ? cl._dfa._true
         : cl._dfa._bool  /* NYI: currently, this is never FALSE since a default effect might get installed turning this into TRUE
                           * should reconsider if handling of default effects changes

--- a/src/dev/flang/fuir/cfg/CFG.java
+++ b/src/dev/flang/fuir/cfg/CFG.java
@@ -492,19 +492,19 @@ public class CFG extends ANY
     put("fuzion.std.nano_time"           , (cfg, cl) -> { } );
     put("fuzion.std.date_time"           , (cfg, cl) -> { } );
 
-    put("effect.replace"                 , (cfg, cl) -> { } );
-    put("effect.default"                 , (cfg, cl) -> { } );
-    put("effect.abortable"               , (cfg, cl) ->
+    put("effect.type.default0"              , (cfg, cl) -> { } );
+    put("effect.type.instate0"              , (cfg, cl) ->
         {
-          var oc = cfg._fuir.clazzActualGeneric(cl, 0);
+          var oc  = cfg._fuir.clazzActualGeneric(cl, 1);
           var call = cfg._fuir.lookupCall(oc);
           if (cfg._fuir.clazzNeedsCode(call))
             {
               cfg.addToCallGraph(cl, call);
             }
         });
-    put("effect.abort0"                     , (cfg, cl) -> { } );
-    put("effect.type.is_installed"          , (cfg, cl) -> { } );
+    put("effect.type.replace0"              , (cfg, cl) -> { } );
+    put("effect.type.abort0"                , (cfg, cl) -> { } );
+    put("effect.type.is_instated0"          , (cfg, cl) -> { } );
     put("fuzion.java.Java_Object.is_null0"  , (cfg, cl) -> { } );
     put("fuzion.java.array_get"             , (cfg, cl) -> { } );
     put("fuzion.java.array_length"          , (cfg, cl) -> { } );

--- a/src/dev/flang/util/FuzionConstants.java
+++ b/src/dev/flang/util/FuzionConstants.java
@@ -104,9 +104,9 @@ public class FuzionConstants extends ANY
 
 
   /**
-   * Name of intrinsic `effect.abortable`.
+   * Name of intrinsic `effect.type.instate0`.
    */
-  public static final String EFFECT_ABORTABLE_NAME = "effect.abortable";
+  public static final String EFFECT_INSTATE_NAME = "effect.type.instate0";
 
 
   /**

--- a/tests/buffered_writer/ex_buffered_writer.fz
+++ b/tests/buffered_writer/ex_buffered_writer.fz
@@ -1,6 +1,6 @@
 ex_buffered_writer =>
   lm : mutate is
-  res := lm.go ()->((io.stdout lm).with ()->
+  res := lm.instate_self ()->((io.stdout lm).with ()->
     x := array u8 1023 i->0x61
     y := array u8 2049 i->0x62
     z := array u8 128 i->0x63

--- a/tests/catch_postcondition/catch_postcondition.fz
+++ b/tests/catch_postcondition/catch_postcondition.fz
@@ -100,7 +100,7 @@ catch_postcondition is
     # use local mutate to store msg passed to `cause`
     lm : mutate.
 
-    res := lm.go ()->
+    res := lm.instate_self ()->
         m := lm.env.new (option String nil)
         (rt.post_fault msg->
             m <- msg

--- a/tests/catch_postcondition/catch_postcondition.fz.expected_err
+++ b/tests/catch_postcondition/catch_postcondition.fz.expected_err
@@ -35,21 +35,13 @@ public postcondition_fault(msg String) => post_fault.cause msg
 catch_postcondition.test#1 i32: --CURDIR--/catch_postcondition.fz:43:5:
     for v := T.one, double v
 ----^
-(catch_postcondition.test#1 i16).post double: --CURDIR--/catch_postcondition.fz:286:8:
+(catch_postcondition.test#1 i16).loop: --CURDIR--/catch_postcondition.fz:286:8:
   say (test i32)
 -------^^^^
-(catch_postcondition.test#1 i16).double#1: --CURDIR--/catch_postcondition.fz:37:7:
-      post
-------^^^^
-        equals result-x x
---------^^^^^^^^^^^^^^^^^
-(catch_postcondition.test#1 i16).loop: --CURDIR--/catch_postcondition.fz:43:21:
-    for v := T.one, double v
---------------------^^^^^^
 (catch_postcondition.test#1 i16).loop: --CURDIR--/catch_postcondition.fz:43:5:
     for v := T.one, double v
 ----^
-... repeated 13 times ...
+... repeated 10 times ...
 
 catch_postcondition.test#1 i16: --CURDIR--/catch_postcondition.fz:43:5:
     for v := T.one, double v
@@ -66,14 +58,20 @@ catch_postcondition.loop.λ.call: --CURDIR--/catch_postcondition.fz:271:28:
 (fuzion.type.runtime.type.fault.type.try (option String)).catch#1.anonymous.res.λ.call.λ.call: $MODULE/eff/fallible.fz:121:13:
       ).run eff.handle.this.try (()->catch m.get.get)
 ------------^^^^^^^^^^^^^^^^^^^
-(fuzion.runtime.fault.run#3 (option String)).λ.call: $MODULE/effect.fz:98:23:
-    cf := Effect_Call f
-----------------------^
-(fuzion.runtime.fault.Effect_Call (option String)).call: $MODULE/effect.fz:154:18:
+(fuzion.runtime.fault.run#3 (option String)).λ.call: $MODULE/effect.fz:199:39:
+    effect.this.instate R effect.this f def.call
+--------------------------------------^
+(fuzion.type.runtime.type.fault.type.instate#4 (option String)).λ.call: $MODULE/effect.fz:100:25:
+    cf := e.Effect_Call code
+------------------------^^^^
+(fuzion.runtime.fault.Effect_Call (option String)).call: $MODULE/effect.fz:191:18:
       set res := f()
 -----------------^
-fuzion.runtime.fault.run#3 (option String): <source position not available>:
+fuzion.type.runtime.type.fault.type.instate#4 (option String): <source position not available>:
 
+fuzion.runtime.fault.run#3 (option String): $MODULE/effect.fz:199:5:
+    effect.this.instate R effect.this f def.call
+----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 (fuzion.type.runtime.type.fault.type.try (option String)).catch#1.anonymous.res.λ.call: $MODULE/eff/fallible.fz:118:7:
       (F.new e->
 ------^^^^^^^^^^
@@ -83,17 +81,29 @@ fuzion.runtime.fault.run#3 (option String): <source position not available>:
 ----------^^^^^^^^^^^^
       ).run eff.handle.this.try (()->catch m.get.get)
 ------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-((eff.ref handle (tuple String String) fuzion.runtime.fault (option String)).lm.go#2 (option String)).λ.call: $MODULE/effect.fz:208:23:
-    cf := Effect_Call f
-----------------------^
-((eff.ref handle (tuple String String) fuzion.runtime.fault (option String)).lm.Effect_Call (option String)).call: $MODULE/effect.fz:154:18:
+((eff.ref handle (tuple String String) fuzion.runtime.fault (option String)).lm.instate_self#2 (option String)).λ.call: $MODULE/effect.fz:145:39:
+    effect.this.instate R effect.this code
+--------------------------------------^^^^
+((eff.type.handle.type (tuple String String) fuzion.runtime.fault (option String)).lm.type.instate#3 (option String)).λ.call: $MODULE/effect.fz:124:17:
+    instate R e code (panic "unexpected abort in {effect.this.type}")
+----------------^^^^
+((eff.type.handle.type (tuple String String) fuzion.runtime.fault (option String)).lm.type.instate#4 (option String)).λ.call: $MODULE/effect.fz:100:25:
+    cf := e.Effect_Call code
+------------------------^^^^
+((eff.ref handle (tuple String String) fuzion.runtime.fault (option String)).lm.Effect_Call (option String)).call: $MODULE/effect.fz:191:18:
       set res := f()
 -----------------^
-(eff.ref handle (tuple String String) fuzion.runtime.fault (option String)).lm.go#2 (option String): <source position not available>:
+(eff.type.handle.type (tuple String String) fuzion.runtime.fault (option String)).lm.type.instate#4 (option String): <source position not available>:
 
+(eff.type.handle.type (tuple String String) fuzion.runtime.fault (option String)).lm.type.instate#3 (option String): $MODULE/effect.fz:124:5:
+    instate R e code (panic "unexpected abort in {effect.this.type}")
+----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+(eff.ref handle (tuple String String) fuzion.runtime.fault (option String)).lm.instate_self#2 (option String): $MODULE/effect.fz:145:5:
+    effect.this.instate R effect.this code
+----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 (fuzion.type.runtime.type.fault.type.try (option String)).catch#1.anonymous.res: $MODULE/eff/fallible.fz:116:10:
-  res => lm.go ()->
----------^^^^^^^^^^
+  res => lm.instate_self ()->
+---------^^^^^^^^^^^^^^^^^^^^
       m := lm.env.new (option ERROR nil)
 ------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
       (F.new e->
@@ -116,27 +126,13 @@ fuzion.runtime.fault.run#3 (option String): <source position not available>:
 catch_postcondition.loop: --CURDIR--/catch_postcondition.fz:272:11:
          .catch s->
 ----------^^^^^
-fuzion.runtime.post_fault.cause#1: --CURDIR--/catch_postcondition.fz:267:3:
+(catch_postcondition.test#1 i32).loop: --CURDIR--/catch_postcondition.fz:267:3:
   for
 --^
-fuzion.runtime.postcondition_fault#1: $MODULE/fuzion/runtime/post_fault.fz:58:43:
-public postcondition_fault(msg String) => post_fault.cause msg
-------------------------------------------^^^^^^^^^^^^^^^^^^^^
-(catch_postcondition.test#1 i32).post double: --CURDIR--/catch_postcondition.fz:38:9:
-        equals result-x x
---------^^^^^^^^^^^^^^^^^
-(catch_postcondition.test#1 i32).double#1: --CURDIR--/catch_postcondition.fz:37:7:
-      post
-------^^^^
-        equals result-x x
---------^^^^^^^^^^^^^^^^^
-(catch_postcondition.test#1 i32).loop: --CURDIR--/catch_postcondition.fz:43:21:
-    for v := T.one, double v
---------------------^^^^^^
 (catch_postcondition.test#1 i32).loop: --CURDIR--/catch_postcondition.fz:43:5:
     for v := T.one, double v
 ----^
-... repeated 29 times ...
+... repeated 28 times ...
 
 catch_postcondition.test#1 i32: --CURDIR--/catch_postcondition.fz:43:5:
     for v := T.one, double v
@@ -153,14 +149,20 @@ catch_postcondition.loop.λ.call: --CURDIR--/catch_postcondition.fz:271:28:
 (fuzion.type.runtime.type.fault.type.try (option String)).catch#1.anonymous.res.λ.call.λ.call: $MODULE/eff/fallible.fz:121:13:
       ).run eff.handle.this.try (()->catch m.get.get)
 ------------^^^^^^^^^^^^^^^^^^^
-(fuzion.runtime.fault.run#3 (option String)).λ.call: $MODULE/effect.fz:98:23:
-    cf := Effect_Call f
-----------------------^
-(fuzion.runtime.fault.Effect_Call (option String)).call: $MODULE/effect.fz:154:18:
+(fuzion.runtime.fault.run#3 (option String)).λ.call: $MODULE/effect.fz:199:39:
+    effect.this.instate R effect.this f def.call
+--------------------------------------^
+(fuzion.type.runtime.type.fault.type.instate#4 (option String)).λ.call: $MODULE/effect.fz:100:25:
+    cf := e.Effect_Call code
+------------------------^^^^
+(fuzion.runtime.fault.Effect_Call (option String)).call: $MODULE/effect.fz:191:18:
       set res := f()
 -----------------^
-fuzion.runtime.fault.run#3 (option String): <source position not available>:
+fuzion.type.runtime.type.fault.type.instate#4 (option String): <source position not available>:
 
+fuzion.runtime.fault.run#3 (option String): $MODULE/effect.fz:199:5:
+    effect.this.instate R effect.this f def.call
+----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 (fuzion.type.runtime.type.fault.type.try (option String)).catch#1.anonymous.res.λ.call: $MODULE/eff/fallible.fz:118:7:
       (F.new e->
 ------^^^^^^^^^^
@@ -170,17 +172,29 @@ fuzion.runtime.fault.run#3 (option String): <source position not available>:
 ----------^^^^^^^^^^^^
       ).run eff.handle.this.try (()->catch m.get.get)
 ------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-((eff.ref handle (tuple String String) fuzion.runtime.fault (option String)).lm.go#2 (option String)).λ.call: $MODULE/effect.fz:208:23:
-    cf := Effect_Call f
-----------------------^
-((eff.ref handle (tuple String String) fuzion.runtime.fault (option String)).lm.Effect_Call (option String)).call: $MODULE/effect.fz:154:18:
+((eff.ref handle (tuple String String) fuzion.runtime.fault (option String)).lm.instate_self#2 (option String)).λ.call: $MODULE/effect.fz:145:39:
+    effect.this.instate R effect.this code
+--------------------------------------^^^^
+((eff.type.handle.type (tuple String String) fuzion.runtime.fault (option String)).lm.type.instate#3 (option String)).λ.call: $MODULE/effect.fz:124:17:
+    instate R e code (panic "unexpected abort in {effect.this.type}")
+----------------^^^^
+((eff.type.handle.type (tuple String String) fuzion.runtime.fault (option String)).lm.type.instate#4 (option String)).λ.call: $MODULE/effect.fz:100:25:
+    cf := e.Effect_Call code
+------------------------^^^^
+((eff.ref handle (tuple String String) fuzion.runtime.fault (option String)).lm.Effect_Call (option String)).call: $MODULE/effect.fz:191:18:
       set res := f()
 -----------------^
-(eff.ref handle (tuple String String) fuzion.runtime.fault (option String)).lm.go#2 (option String): <source position not available>:
+(eff.type.handle.type (tuple String String) fuzion.runtime.fault (option String)).lm.type.instate#4 (option String): <source position not available>:
 
+(eff.type.handle.type (tuple String String) fuzion.runtime.fault (option String)).lm.type.instate#3 (option String): $MODULE/effect.fz:124:5:
+    instate R e code (panic "unexpected abort in {effect.this.type}")
+----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+(eff.ref handle (tuple String String) fuzion.runtime.fault (option String)).lm.instate_self#2 (option String): $MODULE/effect.fz:145:5:
+    effect.this.instate R effect.this code
+----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 (fuzion.type.runtime.type.fault.type.try (option String)).catch#1.anonymous.res: $MODULE/eff/fallible.fz:116:10:
-  res => lm.go ()->
----------^^^^^^^^^^
+  res => lm.instate_self ()->
+---------^^^^^^^^^^^^^^^^^^^^
       m := lm.env.new (option ERROR nil)
 ------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
       (F.new e->
@@ -209,7 +223,7 @@ catch_postcondition.loop: --CURDIR--/catch_postcondition.fz:272:11:
 (catch_postcondition.test#1 i16).loop: --CURDIR--/catch_postcondition.fz:43:5:
     for v := T.one, double v
 ----^
-... repeated 13 times ...
+... repeated 8 times ...
 
 catch_postcondition.test#1 i16: --CURDIR--/catch_postcondition.fz:43:5:
     for v := T.one, double v
@@ -226,14 +240,20 @@ catch_postcondition.loop.λ.call: --CURDIR--/catch_postcondition.fz:252:28:
 (fuzion.type.runtime.type.post_fault.type.try (option String)).catch#1.anonymous.res.λ.call.λ.call: $MODULE/eff/fallible.fz:121:13:
       ).run eff.handle.this.try (()->catch m.get.get)
 ------------^^^^^^^^^^^^^^^^^^^
-(fuzion.runtime.post_fault.run#3 (option String)).λ.call: $MODULE/effect.fz:98:23:
-    cf := Effect_Call f
-----------------------^
-(fuzion.runtime.post_fault.Effect_Call (option String)).call: $MODULE/effect.fz:154:18:
+(fuzion.runtime.post_fault.run#3 (option String)).λ.call: $MODULE/effect.fz:199:39:
+    effect.this.instate R effect.this f def.call
+--------------------------------------^
+(fuzion.type.runtime.type.post_fault.type.instate#4 (option String)).λ.call: $MODULE/effect.fz:100:25:
+    cf := e.Effect_Call code
+------------------------^^^^
+(fuzion.runtime.post_fault.Effect_Call (option String)).call: $MODULE/effect.fz:191:18:
       set res := f()
 -----------------^
-fuzion.runtime.post_fault.run#3 (option String): <source position not available>:
+fuzion.type.runtime.type.post_fault.type.instate#4 (option String): <source position not available>:
 
+fuzion.runtime.post_fault.run#3 (option String): $MODULE/effect.fz:199:5:
+    effect.this.instate R effect.this f def.call
+----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 (fuzion.type.runtime.type.post_fault.type.try (option String)).catch#1.anonymous.res.λ.call: $MODULE/eff/fallible.fz:118:7:
       (F.new e->
 ------^^^^^^^^^^
@@ -243,17 +263,29 @@ fuzion.runtime.post_fault.run#3 (option String): <source position not available>
 ----------^^^^^^^^^^^^
       ).run eff.handle.this.try (()->catch m.get.get)
 ------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-((eff.ref handle String fuzion.runtime.post_fault (option String)).lm.go#2 (option String)).λ.call: $MODULE/effect.fz:208:23:
-    cf := Effect_Call f
-----------------------^
-((eff.ref handle String fuzion.runtime.post_fault (option String)).lm.Effect_Call (option String)).call: $MODULE/effect.fz:154:18:
+((eff.ref handle String fuzion.runtime.post_fault (option String)).lm.instate_self#2 (option String)).λ.call: $MODULE/effect.fz:145:39:
+    effect.this.instate R effect.this code
+--------------------------------------^^^^
+((eff.type.handle.type String fuzion.runtime.post_fault (option String)).lm.type.instate#3 (option String)).λ.call: $MODULE/effect.fz:124:17:
+    instate R e code (panic "unexpected abort in {effect.this.type}")
+----------------^^^^
+((eff.type.handle.type String fuzion.runtime.post_fault (option String)).lm.type.instate#4 (option String)).λ.call: $MODULE/effect.fz:100:25:
+    cf := e.Effect_Call code
+------------------------^^^^
+((eff.ref handle String fuzion.runtime.post_fault (option String)).lm.Effect_Call (option String)).call: $MODULE/effect.fz:191:18:
       set res := f()
 -----------------^
-(eff.ref handle String fuzion.runtime.post_fault (option String)).lm.go#2 (option String): <source position not available>:
+(eff.type.handle.type String fuzion.runtime.post_fault (option String)).lm.type.instate#4 (option String): <source position not available>:
 
+(eff.type.handle.type String fuzion.runtime.post_fault (option String)).lm.type.instate#3 (option String): $MODULE/effect.fz:124:5:
+    instate R e code (panic "unexpected abort in {effect.this.type}")
+----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+(eff.ref handle String fuzion.runtime.post_fault (option String)).lm.instate_self#2 (option String): $MODULE/effect.fz:145:5:
+    effect.this.instate R effect.this code
+----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 (fuzion.type.runtime.type.post_fault.type.try (option String)).catch#1.anonymous.res: $MODULE/eff/fallible.fz:116:10:
-  res => lm.go ()->
----------^^^^^^^^^^
+  res => lm.instate_self ()->
+---------^^^^^^^^^^^^^^^^^^^^
       m := lm.env.new (option ERROR nil)
 ------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
       (F.new e->
@@ -276,21 +308,13 @@ fuzion.runtime.post_fault.run#3 (option String): <source position not available>
 catch_postcondition.loop: --CURDIR--/catch_postcondition.fz:253:11:
          .catch s->
 ----------^^^^^
-(catch_postcondition.test#1 i32).post double: --CURDIR--/catch_postcondition.fz:248:3:
+(catch_postcondition.test#1 i32).loop: --CURDIR--/catch_postcondition.fz:248:3:
   for
 --^
-(catch_postcondition.test#1 i32).double#1: --CURDIR--/catch_postcondition.fz:37:7:
-      post
-------^^^^
-        equals result-x x
---------^^^^^^^^^^^^^^^^^
-(catch_postcondition.test#1 i32).loop: --CURDIR--/catch_postcondition.fz:43:21:
-    for v := T.one, double v
---------------------^^^^^^
 (catch_postcondition.test#1 i32).loop: --CURDIR--/catch_postcondition.fz:43:5:
     for v := T.one, double v
 ----^
-... repeated 29 times ...
+... repeated 26 times ...
 
 catch_postcondition.test#1 i32: --CURDIR--/catch_postcondition.fz:43:5:
     for v := T.one, double v
@@ -307,14 +331,20 @@ catch_postcondition.loop.λ.call: --CURDIR--/catch_postcondition.fz:252:28:
 (fuzion.type.runtime.type.post_fault.type.try (option String)).catch#1.anonymous.res.λ.call.λ.call: $MODULE/eff/fallible.fz:121:13:
       ).run eff.handle.this.try (()->catch m.get.get)
 ------------^^^^^^^^^^^^^^^^^^^
-(fuzion.runtime.post_fault.run#3 (option String)).λ.call: $MODULE/effect.fz:98:23:
-    cf := Effect_Call f
-----------------------^
-(fuzion.runtime.post_fault.Effect_Call (option String)).call: $MODULE/effect.fz:154:18:
+(fuzion.runtime.post_fault.run#3 (option String)).λ.call: $MODULE/effect.fz:199:39:
+    effect.this.instate R effect.this f def.call
+--------------------------------------^
+(fuzion.type.runtime.type.post_fault.type.instate#4 (option String)).λ.call: $MODULE/effect.fz:100:25:
+    cf := e.Effect_Call code
+------------------------^^^^
+(fuzion.runtime.post_fault.Effect_Call (option String)).call: $MODULE/effect.fz:191:18:
       set res := f()
 -----------------^
-fuzion.runtime.post_fault.run#3 (option String): <source position not available>:
+fuzion.type.runtime.type.post_fault.type.instate#4 (option String): <source position not available>:
 
+fuzion.runtime.post_fault.run#3 (option String): $MODULE/effect.fz:199:5:
+    effect.this.instate R effect.this f def.call
+----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 (fuzion.type.runtime.type.post_fault.type.try (option String)).catch#1.anonymous.res.λ.call: $MODULE/eff/fallible.fz:118:7:
       (F.new e->
 ------^^^^^^^^^^
@@ -324,17 +354,29 @@ fuzion.runtime.post_fault.run#3 (option String): <source position not available>
 ----------^^^^^^^^^^^^
       ).run eff.handle.this.try (()->catch m.get.get)
 ------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-((eff.ref handle String fuzion.runtime.post_fault (option String)).lm.go#2 (option String)).λ.call: $MODULE/effect.fz:208:23:
-    cf := Effect_Call f
-----------------------^
-((eff.ref handle String fuzion.runtime.post_fault (option String)).lm.Effect_Call (option String)).call: $MODULE/effect.fz:154:18:
+((eff.ref handle String fuzion.runtime.post_fault (option String)).lm.instate_self#2 (option String)).λ.call: $MODULE/effect.fz:145:39:
+    effect.this.instate R effect.this code
+--------------------------------------^^^^
+((eff.type.handle.type String fuzion.runtime.post_fault (option String)).lm.type.instate#3 (option String)).λ.call: $MODULE/effect.fz:124:17:
+    instate R e code (panic "unexpected abort in {effect.this.type}")
+----------------^^^^
+((eff.type.handle.type String fuzion.runtime.post_fault (option String)).lm.type.instate#4 (option String)).λ.call: $MODULE/effect.fz:100:25:
+    cf := e.Effect_Call code
+------------------------^^^^
+((eff.ref handle String fuzion.runtime.post_fault (option String)).lm.Effect_Call (option String)).call: $MODULE/effect.fz:191:18:
       set res := f()
 -----------------^
-(eff.ref handle String fuzion.runtime.post_fault (option String)).lm.go#2 (option String): <source position not available>:
+(eff.type.handle.type String fuzion.runtime.post_fault (option String)).lm.type.instate#4 (option String): <source position not available>:
 
+(eff.type.handle.type String fuzion.runtime.post_fault (option String)).lm.type.instate#3 (option String): $MODULE/effect.fz:124:5:
+    instate R e code (panic "unexpected abort in {effect.this.type}")
+----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+(eff.ref handle String fuzion.runtime.post_fault (option String)).lm.instate_self#2 (option String): $MODULE/effect.fz:145:5:
+    effect.this.instate R effect.this code
+----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 (fuzion.type.runtime.type.post_fault.type.try (option String)).catch#1.anonymous.res: $MODULE/eff/fallible.fz:116:10:
-  res => lm.go ()->
----------^^^^^^^^^^
+  res => lm.instate_self ()->
+---------^^^^^^^^^^^^^^^^^^^^
       m := lm.env.new (option ERROR nil)
 ------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
       (F.new e->
@@ -363,7 +405,7 @@ catch_postcondition.loop: --CURDIR--/catch_postcondition.fz:253:11:
 (catch_postcondition.test#1 i16).loop: --CURDIR--/catch_postcondition.fz:43:5:
     for v := T.one, double v
 ----^
-... repeated 13 times ...
+... repeated 8 times ...
 
 catch_postcondition.test#1 i16: --CURDIR--/catch_postcondition.fz:43:5:
     for v := T.one, double v
@@ -380,49 +422,59 @@ catch_postcondition.loop.λ.call: --CURDIR--/catch_postcondition.fz:233:28:
 (catch_postcondition.try_post (option String)).catch#1.h.λ.call.λ.call: --CURDIR--/catch_postcondition.fz:108:15:
         ).run try (()->catch m.get.get)
 --------------^^^
-(fuzion.runtime.post_fault.run#3 (option String)).λ.call: $MODULE/effect.fz:98:23:
-    cf := Effect_Call f
-----------------------^
-(fuzion.runtime.post_fault.Effect_Call (option String)).call: $MODULE/effect.fz:154:18:
+(fuzion.runtime.post_fault.run#3 (option String)).λ.call: $MODULE/effect.fz:199:39:
+    effect.this.instate R effect.this f def.call
+--------------------------------------^
+(fuzion.type.runtime.type.post_fault.type.instate#4 (option String)).λ.call: $MODULE/effect.fz:100:25:
+    cf := e.Effect_Call code
+------------------------^^^^
+(fuzion.runtime.post_fault.Effect_Call (option String)).call: $MODULE/effect.fz:191:18:
       set res := f()
 -----------------^
-fuzion.runtime.post_fault.run#3 (option String): <source position not available>:
+fuzion.type.runtime.type.post_fault.type.instate#4 (option String): <source position not available>:
 
+fuzion.runtime.post_fault.run#3 (option String): $MODULE/effect.fz:199:5:
+    effect.this.instate R effect.this f def.call
+----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 (catch_postcondition.try_post (option String)).catch#1.h.λ.call: --CURDIR--/catch_postcondition.fz:108:11:
         ).run try (()->catch m.get.get)
 ----------^^^
-((catch_postcondition.try_post (option String)).catch#1.h.lm.go#2 (option String)).λ.call: $MODULE/effect.fz:208:23:
-    cf := Effect_Call f
-----------------------^
-((catch_postcondition.try_post (option String)).catch#1.h.lm.Effect_Call (option String)).call: $MODULE/effect.fz:154:18:
+((catch_postcondition.try_post (option String)).catch#1.h.lm.instate_self#2 (option String)).λ.call: $MODULE/effect.fz:145:39:
+    effect.this.instate R effect.this code
+--------------------------------------^^^^
+((catch_postcondition.type.try_post.type (option String)).catch#1.type.h.type.lm.type.instate#3 (option String)).λ.call: $MODULE/effect.fz:124:17:
+    instate R e code (panic "unexpected abort in {effect.this.type}")
+----------------^^^^
+((catch_postcondition.type.try_post.type (option String)).catch#1.type.h.type.lm.type.instate#4 (option String)).λ.call: $MODULE/effect.fz:100:25:
+    cf := e.Effect_Call code
+------------------------^^^^
+((catch_postcondition.try_post (option String)).catch#1.h.lm.Effect_Call (option String)).call: $MODULE/effect.fz:191:18:
       set res := f()
 -----------------^
-(catch_postcondition.try_post (option String)).catch#1.h.lm.go#2 (option String): <source position not available>:
+(catch_postcondition.type.try_post.type (option String)).catch#1.type.h.type.lm.type.instate#4 (option String): <source position not available>:
 
+(catch_postcondition.type.try_post.type (option String)).catch#1.type.h.type.lm.type.instate#3 (option String): $MODULE/effect.fz:124:5:
+    instate R e code (panic "unexpected abort in {effect.this.type}")
+----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+(catch_postcondition.try_post (option String)).catch#1.h.lm.instate_self#2 (option String): $MODULE/effect.fz:145:5:
+    effect.this.instate R effect.this code
+----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 (catch_postcondition.try_post (option String)).catch#1.h: --CURDIR--/catch_postcondition.fz:103:15:
-    res := lm.go ()->
---------------^^
+    res := lm.instate_self ()->
+--------------^^^^^^^^^^^^
 (catch_postcondition.try_post (option String)).catch#1: --CURDIR--/catch_postcondition.fz:190:7:
       h.res
 ------^
 catch_postcondition.loop: --CURDIR--/catch_postcondition.fz:234:11:
          .catch s->
 ----------^^^^^
-(catch_postcondition.test#1 i32).post double: --CURDIR--/catch_postcondition.fz:229:3:
+(catch_postcondition.test#1 i32).loop: --CURDIR--/catch_postcondition.fz:229:3:
   for
 --^
-(catch_postcondition.test#1 i32).double#1: --CURDIR--/catch_postcondition.fz:37:7:
-      post
-------^^^^
-        equals result-x x
---------^^^^^^^^^^^^^^^^^
-(catch_postcondition.test#1 i32).loop: --CURDIR--/catch_postcondition.fz:43:21:
-    for v := T.one, double v
---------------------^^^^^^
 (catch_postcondition.test#1 i32).loop: --CURDIR--/catch_postcondition.fz:43:5:
     for v := T.one, double v
 ----^
-... repeated 29 times ...
+... repeated 26 times ...
 
 catch_postcondition.test#1 i32: --CURDIR--/catch_postcondition.fz:43:5:
     for v := T.one, double v
@@ -439,28 +491,46 @@ catch_postcondition.loop.λ.call: --CURDIR--/catch_postcondition.fz:233:28:
 (catch_postcondition.try_post (option String)).catch#1.h.λ.call.λ.call: --CURDIR--/catch_postcondition.fz:108:15:
         ).run try (()->catch m.get.get)
 --------------^^^
-(fuzion.runtime.post_fault.run#3 (option String)).λ.call: $MODULE/effect.fz:98:23:
-    cf := Effect_Call f
-----------------------^
-(fuzion.runtime.post_fault.Effect_Call (option String)).call: $MODULE/effect.fz:154:18:
+(fuzion.runtime.post_fault.run#3 (option String)).λ.call: $MODULE/effect.fz:199:39:
+    effect.this.instate R effect.this f def.call
+--------------------------------------^
+(fuzion.type.runtime.type.post_fault.type.instate#4 (option String)).λ.call: $MODULE/effect.fz:100:25:
+    cf := e.Effect_Call code
+------------------------^^^^
+(fuzion.runtime.post_fault.Effect_Call (option String)).call: $MODULE/effect.fz:191:18:
       set res := f()
 -----------------^
-fuzion.runtime.post_fault.run#3 (option String): <source position not available>:
+fuzion.type.runtime.type.post_fault.type.instate#4 (option String): <source position not available>:
 
+fuzion.runtime.post_fault.run#3 (option String): $MODULE/effect.fz:199:5:
+    effect.this.instate R effect.this f def.call
+----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 (catch_postcondition.try_post (option String)).catch#1.h.λ.call: --CURDIR--/catch_postcondition.fz:108:11:
         ).run try (()->catch m.get.get)
 ----------^^^
-((catch_postcondition.try_post (option String)).catch#1.h.lm.go#2 (option String)).λ.call: $MODULE/effect.fz:208:23:
-    cf := Effect_Call f
-----------------------^
-((catch_postcondition.try_post (option String)).catch#1.h.lm.Effect_Call (option String)).call: $MODULE/effect.fz:154:18:
+((catch_postcondition.try_post (option String)).catch#1.h.lm.instate_self#2 (option String)).λ.call: $MODULE/effect.fz:145:39:
+    effect.this.instate R effect.this code
+--------------------------------------^^^^
+((catch_postcondition.type.try_post.type (option String)).catch#1.type.h.type.lm.type.instate#3 (option String)).λ.call: $MODULE/effect.fz:124:17:
+    instate R e code (panic "unexpected abort in {effect.this.type}")
+----------------^^^^
+((catch_postcondition.type.try_post.type (option String)).catch#1.type.h.type.lm.type.instate#4 (option String)).λ.call: $MODULE/effect.fz:100:25:
+    cf := e.Effect_Call code
+------------------------^^^^
+((catch_postcondition.try_post (option String)).catch#1.h.lm.Effect_Call (option String)).call: $MODULE/effect.fz:191:18:
       set res := f()
 -----------------^
-(catch_postcondition.try_post (option String)).catch#1.h.lm.go#2 (option String): <source position not available>:
+(catch_postcondition.type.try_post.type (option String)).catch#1.type.h.type.lm.type.instate#4 (option String): <source position not available>:
 
+(catch_postcondition.type.try_post.type (option String)).catch#1.type.h.type.lm.type.instate#3 (option String): $MODULE/effect.fz:124:5:
+    instate R e code (panic "unexpected abort in {effect.this.type}")
+----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+(catch_postcondition.try_post (option String)).catch#1.h.lm.instate_self#2 (option String): $MODULE/effect.fz:145:5:
+    effect.this.instate R effect.this code
+----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 (catch_postcondition.try_post (option String)).catch#1.h: --CURDIR--/catch_postcondition.fz:103:15:
-    res := lm.go ()->
---------------^^
+    res := lm.instate_self ()->
+--------------^^^^^^^^^^^^
 (catch_postcondition.try_post (option String)).catch#1: --CURDIR--/catch_postcondition.fz:190:7:
       h.res
 ------^
@@ -473,7 +543,7 @@ catch_postcondition.loop: --CURDIR--/catch_postcondition.fz:234:11:
 (catch_postcondition.test#1 i32).loop: --CURDIR--/catch_postcondition.fz:43:5:
     for v := T.one, double v
 ----^
-... repeated 29 times ...
+... repeated 24 times ...
 
 catch_postcondition.test#1 i32: --CURDIR--/catch_postcondition.fz:43:5:
     for v := T.one, double v
@@ -487,28 +557,46 @@ catch_postcondition.res2.λ.call: --CURDIR--/catch_postcondition.fz:220:21:
 (catch_postcondition.try_post String).catch#1.h.λ.call.λ.call: --CURDIR--/catch_postcondition.fz:108:15:
         ).run try (()->catch m.get.get)
 --------------^^^
-(fuzion.runtime.post_fault.run#3 String).λ.call: $MODULE/effect.fz:98:23:
-    cf := Effect_Call f
-----------------------^
-(fuzion.runtime.post_fault.Effect_Call String).call: $MODULE/effect.fz:154:18:
+(fuzion.runtime.post_fault.run#3 String).λ.call: $MODULE/effect.fz:199:39:
+    effect.this.instate R effect.this f def.call
+--------------------------------------^
+(fuzion.type.runtime.type.post_fault.type.instate#4 String).λ.call: $MODULE/effect.fz:100:25:
+    cf := e.Effect_Call code
+------------------------^^^^
+(fuzion.runtime.post_fault.Effect_Call String).call: $MODULE/effect.fz:191:18:
       set res := f()
 -----------------^
-fuzion.runtime.post_fault.run#3 String: <source position not available>:
+fuzion.type.runtime.type.post_fault.type.instate#4 String: <source position not available>:
 
+fuzion.runtime.post_fault.run#3 String: $MODULE/effect.fz:199:5:
+    effect.this.instate R effect.this f def.call
+----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 (catch_postcondition.try_post String).catch#1.h.λ.call: --CURDIR--/catch_postcondition.fz:108:11:
         ).run try (()->catch m.get.get)
 ----------^^^
-((catch_postcondition.try_post String).catch#1.h.lm.go#2 String).λ.call: $MODULE/effect.fz:208:23:
-    cf := Effect_Call f
-----------------------^
-((catch_postcondition.try_post String).catch#1.h.lm.Effect_Call String).call: $MODULE/effect.fz:154:18:
+((catch_postcondition.try_post String).catch#1.h.lm.instate_self#2 String).λ.call: $MODULE/effect.fz:145:39:
+    effect.this.instate R effect.this code
+--------------------------------------^^^^
+((catch_postcondition.type.try_post.type String).catch#1.type.h.type.lm.type.instate#3 String).λ.call: $MODULE/effect.fz:124:17:
+    instate R e code (panic "unexpected abort in {effect.this.type}")
+----------------^^^^
+((catch_postcondition.type.try_post.type String).catch#1.type.h.type.lm.type.instate#4 String).λ.call: $MODULE/effect.fz:100:25:
+    cf := e.Effect_Call code
+------------------------^^^^
+((catch_postcondition.try_post String).catch#1.h.lm.Effect_Call String).call: $MODULE/effect.fz:191:18:
       set res := f()
 -----------------^
-(catch_postcondition.try_post String).catch#1.h.lm.go#2 String: <source position not available>:
+(catch_postcondition.type.try_post.type String).catch#1.type.h.type.lm.type.instate#4 String: <source position not available>:
 
+(catch_postcondition.type.try_post.type String).catch#1.type.h.type.lm.type.instate#3 String: $MODULE/effect.fz:124:5:
+    instate R e code (panic "unexpected abort in {effect.this.type}")
+----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+(catch_postcondition.try_post String).catch#1.h.lm.instate_self#2 String: $MODULE/effect.fz:145:5:
+    effect.this.instate R effect.this code
+----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 (catch_postcondition.try_post String).catch#1.h: --CURDIR--/catch_postcondition.fz:103:15:
-    res := lm.go ()->
---------------^^
+    res := lm.instate_self ()->
+--------------^^^^^^^^^^^^
 (catch_postcondition.try_post String).catch#1: --CURDIR--/catch_postcondition.fz:190:7:
       h.res
 ------^
@@ -518,16 +606,13 @@ fuzion.runtime.post_fault.run#3 String: <source position not available>:
 catch_postcondition.res2: --CURDIR--/catch_postcondition.fz:220:31:
   res2 => try_post (test i32) || (s->say "*** failed: $s ***"; test u64)
 ------------------------------^^
-(catch_postcondition.test#1 i32).double#1: --CURDIR--/catch_postcondition.fz:221:7:
+(catch_postcondition.test#1 i32).loop: --CURDIR--/catch_postcondition.fz:221:7:
   say res2
 ------^^^^
-(catch_postcondition.test#1 i32).loop: --CURDIR--/catch_postcondition.fz:43:21:
-    for v := T.one, double v
---------------------^^^^^^
 (catch_postcondition.test#1 i32).loop: --CURDIR--/catch_postcondition.fz:43:5:
     for v := T.one, double v
 ----^
-... repeated 29 times ...
+... repeated 25 times ...
 
 catch_postcondition.test#1 i32: --CURDIR--/catch_postcondition.fz:43:5:
     for v := T.one, double v
@@ -541,44 +626,59 @@ catch_postcondition.res.λ.call: --CURDIR--/catch_postcondition.fz:208:12:
 (catch_postcondition.try_post String).catch#1.h.λ.call.λ.call: --CURDIR--/catch_postcondition.fz:108:15:
         ).run try (()->catch m.get.get)
 --------------^^^
-(fuzion.runtime.post_fault.run#3 String).λ.call: $MODULE/effect.fz:98:23:
-    cf := Effect_Call f
-----------------------^
-(fuzion.runtime.post_fault.Effect_Call String).call: $MODULE/effect.fz:154:18:
+(fuzion.runtime.post_fault.run#3 String).λ.call: $MODULE/effect.fz:199:39:
+    effect.this.instate R effect.this f def.call
+--------------------------------------^
+(fuzion.type.runtime.type.post_fault.type.instate#4 String).λ.call: $MODULE/effect.fz:100:25:
+    cf := e.Effect_Call code
+------------------------^^^^
+(fuzion.runtime.post_fault.Effect_Call String).call: $MODULE/effect.fz:191:18:
       set res := f()
 -----------------^
-fuzion.runtime.post_fault.run#3 String: <source position not available>:
+fuzion.type.runtime.type.post_fault.type.instate#4 String: <source position not available>:
 
+fuzion.runtime.post_fault.run#3 String: $MODULE/effect.fz:199:5:
+    effect.this.instate R effect.this f def.call
+----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 (catch_postcondition.try_post String).catch#1.h.λ.call: --CURDIR--/catch_postcondition.fz:108:11:
         ).run try (()->catch m.get.get)
 ----------^^^
-((catch_postcondition.try_post String).catch#1.h.lm.go#2 String).λ.call: $MODULE/effect.fz:208:23:
-    cf := Effect_Call f
-----------------------^
-((catch_postcondition.try_post String).catch#1.h.lm.Effect_Call String).call: $MODULE/effect.fz:154:18:
+((catch_postcondition.try_post String).catch#1.h.lm.instate_self#2 String).λ.call: $MODULE/effect.fz:145:39:
+    effect.this.instate R effect.this code
+--------------------------------------^^^^
+((catch_postcondition.type.try_post.type String).catch#1.type.h.type.lm.type.instate#3 String).λ.call: $MODULE/effect.fz:124:17:
+    instate R e code (panic "unexpected abort in {effect.this.type}")
+----------------^^^^
+((catch_postcondition.type.try_post.type String).catch#1.type.h.type.lm.type.instate#4 String).λ.call: $MODULE/effect.fz:100:25:
+    cf := e.Effect_Call code
+------------------------^^^^
+((catch_postcondition.try_post String).catch#1.h.lm.Effect_Call String).call: $MODULE/effect.fz:191:18:
       set res := f()
 -----------------^
-(catch_postcondition.try_post String).catch#1.h.lm.go#2 String: <source position not available>:
+(catch_postcondition.type.try_post.type String).catch#1.type.h.type.lm.type.instate#4 String: <source position not available>:
 
+(catch_postcondition.type.try_post.type String).catch#1.type.h.type.lm.type.instate#3 String: $MODULE/effect.fz:124:5:
+    instate R e code (panic "unexpected abort in {effect.this.type}")
+----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+(catch_postcondition.try_post String).catch#1.h.lm.instate_self#2 String: $MODULE/effect.fz:145:5:
+    effect.this.instate R effect.this code
+----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 (catch_postcondition.try_post String).catch#1.h: --CURDIR--/catch_postcondition.fz:103:15:
-    res := lm.go ()->
---------------^^
+    res := lm.instate_self ()->
+--------------^^^^^^^^^^^^
 (catch_postcondition.try_post String).catch#1: --CURDIR--/catch_postcondition.fz:190:7:
       h.res
 ------^
 catch_postcondition.res: --CURDIR--/catch_postcondition.fz:209:11:
          .catch s->
 ----------^^^^^
-(catch_postcondition.test#1 i16).double#1: --CURDIR--/catch_postcondition.fz:212:7:
+(catch_postcondition.test#1 i16).loop: --CURDIR--/catch_postcondition.fz:212:7:
   say res
 ------^^^
-(catch_postcondition.test#1 i16).loop: --CURDIR--/catch_postcondition.fz:43:21:
-    for v := T.one, double v
---------------------^^^^^^
 (catch_postcondition.test#1 i16).loop: --CURDIR--/catch_postcondition.fz:43:5:
     for v := T.one, double v
 ----^
-... repeated 13 times ...
+... repeated 9 times ...
 
 catch_postcondition.test#1 i16: --CURDIR--/catch_postcondition.fz:43:5:
     for v := T.one, double v
@@ -592,49 +692,56 @@ catch_postcondition.loop.h.try: --CURDIR--/catch_postcondition.fz:159:44:
 catch_postcondition.loop.h.λ.call.λ.call: --CURDIR--/catch_postcondition.fz:108:15:
         ).run try (()->catch m.get.get)
 --------------^^^
-(fuzion.runtime.post_fault.run#3 (option String)).λ.call: $MODULE/effect.fz:98:23:
-    cf := Effect_Call f
-----------------------^
-(fuzion.runtime.post_fault.Effect_Call (option String)).call: $MODULE/effect.fz:154:18:
+(fuzion.runtime.post_fault.run#3 (option String)).λ.call: $MODULE/effect.fz:199:39:
+    effect.this.instate R effect.this f def.call
+--------------------------------------^
+(fuzion.type.runtime.type.post_fault.type.instate#4 (option String)).λ.call: $MODULE/effect.fz:100:25:
+    cf := e.Effect_Call code
+------------------------^^^^
+(fuzion.runtime.post_fault.Effect_Call (option String)).call: $MODULE/effect.fz:191:18:
       set res := f()
 -----------------^
-fuzion.runtime.post_fault.run#3 (option String): <source position not available>:
+fuzion.type.runtime.type.post_fault.type.instate#4 (option String): <source position not available>:
 
+fuzion.runtime.post_fault.run#3 (option String): $MODULE/effect.fz:199:5:
+    effect.this.instate R effect.this f def.call
+----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 catch_postcondition.loop.h.λ.call: --CURDIR--/catch_postcondition.fz:108:11:
         ).run try (()->catch m.get.get)
 ----------^^^
-(catch_postcondition.loop.h.lm.go#2 (option String)).λ.call: $MODULE/effect.fz:208:23:
-    cf := Effect_Call f
-----------------------^
-(catch_postcondition.loop.h.lm.Effect_Call (option String)).call: $MODULE/effect.fz:154:18:
+(catch_postcondition.loop.h.lm.instate_self#2 (option String)).λ.call: $MODULE/effect.fz:145:39:
+    effect.this.instate R effect.this code
+--------------------------------------^^^^
+(catch_postcondition.type.loop.type.h.type.lm.type.instate#3 (option String)).λ.call: $MODULE/effect.fz:124:17:
+    instate R e code (panic "unexpected abort in {effect.this.type}")
+----------------^^^^
+(catch_postcondition.type.loop.type.h.type.lm.type.instate#4 (option String)).λ.call: $MODULE/effect.fz:100:25:
+    cf := e.Effect_Call code
+------------------------^^^^
+(catch_postcondition.loop.h.lm.Effect_Call (option String)).call: $MODULE/effect.fz:191:18:
       set res := f()
 -----------------^
-catch_postcondition.loop.h.lm.go#2 (option String): <source position not available>:
+catch_postcondition.type.loop.type.h.type.lm.type.instate#4 (option String): <source position not available>:
 
+catch_postcondition.type.loop.type.h.type.lm.type.instate#3 (option String): $MODULE/effect.fz:124:5:
+    instate R e code (panic "unexpected abort in {effect.this.type}")
+----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+catch_postcondition.loop.h.lm.instate_self#2 (option String): $MODULE/effect.fz:145:5:
+    effect.this.instate R effect.this code
+----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 catch_postcondition.loop.h: --CURDIR--/catch_postcondition.fz:103:15:
-    res := lm.go ()->
---------------^^
+    res := lm.instate_self ()->
+--------------^^^^^^^^^^^^
 catch_postcondition.loop: --CURDIR--/catch_postcondition.fz:161:10:
     r := h.res
 ---------^
-fuzion.runtime.postcondition_fault#1: --CURDIR--/catch_postcondition.fz:157:3:
+(catch_postcondition.test#1 i32).loop: --CURDIR--/catch_postcondition.fz:157:3:
   for c in tries.indices do
 --^
-(catch_postcondition.test#1 i32).post double: --CURDIR--/catch_postcondition.fz:38:9:
-        equals result-x x
---------^^^^^^^^^^^^^^^^^
-(catch_postcondition.test#1 i32).double#1: --CURDIR--/catch_postcondition.fz:37:7:
-      post
-------^^^^
-        equals result-x x
---------^^^^^^^^^^^^^^^^^
-(catch_postcondition.test#1 i32).loop: --CURDIR--/catch_postcondition.fz:43:21:
-    for v := T.one, double v
---------------------^^^^^^
 (catch_postcondition.test#1 i32).loop: --CURDIR--/catch_postcondition.fz:43:5:
     for v := T.one, double v
 ----^
-... repeated 29 times ...
+... repeated 27 times ...
 
 catch_postcondition.test#1 i32: --CURDIR--/catch_postcondition.fz:43:5:
     for v := T.one, double v
@@ -648,93 +755,121 @@ catch_postcondition.loop.h.try: --CURDIR--/catch_postcondition.fz:159:44:
 catch_postcondition.loop.h.λ.call.λ.call: --CURDIR--/catch_postcondition.fz:108:15:
         ).run try (()->catch m.get.get)
 --------------^^^
-(fuzion.runtime.post_fault.run#3 (option String)).λ.call: $MODULE/effect.fz:98:23:
-    cf := Effect_Call f
-----------------------^
-(fuzion.runtime.post_fault.Effect_Call (option String)).call: $MODULE/effect.fz:154:18:
+(fuzion.runtime.post_fault.run#3 (option String)).λ.call: $MODULE/effect.fz:199:39:
+    effect.this.instate R effect.this f def.call
+--------------------------------------^
+(fuzion.type.runtime.type.post_fault.type.instate#4 (option String)).λ.call: $MODULE/effect.fz:100:25:
+    cf := e.Effect_Call code
+------------------------^^^^
+(fuzion.runtime.post_fault.Effect_Call (option String)).call: $MODULE/effect.fz:191:18:
       set res := f()
 -----------------^
-fuzion.runtime.post_fault.run#3 (option String): <source position not available>:
+fuzion.type.runtime.type.post_fault.type.instate#4 (option String): <source position not available>:
 
+fuzion.runtime.post_fault.run#3 (option String): $MODULE/effect.fz:199:5:
+    effect.this.instate R effect.this f def.call
+----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 catch_postcondition.loop.h.λ.call: --CURDIR--/catch_postcondition.fz:108:11:
         ).run try (()->catch m.get.get)
 ----------^^^
-(catch_postcondition.loop.h.lm.go#2 (option String)).λ.call: $MODULE/effect.fz:208:23:
-    cf := Effect_Call f
-----------------------^
-(catch_postcondition.loop.h.lm.Effect_Call (option String)).call: $MODULE/effect.fz:154:18:
+(catch_postcondition.loop.h.lm.instate_self#2 (option String)).λ.call: $MODULE/effect.fz:145:39:
+    effect.this.instate R effect.this code
+--------------------------------------^^^^
+(catch_postcondition.type.loop.type.h.type.lm.type.instate#3 (option String)).λ.call: $MODULE/effect.fz:124:17:
+    instate R e code (panic "unexpected abort in {effect.this.type}")
+----------------^^^^
+(catch_postcondition.type.loop.type.h.type.lm.type.instate#4 (option String)).λ.call: $MODULE/effect.fz:100:25:
+    cf := e.Effect_Call code
+------------------------^^^^
+(catch_postcondition.loop.h.lm.Effect_Call (option String)).call: $MODULE/effect.fz:191:18:
       set res := f()
 -----------------^
-catch_postcondition.loop.h.lm.go#2 (option String): <source position not available>:
+catch_postcondition.type.loop.type.h.type.lm.type.instate#4 (option String): <source position not available>:
 
+catch_postcondition.type.loop.type.h.type.lm.type.instate#3 (option String): $MODULE/effect.fz:124:5:
+    instate R e code (panic "unexpected abort in {effect.this.type}")
+----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+catch_postcondition.loop.h.lm.instate_self#2 (option String): $MODULE/effect.fz:145:5:
+    effect.this.instate R effect.this code
+----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 catch_postcondition.loop.h: --CURDIR--/catch_postcondition.fz:103:15:
-    res := lm.go ()->
---------------^^
+    res := lm.instate_self ()->
+--------------^^^^^^^^^^^^
 catch_postcondition.loop: --CURDIR--/catch_postcondition.fz:161:10:
     r := h.res
 ---------^
-(catch_postcondition.test#1 i16).loop: --CURDIR--/catch_postcondition.fz:157:3:
+catch_postcondition.λ.call: --CURDIR--/catch_postcondition.fz:157:3:
   for c in tries.indices do
 --^
-(catch_postcondition.test#1 i16).loop: --CURDIR--/catch_postcondition.fz:43:5:
-    for v := T.one, double v
-----^
-... repeated 8 times ...
-
-catch_postcondition.test#1 i16: --CURDIR--/catch_postcondition.fz:43:5:
-    for v := T.one, double v
-----^
-catch_postcondition.λ.call: --CURDIR--/catch_postcondition.fz:141:56:
-  tries array ()->String := [ (() -> test i32), (() -> test i16), (() -> test i64) ]
--------------------------------------------------------^^^^
 catch_postcondition.z.try: --CURDIR--/catch_postcondition.fz:146:43:
     redef try option String  => tries[c0].call
 ------------------------------------------^^^^
 catch_postcondition.z.λ.call.λ.call: --CURDIR--/catch_postcondition.fz:108:15:
         ).run try (()->catch m.get.get)
 --------------^^^
-(fuzion.runtime.post_fault.run#3 (option String)).λ.call: $MODULE/effect.fz:98:23:
-    cf := Effect_Call f
-----------------------^
-(fuzion.runtime.post_fault.Effect_Call (option String)).call: $MODULE/effect.fz:154:18:
+(fuzion.runtime.post_fault.run#3 (option String)).λ.call: $MODULE/effect.fz:199:39:
+    effect.this.instate R effect.this f def.call
+--------------------------------------^
+(fuzion.type.runtime.type.post_fault.type.instate#4 (option String)).λ.call: $MODULE/effect.fz:100:25:
+    cf := e.Effect_Call code
+------------------------^^^^
+(fuzion.runtime.post_fault.Effect_Call (option String)).call: $MODULE/effect.fz:191:18:
       set res := f()
 -----------------^
-fuzion.runtime.post_fault.run#3 (option String): <source position not available>:
+fuzion.type.runtime.type.post_fault.type.instate#4 (option String): <source position not available>:
 
+fuzion.runtime.post_fault.run#3 (option String): $MODULE/effect.fz:199:5:
+    effect.this.instate R effect.this f def.call
+----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 catch_postcondition.z.λ.call: --CURDIR--/catch_postcondition.fz:108:11:
         ).run try (()->catch m.get.get)
 ----------^^^
-(catch_postcondition.z.lm.go#2 (option String)).λ.call: $MODULE/effect.fz:208:23:
-    cf := Effect_Call f
-----------------------^
-(catch_postcondition.z.lm.Effect_Call (option String)).call: $MODULE/effect.fz:154:18:
+(catch_postcondition.z.lm.instate_self#2 (option String)).λ.call: $MODULE/effect.fz:145:39:
+    effect.this.instate R effect.this code
+--------------------------------------^^^^
+(catch_postcondition.type.z.type.lm.type.instate#3 (option String)).λ.call: $MODULE/effect.fz:124:17:
+    instate R e code (panic "unexpected abort in {effect.this.type}")
+----------------^^^^
+(catch_postcondition.type.z.type.lm.type.instate#4 (option String)).λ.call: $MODULE/effect.fz:100:25:
+    cf := e.Effect_Call code
+------------------------^^^^
+(catch_postcondition.z.lm.Effect_Call (option String)).call: $MODULE/effect.fz:191:18:
       set res := f()
 -----------------^
-catch_postcondition.z.lm.go#2 (option String): <source position not available>:
+catch_postcondition.type.z.type.lm.type.instate#4 (option String): <source position not available>:
 
+catch_postcondition.type.z.type.lm.type.instate#3 (option String): $MODULE/effect.fz:124:5:
+    instate R e code (panic "unexpected abort in {effect.this.type}")
+----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+catch_postcondition.z.lm.instate_self#2 (option String): $MODULE/effect.fz:145:5:
+    effect.this.instate R effect.this code
+----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 catch_postcondition.z: --CURDIR--/catch_postcondition.fz:103:15:
-    res := lm.go ()->
---------------^^
+    res := lm.instate_self ()->
+--------------^^^^^^^^^^^^
 catch_postcondition.z.catch#1: --CURDIR--/catch_postcondition.fz:147:118:
     redef catch(s String) option String => {say "*** failed: $s ***"; c0 <- c0.get + 1; if c0.get < tries.count then z.res else nil}
 ---------------------------------------------------------------------------------------------------------------------^
 catch_postcondition.z.λ.call.λ.call: --CURDIR--/catch_postcondition.fz:108:24:
         ).run try (()->catch m.get.get)
 -----------------------^^^^^
-fuzion.runtime.post_fault.abort: $MODULE/effect.fz:101:14:
+(fuzion.runtime.post_fault.run#3 (option String)).λ.call: $MODULE/effect.fz:199:41:
+    effect.this.instate R effect.this f def.call
+----------------------------------------^^^^^^^^
+fuzion.runtime.post_fault.abort: $MODULE/effect.fz:103:14:
       nil => def()
 -------------^^^
-fuzion.runtime.post_fault.precall abort: $MODULE/effect.fz:66:3:
+fuzion.runtime.post_fault.precall abort: $MODULE/effect.fz:256:3:
   pre
 --^^^
-    safety: effect.is_installed effect.this
-----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    safety: effect.this.is_instated
+----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     safety: abortable
 ----^^^^^^^^^^^^^^^^^
-fuzion.runtime.post_fault.return: $MODULE/effect.fz:112:5:
+fuzion.runtime.post_fault.return: $MODULE/effect.fz:281:5:
     abort
 ----^^^^^
-fuzion.runtime.post_fault.precall return: $MODULE/effect.fz:109:3:
+fuzion.runtime.post_fault.precall return: $MODULE/effect.fz:278:3:
   pre
 --^^^
     safety: abortable
@@ -776,46 +911,53 @@ catch_postcondition.z.try: --CURDIR--/catch_postcondition.fz:146:43:
 catch_postcondition.z.λ.call.λ.call: --CURDIR--/catch_postcondition.fz:108:15:
         ).run try (()->catch m.get.get)
 --------------^^^
-(fuzion.runtime.post_fault.run#3 (option String)).λ.call: $MODULE/effect.fz:98:23:
-    cf := Effect_Call f
-----------------------^
-(fuzion.runtime.post_fault.Effect_Call (option String)).call: $MODULE/effect.fz:154:18:
+(fuzion.runtime.post_fault.run#3 (option String)).λ.call: $MODULE/effect.fz:199:39:
+    effect.this.instate R effect.this f def.call
+--------------------------------------^
+(fuzion.type.runtime.type.post_fault.type.instate#4 (option String)).λ.call: $MODULE/effect.fz:100:25:
+    cf := e.Effect_Call code
+------------------------^^^^
+(fuzion.runtime.post_fault.Effect_Call (option String)).call: $MODULE/effect.fz:191:18:
       set res := f()
 -----------------^
-fuzion.runtime.post_fault.run#3 (option String): <source position not available>:
+fuzion.type.runtime.type.post_fault.type.instate#4 (option String): <source position not available>:
 
+fuzion.runtime.post_fault.run#3 (option String): $MODULE/effect.fz:199:5:
+    effect.this.instate R effect.this f def.call
+----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 catch_postcondition.z.λ.call: --CURDIR--/catch_postcondition.fz:108:11:
         ).run try (()->catch m.get.get)
 ----------^^^
-(catch_postcondition.z.lm.go#2 (option String)).λ.call: $MODULE/effect.fz:208:23:
-    cf := Effect_Call f
-----------------------^
-(catch_postcondition.z.lm.Effect_Call (option String)).call: $MODULE/effect.fz:154:18:
+(catch_postcondition.z.lm.instate_self#2 (option String)).λ.call: $MODULE/effect.fz:145:39:
+    effect.this.instate R effect.this code
+--------------------------------------^^^^
+(catch_postcondition.type.z.type.lm.type.instate#3 (option String)).λ.call: $MODULE/effect.fz:124:17:
+    instate R e code (panic "unexpected abort in {effect.this.type}")
+----------------^^^^
+(catch_postcondition.type.z.type.lm.type.instate#4 (option String)).λ.call: $MODULE/effect.fz:100:25:
+    cf := e.Effect_Call code
+------------------------^^^^
+(catch_postcondition.z.lm.Effect_Call (option String)).call: $MODULE/effect.fz:191:18:
       set res := f()
 -----------------^
-catch_postcondition.z.lm.go#2 (option String): <source position not available>:
+catch_postcondition.type.z.type.lm.type.instate#4 (option String): <source position not available>:
 
+catch_postcondition.type.z.type.lm.type.instate#3 (option String): $MODULE/effect.fz:124:5:
+    instate R e code (panic "unexpected abort in {effect.this.type}")
+----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+catch_postcondition.z.lm.instate_self#2 (option String): $MODULE/effect.fz:145:5:
+    effect.this.instate R effect.this code
+----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 catch_postcondition.z: --CURDIR--/catch_postcondition.fz:103:15:
-    res := lm.go ()->
---------------^^
-fuzion.runtime.postcondition_fault#1: --CURDIR--/catch_postcondition.fz:149:7:
+    res := lm.instate_self ()->
+--------------^^^^^^^^^^^^
+(catch_postcondition.test#1 i32).loop: --CURDIR--/catch_postcondition.fz:149:7:
   say z.res
 ------^
-(catch_postcondition.test#1 i32).post double: --CURDIR--/catch_postcondition.fz:38:9:
-        equals result-x x
---------^^^^^^^^^^^^^^^^^
-(catch_postcondition.test#1 i32).double#1: --CURDIR--/catch_postcondition.fz:37:7:
-      post
-------^^^^
-        equals result-x x
---------^^^^^^^^^^^^^^^^^
-(catch_postcondition.test#1 i32).loop: --CURDIR--/catch_postcondition.fz:43:21:
-    for v := T.one, double v
---------------------^^^^^^
 (catch_postcondition.test#1 i32).loop: --CURDIR--/catch_postcondition.fz:43:5:
     for v := T.one, double v
 ----^
-... repeated 29 times ...
+... repeated 27 times ...
 
 catch_postcondition.test#1 i32: --CURDIR--/catch_postcondition.fz:43:5:
     for v := T.one, double v
@@ -826,46 +968,53 @@ catch_postcondition.anonymous.try: --CURDIR--/catch_postcondition.fz:129:7:
 (catch_postcondition.ref handle_post String).λ.call.λ.call: --CURDIR--/catch_postcondition.fz:108:15:
         ).run try (()->catch m.get.get)
 --------------^^^
-(fuzion.runtime.post_fault.run#3 String).λ.call: $MODULE/effect.fz:98:23:
-    cf := Effect_Call f
-----------------------^
-(fuzion.runtime.post_fault.Effect_Call String).call: $MODULE/effect.fz:154:18:
+(fuzion.runtime.post_fault.run#3 String).λ.call: $MODULE/effect.fz:199:39:
+    effect.this.instate R effect.this f def.call
+--------------------------------------^
+(fuzion.type.runtime.type.post_fault.type.instate#4 String).λ.call: $MODULE/effect.fz:100:25:
+    cf := e.Effect_Call code
+------------------------^^^^
+(fuzion.runtime.post_fault.Effect_Call String).call: $MODULE/effect.fz:191:18:
       set res := f()
 -----------------^
-fuzion.runtime.post_fault.run#3 String: <source position not available>:
+fuzion.type.runtime.type.post_fault.type.instate#4 String: <source position not available>:
 
+fuzion.runtime.post_fault.run#3 String: $MODULE/effect.fz:199:5:
+    effect.this.instate R effect.this f def.call
+----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 (catch_postcondition.ref handle_post String).λ.call: --CURDIR--/catch_postcondition.fz:108:11:
         ).run try (()->catch m.get.get)
 ----------^^^
-((catch_postcondition.ref handle_post String).lm.go#2 String).λ.call: $MODULE/effect.fz:208:23:
-    cf := Effect_Call f
-----------------------^
-((catch_postcondition.ref handle_post String).lm.Effect_Call String).call: $MODULE/effect.fz:154:18:
+((catch_postcondition.ref handle_post String).lm.instate_self#2 String).λ.call: $MODULE/effect.fz:145:39:
+    effect.this.instate R effect.this code
+--------------------------------------^^^^
+((catch_postcondition.type.handle_post.type String).lm.type.instate#3 String).λ.call: $MODULE/effect.fz:124:17:
+    instate R e code (panic "unexpected abort in {effect.this.type}")
+----------------^^^^
+((catch_postcondition.type.handle_post.type String).lm.type.instate#4 String).λ.call: $MODULE/effect.fz:100:25:
+    cf := e.Effect_Call code
+------------------------^^^^
+((catch_postcondition.ref handle_post String).lm.Effect_Call String).call: $MODULE/effect.fz:191:18:
       set res := f()
 -----------------^
-(catch_postcondition.ref handle_post String).lm.go#2 String: <source position not available>:
+(catch_postcondition.type.handle_post.type String).lm.type.instate#4 String: <source position not available>:
 
+(catch_postcondition.type.handle_post.type String).lm.type.instate#3 String: $MODULE/effect.fz:124:5:
+    instate R e code (panic "unexpected abort in {effect.this.type}")
+----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+(catch_postcondition.ref handle_post String).lm.instate_self#2 String: $MODULE/effect.fz:145:5:
+    effect.this.instate R effect.this code
+----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 catch_postcondition.anonymous: --CURDIR--/catch_postcondition.fz:103:15:
-    res := lm.go ()->
---------------^^
-fuzion.runtime.postcondition_fault#1: --CURDIR--/catch_postcondition.fz:127:8:
+    res := lm.instate_self ()->
+--------------^^^^^^^^^^^^
+(catch_postcondition.test#1 i32).loop: --CURDIR--/catch_postcondition.fz:127:8:
   say (ref : handle_post String
 -------^
-(catch_postcondition.test#1 i32).post double: --CURDIR--/catch_postcondition.fz:38:9:
-        equals result-x x
---------^^^^^^^^^^^^^^^^^
-(catch_postcondition.test#1 i32).double#1: --CURDIR--/catch_postcondition.fz:37:7:
-      post
-------^^^^
-        equals result-x x
---------^^^^^^^^^^^^^^^^^
-(catch_postcondition.test#1 i32).loop: --CURDIR--/catch_postcondition.fz:43:21:
-    for v := T.one, double v
---------------------^^^^^^
 (catch_postcondition.test#1 i32).loop: --CURDIR--/catch_postcondition.fz:43:5:
     for v := T.one, double v
 ----^
-... repeated 29 times ...
+... repeated 27 times ...
 
 catch_postcondition.test#1 i32: --CURDIR--/catch_postcondition.fz:43:5:
     for v := T.one, double v
@@ -876,34 +1025,49 @@ catch_postcondition.y.try: --CURDIR--/catch_postcondition.fz:116:30:
 catch_postcondition.y.λ.call.λ.call: --CURDIR--/catch_postcondition.fz:108:15:
         ).run try (()->catch m.get.get)
 --------------^^^
-(fuzion.runtime.post_fault.run#3 String).λ.call: $MODULE/effect.fz:98:23:
-    cf := Effect_Call f
-----------------------^
-(fuzion.runtime.post_fault.Effect_Call String).call: $MODULE/effect.fz:154:18:
+(fuzion.runtime.post_fault.run#3 String).λ.call: $MODULE/effect.fz:199:39:
+    effect.this.instate R effect.this f def.call
+--------------------------------------^
+(fuzion.type.runtime.type.post_fault.type.instate#4 String).λ.call: $MODULE/effect.fz:100:25:
+    cf := e.Effect_Call code
+------------------------^^^^
+(fuzion.runtime.post_fault.Effect_Call String).call: $MODULE/effect.fz:191:18:
       set res := f()
 -----------------^
-fuzion.runtime.post_fault.run#3 String: <source position not available>:
+fuzion.type.runtime.type.post_fault.type.instate#4 String: <source position not available>:
 
+fuzion.runtime.post_fault.run#3 String: $MODULE/effect.fz:199:5:
+    effect.this.instate R effect.this f def.call
+----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 catch_postcondition.y.λ.call: --CURDIR--/catch_postcondition.fz:108:11:
         ).run try (()->catch m.get.get)
 ----------^^^
-(catch_postcondition.y.lm.go#2 String).λ.call: $MODULE/effect.fz:208:23:
-    cf := Effect_Call f
-----------------------^
-(catch_postcondition.y.lm.Effect_Call String).call: $MODULE/effect.fz:154:18:
+(catch_postcondition.y.lm.instate_self#2 String).λ.call: $MODULE/effect.fz:145:39:
+    effect.this.instate R effect.this code
+--------------------------------------^^^^
+(catch_postcondition.type.y.type.lm.type.instate#3 String).λ.call: $MODULE/effect.fz:124:17:
+    instate R e code (panic "unexpected abort in {effect.this.type}")
+----------------^^^^
+(catch_postcondition.type.y.type.lm.type.instate#4 String).λ.call: $MODULE/effect.fz:100:25:
+    cf := e.Effect_Call code
+------------------------^^^^
+(catch_postcondition.y.lm.Effect_Call String).call: $MODULE/effect.fz:191:18:
       set res := f()
 -----------------^
-catch_postcondition.y.lm.go#2 String: <source position not available>:
+catch_postcondition.type.y.type.lm.type.instate#4 String: <source position not available>:
 
+catch_postcondition.type.y.type.lm.type.instate#3 String: $MODULE/effect.fz:124:5:
+    instate R e code (panic "unexpected abort in {effect.this.type}")
+----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+catch_postcondition.y.lm.instate_self#2 String: $MODULE/effect.fz:145:5:
+    effect.this.instate R effect.this code
+----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 catch_postcondition.y: --CURDIR--/catch_postcondition.fz:103:15:
-    res := lm.go ()->
---------------^^
-fuzion.runtime.post_fault.precall abort: --CURDIR--/catch_postcondition.fz:119:7:
+    res := lm.instate_self ()->
+--------------^^^^^^^^^^^^
+catch_postcondition.λ.call#1: --CURDIR--/catch_postcondition.fz:119:7:
   say y.res
 ------^
-catch_postcondition.λ.call#1: --CURDIR--/catch_postcondition.fz:83:21:
-      rt.post_fault.abort).run
---------------------^^^^^
 fuzion.runtime.post_fault.cause#1: $MODULE/eff/fallible.fz:35:6:
   => h e
 -----^
@@ -932,14 +1096,20 @@ catch_postcondition.test#1 i32: --CURDIR--/catch_postcondition.fz:43:5:
 catch_postcondition.λ.call: --CURDIR--/catch_postcondition.fz:84:6:
     (test i32)
 -----^^^^
-(fuzion.runtime.post_fault.run#3 String).λ.call: $MODULE/effect.fz:98:23:
-    cf := Effect_Call f
-----------------------^
-(fuzion.runtime.post_fault.Effect_Call String).call: $MODULE/effect.fz:154:18:
+(fuzion.runtime.post_fault.run#3 String).λ.call: $MODULE/effect.fz:199:39:
+    effect.this.instate R effect.this f def.call
+--------------------------------------^
+(fuzion.type.runtime.type.post_fault.type.instate#4 String).λ.call: $MODULE/effect.fz:100:25:
+    cf := e.Effect_Call code
+------------------------^^^^
+(fuzion.runtime.post_fault.Effect_Call String).call: $MODULE/effect.fz:191:18:
       set res := f()
 -----------------^
-fuzion.runtime.post_fault.run#3 String: <source position not available>:
+fuzion.type.runtime.type.post_fault.type.instate#4 String: <source position not available>:
 
+fuzion.runtime.post_fault.run#3 String: $MODULE/effect.fz:199:5:
+    effect.this.instate R effect.this f def.call
+----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 catch_postcondition: --CURDIR--/catch_postcondition.fz:83:28:
       rt.post_fault.abort).run
 ---------------------------^^^

--- a/tests/choice/choicetest.fz
+++ b/tests/choice/choicetest.fz
@@ -63,7 +63,7 @@ choicetest is
 
   say "creating array:"
   mi : mutate is
-  a := mi.go ()->
+  a := mi.instate_self ()->
     a := (mutate.array Coin).new mi 10 Penny
     a[0] := Penny
     a[1] := Penny

--- a/tests/effect_installed/test_effect.fz
+++ b/tests/effect_installed/test_effect.fz
@@ -45,24 +45,24 @@ test_effect is
   fa Function unit := FA
   fb Function unit := FB
   fc Function unit := FC
-  a.go unit fa
-  b.go unit fb
-  c.go unit fc
-  a.go ()->use_a
-  b.go ()->use_b
-  c.go ()->use_c
-  a.go ()->
-    b.go ()->
-      c.go ()->
+  a.instate_self unit fa
+  b.instate_self unit fb
+  c.instate_self unit fc
+  a.instate_self ()->use_a
+  b.instate_self ()->use_b
+  c.instate_self ()->use_c
+  a.instate_self ()->
+    b.instate_self ()->
+      c.instate_self ()->
         use_a
         use_b
         use_c
-#  a.go ()->use_b_err2
-#  b.go ()->use_c_err3
-#  c.go ()->use_a_err1
-  a.go ()->
-    b.go ()->
-      c.go ()->
+#  a.instate_self ()->use_b_err2
+#  b.instate_self ()->use_c_err3
+#  c.instate_self ()->use_a_err1
+  a.instate_self ()->
+    b.instate_self ()->
+      c.instate_self ()->
         use_a
         use_b
         use_c
@@ -71,12 +71,12 @@ test_effect is
   # the following ones are a little tricky since use_a/b/c are also used in
   # positive cases above, so the call traces might get mixed up.
   #
-  a.go ()->
-    b.go ()->
+  a.instate_self ()->
+    b.instate_self ()->
 #      use_c      # 5. should flag an error: effect not installed
-  a.go ()->
-    c.go ()->
+  a.instate_self ()->
+    c.instate_self ()->
 #      use_b      # 6. should flag an error: effect not installed
-  b.go ()->
-    c.go ()->
+  b.instate_self ()->
+    c.instate_self ()->
 #      use_a      # 7. should flag an error: effect not installed

--- a/tests/effect_installed_negative/test_effect_neg.fz
+++ b/tests/effect_installed_negative/test_effect_neg.fz
@@ -47,24 +47,24 @@ test_effect_neg is
   fa Function unit := FA
   fb Function unit := FB
   fc Function unit := FC
-  a.go unit fa
-  b.go unit fb
-  c.go unit fc
-  a.go ()->use_a
-  b.go ()->use_b
-  c.go ()->use_c
-  a.go ()->
-    b.go ()->
-      c.go ()->
+  a.instate_self unit fa
+  b.instate_self unit fb
+  c.instate_self unit fc
+  a.instate_self ()->use_a
+  b.instate_self ()->use_b
+  c.instate_self ()->use_c
+  a.instate_self ()->
+    b.instate_self ()->
+      c.instate_self ()->
         use_a
         use_b
         use_c
-  a.go ()->use_b_err2
-  b.go ()->use_c_err3
-  c.go ()->use_a_err1
-  a.go ()->
-    b.go ()->
-      c.go ()->
+  a.instate_self ()->use_b_err2
+  b.instate_self ()->use_c_err3
+  c.instate_self ()->use_a_err1
+  a.instate_self ()->
+    b.instate_self ()->
+      c.instate_self ()->
         use_a
         use_b
         use_c
@@ -74,14 +74,14 @@ test_effect_neg is
   # positive cases above, so the call traces might get mixed up.
   #
   if maybe
-    a.go ()->
-      b.go ()->
+    a.instate_self ()->
+      b.instate_self ()->
         use_c      # 5. should flag an error: effect not installedx
   if maybe
-    a.go ()->
-      c.go ()->
+    a.instate_self ()->
+      c.instate_self ()->
         use_b      # 6. should flag an error: effect not installed
   if maybe
-    b.go ()->
-      c.go ()->
+    b.instate_self ()->
+      c.instate_self ()->
         use_a      # 7. should flag an error: effect not installed

--- a/tests/javaBase/javaHello.fz
+++ b/tests/javaBase/javaHello.fz
@@ -113,7 +113,7 @@ javaHello : Java is
     public do_panic(msg String) unit =>
       say "A panic was trigger with msg: $msg"
 
-  _ := (panic p unit).go ()->
+  _ := (panic p unit).instate_self ()->
     Java.java.util.ArrayList.new_I -7
   */
 

--- a/tests/lib_string/stringtest.fz
+++ b/tests/lib_string/stringtest.fz
@@ -45,5 +45,5 @@ stringtest is
   say (String.from_codepoints "hell😀".as_codepoints)
 
   mi : mutate is
-  mi.go ()->
+  mi.instate_self ()->
     say (String.from_mutable_array mi ((mutate.array Any).new mi 1 nil))

--- a/tests/local_mutate/test_local_mutate.fz
+++ b/tests/local_mutate/test_local_mutate.fz
@@ -59,7 +59,7 @@ test_local_mutate is
 
       # run code within an instance of m
       #
-      m.go ()->
+      m.instate_self ()->
         s := m.env.new 0
 
         for e in l do
@@ -68,7 +68,7 @@ test_local_mutate is
         say "inside m.go: s.get = {s.get}"
         say "inside m.go: count = {count}"
 
-      say "using m.go and count: {m.go ()->count}"
+      say "using m.instate_self and count: {m.instate_self ()->count}"
 
       count2 =>
         s := m.env.new 0
@@ -81,7 +81,7 @@ test_local_mutate is
       # say count    # *** will cause compile-time an error, requires m to be installed
 
       neg_test3 =>
-        s := m.go ()->count2
+        s := m.instate_self ()->count2
         say s             # *** will cause an error, requires m to be installed
         "** failed, did not panic **"
 
@@ -95,8 +95,8 @@ test_local_mutate is
                 .catch caught_msg)
 
       neg_test4 =>
-        s := m.go ()->count2
-        m.go ()->
+        s := m.instate_self ()->count2
+        m.instate_self ()->
           s.get <- -12    # *** will cause an error, m has changed!
           say s
         "** failed, did not panic **"
@@ -106,8 +106,8 @@ test_local_mutate is
 
       neg_test5 =>
         q =>
-          s1 := m.go ()->count2
-          m.go ()->
+          s1 := m.instate_self ()->count2
+          m.instate_self ()->
             s1.get <- -12    # *** will cause an error, m has changed!
             say s1
           "** failed, did not panic **"
@@ -130,7 +130,7 @@ test_local_mutate is
         m : mutate is
 
         # execute code with mutate effect `m`:
-        m.go ()->
+        m.instate_self ()->
 
           arr := (mutate.array T).new m c.as_i64 data[0]
 
@@ -220,7 +220,7 @@ test_local_mutate is
                cur.p.close
         r
 
-      r0 := m.go ()->(ring3 from0.as_list)
+      r0 := m.instate_self ()->(ring3 from0.as_list)
       say "left mutate environment m"
       for
         i in 1..10
@@ -357,7 +357,7 @@ test_local_mutate is
         c.freeze
         c
 
-      r := m.go ()->(create_ring2 from0.as_list)
+      r := m.instate_self ()->(create_ring2 from0.as_list)
       say "left mutate environment m"
       say r
       for

--- a/tests/local_mutate/test_local_mutate.fz.expected_out
+++ b/tests/local_mutate/test_local_mutate.fz.expected_out
@@ -1,6 +1,6 @@
 inside m.go: s.get = 81
 inside m.go: count = 81
-using m.go and count: 81
+using m.instate_self and count: 81
 *** got '*** invalid mutate for Type of 'test_local_mutate.test_sum.sum#1.m'' ***
 ok
 *** got '*** invalid mutate for Type of 'test_local_mutate.test_sum.sum#1.m'' ***

--- a/tests/local_mutate_negative/test_local_mutate_neg.fz
+++ b/tests/local_mutate_negative/test_local_mutate_neg.fz
@@ -59,7 +59,7 @@ test_local_mutate_neg is
 
       # run code within an instance of m
       #
-      m.go ()->
+      m.instate_self ()->
         s := m.env.new 0
 
         for e in l do
@@ -68,7 +68,7 @@ test_local_mutate_neg is
         say "inside m.go: s.get = {s.get}"
         say "inside m.go: count = {count}"
 
-      say "using m.go and count: {m.go ()->count}"
+      say "using m.instate_self and count: {m.instate_self ()->count}"
 
       count2 =>
         s := m.env.new 0
@@ -79,7 +79,7 @@ test_local_mutate_neg is
       say count    # *** will cause compile-time an error, requires m to be installed
 
       neg_test3 =>
-        s := m.go ()->count2
+        s := m.instate_self ()->count2
         say s             # *** will cause an error, requires m to be installed
         "** failed, did not panic **"
 
@@ -93,8 +93,8 @@ test_local_mutate_neg is
                 .catch caught_msg)
 
       neg_test4 =>
-        s := m.go ()->count2
-        m.go ()->
+        s := m.instate_self ()->count2
+        m.instate_self ()->
           s.get <- -12    # *** will cause an error, m has changed!
           say s
         "** failed, did not panic **"
@@ -104,8 +104,8 @@ test_local_mutate_neg is
 
       neg_test5 =>
         q =>
-          s1 := m.go ()->count2
-          m.go ()->
+          s1 := m.instate_self ()->count2
+          m.instate_self ()->
             s1.get <- -12    # *** will cause an error, m has changed!
             say s1
           "** failed, did not panic **"

--- a/tests/mutable_linked_list/test_mutable_linked_list.fz
+++ b/tests/mutable_linked_list/test_mutable_linked_list.fz
@@ -23,7 +23,7 @@
 
 test_mutable_linked_list is
   x : mutate is
-  y := x.go ()->
+  y := x.instate_self ()->
     yy := (container.Mutable_Linked_List x i32).new [0,1,2,3,4] false
     yy.append 42
     yy.freeze

--- a/tests/mutate_circular_buffer/ex_circular_buffer.fz
+++ b/tests/mutate_circular_buffer/ex_circular_buffer.fz
@@ -24,7 +24,7 @@
 ex_circular_buffer =>
   m : mutate is
 
-  m.go ()->
+  m.instate_self ()->
     b := (mutate.circular_buffer codepoint).new m 7 "0"
     say (b.put "1")
     say (b.enqueue ["2", "3"])

--- a/tests/process/test_process.fz
+++ b/tests/process/test_process.fz
@@ -47,7 +47,7 @@ test_process =>
     (process.spawn ["cat"]).bind unit p->
       _ := p.write_string "Hello from the other side."
       say p.wait
-      _ := lm.go ()->
+      _ := lm.instate_self ()->
         _ := p.with_out unit lm ()->
           say (io.buffered.read_string lm 1E9)
 
@@ -55,16 +55,16 @@ test_process =>
 
   test "read stdout of process" ()->
     (process.spawn ["echo", "eecchhoo"]).bind unit p->
-      _ := lm.go ()->
+      _ := lm.instate_self ()->
         _ := p.with_out unit lm ()->
           say (io.buffered.read_string lm 1E9)
 
 
 
   test "pass environment variable" ()->
-    (process.env_vars (container.map_of [("MYENVVAR", "content")])).go ()->
+    (process.env_vars (container.map_of [("MYENVVAR", "content")])).instate_self ()->
       (process.spawn ["printenv", "MYENVVAR"]).bind unit p->
-        _ := lm.go ()->
+        _ := lm.instate_self ()->
           _ := p.with_out unit lm ()->
             say (io.buffered.read_string lm 1E9)
 
@@ -73,7 +73,7 @@ test_process =>
   test "feed output of process 1 to process 2" ()->
     (process.spawn ["echo", "'feed me to cat'"]).bind unit p->
       (p | ["cat"]).bind unit p2->
-        _ := lm.go ()->
+        _ := lm.instate_self ()->
           _ := p2.with_out unit lm ()->
             say (io.buffered.read_string lm 1E9)
 
@@ -82,7 +82,7 @@ test_process =>
   test "1kb argument, piped to another process" ()->
     (process.spawn ["echo", "-n", (get_str 1E3)]).bind unit p->
       (p | ["cat"]).bind unit p2->
-        _ := lm.go ()->
+        _ := lm.instate_self ()->
           _ := p2.with_out unit lm ()->
             say (io.buffered.read_string lm 1E9).byte_length
           say p2.wait

--- a/tests/process_buffered_writer/test_process.fz
+++ b/tests/process_buffered_writer/test_process.fz
@@ -34,7 +34,7 @@ test_process =>
   test "write to stdin of process (new)" ()->
     (process.spawn ["cat"]).bind unit p->
       lm : mutate is
-      _ := lm.go ()->
+      _ := lm.instate_self ()->
         _ := p.with_in unit lm ()->
           _ := (io.buffered.writer lm).write "Hello, World!\n".utf8.as_array
           _ := (io.buffered.writer lm).flush

--- a/tests/reg_issue1559_post_condition/test_issue1559.fz
+++ b/tests/reg_issue1559_post_condition/test_issue1559.fz
@@ -22,6 +22,6 @@
 # -----------------------------------------------------------------------
 
 a option String =>
-  mutate.go ()->
+  mutate.instate_self ()->
     ref : String
       redef utf8 => (list u8).empty

--- a/tests/reg_issue1943_type_parameter_as_outer_type/issue1943.fz
+++ b/tests/reg_issue1943_type_parameter_as_outer_type/issue1943.fz
@@ -49,7 +49,7 @@ test_outer_as_type_parameter is
     n
 
   mm : mutate.
-  mm.use ()->
+  mm.instate_self ()->
     {
       cnt := mm.env.new 100
       cnt1 := count mm i32 cnt [1,2,3]

--- a/tests/reg_issue2213/issue_2213.fz
+++ b/tests/reg_issue2213/issue_2213.fz
@@ -1,5 +1,5 @@
 issue_2213 =>
   mi : mutate is
-  mi.go ()->
+  mi.instate_self ()->
     ball is
     balls := (mutate.array ball).new mi 1 ball

--- a/tests/reg_issue2231/reg_issue2231.fz
+++ b/tests/reg_issue2231/reg_issue2231.fz
@@ -23,12 +23,12 @@
 
 reg_issue2231 is
   a := mut ()->i32 ()->0
-  ef : simple_effect is
+  ef : effect is
     inner := 7
     a <- ()->inner
     something =>
       abort
 
-  ef.go ()->
+  ef.instate_self ()->
     reg_issue2231.ef.env.something
   say a.get.call

--- a/tests/reg_issue2231/reg_issue2231.fz.expected_err
+++ b/tests/reg_issue2231/reg_issue2231.fz.expected_err
@@ -1,5 +1,5 @@
 
-error 1: FATAL FAULT `*** panic ***`: *** unexpected abort in Type of 'reg_issue2231.ef'
+error 1: FATAL FAULT `*** panic ***`: unexpected abort in Type of 'reg_issue2231.ef'
 Call stack:
 fuzion.type.runtime.type.fault.type.install_default.λ.call#1: $MODULE/fuzion/runtime/fault.fz:38:7:
       fuzion.sys.fatal_fault kind msg
@@ -16,14 +16,17 @@ panic.cause#1: $MODULE/eff/fallible.fz:35:6:
 panic#1: $MODULE/panic.fz:56:29:
 public panic(msg String) => panic.cause msg
 ----------------------------^^^^^^^^^^^^^^^
-reg_issue2231.ef.abort: $MODULE/effect.fz:213:16:
-               panic msg
----------------^^^^^^^^^
-reg_issue2231.ef.precall abort: $MODULE/effect.fz:66:3:
+(reg_issue2231.type.ef.type.instate#3 void).λ.call: $MODULE/effect.fz:124:22:
+    instate R e code (panic "unexpected abort in {effect.this.type}")
+---------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+reg_issue2231.ef.abort: $MODULE/effect.fz:103:14:
+      nil => def()
+-------------^^^
+reg_issue2231.ef.precall abort: $MODULE/effect.fz:256:3:
   pre
 --^^^
-    safety: effect.is_installed effect.this
-----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    safety: effect.this.is_instated
+----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     safety: abortable
 ----^^^^^^^^^^^^^^^^^
 reg_issue2231.ef.something: --CURDIR--/reg_issue2231.fz:30:7:
@@ -32,17 +35,29 @@ reg_issue2231.ef.something: --CURDIR--/reg_issue2231.fz:30:7:
 reg_issue2231.λ.call: --CURDIR--/reg_issue2231.fz:33:26:
     reg_issue2231.ef.env.something
 -------------------------^^^^^^^^^
-(reg_issue2231.ef.go#2 void).λ.call: $MODULE/effect.fz:208:23:
-    cf := Effect_Call f
-----------------------^
-(reg_issue2231.ef.Effect_Call void).call: $MODULE/effect.fz:154:18:
+(reg_issue2231.ef.instate_self#2 void).λ.call: $MODULE/effect.fz:145:39:
+    effect.this.instate R effect.this code
+--------------------------------------^^^^
+(reg_issue2231.type.ef.type.instate#3 void).λ.call: $MODULE/effect.fz:124:17:
+    instate R e code (panic "unexpected abort in {effect.this.type}")
+----------------^^^^
+(reg_issue2231.type.ef.type.instate#4 void).λ.call: $MODULE/effect.fz:100:25:
+    cf := e.Effect_Call code
+------------------------^^^^
+(reg_issue2231.ef.Effect_Call void).call: $MODULE/effect.fz:191:18:
       set res := f()
 -----------------^
-reg_issue2231.ef.go#2 void: <source position not available>:
+reg_issue2231.type.ef.type.instate#4 void: <source position not available>:
 
+reg_issue2231.type.ef.type.instate#3 void: $MODULE/effect.fz:124:5:
+    instate R e code (panic "unexpected abort in {effect.this.type}")
+----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+reg_issue2231.ef.instate_self#2 void: $MODULE/effect.fz:145:5:
+    effect.this.instate R effect.this code
+----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 reg_issue2231: --CURDIR--/reg_issue2231.fz:32:6:
-  ef.go ()->
------^^
+  ef.instate_self ()->
+-----^^^^^^^^^^^^
 
 *** fatal errors encountered, stopping.
 one error.

--- a/tests/reg_issue2231/reg_issue2231.fz.expected_err_c
+++ b/tests/reg_issue2231/reg_issue2231.fz.expected_err_c
@@ -1,1 +1,1 @@
-*** failed *** panic ***: `*** unexpected abort in Type of 'reg_issue2231.ef'`
+*** failed *** panic ***: `unexpected abort in Type of 'reg_issue2231.ef'`

--- a/tests/reg_issue2231/reg_issue2231.fz.expected_err_jvm
+++ b/tests/reg_issue2231/reg_issue2231.fz.expected_err_jvm
@@ -1,5 +1,5 @@
 
-error 1: FATAL FAULT `*** panic ***`: *** unexpected abort in Type of 'reg_issue2231.ef'
+error 1: FATAL FAULT `*** panic ***`: unexpected abort in Type of 'reg_issue2231.ef'
 Call stack:
 fuzion.sys.fatal_fault#2
 fuzion.type.runtime.type.fault.type.install_default.λ.call#1
@@ -7,7 +7,10 @@ fuzion.runtime.fault.cause#1
 panic.type.install_default.λ.call#1
 panic.cause#1
 panic#1
-reg_issue2231.ef.go#2 void
+(reg_issue2231.type.ef.type.instate#3 void).λ.call
+reg_issue2231.type.ef.type.instate#4 void
+reg_issue2231.type.ef.type.instate#3 void
+reg_issue2231.ef.instate_self#2 void
 reg_issue2231
 
 *** fatal errors encountered, stopping.

--- a/tests/reg_issue2242/reg_issue2242.fz
+++ b/tests/reg_issue2242/reg_issue2242.fz
@@ -53,7 +53,7 @@ reg_issue2242 =>
       quick_sort arr (pi + 1) high
 
   mi : mutate is
-  mi.go ()->
+  mi.instate_self ()->
 
     a := (mutate.array f64).type.new mi 10 0.0
     for i in a.indices do

--- a/tests/reg_issue2280/reg_issue2280.fz
+++ b/tests/reg_issue2280/reg_issue2280.fz
@@ -28,7 +28,7 @@ reg_issue2280 is
   # NYI: this should be public in codepoint, had to copy it over!
 
   lm : mutate is
-  _ := lm.go ()->((io.stdin lm).with ()->
+  _ := lm.instate_self ()->((io.stdin lm).with ()->
     for
 
       t := u32 0, s

--- a/tests/reg_issue2380/reg_issue2380.fz
+++ b/tests/reg_issue2380/reg_issue2380.fz
@@ -24,14 +24,14 @@
 reg_issue2380 is
 
   mi : mutate is
-  input := mi.go ()->
+  input := mi.instate_self ()->
       ((io.stdin mi).with ()->(io.buffered.read_lines mi)).val.filter !=""
                                                           .map (.as_codepoints)
   area := array2 String input.count input[0].count i,j->input[i][j]
 
   part1 =>
     lm : mutate.
-    lm.go ()->
+    lm.instate_self ()->
       visited := (lm.array i32).type.new lm area.length.as_i64 0
       r => 1
       l => 2

--- a/tests/reg_issue2381/reg_issue2381.fz
+++ b/tests/reg_issue2381/reg_issue2381.fz
@@ -24,14 +24,14 @@
 reg_issue2381 is
 
   mi : mutate is
-  input := mi.go ()->
+  input := mi.instate_self ()->
     ((io.stdin mi).with ()->(io.buffered.read_lines mi)).val.filter !=""
                                                         .map (.as_codepoints)
   area := array2 String input.count input[0].count i,j->input[i][j]
 
   part1 =>
     lm : mutate.
-    lm.go ()->
+    lm.instate_self ()->
       visited := (lm.array i32).type.new lm area.length.as_i64 0
       r => 1
       l => 2

--- a/tests/reg_issue2687/reg_issue2687.fz
+++ b/tests/reg_issue2687/reg_issue2687.fz
@@ -24,5 +24,5 @@
 reg_issue2687 =>
   for _ in (1..100) do
     mi : mutate is
-    mi.go ()->
+    mi.instate_self ()->
       d := (mutate.array f64).type.new mi 5000 0.0

--- a/tests/reg_issue3168_parsing_tuples/reg_issue3168_parsing_tuples.fz
+++ b/tests/reg_issue3168_parsing_tuples/reg_issue3168_parsing_tuples.fz
@@ -34,7 +34,7 @@ reg_issue3168_parsing_tuples is
     a := array (Sequence (tuple i32 String)) 0 i->[]
     b := array (Sequence (i32, String)) 0 i->[]
     lm : mutate is
-      lm.go unit ()->
+      lm.instate_self unit ()->
       c := (lm.array (Sequence (tuple i32 String i32))).type.new lm 0 []
       d := (lm.array (Sequence (i32, i32))).type.new lm 0 []
     

--- a/tests/rosettacode_primes/primes.fz
+++ b/tests/rosettacode_primes/primes.fz
@@ -26,7 +26,7 @@
 primes is
 
   mi : mutate is
-  mi.go ()->
+  mi.instate_self ()->
 
     primes(n i64) => // sieve using loops
       _ :=

--- a/tests/stack/stack.fz
+++ b/tests/stack/stack.fz
@@ -23,7 +23,7 @@
 
 stack is
   mi : mutate is
-  mi.go ()->
+  mi.instate_self ()->
     s := container.stack mi i32
     s.push 1
     s.push 2

--- a/tests/stdin/stdintest.fz
+++ b/tests/stdin/stdintest.fz
@@ -26,7 +26,7 @@
 stdintest =>
 
   lm : mutate is
-  say (lm.go ()->((io.stdin lm).with ()->
+  say (lm.instate_self ()->((io.stdin lm).with ()->
 
     read(n i32) => io.buffered.read_string lm n
     read_line => io.buffered.read_line lm ? str String => str | io.end_of_file => ""


### PR DESCRIPTION
This is based on PR #3573.

Add a new term for adding an effect instance to the current context and runing code: to `instate` an effect.

Effects are identified by their type. To support dynamic binding for operations on an effect, we must distinguish the type used to identy the effect, and the type of the actual effect value.  A new feature `effect.type.instate` permits this as follows: Say we have a `ref` effedt `color` with two instances types `green` and `purple`:

    color ref : effect is
      get String => abstract

    green  : color is
      redef get => "green"
    purple : color is
      redef get => "purple"

To `instate` one of them, we need to call `instate` on the effect type `color`, providing an argument of the value type `green` or `purple`:

    color.instate green  ()->{say "color is {color.env.get}"}
    color.instate purple ()->{say "color is {color.env.get}"}

This avoids the need of using effect handlers, e.g. `io.out` currently uses an argument `Print_Handler`, while a `ref` effect `io.Out` could have children like `stdout` that directly redefines `io.Out`'s operations.

This patch does a major cleanup in `effect.fz`, in particular

- effect intrinsics are now all type features of `effect`, they are `module` visible and have names ending `0`.

- two features `effect.type.instate` permit instating an effect with or without support for a default value in case of an abort.

- `effect.instate_self` is a convenience function similar to `effect.run`, which should be removed. `instate_self` does not work for inherited effect values instated for `ref` effect types.

- new featue `effect.type.default` to instate a default effect value.

- new featues `effect.type.replace` and `effect.replace` replace an instated effect by a new value. They replace `effect_mode.replace`

- new feature `effect.type.abort` to replace and abort an instated effect.

- `simple_effect` is no longer needed and marked for removal using `NYI: CLEANUP`

- Marked `use`, `go`. `run` with `NYI: CLEANUP` since these should be removed and replaced by calls to `instate` or `instate_self`.

- tests were changed to no longer use `simple_effect`, `use`, `go`, or `run`.
