### PR TITLE
ast/tests: Improve error message for #3619, add regression test

### DIFF
--- a/src/dev/flang/ast/AbstractFeature.java
+++ b/src/dev/flang/ast/AbstractFeature.java
@@ -287,6 +287,13 @@ public abstract class AbstractFeature extends Expr implements Comparable<Abstrac
 
 
   /**
+   * The sourcecode position of this feature declaration's result type, null if
+   * not available.
+   */
+  public abstract SourcePosition resultTypePos();
+
+
+  /**
    * The result field declared automatically in case hasResultField().
    *
    * @return the result or null if this does not have a result field.

--- a/src/dev/flang/ast/AstErrors.java
+++ b/src/dev/flang/ast/AstErrors.java
@@ -2005,20 +2005,35 @@ public class AstErrors extends ANY
    * The problem is that `v` may refer to `h1` or `h2` such that `v.g` will
    * result in either `h1.e` or `h2.e`.
    *
+   * @param c the call with this problem
+   *
+   * @param arg true if the problematic type is an argument type, false if the
+   * problem is in the result type
+   *
+   * @param t the original argument or result type
+   *
+   * @param from the target type t depends on
+   *
+   * @param to the target type
    */
-  public static void illegalOuterRefTypeInCall(Call c, AbstractType t, AbstractType from, AbstractType to)
+  public static void illegalOuterRefTypeInCall(Call c, boolean arg, AbstractFeature calledOrArg, AbstractType t, AbstractType from, AbstractType to)
   {
+    var art = arg ? "argument type" : "result type";
+    var tp = calledOrArg.resultTypePos();
     error(c.pos(),
-          "Call has an ambiguous result type since target of the call is a " + code("ref") + " type.",
-          "The result type of this call depends on the target type.  Since the target type is a " + code("ref") + " type that " +
-          "may represent a number of different actual dynamic types, the result type is not clearly defined.\n"+
+          "Call has an ambiguous " + art + " since target of the call is a " + code("ref") + " type.",
+          "The " + art + " of this call depends on the target type.  Since the target type is a " + code("ref") + " type that " +
+          "may represent a number of different actual dynamic types, the " + art + " is not clearly defined.\n"+
           "Called feature: " + s(c.calledFeature()) + "\n" +
-          "Raw result type: " + s(t) + "\n" +
+          "Original " + art + ": " + s(t) +
+          (tp != null
+           ? " declared at " + tp.show()
+           : "") + "\n" +
           "Type depending on target: " + s(from) + "\n" +
           "Target type: " + s(to) + "\n" +
           "To solve this, you could try to use a value type as the target type of the call" +
           (c.calledFeature().outer().isThisRef() ? " " : ", e,g., " + s(c.calledFeature().outer().selfType()) + ", ") +
-          "or change the result type of " + s(c.calledFeature()) + " to no longer depend on " + s(from) + ".");
+          "or change the " + art + " of " + s(c.calledFeature()) + " to no longer depend on " + s(from) + ".");
   }
 
 

--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -478,12 +478,12 @@ public class Call extends AbstractCall
    * target of this call and actual type parameters given in this call. Result
    * is interned.
    */
-  private AbstractType actualArgType(Resolution res, AbstractType frmlT, Context context)
+  private AbstractType actualArgType(Resolution res, AbstractType frmlT, AbstractFeature arg, Context context)
   {
     if (PRECONDITIONS) require
       (!frmlT.isOpenGeneric());
 
-    AbstractType result = adjustThisTypeForTarget(frmlT, context);
+    AbstractType result = adjustThisTypeForTarget(frmlT, true, arg, context);
     result = targetTypeOrConstraint(res, context)
       .actualType(result, context)
       .applyTypePars(_calledFeature, _generics);
@@ -1316,7 +1316,7 @@ public class Call extends AbstractCall
               }
             else
               {
-                _resolvedFormalArgumentTypes[argnum + i] = actualArgType(res, frmlT, context);
+                _resolvedFormalArgumentTypes[argnum + i] = actualArgType(res, frmlT, frml, context);
               }
           }
       }
@@ -1455,7 +1455,7 @@ public class Call extends AbstractCall
     var t1 = resolveSelect(frmlT, tt);
     var t2 = t1.applyTypePars(tt);
     var t3 = tt.isGenericArgument() ? t2 : t2.resolve(res, tt.feature().context());
-    var t4 = adjustThisTypeForTarget(t3, context);
+    var t4 = adjustThisTypeForTarget(t3, false, calledFeature(), context);
     var t5 = resolveForCalledFeature(res, t4, tt, context);
     // call may be resolved repeatedly. In case of recursive use of FieldActual
     // (see #2182), we may see `void` as the result type of calls to argument
@@ -1520,12 +1520,16 @@ public class Call extends AbstractCall
    *
    * @param t the formal type to be adjusted.
    *
+   * @param arg true if `t` is the type of an argument, false if `t` is the result type
+   *
+   * @param the declared argument (if arg == true) or the called feature (otherwise).
+   *
    * @param context the source code context where this Call is used
    *
    * @return a type derived from t where `this.type` is replaced by actual types
    * from the call's target where this is possible.
    */
-  private AbstractType adjustThisTypeForTarget(AbstractType t, Context context)
+  private AbstractType adjustThisTypeForTarget(AbstractType t, boolean arg, AbstractFeature calledOrArg, Context context)
   {
     /**
      * For a call `T.f` on a type parameter whose result type contains
@@ -1559,7 +1563,7 @@ public class Call extends AbstractCall
                                           _target.typeForCallTarget());
         var t0 = t;
         t = t.replace_this_type_by_actual_outer(inner,
-                                                (from,to) -> AstErrors.illegalOuterRefTypeInCall(this, t0, from, to),
+                                                (from,to) -> AstErrors.illegalOuterRefTypeInCall(this, arg, calledOrArg, t0, from, to),
                                                 context);
       }
     return t;
@@ -1869,7 +1873,7 @@ public class Call extends AbstractCall
                           }
                         else if (resultExpression(actual) instanceof AbstractLambda al)
                           {
-                            checked[vai] = inferGenericLambdaResult(res, context, t, al, actual.pos(), conflict, foundAt);
+                            checked[vai] = inferGenericLambdaResult(res, context, t, frml, al, actual.pos(), conflict, foundAt);
                           }
                       }
                   }
@@ -2087,6 +2091,7 @@ public class Call extends AbstractCall
   private boolean inferGenericLambdaResult(Resolution res,
                                            Context context,
                                            AbstractType formalType,
+                                           AbstractFeature frml,
                                            AbstractLambda al,
                                            SourcePosition pos,
                                            boolean[] conflict,
@@ -2101,7 +2106,7 @@ public class Call extends AbstractCall
         var ri = rg.index();
         if (rg.feature() == _calledFeature && foundAt.get(ri) == null)
           {
-            var at = actualArgType(res, formalType, context);
+            var at = actualArgType(res, formalType, frml, context);
             if (!at.containsUndefined(true))
               {
                 var rt = al.inferLambdaResultType(res, context, at);

--- a/src/dev/flang/ast/Feature.java
+++ b/src/dev/flang/ast/Feature.java
@@ -808,6 +808,16 @@ public class Feature extends AbstractFeature
 
 
   /**
+   * The sourcecode position of this feature declaration's result type, null if
+   * not available.
+   */
+  public SourcePosition resultTypePos()
+  {
+    return _returnType.posOrNull();
+  }
+
+
+  /**
    * Check for possible errors related to the feature name. Currently, this only
    * checks that no feature uses FuzionConstants.RESULT_NAME as its base name
    * since this is reserved for the implicit result field.

--- a/src/dev/flang/fe/LibraryFeature.java
+++ b/src/dev/flang/fe/LibraryFeature.java
@@ -437,7 +437,7 @@ public class LibraryFeature extends AbstractFeature
    */
   public SourcePosition resultTypePos()
   {
-    return null; // NYI: UNDER DEVELOPMENT: resultTypePos missign for LibraryFeature
+    return null; // NYI: UNDER DEVELOPMENT: resultTypePos currently missing in module file
   }
 
 

--- a/src/dev/flang/fe/LibraryFeature.java
+++ b/src/dev/flang/fe/LibraryFeature.java
@@ -431,6 +431,16 @@ public class LibraryFeature extends AbstractFeature
   }
 
 
+  /**
+   * The sourcecode position of this feature declaration's result type, null if
+   * not available.
+   */
+  public SourcePosition resultTypePos()
+  {
+    return null; // NYI: UNDER DEVELOPMENT: resultTypePos missign for LibraryFeature
+  }
+
+
   public FeatureName featureName()
   {
     var result = _featureName;

--- a/tests/call_with_ambiguous_result_type_negative/call.fz.expected_err
+++ b/tests/call_with_ambiguous_result_type_negative/call.fz.expected_err
@@ -4,7 +4,7 @@
 ---------^
 The result type of this call depends on the target type.  Since the target type is a 'ref' type that may represent a number of different actual dynamic types, the result type is not clearly defined.
 Called feature: 'call_with_ambiguous_result_type.r.g'
-Raw result type: 'call_with_ambiguous_result_type.this.r.this.e'
+Original result type: 'call_with_ambiguous_result_type.this.r.this.e'
 Type depending on target: 'call_with_ambiguous_result_type.this.r.this'
 Target type: 'call_with_ambiguous_result_type.this.r'
 To solve this, you could try to use a value type as the target type of the call or change the result type of 'call_with_ambiguous_result_type.r.g' to no longer depend on 'call_with_ambiguous_result_type.this.r.this'.

--- a/tests/reg_issue3619/Makefile
+++ b/tests/reg_issue3619/Makefile
@@ -1,0 +1,25 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test Makefile
+#
+# -----------------------------------------------------------------------
+
+override NAME = reg_issue3619
+include ../simple.mk

--- a/tests/reg_issue3619/reg_issue3619.fz
+++ b/tests/reg_issue3619/reg_issue3619.fz
@@ -1,0 +1,67 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test reg_issue3619
+#
+# -----------------------------------------------------------------------
+
+reg_issue3619 =>
+
+
+  #  ---------- ---------- ---------- ---------- ---------- ----------
+
+
+  # here is the code from #3619
+
+  r(T type, v T) is
+
+  A ref is
+    f(p r A.this) b => b
+
+  b : A is
+    redef fixed f(p r b) => p.v
+
+  a A := b
+  x b := a.f (r A)
+
+  # `r` contains a value of type `T`, so `r A` contains a value of type `A`.
+  #
+  # `A.f(p r A.this)` returns a value of type `b`, which in `b` is implemented
+  # to return the value `v` stored in `p` which is of type `r b` in this case.
+  #
+  # Now we can call `a.f (r A)` where `a` is a `ref` to an instance of `b` that
+  # would extract a `b` from `r A`, which is impossible.
+
+
+  #  ---------- ---------- ---------- ---------- ---------- ----------
+
+  # here is a second example introduced as a comment added in PR #1426:
+
+  r2 ref is
+    e is
+    g => e
+
+  h1 : r2 is
+  h2 : r2 is
+
+  v r2 := if random.next_bool then h1 else h2
+  x2 := v.g
+
+  # The problem is that `v` may refer to `h1` or `h2` such that `v.g` will
+  # result in either `h1.e` or `h2.e`.

--- a/tests/reg_issue3619/reg_issue3619.fz.expected_err
+++ b/tests/reg_issue3619/reg_issue3619.fz.expected_err
@@ -1,0 +1,25 @@
+
+--CURDIR--/reg_issue3619.fz:41:12: error 1: Call has an ambiguous argument type since target of the call is a 'ref' type.
+  x b := a.f (r A)
+-----------^
+The argument type of this call depends on the target type.  Since the target type is a 'ref' type that may represent a number of different actual dynamic types, the argument type is not clearly defined.
+Called feature: 'reg_issue3619.A.f'
+Original argument type: 'reg_issue3619.this.r reg_issue3619.this.A.this' declared at --CURDIR--/reg_issue3619.fz:35:9:
+    f(p r A.this) b => b
+--------^
+Type depending on target: 'reg_issue3619.this.A.this'
+Target type: 'reg_issue3619.this.A'
+To solve this, you could try to use a value type as the target type of the call or change the argument type of 'reg_issue3619.A.f' to no longer depend on 'reg_issue3619.this.A.this'.
+
+
+--CURDIR--/reg_issue3619.fz:64:11: error 2: Call has an ambiguous result type since target of the call is a 'ref' type.
+  x2 := v.g
+----------^
+The result type of this call depends on the target type.  Since the target type is a 'ref' type that may represent a number of different actual dynamic types, the result type is not clearly defined.
+Called feature: 'reg_issue3619.r2.g'
+Original result type: 'reg_issue3619.this.r2.this.e'
+Type depending on target: 'reg_issue3619.this.r2.this'
+Target type: 'reg_issue3619.this.r2'
+To solve this, you could try to use a value type as the target type of the call or change the result type of 'reg_issue3619.r2.g' to no longer depend on 'reg_issue3619.this.r2.this'.
+
+2 errors.

--- a/tests/reg_issue776/reg_issue776.fz.expected_err
+++ b/tests/reg_issue776/reg_issue776.fz.expected_err
@@ -4,7 +4,7 @@
 ----^
 The result type of this call depends on the target type.  Since the target type is a 'ref' type that may represent a number of different actual dynamic types, the result type is not clearly defined.
 Called feature: 'String.mysubstring.anonymous'
-Raw result type: '(value String.this).mysubstring.anonymous'
+Original result type: '(value String.this).mysubstring.anonymous'
 Type depending on target: 'value String.this'
 Target type: '(value String.this).mysubstring.this.anonymous'
 To solve this, you could try to use a value type as the target type of the call, e,g., '(value String.this).mysubstring', or change the result type of 'String.mysubstring.anonymous' to no longer depend on 'value String.this'.


### PR DESCRIPTION
This hopefully somewhat reduces the confusion caused by errors where feature result types depend on `this`-types of outer features while they are called via an outer `ref` type.

