### PR TITLE
C: When `-XkeepGeneratedCode=on` is set, do not use `File.createTempFile`

### DIFF
--- a/src/dev/flang/be/c/C.java
+++ b/src/dev/flang/be/c/C.java
@@ -683,7 +683,7 @@ public class C extends ANY
   {
     var cl = _fuir.mainClazzId();
     var name = _options._binaryName != null ? _options._binaryName : _fuir.clazzBaseName(cl);
-    var cf = new CFile(name);
+    var cf = new CFile(name, _options._keepGeneratedCode);
     _options.verbosePrintln(" + " + cf.fileName());
     try
       {
@@ -705,10 +705,6 @@ public class C extends ANY
     _options.verbosePrintln(" * " + command.toString("", " ", ""));
     try
       {
-        if (_options._keepGeneratedCode)
-          {
-            Files.copy(Path.of(cf.fileName()), Path.of(System.getProperty("user.dir"), name + ".c"), StandardCopyOption.REPLACE_EXISTING);
-          }
         var p = new ProcessBuilder().inheritIO().command(command).start();
         p.waitFor();
         if (p.exitValue() != 0)

--- a/src/dev/flang/be/c/CFile.java
+++ b/src/dev/flang/be/c/CFile.java
@@ -31,6 +31,7 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
 
 import dev.flang.util.ANY;
 import dev.flang.util.Errors;
@@ -68,9 +69,9 @@ public class CFile extends ANY
 
 
   /**
-   * The temporary file to write the generated C-code to.
+   * The relative path of the file the generated C-code is written to.
    */
-  private File tempFile;
+  private Path _path;
 
 
   /*---------------------------  constructors  ---------------------------*/
@@ -80,14 +81,27 @@ public class CFile extends ANY
    * constructor to instantiate a CFile
    *
    * @param name the name of the binary
+   *
+   * @param keepGeneratedCode true to create a file `name + ".c"` in the current
+   * directory and keep it, false to create a temp file that will be deleted on
+   * exit.
    */
-  public CFile(String name)
+  public CFile(String name, boolean keepGeneratedCode)
   {
     try
       {
-        tempFile = File.createTempFile("fuzion_"+ name + "_", ".c");
-        tempFile.deleteOnExit();
-        _cout = new PrintWriter(Files.newBufferedWriter(tempFile.toPath(), StandardCharsets.UTF_8));
+        if (keepGeneratedCode)
+          {
+            _path = Path.of(System.getProperty("user.dir"), name + ".c");
+          }
+        else
+          {
+            var tempFile = File.createTempFile("fuzion_"+ name + "_", ".c");
+            tempFile.deleteOnExit();
+            _path = tempFile.toPath();
+          }
+
+        _cout = new PrintWriter(Files.newBufferedWriter(_path, StandardCharsets.UTF_8));
       }
     catch (IOException io)
       {
@@ -228,7 +242,7 @@ public class CFile extends ANY
    */
   public String fileName()
   {
-    return tempFile.getAbsolutePath();
+    return _path.toAbsolutePath().toString();
   }
 
 }


### PR DESCRIPTION
I was confused then using `-verbose` and `-XkeepGeneratedCode=on` and I could not find the C files anymore.

With this patch, `-XkeepGeneratedCode=on` will cause not to use temp files at all but generate C files using the main clazz name.
