### PR TITLE
lib: fix oneway monads

### DIFF
--- a/lib/cache.fz
+++ b/lib/cache.fz
@@ -72,7 +72,7 @@ public cache(T type, f () -> T) T =>
   cache_item(val T) is
 
   if !(state unit cache_item).is_instated
-    (state unit cache_item unit (cache_item f()) unit).default
+    (state unit cache_item unit (cache_item f()) oneway_monad_mode.inst).default
 
   state_get cache_item
     .val

--- a/lib/handles.fz
+++ b/lib/handles.fz
@@ -65,8 +65,11 @@ private:public handles(
   # NYI: As soon as one-way monads are enforced, this array can be implemented
   # using marray, reducing the overhead of an update from O(count) to O(1)!
   #
-  ar array T
-  ) : oneway_monad X (handles T X)
+  ar array T,
+
+  # `plain` monad or effect to be `inst`alled or `repl`aced by new value?
+  mode oneway_monad_mode.val
+  ) : oneway_monad X (handles T X) mode
 is
 
   # number of handles created
@@ -85,7 +88,7 @@ is
     debug: result.has_last
   =>
     na := array T count+1 (i -> if (i < count) ar[i] else w)
-    handles T X v na
+    handles T X v na mode.next
 
 
   # has one element been created using 'new'?
@@ -133,7 +136,7 @@ is
     # the new value to be stored with 'h'
     w T)
   =>
-    handles T X v (ar.put h.x w)
+    handles T X v (ar.put h.x w) mode.next
 
 
   # create a new instance with the value refered to by a given handle read and
@@ -161,24 +164,24 @@ is
     f T->T
     )
   =>
-    _ := handles T X v (ar.put x (f ar[x]))
+    _ := handles T X v (ar.put x (f ar[x])) mode.next
 
 
   public redef infix >>= (f X -> handles T X) => bind X f
 
   public bind(B type, f X -> handles T B) handles T B =>
-    handles T B (f v).v ar
+    handles T B (f v).v ar oneway_monad_mode.plain
 
-  public return( B type, w B) => handles T B w ar
+  public return( B type, w B) => handles T B w ar oneway_monad_mode.plain
 
 # short-hand for creating and installing an empty set of handles of given type.
 #
 public handles(T type, rr ()->unit) =>
-  (handles T unit).instate (handles T unit unit (array T 0 x->do)) rr
+  (handles T unit unit (array T 0 x->do) oneway_monad_mode.inst).instate_self rr
 
 # short-hand for creating an empty set of handles of given type.
 #
-public handles_(T type) => handles T unit unit (array T 0 x->do)
+public handles_(T type) => handles T unit unit (array T 0 x->do) oneway_monad_mode.plain
 
 
 # short-hand for accessing handles monad for given type in current environment
@@ -222,7 +225,7 @@ handles_type(T type) is
   # install default instance of handles
   #
   install_default unit =>
-    (handles T unit unit (array T 0 x->do)).default
+    (handles T unit unit (array T 0 x->do) oneway_monad_mode.inst).default
 
 
 # initializes a new handle with the given initial value

--- a/lib/handles2.fz
+++ b/lib/handles2.fz
@@ -39,8 +39,11 @@ private:public handles2(
   # the inner value of this monad
   public v X,
 
-  last_opt option (handle2_0 T)
-  ) : oneway_monad X (handles2 T X)
+  last_opt option (handle2_0 T),
+
+  # `plain` monad or effect to be `inst`alled or `repl`aced by new value?
+  mode oneway_monad_mode.val
+  ) : oneway_monad X (handles2 T X) mode
 is
 
   # create a new instance with one additional handle
@@ -54,7 +57,7 @@ is
   post
     debug: result.has_last
   =>
-    handles2 T X v (handle2_0 w)
+    handles2 T X v (handle2_0 w) mode.next
 
 
   # has one element been created using 'new'?
@@ -103,7 +106,7 @@ is
     w T)
   =>
     h.put w
-    handles2 T X v last_opt
+    handles2 T X v last_opt mode.next
 
 
   # create a new instance with the value referred to by a given handle read and
@@ -118,24 +121,24 @@ is
     )
   =>
     h.put (f h.get)
-    handles2 T X v last_opt
+    handles2 T X v last_opt mode.next
 
 
   public redef infix >>= (f X -> handles2 T X) => bind X f
 
   public bind(B type, f X -> handles2 T B) handles2 T B =>
-    handles2 T B (f v).v last_opt
+    handles2 T B (f v).v last_opt oneway_monad_mode.plain
 
-  public return(B type, w B) => handles2 T B w last_opt
+  public return(B type, w B) => handles2 T B w last_opt oneway_monad_mode.plain
 
 # short-hand for creating and installing an empty set of handles2 of given type.
 #
 handles2(T type, rr ()->unit) =>
-  (handles2 T unit).instate (handles2 T unit unit nil) rr
+  (handles2 T unit unit nil oneway_monad_mode.inst).instate_self rr
 
 # short-hand for creating an empty set of handles2 of given type.
 #
-handles2_(T type) => handles2 T unit unit nil
+handles2_(T type) => handles2 T unit unit nil oneway_monad_mode.plain
 
 
 # short-hand for accessing handles monad for given type in current environment
@@ -176,7 +179,7 @@ handles2_type(T type) is
   # install default instance of handles2
   #
   install_default unit =>
-    (handles2 T unit unit nil).default
+    (handles2 T unit unit nil oneway_monad_mode.inst).default
 
 
 # create a new handle2 using the handles2 instance from the current environment

--- a/lib/oneway_monad.fz
+++ b/lib/oneway_monad.fz
@@ -26,13 +26,53 @@
 # oneway_monad -- heir feature of all one-way monads.
 #
 # oneway_monad is the heir feature of all one-way monads. A one-way monad is
-# a monadic feature that can be accessed only through the environment and
-# that will be replaced in the environment whenever a new instance is created.
+# a monadic feature that can be accessed as a effect through the environment
+# and that will be replaced in the environment whenever a new instance is
+# created.  Alternatively, this can be used as a monad that wraps around a
+# function result type A.
 #
 public oneway_monad(
 
+  # the type wrapped by this monad, `unit` in case this is used as an
+  # effect.
   A type,
 
-  OMA type : oneway_monad A OMA
+  # NYI: CLEANUP: replace by `oneway_monad.this`
+  OMA type : oneway_monad A OMA,
+
+  # `plain` monad or effect to be `inst`alled or `repl`aced by new value?
+  #
+  # if `repl`, `replace` will be called. If `inst`, this has to be
+  # `instated` by the caller.  `plain` does not instate or replace this,
+  # which is not needed if used as an explicit monad.
+  #
+  mode oneway_monad_mode.val
   ) : monad A OMA, effect
 is
+
+  match mode
+    oneway_monad_mode.plain =>
+    oneway_monad_mode.inst  => # instate will be done by caller
+    oneway_monad_mode.repl  => replace
+
+
+# enum of the mode argument.
+#
+public oneway_monad_mode is
+
+  public plain is   # a plain oneway_monad, not instated
+  public inst  is   # an effect that will be instated
+  public repl  is   # an effect that will replace an instated one
+
+  # enum type plain | inst | repl
+  public fixed val : choice plain inst repl is
+
+    # for a given mode, return the mode of a new instance of a oneway_monad.
+    # This returns either `plain` for a plain monad, or `repl` for a an
+    # instated effect.
+    #
+    public next val
+    =>
+      match val.this
+        plain      => oneway_monad_mode.plain
+        inst, repl => oneway_monad_mode.repl

--- a/lib/state.fz
+++ b/lib/state.fz
@@ -40,8 +40,9 @@ public state(
   # the current state
   get S,
 
-  _ unit
-  ) : oneway_monad T (state T S)
+  # `plain` monad or effect to be `inst`alled or `repl`aced by new value?
+  mode oneway_monad_mode.val
+  ) : oneway_monad T (state T S) mode
 is
 
   # monadic operator
@@ -59,23 +60,25 @@ is
 
   # return function
   #
-  public return (a T) => state a get unit
+  public return (a T) => state a get mode.next
 
 
   # map this using f
   #
   public map (B type, f T -> B) state B S =>
-    state (f val) get unit
+    state (f val) get mode.next
 
 
   # modify the state, leaving the contents unchanged
   #
-  public modify (f S -> S) => state val (f get) unit
+  public modify (f S -> S) =>
+    state val (f get) mode.next
 
 
   # set state to new, leaving the contents unchanged
   #
-  public put (new S) => state val new unit
+  public put (new S) =>
+    state val new mode.next
 
 
   # converts option to a string
@@ -90,7 +93,8 @@ is
 # state with 1 argument is short hand for a state containing unit and
 # initial_value
 #
-public state(S type, initial_value S) => state unit initial_value unit
+public state(S type, initial_value S) => state unit initial_value oneway_monad_mode.plain
+
 
 # install new state monad for type S and run r within that state monad
 #
@@ -98,7 +102,7 @@ public state(S type, initial_value S) => state unit initial_value unit
 #
 public state(S, R type, initial_value S, r ()->R) =>
   res option R := nil
-  (state unit S).instate (state unit S unit initial_value unit) (()->set res := r.call)
+  (state unit S).instate (state unit S unit initial_value oneway_monad_mode.inst) (()->set res := r.call)
   res.get
 
 


### PR DESCRIPTION
PR#3574 broke this removing the effect mode. This is required to be able to create oneway monads that are either classic monads that wrap function results or effects in the environment.

