### PR TITLE
ast: fix precondition failure, AbstractType.asString

### DIFF
--- a/src/dev/flang/ast/AbstractType.java
+++ b/src/dev/flang/ast/AbstractType.java
@@ -1811,7 +1811,7 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
     else
       {
         var o = outer();
-        String outer = o != null && !o.feature().isUniverse() ? o.asStringWrapped(humanReadable) + "." : "";
+        String outer = o != null && (o.isGenericArgument() || !o.feature().isUniverse()) ? o.asStringWrapped(humanReadable) + "." : "";
         var f = feature();
         var typeType = f.isTypeFeature();
         if (typeType)


### PR DESCRIPTION
Problem was the feature() was called on parametric type.

