### PR TITLE
fuir: change output of `codeAtAsString` for `Assign`

### DIFF
--- a/src/dev/flang/fuir/FUIR.java
+++ b/src/dev/flang/fuir/FUIR.java
@@ -1995,7 +1995,7 @@ public class FUIR extends IR
   {
     return switch (codeAt(s))
       {
-      case Assign  -> "Assign to " + clazzAsString(accessedClazz(s));
+      case Assign  -> "Assign " + clazzAsString(assignedType(s)) + " to " + clazzAsString(accessedClazz(s));
       case Box     -> "Box "       + clazzAsString(boxValueClazz(s)) + " => " + clazzAsString(boxResultClazz  (s));
       case Call    -> {
                         var sb = new StringBuilder("Call ");


### PR DESCRIPTION
example output:
```
process b(0 args) at 805306375: Assign Type to b.#result stack is [aload 0->invokeStatic fzC__Bb.fzBox->invokeStatic fzC_1u.fzRoutine, aload 0]
```

