### PR TITLE
ast: improve error message when redefining hidden feature

### DIFF
--- a/src/dev/flang/ast/AstErrors.java
+++ b/src/dev/flang/ast/AstErrors.java
@@ -1060,7 +1060,7 @@ public class AstErrors extends ANY
     error(f.pos(),
           "Feature declared using modifier " + skw("redef") + " does not redefine another feature",
           "Redefining feature: " + s(f) + "\n" +
-          "To solve this, check spelling and argument count against the feature you want to redefine or " +
+          "To solve this, check spelling and argument count against the feature you want to redefine and make sure the feature to be redefined is visible where it is redefined or " +
           "remove " + skw("redef") + " modifier in the declaration of " + s(f) + ".");
   }
 

--- a/src/dev/flang/ast/AstErrors.java
+++ b/src/dev/flang/ast/AstErrors.java
@@ -1055,13 +1055,25 @@ public class AstErrors extends ANY
                    "declaration of " + s(f) + ".");
   }
 
-  public static void redefineModifierDoesNotRedefine(AbstractFeature f)
+  public static void redefineModifierDoesNotRedefine(AbstractFeature f, List<FeatureAndOuter> hiddenFeaturesSameSignature)
   {
     error(f.pos(),
           "Feature declared using modifier " + skw("redef") + " does not redefine another feature",
           "Redefining feature: " + s(f) + "\n" +
-          "To solve this, check spelling and argument count against the feature you want to redefine and make sure the feature to be redefined is visible where it is redefined or " +
-          "remove " + skw("redef") + " modifier in the declaration of " + s(f) + ".");
+          "To solve this, check spelling and argument count against the feature you want to redefine or " +
+          "remove " + skw("redef") + " modifier in the declaration of " + s(f) + "." +
+          redefOfPrivateFeature(f, hiddenFeaturesSameSignature));
+  }
+
+  private static String redefOfPrivateFeature(AbstractFeature f, List<FeatureAndOuter> sameSignature)
+  {
+    AbstractFeature outer = f.outer();
+
+    return sameSignature.isEmpty()
+            ? ""
+            : "\nAlso make sure that the feature to be redefined is visible where it is redefined. " +
+              "There is the feature " + s(sameSignature.getFirst()._feature) +
+              " that could be made public to allow redefinition in " + s(outer) + ".";
   }
 
   static void notRedefinedContractMustNotUseElseOrThen(SourcePosition pos, AbstractFeature f, PreOrPost preOrPost)

--- a/src/dev/flang/fe/SourceModule.java
+++ b/src/dev/flang/fe/SourceModule.java
@@ -40,6 +40,7 @@ import java.util.SortedMap;
 import java.util.Stack;
 import java.util.TreeMap;
 import java.util.TreeSet;
+import java.util.stream.Collectors;
 
 import dev.flang.ast.AbstractAssign;
 import dev.flang.ast.AbstractBlock;
@@ -945,7 +946,9 @@ A post-condition of a feature that redefines one or several inherited features m
 A feature that does not redefine an inherited feature must not use the `redef` modifier.
     // end::fuzion_rule_PARS_NO_REDEF[]
             */
-            AstErrors.redefineModifierDoesNotRedefine(f);
+            List<FeatureAndOuter> hiddenFeaturesSameSignature = lookup(outer, f.featureName().baseName(), null, true, true);
+            hiddenFeaturesSameSignature = hiddenFeaturesSameSignature.stream().filter(fan->fan._feature.featureName().equals(f.featureName())).collect(List.collector());
+            AstErrors.redefineModifierDoesNotRedefine(f, hiddenFeaturesSameSignature);
           }
         else if (c._hasPreElse != null)
           {

--- a/src/dev/flang/fe/SourceModule.java
+++ b/src/dev/flang/fe/SourceModule.java
@@ -946,8 +946,8 @@ A post-condition of a feature that redefines one or several inherited features m
 A feature that does not redefine an inherited feature must not use the `redef` modifier.
     // end::fuzion_rule_PARS_NO_REDEF[]
             */
-            List<FeatureAndOuter> hiddenFeaturesSameSignature = lookup(outer, f.featureName().baseName(), null, true, true);
-            hiddenFeaturesSameSignature = hiddenFeaturesSameSignature.stream().filter(fan->fan._feature.featureName().equals(f.featureName())).collect(List.collector());
+            List<FeatureAndOuter> hiddenFeaturesSameSignature = lookup(outer, f.featureName().baseName(), null, true, true)
+              .stream().filter(fo->fo._feature.featureName().equals(f.featureName())).collect(List.collector());
             AstErrors.redefineModifierDoesNotRedefine(f, hiddenFeaturesSameSignature);
           }
         else if (c._hasPreElse != null)


### PR DESCRIPTION
fix #3312

example
```
FUZION_DISABLE_ANSI_ESCAPES=true fz -sourceDirs=/tmp/ /tmp/3312_child.fz

/tmp/3312_child.fz:2:9: error 1: Feature declared using modifier 'redef' does not redefine another feature
  redef get => "I'm child"
--------^^^
Redefining feature: 'child.get'
To solve this, check spelling and argument count against the feature you want to redefine and make sure the feature to be redefined is visible where it is redefined or remove 'redef' modifier in the declaration of 'child.get'.

one error.

```