### PR TITLE
Makefile: do not run EBNF script with `all` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -418,7 +418,7 @@ FZ_MODULES = \
 			$(MOD_NOM)
 
 .PHONY: all
-all: $(FUZION_BASE) $(FUZION_JAVA_MODULES) $(FUZION_FILES) $(MOD_FZ_CMD) $(FUZION_EBNF)
+all: $(FUZION_BASE) $(FUZION_JAVA_MODULES) $(FUZION_FILES) $(MOD_FZ_CMD)
 
 # everything but rarely used java modules
 .PHONY: min-java


### PR DESCRIPTION
This causes problems with the Jenkins/Dockerfile build that are otherwise hard to work around.