### PR TITLE
effect: Made `effect.abort` a type feature and removed `effect.run`, fix #3634

### DIFF
--- a/lib/eff/fallible.fz
+++ b/lib/eff/fallible.fz
@@ -88,11 +88,10 @@ public fallible(ERROR type, h ERROR->void) : effect is
 
       lm.instate_self ()->
         m := lm.env.new (option ERROR nil)
-        (fallible.this.new e->
-          m <- e
-          fallible.this.env.return
-        ).run code_try (()->code_catch m.get.get)
-
+        v := fallible.this.new e->
+               m <- e
+               fallible.this.type.abort
+        fallible.this.instate T v code_try (()->code_catch m.get.get)
 
     # infix alias for catch
     #
@@ -115,10 +114,10 @@ handle(ERROR type, F type : fallible ERROR, T type) is
 
   res => lm.instate_self ()->
       m := lm.env.new (option ERROR nil)
-      (F.new e->
-          m <- e
-          F.env.return
-      ).run eff.handle.this.try (()->catch m.get.get)
+      v := F.new e->
+             m <- e
+             F.abort
+      F.instate T v try (()->catch m.get.get)
 
 
   # NYI: BUG: #3159 The following code is a variant using the state effect instead of mutate. This
@@ -129,7 +128,7 @@ handle(ERROR type, F type : fallible ERROR, T type) is
   s(val option ERROR) is
 
   res_broken => state s T (s nil) ()->
-    (F.new e->
-        _ := state_put (s e)
-        F.env.return
-    ).run try (()->catch (state_get s).val.get)
+    v := F.new e->
+           _ := state_put (s e)
+           F.abort
+    F.instate T v try (()->catch (state_get s).val.get)

--- a/lib/effect.fz
+++ b/lib/effect.fz
@@ -210,14 +210,6 @@ public effect is
       set res := f()
 
 
-  # execute the code of 'f' in the context of this effect
-  #
-  # NYI: CLEANUP: REMOVE, use type.instate instead
-  #
-  public run(R type, f () -> R, def ()->R) R =>
-    effect.this.instate R effect.this f def.call
-
-
   # --------------------  replacing effect instances  --------------------
 
 
@@ -271,12 +263,12 @@ public effect is
   # replace existing effect of type `effect.this` by the new effect value `effect.this`.
   # and abort code execution to return to the point where the effect was instated.
   #
-  public abort void
+  public type.abort void
   pre
     safety: effect.this.is_instated
-    safety: abortable
+    safety: effect.this.env.abortable
   =>
-    effect.this.abort0 effect.this
+    effect.this.abort0 effect.this.env
 
 
   # does this effect support abort?
@@ -299,50 +291,9 @@ public effect is
   # jargon (and remove `return`) or to stick with it (and rename `abort` as
   # `return`).
   #
-  public return void
+  public type.return void
   pre
-    safety: abortable
+    safety: effect.this.is_instated
+    safety: effect.this.env.abortable
   =>
     abort
-
-# --------------------  effect helper features  --------------------
-
-
-# simple_effect provides a simple means to define and use an effect
-#
-# user-defined effects should inherit from this feature and add
-# operations as inner features or fields of function type.
-#
-# To install this effect to execute a function, simple_effect.use
-# can be called.
-#
-# NYI: CLEANUP: REMOVE, use effect instead
-#
-public simple_effect : effect
-is
-
-  # install this simple_effect and run code
-  #
-  # In case of an `abort`, `use` panics
-  #
-  # NYI: CLEANUP: REMOVE, use effect.instate instead
-  #
-  public use(code ()->unit) unit =>
-    simple_effect.this.instate simple_effect.this code
-
-
-  # install this effect and run code that produces a result of
-  # type T. panic in case abort is called.
-  #
-  # NYI: CLEANUP: REMOVE, use effect.instate instead
-  #
-  public go(T type, code ()->T) T =>
-    simple_effect.this.instate T simple_effect.this code ()->
-             msg := "*** unexpected abort in {simple_effect.this.type}"
-             if abortable
-               panic msg
-             else
-               # the user should not be able to produce this state: since the effect is
-               # not abortable cf can only return with a result. So we do a low-level
-               # panic that does not show up as a used effect:
-               fuzion.std.panic msg

--- a/lib/io/buffered/reader.fz
+++ b/lib/io/buffered/reader.fz
@@ -46,7 +46,7 @@ public reader(LM type : mutate, rp Read_Provider, buf_size i32) : effect is
   # resulting 'outcome'.
   #
   public with(R type, f ()->R) outcome R =>
-    try (reader LM) R (() -> run f (() -> exit 1))
+    try (reader LM) R (() -> reader.this.instate R reader.this f (() -> exit 1))
 
 
   # terminate immediately with the given error wrapped in 'option'.

--- a/lib/io/buffered/writer.fz
+++ b/lib/io/buffered/writer.fz
@@ -41,7 +41,7 @@ public writer(LM type : mutate, wp Write_Provider, buf_size i32) : effect is
   # resulting 'outcome'.
   #
   public with (R type, f ()->R) outcome R =>
-    try (writer LM) R (() -> run f (() -> exit 1))
+    try (writer LM) R (() -> writer.this.instate R writer.this f (() -> exit 1))
 
 
   # terminate immediately with the given error wrapped in 'option'.

--- a/tests/catch_postcondition/catch_postcondition.fz
+++ b/tests/catch_postcondition/catch_postcondition.fz
@@ -78,11 +78,13 @@ catch_postcondition is
 
   say "install our own fault handler that prints message and tries again:"
 
-  say ((rt.post_fault msg->
-      say "postcondition failed: $msg"
-      rt.post_fault.abort).run
-    (test i32)
-    (test u64))
+  say (fuzion.runtime.post_fault.instate
+        String
+        (rt.post_fault msg->
+          say "postcondition failed: $msg"
+          fuzion.runtime.post_fault.abort)
+        (test i32)
+        (test u64))
 
   say ""
 
@@ -102,10 +104,13 @@ catch_postcondition is
 
     res := lm.instate_self ()->
         m := lm.env.new (option String nil)
-        (rt.post_fault msg->
+        (fuzion.runtime.post_fault.instate
+          T
+          (rt.post_fault msg->
             m <- msg
-            rt.post_fault.return
-        ).run try (()->catch m.get.get)
+            fuzion.runtime.post_fault.abort)
+          try
+          (() -> catch m.get.get))
 
 
   # -------------------------------

--- a/tests/catch_postcondition/catch_postcondition.fz.expected_err
+++ b/tests/catch_postcondition/catch_postcondition.fz.expected_err
@@ -35,646 +35,9 @@ public postcondition_fault(msg String) => post_fault.cause msg
 catch_postcondition.test#1 i32: --CURDIR--/catch_postcondition.fz:43:5:
     for v := T.one, double v
 ----^
-(catch_postcondition.test#1 i16).loop: --CURDIR--/catch_postcondition.fz:286:8:
+(catch_postcondition.test#1 i16).loop: --CURDIR--/catch_postcondition.fz:291:8:
   say (test i32)
 -------^^^^
-(catch_postcondition.test#1 i16).loop: --CURDIR--/catch_postcondition.fz:43:5:
-    for v := T.one, double v
-----^
-... repeated 10 times ...
-
-catch_postcondition.test#1 i16: --CURDIR--/catch_postcondition.fz:43:5:
-    for v := T.one, double v
-----^
-catch_postcondition.λ.call: --CURDIR--/catch_postcondition.fz:141:56:
-  tries array ()->String := [ (() -> test i32), (() -> test i16), (() -> test i64) ]
--------------------------------------------------------^^^^
-catch_postcondition.loop.λ.call: --CURDIR--/catch_postcondition.fz:271:28:
-           option tries[c].call
----------------------------^^^^
-(fuzion.type.runtime.type.fault.type.try (option String)).catch#1.anonymous.try: $MODULE/eff/fallible.fz:75:23:
-         redef try => code_try.call
-----------------------^^^^^^^^^^^^^
-(fuzion.type.runtime.type.fault.type.try (option String)).catch#1.anonymous.res.λ.call.λ.call: $MODULE/eff/fallible.fz:121:13:
-      ).run eff.handle.this.try (()->catch m.get.get)
-------------^^^^^^^^^^^^^^^^^^^
-(fuzion.runtime.fault.run#3 (option String)).λ.call: $MODULE/effect.fz:199:39:
-    effect.this.instate R effect.this f def.call
---------------------------------------^
-(fuzion.type.runtime.type.fault.type.instate#4 (option String)).λ.call: $MODULE/effect.fz:100:25:
-    cf := e.Effect_Call code
-------------------------^^^^
-(fuzion.runtime.fault.Effect_Call (option String)).call: $MODULE/effect.fz:191:18:
-      set res := f()
------------------^
-fuzion.type.runtime.type.fault.type.instate#4 (option String): <source position not available>:
-
-fuzion.runtime.fault.run#3 (option String): $MODULE/effect.fz:199:5:
-    effect.this.instate R effect.this f def.call
-----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-(fuzion.type.runtime.type.fault.type.try (option String)).catch#1.anonymous.res.λ.call: $MODULE/eff/fallible.fz:118:7:
-      (F.new e->
-------^^^^^^^^^^
-          m <- e
-----------^^^^^^
-          F.env.return
-----------^^^^^^^^^^^^
-      ).run eff.handle.this.try (()->catch m.get.get)
-------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-((eff.ref handle (tuple String String) fuzion.runtime.fault (option String)).lm.instate_self#2 (option String)).λ.call: $MODULE/effect.fz:145:39:
-    effect.this.instate R effect.this code
---------------------------------------^^^^
-((eff.type.handle.type (tuple String String) fuzion.runtime.fault (option String)).lm.type.instate#3 (option String)).λ.call: $MODULE/effect.fz:124:17:
-    instate R e code (panic "unexpected abort in {effect.this.type}")
-----------------^^^^
-((eff.type.handle.type (tuple String String) fuzion.runtime.fault (option String)).lm.type.instate#4 (option String)).λ.call: $MODULE/effect.fz:100:25:
-    cf := e.Effect_Call code
-------------------------^^^^
-((eff.ref handle (tuple String String) fuzion.runtime.fault (option String)).lm.Effect_Call (option String)).call: $MODULE/effect.fz:191:18:
-      set res := f()
------------------^
-(eff.type.handle.type (tuple String String) fuzion.runtime.fault (option String)).lm.type.instate#4 (option String): <source position not available>:
-
-(eff.type.handle.type (tuple String String) fuzion.runtime.fault (option String)).lm.type.instate#3 (option String): $MODULE/effect.fz:124:5:
-    instate R e code (panic "unexpected abort in {effect.this.type}")
-----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-(eff.ref handle (tuple String String) fuzion.runtime.fault (option String)).lm.instate_self#2 (option String): $MODULE/effect.fz:145:5:
-    effect.this.instate R effect.this code
-----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-(fuzion.type.runtime.type.fault.type.try (option String)).catch#1.anonymous.res: $MODULE/eff/fallible.fz:116:10:
-  res => lm.instate_self ()->
----------^^^^^^^^^^^^^^^^^^^^
-      m := lm.env.new (option ERROR nil)
-------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-      (F.new e->
-------^^^^^^^^^^
-          m <- e
-----------^^^^^^
-          F.env.return
-----------^^^^^^^^^^^^
-      ).run eff.handle.this.try (()->catch m.get.get)
-------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-(fuzion.type.runtime.type.fault.type.try (option String)).catch#1: $MODULE/eff/fallible.fz:74:7:
-      (ref : eff.handle ERROR fallible.this T
-------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-         redef try => code_try.call
----------^^^^^^^^^^^^^^^^^^^^^^^^^^
-         redef catch(e ERROR) => code_catch e
----------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-      ).res
-------^^^^^
-catch_postcondition.loop: --CURDIR--/catch_postcondition.fz:272:11:
-         .catch s->
-----------^^^^^
-(catch_postcondition.test#1 i32).loop: --CURDIR--/catch_postcondition.fz:267:3:
-  for
---^
-(catch_postcondition.test#1 i32).loop: --CURDIR--/catch_postcondition.fz:43:5:
-    for v := T.one, double v
-----^
-... repeated 28 times ...
-
-catch_postcondition.test#1 i32: --CURDIR--/catch_postcondition.fz:43:5:
-    for v := T.one, double v
-----^
-catch_postcondition.λ.call: --CURDIR--/catch_postcondition.fz:141:38:
-  tries array ()->String := [ (() -> test i32), (() -> test i16), (() -> test i64) ]
--------------------------------------^^^^
-catch_postcondition.loop.λ.call: --CURDIR--/catch_postcondition.fz:271:28:
-           option tries[c].call
----------------------------^^^^
-(fuzion.type.runtime.type.fault.type.try (option String)).catch#1.anonymous.try: $MODULE/eff/fallible.fz:75:23:
-         redef try => code_try.call
-----------------------^^^^^^^^^^^^^
-(fuzion.type.runtime.type.fault.type.try (option String)).catch#1.anonymous.res.λ.call.λ.call: $MODULE/eff/fallible.fz:121:13:
-      ).run eff.handle.this.try (()->catch m.get.get)
-------------^^^^^^^^^^^^^^^^^^^
-(fuzion.runtime.fault.run#3 (option String)).λ.call: $MODULE/effect.fz:199:39:
-    effect.this.instate R effect.this f def.call
---------------------------------------^
-(fuzion.type.runtime.type.fault.type.instate#4 (option String)).λ.call: $MODULE/effect.fz:100:25:
-    cf := e.Effect_Call code
-------------------------^^^^
-(fuzion.runtime.fault.Effect_Call (option String)).call: $MODULE/effect.fz:191:18:
-      set res := f()
------------------^
-fuzion.type.runtime.type.fault.type.instate#4 (option String): <source position not available>:
-
-fuzion.runtime.fault.run#3 (option String): $MODULE/effect.fz:199:5:
-    effect.this.instate R effect.this f def.call
-----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-(fuzion.type.runtime.type.fault.type.try (option String)).catch#1.anonymous.res.λ.call: $MODULE/eff/fallible.fz:118:7:
-      (F.new e->
-------^^^^^^^^^^
-          m <- e
-----------^^^^^^
-          F.env.return
-----------^^^^^^^^^^^^
-      ).run eff.handle.this.try (()->catch m.get.get)
-------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-((eff.ref handle (tuple String String) fuzion.runtime.fault (option String)).lm.instate_self#2 (option String)).λ.call: $MODULE/effect.fz:145:39:
-    effect.this.instate R effect.this code
---------------------------------------^^^^
-((eff.type.handle.type (tuple String String) fuzion.runtime.fault (option String)).lm.type.instate#3 (option String)).λ.call: $MODULE/effect.fz:124:17:
-    instate R e code (panic "unexpected abort in {effect.this.type}")
-----------------^^^^
-((eff.type.handle.type (tuple String String) fuzion.runtime.fault (option String)).lm.type.instate#4 (option String)).λ.call: $MODULE/effect.fz:100:25:
-    cf := e.Effect_Call code
-------------------------^^^^
-((eff.ref handle (tuple String String) fuzion.runtime.fault (option String)).lm.Effect_Call (option String)).call: $MODULE/effect.fz:191:18:
-      set res := f()
------------------^
-(eff.type.handle.type (tuple String String) fuzion.runtime.fault (option String)).lm.type.instate#4 (option String): <source position not available>:
-
-(eff.type.handle.type (tuple String String) fuzion.runtime.fault (option String)).lm.type.instate#3 (option String): $MODULE/effect.fz:124:5:
-    instate R e code (panic "unexpected abort in {effect.this.type}")
-----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-(eff.ref handle (tuple String String) fuzion.runtime.fault (option String)).lm.instate_self#2 (option String): $MODULE/effect.fz:145:5:
-    effect.this.instate R effect.this code
-----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-(fuzion.type.runtime.type.fault.type.try (option String)).catch#1.anonymous.res: $MODULE/eff/fallible.fz:116:10:
-  res => lm.instate_self ()->
----------^^^^^^^^^^^^^^^^^^^^
-      m := lm.env.new (option ERROR nil)
-------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-      (F.new e->
-------^^^^^^^^^^
-          m <- e
-----------^^^^^^
-          F.env.return
-----------^^^^^^^^^^^^
-      ).run eff.handle.this.try (()->catch m.get.get)
-------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-(fuzion.type.runtime.type.fault.type.try (option String)).catch#1: $MODULE/eff/fallible.fz:74:7:
-      (ref : eff.handle ERROR fallible.this T
-------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-         redef try => code_try.call
----------^^^^^^^^^^^^^^^^^^^^^^^^^^
-         redef catch(e ERROR) => code_catch e
----------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-      ).res
-------^^^^^
-catch_postcondition.loop: --CURDIR--/catch_postcondition.fz:272:11:
-         .catch s->
-----------^^^^^
-(catch_postcondition.test#1 i16).loop: --CURDIR--/catch_postcondition.fz:267:3:
-  for
---^
-(catch_postcondition.test#1 i16).loop: --CURDIR--/catch_postcondition.fz:43:5:
-    for v := T.one, double v
-----^
-... repeated 8 times ...
-
-catch_postcondition.test#1 i16: --CURDIR--/catch_postcondition.fz:43:5:
-    for v := T.one, double v
-----^
-catch_postcondition.λ.call: --CURDIR--/catch_postcondition.fz:141:56:
-  tries array ()->String := [ (() -> test i32), (() -> test i16), (() -> test i64) ]
--------------------------------------------------------^^^^
-catch_postcondition.loop.λ.call: --CURDIR--/catch_postcondition.fz:252:28:
-           option tries[c].call
----------------------------^^^^
-(fuzion.type.runtime.type.post_fault.type.try (option String)).catch#1.anonymous.try: $MODULE/eff/fallible.fz:75:23:
-         redef try => code_try.call
-----------------------^^^^^^^^^^^^^
-(fuzion.type.runtime.type.post_fault.type.try (option String)).catch#1.anonymous.res.λ.call.λ.call: $MODULE/eff/fallible.fz:121:13:
-      ).run eff.handle.this.try (()->catch m.get.get)
-------------^^^^^^^^^^^^^^^^^^^
-(fuzion.runtime.post_fault.run#3 (option String)).λ.call: $MODULE/effect.fz:199:39:
-    effect.this.instate R effect.this f def.call
---------------------------------------^
-(fuzion.type.runtime.type.post_fault.type.instate#4 (option String)).λ.call: $MODULE/effect.fz:100:25:
-    cf := e.Effect_Call code
-------------------------^^^^
-(fuzion.runtime.post_fault.Effect_Call (option String)).call: $MODULE/effect.fz:191:18:
-      set res := f()
------------------^
-fuzion.type.runtime.type.post_fault.type.instate#4 (option String): <source position not available>:
-
-fuzion.runtime.post_fault.run#3 (option String): $MODULE/effect.fz:199:5:
-    effect.this.instate R effect.this f def.call
-----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-(fuzion.type.runtime.type.post_fault.type.try (option String)).catch#1.anonymous.res.λ.call: $MODULE/eff/fallible.fz:118:7:
-      (F.new e->
-------^^^^^^^^^^
-          m <- e
-----------^^^^^^
-          F.env.return
-----------^^^^^^^^^^^^
-      ).run eff.handle.this.try (()->catch m.get.get)
-------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-((eff.ref handle String fuzion.runtime.post_fault (option String)).lm.instate_self#2 (option String)).λ.call: $MODULE/effect.fz:145:39:
-    effect.this.instate R effect.this code
---------------------------------------^^^^
-((eff.type.handle.type String fuzion.runtime.post_fault (option String)).lm.type.instate#3 (option String)).λ.call: $MODULE/effect.fz:124:17:
-    instate R e code (panic "unexpected abort in {effect.this.type}")
-----------------^^^^
-((eff.type.handle.type String fuzion.runtime.post_fault (option String)).lm.type.instate#4 (option String)).λ.call: $MODULE/effect.fz:100:25:
-    cf := e.Effect_Call code
-------------------------^^^^
-((eff.ref handle String fuzion.runtime.post_fault (option String)).lm.Effect_Call (option String)).call: $MODULE/effect.fz:191:18:
-      set res := f()
------------------^
-(eff.type.handle.type String fuzion.runtime.post_fault (option String)).lm.type.instate#4 (option String): <source position not available>:
-
-(eff.type.handle.type String fuzion.runtime.post_fault (option String)).lm.type.instate#3 (option String): $MODULE/effect.fz:124:5:
-    instate R e code (panic "unexpected abort in {effect.this.type}")
-----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-(eff.ref handle String fuzion.runtime.post_fault (option String)).lm.instate_self#2 (option String): $MODULE/effect.fz:145:5:
-    effect.this.instate R effect.this code
-----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-(fuzion.type.runtime.type.post_fault.type.try (option String)).catch#1.anonymous.res: $MODULE/eff/fallible.fz:116:10:
-  res => lm.instate_self ()->
----------^^^^^^^^^^^^^^^^^^^^
-      m := lm.env.new (option ERROR nil)
-------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-      (F.new e->
-------^^^^^^^^^^
-          m <- e
-----------^^^^^^
-          F.env.return
-----------^^^^^^^^^^^^
-      ).run eff.handle.this.try (()->catch m.get.get)
-------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-(fuzion.type.runtime.type.post_fault.type.try (option String)).catch#1: $MODULE/eff/fallible.fz:74:7:
-      (ref : eff.handle ERROR fallible.this T
-------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-         redef try => code_try.call
----------^^^^^^^^^^^^^^^^^^^^^^^^^^
-         redef catch(e ERROR) => code_catch e
----------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-      ).res
-------^^^^^
-catch_postcondition.loop: --CURDIR--/catch_postcondition.fz:253:11:
-         .catch s->
-----------^^^^^
-(catch_postcondition.test#1 i32).loop: --CURDIR--/catch_postcondition.fz:248:3:
-  for
---^
-(catch_postcondition.test#1 i32).loop: --CURDIR--/catch_postcondition.fz:43:5:
-    for v := T.one, double v
-----^
-... repeated 26 times ...
-
-catch_postcondition.test#1 i32: --CURDIR--/catch_postcondition.fz:43:5:
-    for v := T.one, double v
-----^
-catch_postcondition.λ.call: --CURDIR--/catch_postcondition.fz:141:38:
-  tries array ()->String := [ (() -> test i32), (() -> test i16), (() -> test i64) ]
--------------------------------------^^^^
-catch_postcondition.loop.λ.call: --CURDIR--/catch_postcondition.fz:252:28:
-           option tries[c].call
----------------------------^^^^
-(fuzion.type.runtime.type.post_fault.type.try (option String)).catch#1.anonymous.try: $MODULE/eff/fallible.fz:75:23:
-         redef try => code_try.call
-----------------------^^^^^^^^^^^^^
-(fuzion.type.runtime.type.post_fault.type.try (option String)).catch#1.anonymous.res.λ.call.λ.call: $MODULE/eff/fallible.fz:121:13:
-      ).run eff.handle.this.try (()->catch m.get.get)
-------------^^^^^^^^^^^^^^^^^^^
-(fuzion.runtime.post_fault.run#3 (option String)).λ.call: $MODULE/effect.fz:199:39:
-    effect.this.instate R effect.this f def.call
---------------------------------------^
-(fuzion.type.runtime.type.post_fault.type.instate#4 (option String)).λ.call: $MODULE/effect.fz:100:25:
-    cf := e.Effect_Call code
-------------------------^^^^
-(fuzion.runtime.post_fault.Effect_Call (option String)).call: $MODULE/effect.fz:191:18:
-      set res := f()
------------------^
-fuzion.type.runtime.type.post_fault.type.instate#4 (option String): <source position not available>:
-
-fuzion.runtime.post_fault.run#3 (option String): $MODULE/effect.fz:199:5:
-    effect.this.instate R effect.this f def.call
-----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-(fuzion.type.runtime.type.post_fault.type.try (option String)).catch#1.anonymous.res.λ.call: $MODULE/eff/fallible.fz:118:7:
-      (F.new e->
-------^^^^^^^^^^
-          m <- e
-----------^^^^^^
-          F.env.return
-----------^^^^^^^^^^^^
-      ).run eff.handle.this.try (()->catch m.get.get)
-------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-((eff.ref handle String fuzion.runtime.post_fault (option String)).lm.instate_self#2 (option String)).λ.call: $MODULE/effect.fz:145:39:
-    effect.this.instate R effect.this code
---------------------------------------^^^^
-((eff.type.handle.type String fuzion.runtime.post_fault (option String)).lm.type.instate#3 (option String)).λ.call: $MODULE/effect.fz:124:17:
-    instate R e code (panic "unexpected abort in {effect.this.type}")
-----------------^^^^
-((eff.type.handle.type String fuzion.runtime.post_fault (option String)).lm.type.instate#4 (option String)).λ.call: $MODULE/effect.fz:100:25:
-    cf := e.Effect_Call code
-------------------------^^^^
-((eff.ref handle String fuzion.runtime.post_fault (option String)).lm.Effect_Call (option String)).call: $MODULE/effect.fz:191:18:
-      set res := f()
------------------^
-(eff.type.handle.type String fuzion.runtime.post_fault (option String)).lm.type.instate#4 (option String): <source position not available>:
-
-(eff.type.handle.type String fuzion.runtime.post_fault (option String)).lm.type.instate#3 (option String): $MODULE/effect.fz:124:5:
-    instate R e code (panic "unexpected abort in {effect.this.type}")
-----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-(eff.ref handle String fuzion.runtime.post_fault (option String)).lm.instate_self#2 (option String): $MODULE/effect.fz:145:5:
-    effect.this.instate R effect.this code
-----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-(fuzion.type.runtime.type.post_fault.type.try (option String)).catch#1.anonymous.res: $MODULE/eff/fallible.fz:116:10:
-  res => lm.instate_self ()->
----------^^^^^^^^^^^^^^^^^^^^
-      m := lm.env.new (option ERROR nil)
-------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-      (F.new e->
-------^^^^^^^^^^
-          m <- e
-----------^^^^^^
-          F.env.return
-----------^^^^^^^^^^^^
-      ).run eff.handle.this.try (()->catch m.get.get)
-------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-(fuzion.type.runtime.type.post_fault.type.try (option String)).catch#1: $MODULE/eff/fallible.fz:74:7:
-      (ref : eff.handle ERROR fallible.this T
-------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-         redef try => code_try.call
----------^^^^^^^^^^^^^^^^^^^^^^^^^^
-         redef catch(e ERROR) => code_catch e
----------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-      ).res
-------^^^^^
-catch_postcondition.loop: --CURDIR--/catch_postcondition.fz:253:11:
-         .catch s->
-----------^^^^^
-(catch_postcondition.test#1 i16).loop: --CURDIR--/catch_postcondition.fz:248:3:
-  for
---^
-(catch_postcondition.test#1 i16).loop: --CURDIR--/catch_postcondition.fz:43:5:
-    for v := T.one, double v
-----^
-... repeated 8 times ...
-
-catch_postcondition.test#1 i16: --CURDIR--/catch_postcondition.fz:43:5:
-    for v := T.one, double v
-----^
-catch_postcondition.λ.call: --CURDIR--/catch_postcondition.fz:141:56:
-  tries array ()->String := [ (() -> test i32), (() -> test i16), (() -> test i64) ]
--------------------------------------------------------^^^^
-catch_postcondition.loop.λ.call: --CURDIR--/catch_postcondition.fz:233:28:
-           option tries[c].call
----------------------------^^^^
-(catch_postcondition.try_post (option String)).catch#1.h.try: --CURDIR--/catch_postcondition.fz:188:34:
-        redef try             => code_try()
----------------------------------^^^^^^^^
-(catch_postcondition.try_post (option String)).catch#1.h.λ.call.λ.call: --CURDIR--/catch_postcondition.fz:108:15:
-        ).run try (()->catch m.get.get)
---------------^^^
-(fuzion.runtime.post_fault.run#3 (option String)).λ.call: $MODULE/effect.fz:199:39:
-    effect.this.instate R effect.this f def.call
---------------------------------------^
-(fuzion.type.runtime.type.post_fault.type.instate#4 (option String)).λ.call: $MODULE/effect.fz:100:25:
-    cf := e.Effect_Call code
-------------------------^^^^
-(fuzion.runtime.post_fault.Effect_Call (option String)).call: $MODULE/effect.fz:191:18:
-      set res := f()
------------------^
-fuzion.type.runtime.type.post_fault.type.instate#4 (option String): <source position not available>:
-
-fuzion.runtime.post_fault.run#3 (option String): $MODULE/effect.fz:199:5:
-    effect.this.instate R effect.this f def.call
-----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-(catch_postcondition.try_post (option String)).catch#1.h.λ.call: --CURDIR--/catch_postcondition.fz:108:11:
-        ).run try (()->catch m.get.get)
-----------^^^
-((catch_postcondition.try_post (option String)).catch#1.h.lm.instate_self#2 (option String)).λ.call: $MODULE/effect.fz:145:39:
-    effect.this.instate R effect.this code
---------------------------------------^^^^
-((catch_postcondition.type.try_post.type (option String)).catch#1.type.h.type.lm.type.instate#3 (option String)).λ.call: $MODULE/effect.fz:124:17:
-    instate R e code (panic "unexpected abort in {effect.this.type}")
-----------------^^^^
-((catch_postcondition.type.try_post.type (option String)).catch#1.type.h.type.lm.type.instate#4 (option String)).λ.call: $MODULE/effect.fz:100:25:
-    cf := e.Effect_Call code
-------------------------^^^^
-((catch_postcondition.try_post (option String)).catch#1.h.lm.Effect_Call (option String)).call: $MODULE/effect.fz:191:18:
-      set res := f()
------------------^
-(catch_postcondition.type.try_post.type (option String)).catch#1.type.h.type.lm.type.instate#4 (option String): <source position not available>:
-
-(catch_postcondition.type.try_post.type (option String)).catch#1.type.h.type.lm.type.instate#3 (option String): $MODULE/effect.fz:124:5:
-    instate R e code (panic "unexpected abort in {effect.this.type}")
-----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-(catch_postcondition.try_post (option String)).catch#1.h.lm.instate_self#2 (option String): $MODULE/effect.fz:145:5:
-    effect.this.instate R effect.this code
-----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-(catch_postcondition.try_post (option String)).catch#1.h: --CURDIR--/catch_postcondition.fz:103:15:
-    res := lm.instate_self ()->
---------------^^^^^^^^^^^^
-(catch_postcondition.try_post (option String)).catch#1: --CURDIR--/catch_postcondition.fz:190:7:
-      h.res
-------^
-catch_postcondition.loop: --CURDIR--/catch_postcondition.fz:234:11:
-         .catch s->
-----------^^^^^
-(catch_postcondition.test#1 i32).loop: --CURDIR--/catch_postcondition.fz:229:3:
-  for
---^
-(catch_postcondition.test#1 i32).loop: --CURDIR--/catch_postcondition.fz:43:5:
-    for v := T.one, double v
-----^
-... repeated 26 times ...
-
-catch_postcondition.test#1 i32: --CURDIR--/catch_postcondition.fz:43:5:
-    for v := T.one, double v
-----^
-catch_postcondition.λ.call: --CURDIR--/catch_postcondition.fz:141:38:
-  tries array ()->String := [ (() -> test i32), (() -> test i16), (() -> test i64) ]
--------------------------------------^^^^
-catch_postcondition.loop.λ.call: --CURDIR--/catch_postcondition.fz:233:28:
-           option tries[c].call
----------------------------^^^^
-(catch_postcondition.try_post (option String)).catch#1.h.try: --CURDIR--/catch_postcondition.fz:188:34:
-        redef try             => code_try()
----------------------------------^^^^^^^^
-(catch_postcondition.try_post (option String)).catch#1.h.λ.call.λ.call: --CURDIR--/catch_postcondition.fz:108:15:
-        ).run try (()->catch m.get.get)
---------------^^^
-(fuzion.runtime.post_fault.run#3 (option String)).λ.call: $MODULE/effect.fz:199:39:
-    effect.this.instate R effect.this f def.call
---------------------------------------^
-(fuzion.type.runtime.type.post_fault.type.instate#4 (option String)).λ.call: $MODULE/effect.fz:100:25:
-    cf := e.Effect_Call code
-------------------------^^^^
-(fuzion.runtime.post_fault.Effect_Call (option String)).call: $MODULE/effect.fz:191:18:
-      set res := f()
------------------^
-fuzion.type.runtime.type.post_fault.type.instate#4 (option String): <source position not available>:
-
-fuzion.runtime.post_fault.run#3 (option String): $MODULE/effect.fz:199:5:
-    effect.this.instate R effect.this f def.call
-----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-(catch_postcondition.try_post (option String)).catch#1.h.λ.call: --CURDIR--/catch_postcondition.fz:108:11:
-        ).run try (()->catch m.get.get)
-----------^^^
-((catch_postcondition.try_post (option String)).catch#1.h.lm.instate_self#2 (option String)).λ.call: $MODULE/effect.fz:145:39:
-    effect.this.instate R effect.this code
---------------------------------------^^^^
-((catch_postcondition.type.try_post.type (option String)).catch#1.type.h.type.lm.type.instate#3 (option String)).λ.call: $MODULE/effect.fz:124:17:
-    instate R e code (panic "unexpected abort in {effect.this.type}")
-----------------^^^^
-((catch_postcondition.type.try_post.type (option String)).catch#1.type.h.type.lm.type.instate#4 (option String)).λ.call: $MODULE/effect.fz:100:25:
-    cf := e.Effect_Call code
-------------------------^^^^
-((catch_postcondition.try_post (option String)).catch#1.h.lm.Effect_Call (option String)).call: $MODULE/effect.fz:191:18:
-      set res := f()
------------------^
-(catch_postcondition.type.try_post.type (option String)).catch#1.type.h.type.lm.type.instate#4 (option String): <source position not available>:
-
-(catch_postcondition.type.try_post.type (option String)).catch#1.type.h.type.lm.type.instate#3 (option String): $MODULE/effect.fz:124:5:
-    instate R e code (panic "unexpected abort in {effect.this.type}")
-----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-(catch_postcondition.try_post (option String)).catch#1.h.lm.instate_self#2 (option String): $MODULE/effect.fz:145:5:
-    effect.this.instate R effect.this code
-----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-(catch_postcondition.try_post (option String)).catch#1.h: --CURDIR--/catch_postcondition.fz:103:15:
-    res := lm.instate_self ()->
---------------^^^^^^^^^^^^
-(catch_postcondition.try_post (option String)).catch#1: --CURDIR--/catch_postcondition.fz:190:7:
-      h.res
-------^
-catch_postcondition.loop: --CURDIR--/catch_postcondition.fz:234:11:
-         .catch s->
-----------^^^^^
-(catch_postcondition.test#1 i32).loop: --CURDIR--/catch_postcondition.fz:229:3:
-  for
---^
-(catch_postcondition.test#1 i32).loop: --CURDIR--/catch_postcondition.fz:43:5:
-    for v := T.one, double v
-----^
-... repeated 24 times ...
-
-catch_postcondition.test#1 i32: --CURDIR--/catch_postcondition.fz:43:5:
-    for v := T.one, double v
-----^
-catch_postcondition.res2.λ.call: --CURDIR--/catch_postcondition.fz:220:21:
-  res2 => try_post (test i32) || (s->say "*** failed: $s ***"; test u64)
---------------------^^^^
-(catch_postcondition.try_post String).catch#1.h.try: --CURDIR--/catch_postcondition.fz:188:34:
-        redef try             => code_try()
----------------------------------^^^^^^^^
-(catch_postcondition.try_post String).catch#1.h.λ.call.λ.call: --CURDIR--/catch_postcondition.fz:108:15:
-        ).run try (()->catch m.get.get)
---------------^^^
-(fuzion.runtime.post_fault.run#3 String).λ.call: $MODULE/effect.fz:199:39:
-    effect.this.instate R effect.this f def.call
---------------------------------------^
-(fuzion.type.runtime.type.post_fault.type.instate#4 String).λ.call: $MODULE/effect.fz:100:25:
-    cf := e.Effect_Call code
-------------------------^^^^
-(fuzion.runtime.post_fault.Effect_Call String).call: $MODULE/effect.fz:191:18:
-      set res := f()
------------------^
-fuzion.type.runtime.type.post_fault.type.instate#4 String: <source position not available>:
-
-fuzion.runtime.post_fault.run#3 String: $MODULE/effect.fz:199:5:
-    effect.this.instate R effect.this f def.call
-----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-(catch_postcondition.try_post String).catch#1.h.λ.call: --CURDIR--/catch_postcondition.fz:108:11:
-        ).run try (()->catch m.get.get)
-----------^^^
-((catch_postcondition.try_post String).catch#1.h.lm.instate_self#2 String).λ.call: $MODULE/effect.fz:145:39:
-    effect.this.instate R effect.this code
---------------------------------------^^^^
-((catch_postcondition.type.try_post.type String).catch#1.type.h.type.lm.type.instate#3 String).λ.call: $MODULE/effect.fz:124:17:
-    instate R e code (panic "unexpected abort in {effect.this.type}")
-----------------^^^^
-((catch_postcondition.type.try_post.type String).catch#1.type.h.type.lm.type.instate#4 String).λ.call: $MODULE/effect.fz:100:25:
-    cf := e.Effect_Call code
-------------------------^^^^
-((catch_postcondition.try_post String).catch#1.h.lm.Effect_Call String).call: $MODULE/effect.fz:191:18:
-      set res := f()
------------------^
-(catch_postcondition.type.try_post.type String).catch#1.type.h.type.lm.type.instate#4 String: <source position not available>:
-
-(catch_postcondition.type.try_post.type String).catch#1.type.h.type.lm.type.instate#3 String: $MODULE/effect.fz:124:5:
-    instate R e code (panic "unexpected abort in {effect.this.type}")
-----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-(catch_postcondition.try_post String).catch#1.h.lm.instate_self#2 String: $MODULE/effect.fz:145:5:
-    effect.this.instate R effect.this code
-----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-(catch_postcondition.try_post String).catch#1.h: --CURDIR--/catch_postcondition.fz:103:15:
-    res := lm.instate_self ()->
---------------^^^^^^^^^^^^
-(catch_postcondition.try_post String).catch#1: --CURDIR--/catch_postcondition.fz:190:7:
-      h.res
-------^
-(catch_postcondition.try_post String).infix ||#1: --CURDIR--/catch_postcondition.fz:201:40:
-    infix || (code_catch String->T) => catch code_catch
----------------------------------------^^^^^
-catch_postcondition.res2: --CURDIR--/catch_postcondition.fz:220:31:
-  res2 => try_post (test i32) || (s->say "*** failed: $s ***"; test u64)
-------------------------------^^
-(catch_postcondition.test#1 i32).loop: --CURDIR--/catch_postcondition.fz:221:7:
-  say res2
-------^^^^
-(catch_postcondition.test#1 i32).loop: --CURDIR--/catch_postcondition.fz:43:5:
-    for v := T.one, double v
-----^
-... repeated 25 times ...
-
-catch_postcondition.test#1 i32: --CURDIR--/catch_postcondition.fz:43:5:
-    for v := T.one, double v
-----^
-catch_postcondition.res.λ.call: --CURDIR--/catch_postcondition.fz:208:12:
-           test i32
------------^^^^
-(catch_postcondition.try_post String).catch#1.h.try: --CURDIR--/catch_postcondition.fz:188:34:
-        redef try             => code_try()
----------------------------------^^^^^^^^
-(catch_postcondition.try_post String).catch#1.h.λ.call.λ.call: --CURDIR--/catch_postcondition.fz:108:15:
-        ).run try (()->catch m.get.get)
---------------^^^
-(fuzion.runtime.post_fault.run#3 String).λ.call: $MODULE/effect.fz:199:39:
-    effect.this.instate R effect.this f def.call
---------------------------------------^
-(fuzion.type.runtime.type.post_fault.type.instate#4 String).λ.call: $MODULE/effect.fz:100:25:
-    cf := e.Effect_Call code
-------------------------^^^^
-(fuzion.runtime.post_fault.Effect_Call String).call: $MODULE/effect.fz:191:18:
-      set res := f()
------------------^
-fuzion.type.runtime.type.post_fault.type.instate#4 String: <source position not available>:
-
-fuzion.runtime.post_fault.run#3 String: $MODULE/effect.fz:199:5:
-    effect.this.instate R effect.this f def.call
-----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-(catch_postcondition.try_post String).catch#1.h.λ.call: --CURDIR--/catch_postcondition.fz:108:11:
-        ).run try (()->catch m.get.get)
-----------^^^
-((catch_postcondition.try_post String).catch#1.h.lm.instate_self#2 String).λ.call: $MODULE/effect.fz:145:39:
-    effect.this.instate R effect.this code
---------------------------------------^^^^
-((catch_postcondition.type.try_post.type String).catch#1.type.h.type.lm.type.instate#3 String).λ.call: $MODULE/effect.fz:124:17:
-    instate R e code (panic "unexpected abort in {effect.this.type}")
-----------------^^^^
-((catch_postcondition.type.try_post.type String).catch#1.type.h.type.lm.type.instate#4 String).λ.call: $MODULE/effect.fz:100:25:
-    cf := e.Effect_Call code
-------------------------^^^^
-((catch_postcondition.try_post String).catch#1.h.lm.Effect_Call String).call: $MODULE/effect.fz:191:18:
-      set res := f()
------------------^
-(catch_postcondition.type.try_post.type String).catch#1.type.h.type.lm.type.instate#4 String: <source position not available>:
-
-(catch_postcondition.type.try_post.type String).catch#1.type.h.type.lm.type.instate#3 String: $MODULE/effect.fz:124:5:
-    instate R e code (panic "unexpected abort in {effect.this.type}")
-----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-(catch_postcondition.try_post String).catch#1.h.lm.instate_self#2 String: $MODULE/effect.fz:145:5:
-    effect.this.instate R effect.this code
-----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-(catch_postcondition.try_post String).catch#1.h: --CURDIR--/catch_postcondition.fz:103:15:
-    res := lm.instate_self ()->
---------------^^^^^^^^^^^^
-(catch_postcondition.try_post String).catch#1: --CURDIR--/catch_postcondition.fz:190:7:
-      h.res
-------^
-catch_postcondition.res: --CURDIR--/catch_postcondition.fz:209:11:
-         .catch s->
-----------^^^^^
-(catch_postcondition.test#1 i16).loop: --CURDIR--/catch_postcondition.fz:212:7:
-  say res
-------^^^
 (catch_postcondition.test#1 i16).loop: --CURDIR--/catch_postcondition.fz:43:5:
     for v := T.one, double v
 ----^
@@ -683,60 +46,76 @@ catch_postcondition.res: --CURDIR--/catch_postcondition.fz:209:11:
 catch_postcondition.test#1 i16: --CURDIR--/catch_postcondition.fz:43:5:
     for v := T.one, double v
 ----^
-catch_postcondition.λ.call: --CURDIR--/catch_postcondition.fz:141:56:
+catch_postcondition.λ.call: --CURDIR--/catch_postcondition.fz:146:56:
   tries array ()->String := [ (() -> test i32), (() -> test i16), (() -> test i64) ]
 -------------------------------------------------------^^^^
-catch_postcondition.loop.h.try: --CURDIR--/catch_postcondition.fz:159:44:
-      redef try option String  => tries[c].call
--------------------------------------------^^^^
-catch_postcondition.loop.h.λ.call.λ.call: --CURDIR--/catch_postcondition.fz:108:15:
-        ).run try (()->catch m.get.get)
---------------^^^
-(fuzion.runtime.post_fault.run#3 (option String)).λ.call: $MODULE/effect.fz:199:39:
-    effect.this.instate R effect.this f def.call
---------------------------------------^
-(fuzion.type.runtime.type.post_fault.type.instate#4 (option String)).λ.call: $MODULE/effect.fz:100:25:
+catch_postcondition.loop.λ.call: --CURDIR--/catch_postcondition.fz:276:28:
+           option tries[c].call
+---------------------------^^^^
+(fuzion.type.runtime.type.fault.type.try (option String)).catch#1.anonymous.try: $MODULE/eff/fallible.fz:75:23:
+         redef try => code_try.call
+----------------------^^^^^^^^^^^^^
+(fuzion.type.runtime.type.fault.type.try (option String)).catch#1.anonymous.res.λ.call.λ.call: $MODULE/eff/fallible.fz:120:21:
+      F.instate T v try (()->catch m.get.get)
+--------------------^^^
+(fuzion.type.runtime.type.fault.type.instate#4 (option String)).λ.call: $MODULE/effect.fz:119:25:
     cf := e.Effect_Call code
 ------------------------^^^^
-(fuzion.runtime.post_fault.Effect_Call (option String)).call: $MODULE/effect.fz:191:18:
+(fuzion.runtime.fault.Effect_Call (option String)).call: $MODULE/effect.fz:210:18:
       set res := f()
 -----------------^
-fuzion.type.runtime.type.post_fault.type.instate#4 (option String): <source position not available>:
+fuzion.type.runtime.type.fault.type.instate#4 (option String): <source position not available>:
 
-fuzion.runtime.post_fault.run#3 (option String): $MODULE/effect.fz:199:5:
-    effect.this.instate R effect.this f def.call
-----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-catch_postcondition.loop.h.λ.call: --CURDIR--/catch_postcondition.fz:108:11:
-        ).run try (()->catch m.get.get)
-----------^^^
-(catch_postcondition.loop.h.lm.instate_self#2 (option String)).λ.call: $MODULE/effect.fz:145:39:
+(fuzion.type.runtime.type.fault.type.try (option String)).catch#1.anonymous.res.λ.call: $MODULE/eff/fallible.fz:120:7:
+      F.instate T v try (()->catch m.get.get)
+------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+((eff.ref handle (tuple String String) fuzion.runtime.fault (option String)).lm.instate_self#2 (option String)).λ.call: $MODULE/effect.fz:164:39:
     effect.this.instate R effect.this code
 --------------------------------------^^^^
-(catch_postcondition.type.loop.type.h.type.lm.type.instate#3 (option String)).λ.call: $MODULE/effect.fz:124:17:
+((eff.type.handle.type (tuple String String) fuzion.runtime.fault (option String)).lm.type.instate#3 (option String)).λ.call: $MODULE/effect.fz:143:17:
     instate R e code (panic "unexpected abort in {effect.this.type}")
 ----------------^^^^
-(catch_postcondition.type.loop.type.h.type.lm.type.instate#4 (option String)).λ.call: $MODULE/effect.fz:100:25:
+((eff.type.handle.type (tuple String String) fuzion.runtime.fault (option String)).lm.type.instate#4 (option String)).λ.call: $MODULE/effect.fz:119:25:
     cf := e.Effect_Call code
 ------------------------^^^^
-(catch_postcondition.loop.h.lm.Effect_Call (option String)).call: $MODULE/effect.fz:191:18:
+((eff.ref handle (tuple String String) fuzion.runtime.fault (option String)).lm.Effect_Call (option String)).call: $MODULE/effect.fz:210:18:
       set res := f()
 -----------------^
-catch_postcondition.type.loop.type.h.type.lm.type.instate#4 (option String): <source position not available>:
+(eff.type.handle.type (tuple String String) fuzion.runtime.fault (option String)).lm.type.instate#4 (option String): <source position not available>:
 
-catch_postcondition.type.loop.type.h.type.lm.type.instate#3 (option String): $MODULE/effect.fz:124:5:
+(eff.type.handle.type (tuple String String) fuzion.runtime.fault (option String)).lm.type.instate#3 (option String): $MODULE/effect.fz:143:5:
     instate R e code (panic "unexpected abort in {effect.this.type}")
 ----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-catch_postcondition.loop.h.lm.instate_self#2 (option String): $MODULE/effect.fz:145:5:
+(eff.ref handle (tuple String String) fuzion.runtime.fault (option String)).lm.instate_self#2 (option String): $MODULE/effect.fz:164:5:
     effect.this.instate R effect.this code
 ----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-catch_postcondition.loop.h: --CURDIR--/catch_postcondition.fz:103:15:
-    res := lm.instate_self ()->
---------------^^^^^^^^^^^^
-catch_postcondition.loop: --CURDIR--/catch_postcondition.fz:161:10:
-    r := h.res
----------^
-(catch_postcondition.test#1 i32).loop: --CURDIR--/catch_postcondition.fz:157:3:
-  for c in tries.indices do
+(fuzion.type.runtime.type.fault.type.try (option String)).catch#1.anonymous.res: $MODULE/eff/fallible.fz:115:10:
+  res => lm.instate_self ()->
+---------^^^^^^^^^^^^^^^^^^^^
+      m := lm.env.new (option ERROR nil)
+------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      v := F.new e->
+------^^^^^^^^^^^^^^
+             m <- e
+-------------^^^^^^
+             F.abort
+-------------^^^^^^^
+      F.instate T v try (()->catch m.get.get)
+------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+(fuzion.type.runtime.type.fault.type.try (option String)).catch#1: $MODULE/eff/fallible.fz:74:7:
+      (ref : eff.handle ERROR fallible.this T
+------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+         redef try => code_try.call
+---------^^^^^^^^^^^^^^^^^^^^^^^^^^
+         redef catch(e ERROR) => code_catch e
+---------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      ).res
+------^^^^^
+catch_postcondition.loop: --CURDIR--/catch_postcondition.fz:277:11:
+         .catch s->
+----------^^^^^
+(catch_postcondition.test#1 i32).loop: --CURDIR--/catch_postcondition.fz:272:3:
+  for
 --^
 (catch_postcondition.test#1 i32).loop: --CURDIR--/catch_postcondition.fz:43:5:
     for v := T.one, double v
@@ -746,137 +125,660 @@ catch_postcondition.loop: --CURDIR--/catch_postcondition.fz:161:10:
 catch_postcondition.test#1 i32: --CURDIR--/catch_postcondition.fz:43:5:
     for v := T.one, double v
 ----^
-catch_postcondition.λ.call: --CURDIR--/catch_postcondition.fz:141:38:
+catch_postcondition.λ.call: --CURDIR--/catch_postcondition.fz:146:38:
   tries array ()->String := [ (() -> test i32), (() -> test i16), (() -> test i64) ]
 -------------------------------------^^^^
-catch_postcondition.loop.h.try: --CURDIR--/catch_postcondition.fz:159:44:
-      redef try option String  => tries[c].call
--------------------------------------------^^^^
-catch_postcondition.loop.h.λ.call.λ.call: --CURDIR--/catch_postcondition.fz:108:15:
-        ).run try (()->catch m.get.get)
---------------^^^
-(fuzion.runtime.post_fault.run#3 (option String)).λ.call: $MODULE/effect.fz:199:39:
-    effect.this.instate R effect.this f def.call
---------------------------------------^
-(fuzion.type.runtime.type.post_fault.type.instate#4 (option String)).λ.call: $MODULE/effect.fz:100:25:
+catch_postcondition.loop.λ.call: --CURDIR--/catch_postcondition.fz:276:28:
+           option tries[c].call
+---------------------------^^^^
+(fuzion.type.runtime.type.fault.type.try (option String)).catch#1.anonymous.try: $MODULE/eff/fallible.fz:75:23:
+         redef try => code_try.call
+----------------------^^^^^^^^^^^^^
+(fuzion.type.runtime.type.fault.type.try (option String)).catch#1.anonymous.res.λ.call.λ.call: $MODULE/eff/fallible.fz:120:21:
+      F.instate T v try (()->catch m.get.get)
+--------------------^^^
+(fuzion.type.runtime.type.fault.type.instate#4 (option String)).λ.call: $MODULE/effect.fz:119:25:
     cf := e.Effect_Call code
 ------------------------^^^^
-(fuzion.runtime.post_fault.Effect_Call (option String)).call: $MODULE/effect.fz:191:18:
+(fuzion.runtime.fault.Effect_Call (option String)).call: $MODULE/effect.fz:210:18:
+      set res := f()
+-----------------^
+fuzion.type.runtime.type.fault.type.instate#4 (option String): <source position not available>:
+
+(fuzion.type.runtime.type.fault.type.try (option String)).catch#1.anonymous.res.λ.call: $MODULE/eff/fallible.fz:120:7:
+      F.instate T v try (()->catch m.get.get)
+------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+((eff.ref handle (tuple String String) fuzion.runtime.fault (option String)).lm.instate_self#2 (option String)).λ.call: $MODULE/effect.fz:164:39:
+    effect.this.instate R effect.this code
+--------------------------------------^^^^
+((eff.type.handle.type (tuple String String) fuzion.runtime.fault (option String)).lm.type.instate#3 (option String)).λ.call: $MODULE/effect.fz:143:17:
+    instate R e code (panic "unexpected abort in {effect.this.type}")
+----------------^^^^
+((eff.type.handle.type (tuple String String) fuzion.runtime.fault (option String)).lm.type.instate#4 (option String)).λ.call: $MODULE/effect.fz:119:25:
+    cf := e.Effect_Call code
+------------------------^^^^
+((eff.ref handle (tuple String String) fuzion.runtime.fault (option String)).lm.Effect_Call (option String)).call: $MODULE/effect.fz:210:18:
+      set res := f()
+-----------------^
+(eff.type.handle.type (tuple String String) fuzion.runtime.fault (option String)).lm.type.instate#4 (option String): <source position not available>:
+
+(eff.type.handle.type (tuple String String) fuzion.runtime.fault (option String)).lm.type.instate#3 (option String): $MODULE/effect.fz:143:5:
+    instate R e code (panic "unexpected abort in {effect.this.type}")
+----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+(eff.ref handle (tuple String String) fuzion.runtime.fault (option String)).lm.instate_self#2 (option String): $MODULE/effect.fz:164:5:
+    effect.this.instate R effect.this code
+----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+(fuzion.type.runtime.type.fault.type.try (option String)).catch#1.anonymous.res: $MODULE/eff/fallible.fz:115:10:
+  res => lm.instate_self ()->
+---------^^^^^^^^^^^^^^^^^^^^
+      m := lm.env.new (option ERROR nil)
+------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      v := F.new e->
+------^^^^^^^^^^^^^^
+             m <- e
+-------------^^^^^^
+             F.abort
+-------------^^^^^^^
+      F.instate T v try (()->catch m.get.get)
+------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+(fuzion.type.runtime.type.fault.type.try (option String)).catch#1: $MODULE/eff/fallible.fz:74:7:
+      (ref : eff.handle ERROR fallible.this T
+------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+         redef try => code_try.call
+---------^^^^^^^^^^^^^^^^^^^^^^^^^^
+         redef catch(e ERROR) => code_catch e
+---------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      ).res
+------^^^^^
+catch_postcondition.loop: --CURDIR--/catch_postcondition.fz:277:11:
+         .catch s->
+----------^^^^^
+(catch_postcondition.test#1 i16).loop: --CURDIR--/catch_postcondition.fz:272:3:
+  for
+--^
+(catch_postcondition.test#1 i16).loop: --CURDIR--/catch_postcondition.fz:43:5:
+    for v := T.one, double v
+----^
+... repeated 7 times ...
+
+catch_postcondition.test#1 i16: --CURDIR--/catch_postcondition.fz:43:5:
+    for v := T.one, double v
+----^
+catch_postcondition.λ.call: --CURDIR--/catch_postcondition.fz:146:56:
+  tries array ()->String := [ (() -> test i32), (() -> test i16), (() -> test i64) ]
+-------------------------------------------------------^^^^
+catch_postcondition.loop.λ.call: --CURDIR--/catch_postcondition.fz:257:28:
+           option tries[c].call
+---------------------------^^^^
+(fuzion.type.runtime.type.post_fault.type.try (option String)).catch#1.anonymous.try: $MODULE/eff/fallible.fz:75:23:
+         redef try => code_try.call
+----------------------^^^^^^^^^^^^^
+(fuzion.type.runtime.type.post_fault.type.try (option String)).catch#1.anonymous.res.λ.call.λ.call: $MODULE/eff/fallible.fz:120:21:
+      F.instate T v try (()->catch m.get.get)
+--------------------^^^
+(fuzion.type.runtime.type.post_fault.type.instate#4 (option String)).λ.call: $MODULE/effect.fz:119:25:
+    cf := e.Effect_Call code
+------------------------^^^^
+(fuzion.runtime.post_fault.Effect_Call (option String)).call: $MODULE/effect.fz:210:18:
       set res := f()
 -----------------^
 fuzion.type.runtime.type.post_fault.type.instate#4 (option String): <source position not available>:
 
-fuzion.runtime.post_fault.run#3 (option String): $MODULE/effect.fz:199:5:
-    effect.this.instate R effect.this f def.call
-----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-catch_postcondition.loop.h.λ.call: --CURDIR--/catch_postcondition.fz:108:11:
-        ).run try (()->catch m.get.get)
-----------^^^
-(catch_postcondition.loop.h.lm.instate_self#2 (option String)).λ.call: $MODULE/effect.fz:145:39:
+(fuzion.type.runtime.type.post_fault.type.try (option String)).catch#1.anonymous.res.λ.call: $MODULE/eff/fallible.fz:120:7:
+      F.instate T v try (()->catch m.get.get)
+------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+((eff.ref handle String fuzion.runtime.post_fault (option String)).lm.instate_self#2 (option String)).λ.call: $MODULE/effect.fz:164:39:
     effect.this.instate R effect.this code
 --------------------------------------^^^^
-(catch_postcondition.type.loop.type.h.type.lm.type.instate#3 (option String)).λ.call: $MODULE/effect.fz:124:17:
+((eff.type.handle.type String fuzion.runtime.post_fault (option String)).lm.type.instate#3 (option String)).λ.call: $MODULE/effect.fz:143:17:
     instate R e code (panic "unexpected abort in {effect.this.type}")
 ----------------^^^^
-(catch_postcondition.type.loop.type.h.type.lm.type.instate#4 (option String)).λ.call: $MODULE/effect.fz:100:25:
+((eff.type.handle.type String fuzion.runtime.post_fault (option String)).lm.type.instate#4 (option String)).λ.call: $MODULE/effect.fz:119:25:
     cf := e.Effect_Call code
 ------------------------^^^^
-(catch_postcondition.loop.h.lm.Effect_Call (option String)).call: $MODULE/effect.fz:191:18:
+((eff.ref handle String fuzion.runtime.post_fault (option String)).lm.Effect_Call (option String)).call: $MODULE/effect.fz:210:18:
+      set res := f()
+-----------------^
+(eff.type.handle.type String fuzion.runtime.post_fault (option String)).lm.type.instate#4 (option String): <source position not available>:
+
+(eff.type.handle.type String fuzion.runtime.post_fault (option String)).lm.type.instate#3 (option String): $MODULE/effect.fz:143:5:
+    instate R e code (panic "unexpected abort in {effect.this.type}")
+----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+(eff.ref handle String fuzion.runtime.post_fault (option String)).lm.instate_self#2 (option String): $MODULE/effect.fz:164:5:
+    effect.this.instate R effect.this code
+----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+(fuzion.type.runtime.type.post_fault.type.try (option String)).catch#1.anonymous.res: $MODULE/eff/fallible.fz:115:10:
+  res => lm.instate_self ()->
+---------^^^^^^^^^^^^^^^^^^^^
+      m := lm.env.new (option ERROR nil)
+------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      v := F.new e->
+------^^^^^^^^^^^^^^
+             m <- e
+-------------^^^^^^
+             F.abort
+-------------^^^^^^^
+      F.instate T v try (()->catch m.get.get)
+------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+(fuzion.type.runtime.type.post_fault.type.try (option String)).catch#1: $MODULE/eff/fallible.fz:74:7:
+      (ref : eff.handle ERROR fallible.this T
+------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+         redef try => code_try.call
+---------^^^^^^^^^^^^^^^^^^^^^^^^^^
+         redef catch(e ERROR) => code_catch e
+---------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      ).res
+------^^^^^
+catch_postcondition.loop: --CURDIR--/catch_postcondition.fz:258:11:
+         .catch s->
+----------^^^^^
+(catch_postcondition.test#1 i32).loop: --CURDIR--/catch_postcondition.fz:253:3:
+  for
+--^
+(catch_postcondition.test#1 i32).loop: --CURDIR--/catch_postcondition.fz:43:5:
+    for v := T.one, double v
+----^
+... repeated 25 times ...
+
+catch_postcondition.test#1 i32: --CURDIR--/catch_postcondition.fz:43:5:
+    for v := T.one, double v
+----^
+catch_postcondition.λ.call: --CURDIR--/catch_postcondition.fz:146:38:
+  tries array ()->String := [ (() -> test i32), (() -> test i16), (() -> test i64) ]
+-------------------------------------^^^^
+catch_postcondition.loop.λ.call: --CURDIR--/catch_postcondition.fz:257:28:
+           option tries[c].call
+---------------------------^^^^
+(fuzion.type.runtime.type.post_fault.type.try (option String)).catch#1.anonymous.try: $MODULE/eff/fallible.fz:75:23:
+         redef try => code_try.call
+----------------------^^^^^^^^^^^^^
+(fuzion.type.runtime.type.post_fault.type.try (option String)).catch#1.anonymous.res.λ.call.λ.call: $MODULE/eff/fallible.fz:120:21:
+      F.instate T v try (()->catch m.get.get)
+--------------------^^^
+(fuzion.type.runtime.type.post_fault.type.instate#4 (option String)).λ.call: $MODULE/effect.fz:119:25:
+    cf := e.Effect_Call code
+------------------------^^^^
+(fuzion.runtime.post_fault.Effect_Call (option String)).call: $MODULE/effect.fz:210:18:
+      set res := f()
+-----------------^
+fuzion.type.runtime.type.post_fault.type.instate#4 (option String): <source position not available>:
+
+(fuzion.type.runtime.type.post_fault.type.try (option String)).catch#1.anonymous.res.λ.call: $MODULE/eff/fallible.fz:120:7:
+      F.instate T v try (()->catch m.get.get)
+------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+((eff.ref handle String fuzion.runtime.post_fault (option String)).lm.instate_self#2 (option String)).λ.call: $MODULE/effect.fz:164:39:
+    effect.this.instate R effect.this code
+--------------------------------------^^^^
+((eff.type.handle.type String fuzion.runtime.post_fault (option String)).lm.type.instate#3 (option String)).λ.call: $MODULE/effect.fz:143:17:
+    instate R e code (panic "unexpected abort in {effect.this.type}")
+----------------^^^^
+((eff.type.handle.type String fuzion.runtime.post_fault (option String)).lm.type.instate#4 (option String)).λ.call: $MODULE/effect.fz:119:25:
+    cf := e.Effect_Call code
+------------------------^^^^
+((eff.ref handle String fuzion.runtime.post_fault (option String)).lm.Effect_Call (option String)).call: $MODULE/effect.fz:210:18:
+      set res := f()
+-----------------^
+(eff.type.handle.type String fuzion.runtime.post_fault (option String)).lm.type.instate#4 (option String): <source position not available>:
+
+(eff.type.handle.type String fuzion.runtime.post_fault (option String)).lm.type.instate#3 (option String): $MODULE/effect.fz:143:5:
+    instate R e code (panic "unexpected abort in {effect.this.type}")
+----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+(eff.ref handle String fuzion.runtime.post_fault (option String)).lm.instate_self#2 (option String): $MODULE/effect.fz:164:5:
+    effect.this.instate R effect.this code
+----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+(fuzion.type.runtime.type.post_fault.type.try (option String)).catch#1.anonymous.res: $MODULE/eff/fallible.fz:115:10:
+  res => lm.instate_self ()->
+---------^^^^^^^^^^^^^^^^^^^^
+      m := lm.env.new (option ERROR nil)
+------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      v := F.new e->
+------^^^^^^^^^^^^^^
+             m <- e
+-------------^^^^^^
+             F.abort
+-------------^^^^^^^
+      F.instate T v try (()->catch m.get.get)
+------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+(fuzion.type.runtime.type.post_fault.type.try (option String)).catch#1: $MODULE/eff/fallible.fz:74:7:
+      (ref : eff.handle ERROR fallible.this T
+------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+         redef try => code_try.call
+---------^^^^^^^^^^^^^^^^^^^^^^^^^^
+         redef catch(e ERROR) => code_catch e
+---------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      ).res
+------^^^^^
+catch_postcondition.loop: --CURDIR--/catch_postcondition.fz:258:11:
+         .catch s->
+----------^^^^^
+(catch_postcondition.test#1 i16).loop: --CURDIR--/catch_postcondition.fz:253:3:
+  for
+--^
+(catch_postcondition.test#1 i16).loop: --CURDIR--/catch_postcondition.fz:43:5:
+    for v := T.one, double v
+----^
+... repeated 7 times ...
+
+catch_postcondition.test#1 i16: --CURDIR--/catch_postcondition.fz:43:5:
+    for v := T.one, double v
+----^
+catch_postcondition.λ.call: --CURDIR--/catch_postcondition.fz:146:56:
+  tries array ()->String := [ (() -> test i32), (() -> test i16), (() -> test i64) ]
+-------------------------------------------------------^^^^
+catch_postcondition.loop.λ.call: --CURDIR--/catch_postcondition.fz:238:28:
+           option tries[c].call
+---------------------------^^^^
+(catch_postcondition.try_post (option String)).catch#1.h.try: --CURDIR--/catch_postcondition.fz:193:34:
+        redef try             => code_try()
+---------------------------------^^^^^^^^
+(catch_postcondition.try_post (option String)).catch#1.h.λ.call.λ.call: --CURDIR--/catch_postcondition.fz:112:11:
+          try
+----------^^^
+(fuzion.type.runtime.type.post_fault.type.instate#4 (option String)).λ.call: $MODULE/effect.fz:119:25:
+    cf := e.Effect_Call code
+------------------------^^^^
+(fuzion.runtime.post_fault.Effect_Call (option String)).call: $MODULE/effect.fz:210:18:
+      set res := f()
+-----------------^
+fuzion.type.runtime.type.post_fault.type.instate#4 (option String): <source position not available>:
+
+(catch_postcondition.try_post (option String)).catch#1.h.λ.call: --CURDIR--/catch_postcondition.fz:107:36:
+        (fuzion.runtime.post_fault.instate
+-----------------------------------^^^^^^^
+((catch_postcondition.try_post (option String)).catch#1.h.lm.instate_self#2 (option String)).λ.call: $MODULE/effect.fz:164:39:
+    effect.this.instate R effect.this code
+--------------------------------------^^^^
+((catch_postcondition.type.try_post.type (option String)).catch#1.type.h.type.lm.type.instate#3 (option String)).λ.call: $MODULE/effect.fz:143:17:
+    instate R e code (panic "unexpected abort in {effect.this.type}")
+----------------^^^^
+((catch_postcondition.type.try_post.type (option String)).catch#1.type.h.type.lm.type.instate#4 (option String)).λ.call: $MODULE/effect.fz:119:25:
+    cf := e.Effect_Call code
+------------------------^^^^
+((catch_postcondition.try_post (option String)).catch#1.h.lm.Effect_Call (option String)).call: $MODULE/effect.fz:210:18:
+      set res := f()
+-----------------^
+(catch_postcondition.type.try_post.type (option String)).catch#1.type.h.type.lm.type.instate#4 (option String): <source position not available>:
+
+(catch_postcondition.type.try_post.type (option String)).catch#1.type.h.type.lm.type.instate#3 (option String): $MODULE/effect.fz:143:5:
+    instate R e code (panic "unexpected abort in {effect.this.type}")
+----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+(catch_postcondition.try_post (option String)).catch#1.h.lm.instate_self#2 (option String): $MODULE/effect.fz:164:5:
+    effect.this.instate R effect.this code
+----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+(catch_postcondition.try_post (option String)).catch#1.h: --CURDIR--/catch_postcondition.fz:105:15:
+    res := lm.instate_self ()->
+--------------^^^^^^^^^^^^
+(catch_postcondition.try_post (option String)).catch#1: --CURDIR--/catch_postcondition.fz:195:7:
+      h.res
+------^
+catch_postcondition.loop: --CURDIR--/catch_postcondition.fz:239:11:
+         .catch s->
+----------^^^^^
+(catch_postcondition.test#1 i32).loop: --CURDIR--/catch_postcondition.fz:234:3:
+  for
+--^
+(catch_postcondition.test#1 i32).loop: --CURDIR--/catch_postcondition.fz:43:5:
+    for v := T.one, double v
+----^
+... repeated 25 times ...
+
+catch_postcondition.test#1 i32: --CURDIR--/catch_postcondition.fz:43:5:
+    for v := T.one, double v
+----^
+catch_postcondition.λ.call: --CURDIR--/catch_postcondition.fz:146:38:
+  tries array ()->String := [ (() -> test i32), (() -> test i16), (() -> test i64) ]
+-------------------------------------^^^^
+catch_postcondition.loop.λ.call: --CURDIR--/catch_postcondition.fz:238:28:
+           option tries[c].call
+---------------------------^^^^
+(catch_postcondition.try_post (option String)).catch#1.h.try: --CURDIR--/catch_postcondition.fz:193:34:
+        redef try             => code_try()
+---------------------------------^^^^^^^^
+(catch_postcondition.try_post (option String)).catch#1.h.λ.call.λ.call: --CURDIR--/catch_postcondition.fz:112:11:
+          try
+----------^^^
+(fuzion.type.runtime.type.post_fault.type.instate#4 (option String)).λ.call: $MODULE/effect.fz:119:25:
+    cf := e.Effect_Call code
+------------------------^^^^
+(fuzion.runtime.post_fault.Effect_Call (option String)).call: $MODULE/effect.fz:210:18:
+      set res := f()
+-----------------^
+fuzion.type.runtime.type.post_fault.type.instate#4 (option String): <source position not available>:
+
+(catch_postcondition.try_post (option String)).catch#1.h.λ.call: --CURDIR--/catch_postcondition.fz:107:36:
+        (fuzion.runtime.post_fault.instate
+-----------------------------------^^^^^^^
+((catch_postcondition.try_post (option String)).catch#1.h.lm.instate_self#2 (option String)).λ.call: $MODULE/effect.fz:164:39:
+    effect.this.instate R effect.this code
+--------------------------------------^^^^
+((catch_postcondition.type.try_post.type (option String)).catch#1.type.h.type.lm.type.instate#3 (option String)).λ.call: $MODULE/effect.fz:143:17:
+    instate R e code (panic "unexpected abort in {effect.this.type}")
+----------------^^^^
+((catch_postcondition.type.try_post.type (option String)).catch#1.type.h.type.lm.type.instate#4 (option String)).λ.call: $MODULE/effect.fz:119:25:
+    cf := e.Effect_Call code
+------------------------^^^^
+((catch_postcondition.try_post (option String)).catch#1.h.lm.Effect_Call (option String)).call: $MODULE/effect.fz:210:18:
+      set res := f()
+-----------------^
+(catch_postcondition.type.try_post.type (option String)).catch#1.type.h.type.lm.type.instate#4 (option String): <source position not available>:
+
+(catch_postcondition.type.try_post.type (option String)).catch#1.type.h.type.lm.type.instate#3 (option String): $MODULE/effect.fz:143:5:
+    instate R e code (panic "unexpected abort in {effect.this.type}")
+----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+(catch_postcondition.try_post (option String)).catch#1.h.lm.instate_self#2 (option String): $MODULE/effect.fz:164:5:
+    effect.this.instate R effect.this code
+----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+(catch_postcondition.try_post (option String)).catch#1.h: --CURDIR--/catch_postcondition.fz:105:15:
+    res := lm.instate_self ()->
+--------------^^^^^^^^^^^^
+(catch_postcondition.try_post (option String)).catch#1: --CURDIR--/catch_postcondition.fz:195:7:
+      h.res
+------^
+catch_postcondition.loop: --CURDIR--/catch_postcondition.fz:239:11:
+         .catch s->
+----------^^^^^
+(catch_postcondition.test#1 i32).loop: --CURDIR--/catch_postcondition.fz:234:3:
+  for
+--^
+(catch_postcondition.test#1 i32).loop: --CURDIR--/catch_postcondition.fz:43:5:
+    for v := T.one, double v
+----^
+... repeated 23 times ...
+
+catch_postcondition.test#1 i32: --CURDIR--/catch_postcondition.fz:43:5:
+    for v := T.one, double v
+----^
+catch_postcondition.res2.λ.call: --CURDIR--/catch_postcondition.fz:225:21:
+  res2 => try_post (test i32) || (s->say "*** failed: $s ***"; test u64)
+--------------------^^^^
+(catch_postcondition.try_post String).catch#1.h.try: --CURDIR--/catch_postcondition.fz:193:34:
+        redef try             => code_try()
+---------------------------------^^^^^^^^
+(catch_postcondition.try_post String).catch#1.h.λ.call.λ.call: --CURDIR--/catch_postcondition.fz:112:11:
+          try
+----------^^^
+(fuzion.type.runtime.type.post_fault.type.instate#4 String).λ.call: $MODULE/effect.fz:119:25:
+    cf := e.Effect_Call code
+------------------------^^^^
+(fuzion.runtime.post_fault.Effect_Call String).call: $MODULE/effect.fz:210:18:
+      set res := f()
+-----------------^
+fuzion.type.runtime.type.post_fault.type.instate#4 String: <source position not available>:
+
+(catch_postcondition.try_post String).catch#1.h.λ.call: --CURDIR--/catch_postcondition.fz:107:36:
+        (fuzion.runtime.post_fault.instate
+-----------------------------------^^^^^^^
+((catch_postcondition.try_post String).catch#1.h.lm.instate_self#2 String).λ.call: $MODULE/effect.fz:164:39:
+    effect.this.instate R effect.this code
+--------------------------------------^^^^
+((catch_postcondition.type.try_post.type String).catch#1.type.h.type.lm.type.instate#3 String).λ.call: $MODULE/effect.fz:143:17:
+    instate R e code (panic "unexpected abort in {effect.this.type}")
+----------------^^^^
+((catch_postcondition.type.try_post.type String).catch#1.type.h.type.lm.type.instate#4 String).λ.call: $MODULE/effect.fz:119:25:
+    cf := e.Effect_Call code
+------------------------^^^^
+((catch_postcondition.try_post String).catch#1.h.lm.Effect_Call String).call: $MODULE/effect.fz:210:18:
+      set res := f()
+-----------------^
+(catch_postcondition.type.try_post.type String).catch#1.type.h.type.lm.type.instate#4 String: <source position not available>:
+
+(catch_postcondition.type.try_post.type String).catch#1.type.h.type.lm.type.instate#3 String: $MODULE/effect.fz:143:5:
+    instate R e code (panic "unexpected abort in {effect.this.type}")
+----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+(catch_postcondition.try_post String).catch#1.h.lm.instate_self#2 String: $MODULE/effect.fz:164:5:
+    effect.this.instate R effect.this code
+----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+(catch_postcondition.try_post String).catch#1.h: --CURDIR--/catch_postcondition.fz:105:15:
+    res := lm.instate_self ()->
+--------------^^^^^^^^^^^^
+(catch_postcondition.try_post String).catch#1: --CURDIR--/catch_postcondition.fz:195:7:
+      h.res
+------^
+(catch_postcondition.try_post String).infix ||#1: --CURDIR--/catch_postcondition.fz:206:40:
+    infix || (code_catch String->T) => catch code_catch
+---------------------------------------^^^^^
+catch_postcondition.res2: --CURDIR--/catch_postcondition.fz:225:31:
+  res2 => try_post (test i32) || (s->say "*** failed: $s ***"; test u64)
+------------------------------^^
+(catch_postcondition.test#1 i32).loop: --CURDIR--/catch_postcondition.fz:226:7:
+  say res2
+------^^^^
+(catch_postcondition.test#1 i32).loop: --CURDIR--/catch_postcondition.fz:43:5:
+    for v := T.one, double v
+----^
+... repeated 24 times ...
+
+catch_postcondition.test#1 i32: --CURDIR--/catch_postcondition.fz:43:5:
+    for v := T.one, double v
+----^
+catch_postcondition.res.λ.call: --CURDIR--/catch_postcondition.fz:213:12:
+           test i32
+-----------^^^^
+(catch_postcondition.try_post String).catch#1.h.try: --CURDIR--/catch_postcondition.fz:193:34:
+        redef try             => code_try()
+---------------------------------^^^^^^^^
+(catch_postcondition.try_post String).catch#1.h.λ.call.λ.call: --CURDIR--/catch_postcondition.fz:112:11:
+          try
+----------^^^
+(fuzion.type.runtime.type.post_fault.type.instate#4 String).λ.call: $MODULE/effect.fz:119:25:
+    cf := e.Effect_Call code
+------------------------^^^^
+(fuzion.runtime.post_fault.Effect_Call String).call: $MODULE/effect.fz:210:18:
+      set res := f()
+-----------------^
+fuzion.type.runtime.type.post_fault.type.instate#4 String: <source position not available>:
+
+(catch_postcondition.try_post String).catch#1.h.λ.call: --CURDIR--/catch_postcondition.fz:107:36:
+        (fuzion.runtime.post_fault.instate
+-----------------------------------^^^^^^^
+((catch_postcondition.try_post String).catch#1.h.lm.instate_self#2 String).λ.call: $MODULE/effect.fz:164:39:
+    effect.this.instate R effect.this code
+--------------------------------------^^^^
+((catch_postcondition.type.try_post.type String).catch#1.type.h.type.lm.type.instate#3 String).λ.call: $MODULE/effect.fz:143:17:
+    instate R e code (panic "unexpected abort in {effect.this.type}")
+----------------^^^^
+((catch_postcondition.type.try_post.type String).catch#1.type.h.type.lm.type.instate#4 String).λ.call: $MODULE/effect.fz:119:25:
+    cf := e.Effect_Call code
+------------------------^^^^
+((catch_postcondition.try_post String).catch#1.h.lm.Effect_Call String).call: $MODULE/effect.fz:210:18:
+      set res := f()
+-----------------^
+(catch_postcondition.type.try_post.type String).catch#1.type.h.type.lm.type.instate#4 String: <source position not available>:
+
+(catch_postcondition.type.try_post.type String).catch#1.type.h.type.lm.type.instate#3 String: $MODULE/effect.fz:143:5:
+    instate R e code (panic "unexpected abort in {effect.this.type}")
+----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+(catch_postcondition.try_post String).catch#1.h.lm.instate_self#2 String: $MODULE/effect.fz:164:5:
+    effect.this.instate R effect.this code
+----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+(catch_postcondition.try_post String).catch#1.h: --CURDIR--/catch_postcondition.fz:105:15:
+    res := lm.instate_self ()->
+--------------^^^^^^^^^^^^
+(catch_postcondition.try_post String).catch#1: --CURDIR--/catch_postcondition.fz:195:7:
+      h.res
+------^
+catch_postcondition.res: --CURDIR--/catch_postcondition.fz:214:11:
+         .catch s->
+----------^^^^^
+(catch_postcondition.test#1 i16).loop: --CURDIR--/catch_postcondition.fz:217:7:
+  say res
+------^^^
+(catch_postcondition.test#1 i16).loop: --CURDIR--/catch_postcondition.fz:43:5:
+    for v := T.one, double v
+----^
+... repeated 8 times ...
+
+catch_postcondition.test#1 i16: --CURDIR--/catch_postcondition.fz:43:5:
+    for v := T.one, double v
+----^
+catch_postcondition.λ.call: --CURDIR--/catch_postcondition.fz:146:56:
+  tries array ()->String := [ (() -> test i32), (() -> test i16), (() -> test i64) ]
+-------------------------------------------------------^^^^
+catch_postcondition.loop.h.try: --CURDIR--/catch_postcondition.fz:164:44:
+      redef try option String  => tries[c].call
+-------------------------------------------^^^^
+catch_postcondition.loop.h.λ.call.λ.call: --CURDIR--/catch_postcondition.fz:112:11:
+          try
+----------^^^
+(fuzion.type.runtime.type.post_fault.type.instate#4 (option String)).λ.call: $MODULE/effect.fz:119:25:
+    cf := e.Effect_Call code
+------------------------^^^^
+(fuzion.runtime.post_fault.Effect_Call (option String)).call: $MODULE/effect.fz:210:18:
+      set res := f()
+-----------------^
+fuzion.type.runtime.type.post_fault.type.instate#4 (option String): <source position not available>:
+
+catch_postcondition.loop.h.λ.call: --CURDIR--/catch_postcondition.fz:107:36:
+        (fuzion.runtime.post_fault.instate
+-----------------------------------^^^^^^^
+(catch_postcondition.loop.h.lm.instate_self#2 (option String)).λ.call: $MODULE/effect.fz:164:39:
+    effect.this.instate R effect.this code
+--------------------------------------^^^^
+(catch_postcondition.type.loop.type.h.type.lm.type.instate#3 (option String)).λ.call: $MODULE/effect.fz:143:17:
+    instate R e code (panic "unexpected abort in {effect.this.type}")
+----------------^^^^
+(catch_postcondition.type.loop.type.h.type.lm.type.instate#4 (option String)).λ.call: $MODULE/effect.fz:119:25:
+    cf := e.Effect_Call code
+------------------------^^^^
+(catch_postcondition.loop.h.lm.Effect_Call (option String)).call: $MODULE/effect.fz:210:18:
       set res := f()
 -----------------^
 catch_postcondition.type.loop.type.h.type.lm.type.instate#4 (option String): <source position not available>:
 
-catch_postcondition.type.loop.type.h.type.lm.type.instate#3 (option String): $MODULE/effect.fz:124:5:
+catch_postcondition.type.loop.type.h.type.lm.type.instate#3 (option String): $MODULE/effect.fz:143:5:
     instate R e code (panic "unexpected abort in {effect.this.type}")
 ----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-catch_postcondition.loop.h.lm.instate_self#2 (option String): $MODULE/effect.fz:145:5:
+catch_postcondition.loop.h.lm.instate_self#2 (option String): $MODULE/effect.fz:164:5:
     effect.this.instate R effect.this code
 ----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-catch_postcondition.loop.h: --CURDIR--/catch_postcondition.fz:103:15:
+catch_postcondition.loop.h: --CURDIR--/catch_postcondition.fz:105:15:
     res := lm.instate_self ()->
 --------------^^^^^^^^^^^^
-catch_postcondition.loop: --CURDIR--/catch_postcondition.fz:161:10:
+catch_postcondition.loop: --CURDIR--/catch_postcondition.fz:166:10:
     r := h.res
 ---------^
-catch_postcondition.λ.call: --CURDIR--/catch_postcondition.fz:157:3:
+(catch_postcondition.test#1 i32).loop: --CURDIR--/catch_postcondition.fz:162:3:
   for c in tries.indices do
 --^
-catch_postcondition.z.try: --CURDIR--/catch_postcondition.fz:146:43:
-    redef try option String  => tries[c0].call
-------------------------------------------^^^^
-catch_postcondition.z.λ.call.λ.call: --CURDIR--/catch_postcondition.fz:108:15:
-        ).run try (()->catch m.get.get)
---------------^^^
-(fuzion.runtime.post_fault.run#3 (option String)).λ.call: $MODULE/effect.fz:199:39:
-    effect.this.instate R effect.this f def.call
---------------------------------------^
-(fuzion.type.runtime.type.post_fault.type.instate#4 (option String)).λ.call: $MODULE/effect.fz:100:25:
+(catch_postcondition.test#1 i32).loop: --CURDIR--/catch_postcondition.fz:43:5:
+    for v := T.one, double v
+----^
+... repeated 26 times ...
+
+catch_postcondition.test#1 i32: --CURDIR--/catch_postcondition.fz:43:5:
+    for v := T.one, double v
+----^
+catch_postcondition.λ.call: --CURDIR--/catch_postcondition.fz:146:38:
+  tries array ()->String := [ (() -> test i32), (() -> test i16), (() -> test i64) ]
+-------------------------------------^^^^
+catch_postcondition.loop.h.try: --CURDIR--/catch_postcondition.fz:164:44:
+      redef try option String  => tries[c].call
+-------------------------------------------^^^^
+catch_postcondition.loop.h.λ.call.λ.call: --CURDIR--/catch_postcondition.fz:112:11:
+          try
+----------^^^
+(fuzion.type.runtime.type.post_fault.type.instate#4 (option String)).λ.call: $MODULE/effect.fz:119:25:
     cf := e.Effect_Call code
 ------------------------^^^^
-(fuzion.runtime.post_fault.Effect_Call (option String)).call: $MODULE/effect.fz:191:18:
+(fuzion.runtime.post_fault.Effect_Call (option String)).call: $MODULE/effect.fz:210:18:
       set res := f()
 -----------------^
 fuzion.type.runtime.type.post_fault.type.instate#4 (option String): <source position not available>:
 
-fuzion.runtime.post_fault.run#3 (option String): $MODULE/effect.fz:199:5:
-    effect.this.instate R effect.this f def.call
-----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-catch_postcondition.z.λ.call: --CURDIR--/catch_postcondition.fz:108:11:
-        ).run try (()->catch m.get.get)
-----------^^^
-(catch_postcondition.z.lm.instate_self#2 (option String)).λ.call: $MODULE/effect.fz:145:39:
+catch_postcondition.loop.h.λ.call: --CURDIR--/catch_postcondition.fz:107:36:
+        (fuzion.runtime.post_fault.instate
+-----------------------------------^^^^^^^
+(catch_postcondition.loop.h.lm.instate_self#2 (option String)).λ.call: $MODULE/effect.fz:164:39:
     effect.this.instate R effect.this code
 --------------------------------------^^^^
-(catch_postcondition.type.z.type.lm.type.instate#3 (option String)).λ.call: $MODULE/effect.fz:124:17:
+(catch_postcondition.type.loop.type.h.type.lm.type.instate#3 (option String)).λ.call: $MODULE/effect.fz:143:17:
     instate R e code (panic "unexpected abort in {effect.this.type}")
 ----------------^^^^
-(catch_postcondition.type.z.type.lm.type.instate#4 (option String)).λ.call: $MODULE/effect.fz:100:25:
+(catch_postcondition.type.loop.type.h.type.lm.type.instate#4 (option String)).λ.call: $MODULE/effect.fz:119:25:
     cf := e.Effect_Call code
 ------------------------^^^^
-(catch_postcondition.z.lm.Effect_Call (option String)).call: $MODULE/effect.fz:191:18:
+(catch_postcondition.loop.h.lm.Effect_Call (option String)).call: $MODULE/effect.fz:210:18:
+      set res := f()
+-----------------^
+catch_postcondition.type.loop.type.h.type.lm.type.instate#4 (option String): <source position not available>:
+
+catch_postcondition.type.loop.type.h.type.lm.type.instate#3 (option String): $MODULE/effect.fz:143:5:
+    instate R e code (panic "unexpected abort in {effect.this.type}")
+----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+catch_postcondition.loop.h.lm.instate_self#2 (option String): $MODULE/effect.fz:164:5:
+    effect.this.instate R effect.this code
+----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+catch_postcondition.loop.h: --CURDIR--/catch_postcondition.fz:105:15:
+    res := lm.instate_self ()->
+--------------^^^^^^^^^^^^
+catch_postcondition.loop: --CURDIR--/catch_postcondition.fz:166:10:
+    r := h.res
+---------^
+catch_postcondition.test#1 i16: --CURDIR--/catch_postcondition.fz:162:3:
+  for c in tries.indices do
+--^
+catch_postcondition.λ.call: --CURDIR--/catch_postcondition.fz:146:56:
+  tries array ()->String := [ (() -> test i32), (() -> test i16), (() -> test i64) ]
+-------------------------------------------------------^^^^
+catch_postcondition.z.try: --CURDIR--/catch_postcondition.fz:151:43:
+    redef try option String  => tries[c0].call
+------------------------------------------^^^^
+catch_postcondition.z.λ.call.λ.call: --CURDIR--/catch_postcondition.fz:112:11:
+          try
+----------^^^
+(fuzion.type.runtime.type.post_fault.type.instate#4 (option String)).λ.call: $MODULE/effect.fz:119:25:
+    cf := e.Effect_Call code
+------------------------^^^^
+(fuzion.runtime.post_fault.Effect_Call (option String)).call: $MODULE/effect.fz:210:18:
+      set res := f()
+-----------------^
+fuzion.type.runtime.type.post_fault.type.instate#4 (option String): <source position not available>:
+
+catch_postcondition.z.λ.call: --CURDIR--/catch_postcondition.fz:107:36:
+        (fuzion.runtime.post_fault.instate
+-----------------------------------^^^^^^^
+(catch_postcondition.z.lm.instate_self#2 (option String)).λ.call: $MODULE/effect.fz:164:39:
+    effect.this.instate R effect.this code
+--------------------------------------^^^^
+(catch_postcondition.type.z.type.lm.type.instate#3 (option String)).λ.call: $MODULE/effect.fz:143:17:
+    instate R e code (panic "unexpected abort in {effect.this.type}")
+----------------^^^^
+(catch_postcondition.type.z.type.lm.type.instate#4 (option String)).λ.call: $MODULE/effect.fz:119:25:
+    cf := e.Effect_Call code
+------------------------^^^^
+(catch_postcondition.z.lm.Effect_Call (option String)).call: $MODULE/effect.fz:210:18:
       set res := f()
 -----------------^
 catch_postcondition.type.z.type.lm.type.instate#4 (option String): <source position not available>:
 
-catch_postcondition.type.z.type.lm.type.instate#3 (option String): $MODULE/effect.fz:124:5:
+catch_postcondition.type.z.type.lm.type.instate#3 (option String): $MODULE/effect.fz:143:5:
     instate R e code (panic "unexpected abort in {effect.this.type}")
 ----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-catch_postcondition.z.lm.instate_self#2 (option String): $MODULE/effect.fz:145:5:
+catch_postcondition.z.lm.instate_self#2 (option String): $MODULE/effect.fz:164:5:
     effect.this.instate R effect.this code
 ----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-catch_postcondition.z: --CURDIR--/catch_postcondition.fz:103:15:
+catch_postcondition.z: --CURDIR--/catch_postcondition.fz:105:15:
     res := lm.instate_self ()->
 --------------^^^^^^^^^^^^
-catch_postcondition.z.catch#1: --CURDIR--/catch_postcondition.fz:147:118:
+catch_postcondition.z.catch#1: --CURDIR--/catch_postcondition.fz:152:118:
     redef catch(s String) option String => {say "*** failed: $s ***"; c0 <- c0.get + 1; if c0.get < tries.count then z.res else nil}
 ---------------------------------------------------------------------------------------------------------------------^
-catch_postcondition.z.λ.call.λ.call: --CURDIR--/catch_postcondition.fz:108:24:
-        ).run try (()->catch m.get.get)
------------------------^^^^^
-(fuzion.runtime.post_fault.run#3 (option String)).λ.call: $MODULE/effect.fz:199:41:
-    effect.this.instate R effect.this f def.call
-----------------------------------------^^^^^^^^
-fuzion.runtime.post_fault.abort: $MODULE/effect.fz:103:14:
+catch_postcondition.z.λ.call.λ.call: --CURDIR--/catch_postcondition.fz:113:18:
+          (() -> catch m.get.get))
+-----------------^^^^^
+fuzion.type.runtime.type.post_fault.type.abort: $MODULE/effect.fz:122:14:
       nil => def()
 -------------^^^
-fuzion.runtime.post_fault.precall abort: $MODULE/effect.fz:256:3:
+fuzion.type.runtime.type.post_fault.type.precall abort: $MODULE/effect.fz:267:3:
   pre
 --^^^
     safety: effect.this.is_instated
 ----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    safety: abortable
-----^^^^^^^^^^^^^^^^^
-fuzion.runtime.post_fault.return: $MODULE/effect.fz:281:5:
-    abort
-----^^^^^
-fuzion.runtime.post_fault.precall return: $MODULE/effect.fz:278:3:
-  pre
---^^^
-    safety: abortable
-----^^^^^^^^^^^^^^^^^
-catch_postcondition.z.λ.call.λ.call#1: --CURDIR--/catch_postcondition.fz:107:27:
-            rt.post_fault.return
---------------------------^^^^^^
+    safety: effect.this.env.abortable
+----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+catch_postcondition.z.λ.call.λ.call#1: --CURDIR--/catch_postcondition.fz:111:39:
+            fuzion.runtime.post_fault.abort)
+--------------------------------------^^^^^
 fuzion.runtime.post_fault.cause#1: $MODULE/eff/fallible.fz:35:6:
   => h e
 -----^
@@ -902,172 +804,157 @@ public postcondition_fault(msg String) => post_fault.cause msg
 catch_postcondition.test#1 i32: --CURDIR--/catch_postcondition.fz:43:5:
     for v := T.one, double v
 ----^
-catch_postcondition.λ.call: --CURDIR--/catch_postcondition.fz:141:38:
+catch_postcondition.λ.call: --CURDIR--/catch_postcondition.fz:146:38:
   tries array ()->String := [ (() -> test i32), (() -> test i16), (() -> test i64) ]
 -------------------------------------^^^^
-catch_postcondition.z.try: --CURDIR--/catch_postcondition.fz:146:43:
+catch_postcondition.z.try: --CURDIR--/catch_postcondition.fz:151:43:
     redef try option String  => tries[c0].call
 ------------------------------------------^^^^
-catch_postcondition.z.λ.call.λ.call: --CURDIR--/catch_postcondition.fz:108:15:
-        ).run try (()->catch m.get.get)
---------------^^^
-(fuzion.runtime.post_fault.run#3 (option String)).λ.call: $MODULE/effect.fz:199:39:
-    effect.this.instate R effect.this f def.call
---------------------------------------^
-(fuzion.type.runtime.type.post_fault.type.instate#4 (option String)).λ.call: $MODULE/effect.fz:100:25:
+catch_postcondition.z.λ.call.λ.call: --CURDIR--/catch_postcondition.fz:112:11:
+          try
+----------^^^
+(fuzion.type.runtime.type.post_fault.type.instate#4 (option String)).λ.call: $MODULE/effect.fz:119:25:
     cf := e.Effect_Call code
 ------------------------^^^^
-(fuzion.runtime.post_fault.Effect_Call (option String)).call: $MODULE/effect.fz:191:18:
+(fuzion.runtime.post_fault.Effect_Call (option String)).call: $MODULE/effect.fz:210:18:
       set res := f()
 -----------------^
 fuzion.type.runtime.type.post_fault.type.instate#4 (option String): <source position not available>:
 
-fuzion.runtime.post_fault.run#3 (option String): $MODULE/effect.fz:199:5:
-    effect.this.instate R effect.this f def.call
-----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-catch_postcondition.z.λ.call: --CURDIR--/catch_postcondition.fz:108:11:
-        ).run try (()->catch m.get.get)
-----------^^^
-(catch_postcondition.z.lm.instate_self#2 (option String)).λ.call: $MODULE/effect.fz:145:39:
+catch_postcondition.z.λ.call: --CURDIR--/catch_postcondition.fz:107:36:
+        (fuzion.runtime.post_fault.instate
+-----------------------------------^^^^^^^
+(catch_postcondition.z.lm.instate_self#2 (option String)).λ.call: $MODULE/effect.fz:164:39:
     effect.this.instate R effect.this code
 --------------------------------------^^^^
-(catch_postcondition.type.z.type.lm.type.instate#3 (option String)).λ.call: $MODULE/effect.fz:124:17:
+(catch_postcondition.type.z.type.lm.type.instate#3 (option String)).λ.call: $MODULE/effect.fz:143:17:
     instate R e code (panic "unexpected abort in {effect.this.type}")
 ----------------^^^^
-(catch_postcondition.type.z.type.lm.type.instate#4 (option String)).λ.call: $MODULE/effect.fz:100:25:
+(catch_postcondition.type.z.type.lm.type.instate#4 (option String)).λ.call: $MODULE/effect.fz:119:25:
     cf := e.Effect_Call code
 ------------------------^^^^
-(catch_postcondition.z.lm.Effect_Call (option String)).call: $MODULE/effect.fz:191:18:
+(catch_postcondition.z.lm.Effect_Call (option String)).call: $MODULE/effect.fz:210:18:
       set res := f()
 -----------------^
 catch_postcondition.type.z.type.lm.type.instate#4 (option String): <source position not available>:
 
-catch_postcondition.type.z.type.lm.type.instate#3 (option String): $MODULE/effect.fz:124:5:
+catch_postcondition.type.z.type.lm.type.instate#3 (option String): $MODULE/effect.fz:143:5:
     instate R e code (panic "unexpected abort in {effect.this.type}")
 ----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-catch_postcondition.z.lm.instate_self#2 (option String): $MODULE/effect.fz:145:5:
+catch_postcondition.z.lm.instate_self#2 (option String): $MODULE/effect.fz:164:5:
     effect.this.instate R effect.this code
 ----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-catch_postcondition.z: --CURDIR--/catch_postcondition.fz:103:15:
+catch_postcondition.z: --CURDIR--/catch_postcondition.fz:105:15:
     res := lm.instate_self ()->
 --------------^^^^^^^^^^^^
-(catch_postcondition.test#1 i32).loop: --CURDIR--/catch_postcondition.fz:149:7:
+(catch_postcondition.test#1 i32).loop: --CURDIR--/catch_postcondition.fz:154:7:
   say z.res
 ------^
 (catch_postcondition.test#1 i32).loop: --CURDIR--/catch_postcondition.fz:43:5:
     for v := T.one, double v
 ----^
-... repeated 27 times ...
+... repeated 26 times ...
 
 catch_postcondition.test#1 i32: --CURDIR--/catch_postcondition.fz:43:5:
     for v := T.one, double v
 ----^
-catch_postcondition.anonymous.try: --CURDIR--/catch_postcondition.fz:129:7:
+catch_postcondition.anonymous.try: --CURDIR--/catch_postcondition.fz:134:7:
       test i32
 ------^^^^
-(catch_postcondition.ref handle_post String).λ.call.λ.call: --CURDIR--/catch_postcondition.fz:108:15:
-        ).run try (()->catch m.get.get)
---------------^^^
-(fuzion.runtime.post_fault.run#3 String).λ.call: $MODULE/effect.fz:199:39:
-    effect.this.instate R effect.this f def.call
---------------------------------------^
-(fuzion.type.runtime.type.post_fault.type.instate#4 String).λ.call: $MODULE/effect.fz:100:25:
+(catch_postcondition.ref handle_post String).λ.call.λ.call: --CURDIR--/catch_postcondition.fz:112:11:
+          try
+----------^^^
+(fuzion.type.runtime.type.post_fault.type.instate#4 String).λ.call: $MODULE/effect.fz:119:25:
     cf := e.Effect_Call code
 ------------------------^^^^
-(fuzion.runtime.post_fault.Effect_Call String).call: $MODULE/effect.fz:191:18:
+(fuzion.runtime.post_fault.Effect_Call String).call: $MODULE/effect.fz:210:18:
       set res := f()
 -----------------^
 fuzion.type.runtime.type.post_fault.type.instate#4 String: <source position not available>:
 
-fuzion.runtime.post_fault.run#3 String: $MODULE/effect.fz:199:5:
-    effect.this.instate R effect.this f def.call
-----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-(catch_postcondition.ref handle_post String).λ.call: --CURDIR--/catch_postcondition.fz:108:11:
-        ).run try (()->catch m.get.get)
-----------^^^
-((catch_postcondition.ref handle_post String).lm.instate_self#2 String).λ.call: $MODULE/effect.fz:145:39:
+(catch_postcondition.ref handle_post String).λ.call: --CURDIR--/catch_postcondition.fz:107:36:
+        (fuzion.runtime.post_fault.instate
+-----------------------------------^^^^^^^
+((catch_postcondition.ref handle_post String).lm.instate_self#2 String).λ.call: $MODULE/effect.fz:164:39:
     effect.this.instate R effect.this code
 --------------------------------------^^^^
-((catch_postcondition.type.handle_post.type String).lm.type.instate#3 String).λ.call: $MODULE/effect.fz:124:17:
+((catch_postcondition.type.handle_post.type String).lm.type.instate#3 String).λ.call: $MODULE/effect.fz:143:17:
     instate R e code (panic "unexpected abort in {effect.this.type}")
 ----------------^^^^
-((catch_postcondition.type.handle_post.type String).lm.type.instate#4 String).λ.call: $MODULE/effect.fz:100:25:
+((catch_postcondition.type.handle_post.type String).lm.type.instate#4 String).λ.call: $MODULE/effect.fz:119:25:
     cf := e.Effect_Call code
 ------------------------^^^^
-((catch_postcondition.ref handle_post String).lm.Effect_Call String).call: $MODULE/effect.fz:191:18:
+((catch_postcondition.ref handle_post String).lm.Effect_Call String).call: $MODULE/effect.fz:210:18:
       set res := f()
 -----------------^
 (catch_postcondition.type.handle_post.type String).lm.type.instate#4 String: <source position not available>:
 
-(catch_postcondition.type.handle_post.type String).lm.type.instate#3 String: $MODULE/effect.fz:124:5:
+(catch_postcondition.type.handle_post.type String).lm.type.instate#3 String: $MODULE/effect.fz:143:5:
     instate R e code (panic "unexpected abort in {effect.this.type}")
 ----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-(catch_postcondition.ref handle_post String).lm.instate_self#2 String: $MODULE/effect.fz:145:5:
+(catch_postcondition.ref handle_post String).lm.instate_self#2 String: $MODULE/effect.fz:164:5:
     effect.this.instate R effect.this code
 ----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-catch_postcondition.anonymous: --CURDIR--/catch_postcondition.fz:103:15:
+catch_postcondition.anonymous: --CURDIR--/catch_postcondition.fz:105:15:
     res := lm.instate_self ()->
 --------------^^^^^^^^^^^^
-(catch_postcondition.test#1 i32).loop: --CURDIR--/catch_postcondition.fz:127:8:
+(catch_postcondition.test#1 i32).loop: --CURDIR--/catch_postcondition.fz:132:8:
   say (ref : handle_post String
 -------^
 (catch_postcondition.test#1 i32).loop: --CURDIR--/catch_postcondition.fz:43:5:
     for v := T.one, double v
 ----^
-... repeated 27 times ...
+... repeated 26 times ...
 
 catch_postcondition.test#1 i32: --CURDIR--/catch_postcondition.fz:43:5:
     for v := T.one, double v
 ----^
-catch_postcondition.y.try: --CURDIR--/catch_postcondition.fz:116:30:
+catch_postcondition.y.try: --CURDIR--/catch_postcondition.fz:121:30:
     redef try             => test i32
 -----------------------------^^^^
-catch_postcondition.y.λ.call.λ.call: --CURDIR--/catch_postcondition.fz:108:15:
-        ).run try (()->catch m.get.get)
---------------^^^
-(fuzion.runtime.post_fault.run#3 String).λ.call: $MODULE/effect.fz:199:39:
-    effect.this.instate R effect.this f def.call
---------------------------------------^
-(fuzion.type.runtime.type.post_fault.type.instate#4 String).λ.call: $MODULE/effect.fz:100:25:
+catch_postcondition.y.λ.call.λ.call: --CURDIR--/catch_postcondition.fz:112:11:
+          try
+----------^^^
+(fuzion.type.runtime.type.post_fault.type.instate#4 String).λ.call: $MODULE/effect.fz:119:25:
     cf := e.Effect_Call code
 ------------------------^^^^
-(fuzion.runtime.post_fault.Effect_Call String).call: $MODULE/effect.fz:191:18:
+(fuzion.runtime.post_fault.Effect_Call String).call: $MODULE/effect.fz:210:18:
       set res := f()
 -----------------^
 fuzion.type.runtime.type.post_fault.type.instate#4 String: <source position not available>:
 
-fuzion.runtime.post_fault.run#3 String: $MODULE/effect.fz:199:5:
-    effect.this.instate R effect.this f def.call
-----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-catch_postcondition.y.λ.call: --CURDIR--/catch_postcondition.fz:108:11:
-        ).run try (()->catch m.get.get)
-----------^^^
-(catch_postcondition.y.lm.instate_self#2 String).λ.call: $MODULE/effect.fz:145:39:
+catch_postcondition.y.λ.call: --CURDIR--/catch_postcondition.fz:107:36:
+        (fuzion.runtime.post_fault.instate
+-----------------------------------^^^^^^^
+(catch_postcondition.y.lm.instate_self#2 String).λ.call: $MODULE/effect.fz:164:39:
     effect.this.instate R effect.this code
 --------------------------------------^^^^
-(catch_postcondition.type.y.type.lm.type.instate#3 String).λ.call: $MODULE/effect.fz:124:17:
+(catch_postcondition.type.y.type.lm.type.instate#3 String).λ.call: $MODULE/effect.fz:143:17:
     instate R e code (panic "unexpected abort in {effect.this.type}")
 ----------------^^^^
-(catch_postcondition.type.y.type.lm.type.instate#4 String).λ.call: $MODULE/effect.fz:100:25:
+(catch_postcondition.type.y.type.lm.type.instate#4 String).λ.call: $MODULE/effect.fz:119:25:
     cf := e.Effect_Call code
 ------------------------^^^^
-(catch_postcondition.y.lm.Effect_Call String).call: $MODULE/effect.fz:191:18:
+(catch_postcondition.y.lm.Effect_Call String).call: $MODULE/effect.fz:210:18:
       set res := f()
 -----------------^
 catch_postcondition.type.y.type.lm.type.instate#4 String: <source position not available>:
 
-catch_postcondition.type.y.type.lm.type.instate#3 String: $MODULE/effect.fz:124:5:
+catch_postcondition.type.y.type.lm.type.instate#3 String: $MODULE/effect.fz:143:5:
     instate R e code (panic "unexpected abort in {effect.this.type}")
 ----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-catch_postcondition.y.lm.instate_self#2 String: $MODULE/effect.fz:145:5:
+catch_postcondition.y.lm.instate_self#2 String: $MODULE/effect.fz:164:5:
     effect.this.instate R effect.this code
 ----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-catch_postcondition.y: --CURDIR--/catch_postcondition.fz:103:15:
+catch_postcondition.y: --CURDIR--/catch_postcondition.fz:105:15:
     res := lm.instate_self ()->
 --------------^^^^^^^^^^^^
-catch_postcondition.λ.call#1: --CURDIR--/catch_postcondition.fz:119:7:
+fuzion.type.runtime.type.post_fault.type.precall abort: --CURDIR--/catch_postcondition.fz:124:7:
   say y.res
 ------^
+catch_postcondition.λ.call#1: --CURDIR--/catch_postcondition.fz:85:37:
+          fuzion.runtime.post_fault.abort)
+------------------------------------^^^^^
 fuzion.runtime.post_fault.cause#1: $MODULE/eff/fallible.fz:35:6:
   => h e
 -----^
@@ -1093,26 +980,20 @@ public postcondition_fault(msg String) => post_fault.cause msg
 catch_postcondition.test#1 i32: --CURDIR--/catch_postcondition.fz:43:5:
     for v := T.one, double v
 ----^
-catch_postcondition.λ.call: --CURDIR--/catch_postcondition.fz:84:6:
-    (test i32)
------^^^^
-(fuzion.runtime.post_fault.run#3 String).λ.call: $MODULE/effect.fz:199:39:
-    effect.this.instate R effect.this f def.call
---------------------------------------^
-(fuzion.type.runtime.type.post_fault.type.instate#4 String).λ.call: $MODULE/effect.fz:100:25:
+catch_postcondition.λ.call: --CURDIR--/catch_postcondition.fz:86:10:
+        (test i32)
+---------^^^^
+(fuzion.type.runtime.type.post_fault.type.instate#4 String).λ.call: $MODULE/effect.fz:119:25:
     cf := e.Effect_Call code
 ------------------------^^^^
-(fuzion.runtime.post_fault.Effect_Call String).call: $MODULE/effect.fz:191:18:
+(fuzion.runtime.post_fault.Effect_Call String).call: $MODULE/effect.fz:210:18:
       set res := f()
 -----------------^
 fuzion.type.runtime.type.post_fault.type.instate#4 String: <source position not available>:
 
-fuzion.runtime.post_fault.run#3 String: $MODULE/effect.fz:199:5:
-    effect.this.instate R effect.this f def.call
-----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-catch_postcondition: --CURDIR--/catch_postcondition.fz:83:28:
-      rt.post_fault.abort).run
----------------------------^^^
+catch_postcondition: --CURDIR--/catch_postcondition.fz:81:34:
+  say (fuzion.runtime.post_fault.instate
+---------------------------------^^^^^^^
 
 *** fatal errors encountered, stopping.
 one error.

--- a/tests/reg_issue2231/reg_issue2231.fz
+++ b/tests/reg_issue2231/reg_issue2231.fz
@@ -27,7 +27,7 @@ reg_issue2231 is
     inner := 7
     a <- ()->inner
     something =>
-      abort
+      ef.abort
 
   ef.instate_self ()->
     reg_issue2231.ef.env.something

--- a/tests/reg_issue2231/reg_issue2231.fz.expected_err
+++ b/tests/reg_issue2231/reg_issue2231.fz.expected_err
@@ -16,43 +16,43 @@ panic.cause#1: $MODULE/eff/fallible.fz:35:6:
 panic#1: $MODULE/panic.fz:56:29:
 public panic(msg String) => panic.cause msg
 ----------------------------^^^^^^^^^^^^^^^
-(reg_issue2231.type.ef.type.instate#3 void).λ.call: $MODULE/effect.fz:124:22:
+(reg_issue2231.type.ef.type.instate#3 void).λ.call: $MODULE/effect.fz:143:22:
     instate R e code (panic "unexpected abort in {effect.this.type}")
 ---------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-reg_issue2231.ef.abort: $MODULE/effect.fz:103:14:
+reg_issue2231.type.ef.type.abort: $MODULE/effect.fz:122:14:
       nil => def()
 -------------^^^
-reg_issue2231.ef.precall abort: $MODULE/effect.fz:256:3:
+reg_issue2231.type.ef.type.precall abort: $MODULE/effect.fz:267:3:
   pre
 --^^^
     safety: effect.this.is_instated
 ----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    safety: abortable
-----^^^^^^^^^^^^^^^^^
-reg_issue2231.ef.something: --CURDIR--/reg_issue2231.fz:30:7:
-      abort
-------^^^^^
+    safety: effect.this.env.abortable
+----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+reg_issue2231.ef.something: --CURDIR--/reg_issue2231.fz:30:10:
+      ef.abort
+---------^^^^^
 reg_issue2231.λ.call: --CURDIR--/reg_issue2231.fz:33:26:
     reg_issue2231.ef.env.something
 -------------------------^^^^^^^^^
-(reg_issue2231.ef.instate_self#2 void).λ.call: $MODULE/effect.fz:145:39:
+(reg_issue2231.ef.instate_self#2 void).λ.call: $MODULE/effect.fz:164:39:
     effect.this.instate R effect.this code
 --------------------------------------^^^^
-(reg_issue2231.type.ef.type.instate#3 void).λ.call: $MODULE/effect.fz:124:17:
+(reg_issue2231.type.ef.type.instate#3 void).λ.call: $MODULE/effect.fz:143:17:
     instate R e code (panic "unexpected abort in {effect.this.type}")
 ----------------^^^^
-(reg_issue2231.type.ef.type.instate#4 void).λ.call: $MODULE/effect.fz:100:25:
+(reg_issue2231.type.ef.type.instate#4 void).λ.call: $MODULE/effect.fz:119:25:
     cf := e.Effect_Call code
 ------------------------^^^^
-(reg_issue2231.ef.Effect_Call void).call: $MODULE/effect.fz:191:18:
+(reg_issue2231.ef.Effect_Call void).call: $MODULE/effect.fz:210:18:
       set res := f()
 -----------------^
 reg_issue2231.type.ef.type.instate#4 void: <source position not available>:
 
-reg_issue2231.type.ef.type.instate#3 void: $MODULE/effect.fz:124:5:
+reg_issue2231.type.ef.type.instate#3 void: $MODULE/effect.fz:143:5:
     instate R e code (panic "unexpected abort in {effect.this.type}")
 ----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-reg_issue2231.ef.instate_self#2 void: $MODULE/effect.fz:145:5:
+reg_issue2231.ef.instate_self#2 void: $MODULE/effect.fz:164:5:
     effect.this.instate R effect.this code
 ----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 reg_issue2231: --CURDIR--/reg_issue2231.fz:32:6:


### PR DESCRIPTION
`effect.abort` must be a type feature to support aborting a `ref` effect whose type may be different than the effect value`s type, as shown in #3634.

This also contains cleanup to remove `effect.run` and `simple_effect` that should no longer be used.
