### PR TITLE
ast: front-end robustness: avoid null pointer and index out of bouds

### DIFF
--- a/src/dev/flang/ast/Feature.java
+++ b/src/dev/flang/ast/Feature.java
@@ -2186,7 +2186,7 @@ A ((Choice)) declaration must not contain a result type.
       }
 
     if (POSTCONDITIONS) ensure
-      (isTypeFeaturesThisType() || selfType() == Types.resolved.t_Const_String || result != Types.resolved.t_Const_String);
+      (isTypeFeaturesThisType() || Types.resolved == null || selfType() == Types.resolved.t_Const_String || result != Types.resolved.t_Const_String);
 
     return result;
   }

--- a/src/dev/flang/ast/ParsedCall.java
+++ b/src/dev/flang/ast/ParsedCall.java
@@ -571,7 +571,7 @@ public class ParsedCall extends Call
                 g.add(t);
               }
             ai.set(Expr.NO_VALUE);  // make sure visit() no longer visits this
-            if (ts.get(ti).kind() != AbstractFeature.Kind.OpenTypeParameter)
+            if (ti > ts.size() && ts.get(ti).kind() != AbstractFeature.Kind.OpenTypeParameter)
               {
                 ti++;
               }


### PR DESCRIPTION
This fixes two locations that resulted in `fz` throwing runtime exceptions while I was working on effects.
