### PR TITLE
fix ulimit problems that occur in windows / linux actions

### DIFF
--- a/tests/check_simple_example_c.sh
+++ b/tests/check_simple_example_c.sh
@@ -61,7 +61,8 @@ else
     rm -f testbin
 
     # limit cpu time and stack size for executing test
-    ulimit -S -t 120 -s 1024
+    ulimit -S -t 120  || echo "failed setting limit via ulimit"
+    ulimit -S -s 1024 || echo "failed setting limit via ulimit"
 
     EXIT_CODE=$( ( (FUZION_DISABLE_ANSI_ESCAPES=true FUZION_JAVA_OPTIONS="${FUZION_JAVA_OPTIONS="-Xss${FUZION_JAVA_STACK_SIZE=5m}"} ${OPT:-}" $1 -XmaxErrors=-1 -c "$2" -o=testbin                && ./testbin) 2>tmp_err.txt | head -n 10000) > tmp_out.txt; echo $?)
 

--- a/tests/check_simple_example_int.sh
+++ b/tests/check_simple_example_int.sh
@@ -59,7 +59,7 @@ else
     head -n 1 "$2" | grep -q -E "# fuzion.debugLevel=0( .*)$" && export OPT=-Dfuzion.debugLevel=0
 
     # limit cpu time for executing test
-    ulimit -S -t 300
+    ulimit -S -t 600 || echo "failed setting limit via ulimit"
 
     EXIT_CODE=$(FUZION_DISABLE_ANSI_ESCAPES=true FUZION_JAVA_OPTIONS="${FUZION_JAVA_OPTIONS="-Xss${FUZION_JAVA_STACK_SIZE=5m}"} ${OPT:-}" $1 -XmaxErrors=-1 -interpreter "$2" >tmp_out.txt 2>tmp_err.txt; echo $?)
 

--- a/tests/check_simple_example_jvm.sh
+++ b/tests/check_simple_example_jvm.sh
@@ -58,7 +58,7 @@ else
     head -n 1 "$2" | grep -q -E "# fuzion.debugLevel=0( .*)$" && export OPT=-Dfuzion.debugLevel=0
 
     # limit cpu time for executing test
-    ulimit -S -t 120
+    ulimit -S -t 120 || echo "failed setting limit via ulimit"
 
     EXIT_CODE=$(FUZION_DISABLE_ANSI_ESCAPES=true FUZION_JAVA_OPTIONS="${FUZION_JAVA_OPTIONS="-Xss${FUZION_JAVA_STACK_SIZE=5m}"} ${OPT:-}" $1 -XmaxErrors=-1 -jvm "$2" >tmp_out.txt 2>tmp_err.txt; echo $?)
 


### PR DESCRIPTION
problem:
1) (windows) ulimit: cpu time: cannot modify limit: Invalid argument
2) (linux): increase time for interpreter test, onesCount takes longer than 300sec


