### PR TITLE
lib: move `infix ∈` and `infix ∉` from `property.equatable` to `universe`

### DIFF
--- a/lib/equals.fz
+++ b/lib/equals.fz
@@ -44,6 +44,36 @@ public infix =(T type : property.equatable, a, b T) => equals T a b
 public infix !=(T type : property.equatable, a, b T) => !equals T a b
 
 
+# is `a` contained in `Set` `s`?
+#
+# This should usually be called using type inference as in
+#
+#   my_set := set_of ["A","B","C"]
+#   say ("B" ∈ my_set)
+#   say ("D" ∈ my_set)
+#
+public infix ∈ (T type : property.equatable,
+                a T,
+                s container.Set T)
+=>
+  s.contains a
+
+
+# is `a` not contained in `Set` `s`?
+#
+# This should usually be called using type inference as in
+#
+#   my_set := set_of ["A","B","C"]
+#   say ("B" ∉ my_set)
+#   say ("D" ∉ my_set)
+#
+public infix ∉ (T type : property.equatable,
+                a T,
+                s container.Set T)
+=>
+  !(s.contains a)
+
+
 # lteq -- feature that compares two values using the lteq relation
 # defined in their type
 #

--- a/lib/property/equatable.fz
+++ b/lib/property/equatable.fz
@@ -40,35 +40,3 @@ public equatable is
   # as 'b'.
   #
   public type.equality(a, b equatable.this) bool => abstract
-
-
-  # is this part of given set
-  #
-  element_of(s container.Set equatable.this) => s.contains equatable.this
-
-
-  # is this not part of given set
-  #
-  not_element_of(s container.Set equatable.this) => !(equatable.this.element_of s)
-
-
-  # is `this` contained in `Set` `s`?
-  #
-  # This should usually be called using type inference as in
-  #
-  #   my_set := set_of ["A","B","C"]
-  #   say ("B" ∈ my_set)
-  #   say ("D" ∈ my_set)
-  #
-  public infix ∈ (s container.Set equatable.this) => element_of s
-
-
-  # is `this` not contained in `Set` `s`?
-  #
-  # This should usually be called using type inference as in
-  #
-  #   my_set := set_of ["A","B","C"]
-  #   say ("B" ∉ my_set)
-  #   say ("D" ∉ my_set)
-  #
-  public infix ∉ (s container.Set  equatable.this) => not_element_of s


### PR DESCRIPTION
These do not work properly for `ref` types due to #3619.

This change fixes running `idiom119ex.fz` and `idiom232ex.fz`.

