### PR TITLE
ast: Move call to  `NumLiteral.checkRange` to the CHECK_TYPES phase

### DIFF
--- a/src/dev/flang/ast/Constant.java
+++ b/src/dev/flang/ast/Constant.java
@@ -128,6 +128,16 @@ public abstract class Constant extends Expr
 
 
   /**
+   * Check that this constant is in the range allowed for its type().
+   *
+   * This is redefined by NumLiteral to check the range of the constant.
+   */
+  void checkRange()
+  {
+  }
+
+
+  /**
    * This expression as a compile time constant.
    */
   @Override

--- a/src/dev/flang/ast/Feature.java
+++ b/src/dev/flang/ast/Feature.java
@@ -1931,6 +1931,7 @@ A ((Choice)) declaration must not contain a result type.
 
             public void         action(AbstractAssign a, AbstractFeature outer) {        a.checkTypes(res,  _context);           }
             public Call         action(Call           c, AbstractFeature outer) {        c.checkTypes(res,  _context); return c; }
+            public Constant     action(Constant       c, AbstractFeature outer) {        c.checkRange();               return c; }
             public Expr         action(If             i, AbstractFeature outer) {        i.checkTypes(      _context); return i; }
             public Expr         action(InlineArray    i, AbstractFeature outer) {        i.checkTypes(      _context); return i; }
             public AbstractType action(AbstractType   t, AbstractFeature outer) { return t.checkConstraints(_context);           }

--- a/src/dev/flang/ast/NumLiteral.java
+++ b/src/dev/flang/ast/NumLiteral.java
@@ -419,7 +419,6 @@ public class NumLiteral extends Constant
     if (_type == null)
       {
         _type = typeForCallTarget();
-        checkRange();
       }
     return _type;
   }
@@ -714,6 +713,7 @@ public class NumLiteral extends Constant
   /**
    * Check that this constant is in the range allowed for its type_.
    */
+  @Override
   void checkRange()
   {
     if (PRECONDITIONS) require
@@ -866,7 +866,6 @@ public class NumLiteral extends Constant
         if (_type == null && findConstantType(t) != null)
           {
             _type = t;
-            checkRange();
           }
       }
     return result;


### PR DESCRIPTION
This should later permit removing `typeForCallTarget` or `typeForInferencing`. 