### PR TITLE
ast: env, add checkTypes

### DIFF
--- a/src/dev/flang/ast/Env.java
+++ b/src/dev/flang/ast/Env.java
@@ -26,6 +26,7 @@ Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
 
 package dev.flang.ast;
 
+import dev.flang.util.Errors;
 import dev.flang.util.SourcePosition;
 
 
@@ -103,20 +104,22 @@ public class Env extends ExprWithPos
 
 
   /**
-   * determine the static type of all expressions and declared features in this feature
-   *
-   * @param res this is called during type resolution, res gives the resolution
-   * instance.
-   *
-   * @param context the source code context where this Call is used
-   *
-   * @return a call to the outer references to access the value represented by
-   * this.
+   * check the type of this Env expression
    */
-  public Expr resolveTypes(Resolution res, Context context)
+  public void checkTypes()
   {
-    _type = _type.resolve(res, context);
-    return this;
+    var t = _type;
+    while (t != null && !t.isGenericArgument())
+      {
+        if (t.feature().isTypeFeature())
+          {
+            Errors.fatal("NYI: UNDER DEVELOPMENT: implementation restriction." + System.lineSeparator() +
+                          "env type contains type feature type." + System.lineSeparator() +
+                          pos() + System.lineSeparator() +
+                          type());
+          }
+        t = t.outer();
+      }
   }
 
 

--- a/src/dev/flang/ast/Feature.java
+++ b/src/dev/flang/ast/Feature.java
@@ -1927,15 +1927,16 @@ A ((Choice)) declaration must not contain a result type.
         _resultType = _resultType.checkChoice(_posOfReturnType, context());
         visit(new ContextVisitor(context()) {
             /* if an error is reported in a call it might no longer make sense to check the actuals: */
-            public boolean visitActualsLate() { return true; }
+            @Override public boolean visitActualsLate() { return true; }
 
-            public void         action(AbstractAssign a, AbstractFeature outer) {        a.checkTypes(res,  _context);           }
-            public Call         action(Call           c, AbstractFeature outer) {        c.checkTypes(res,  _context); return c; }
-            public Expr         action(If             i, AbstractFeature outer) {        i.checkTypes(      _context); return i; }
-            public Expr         action(InlineArray    i, AbstractFeature outer) {        i.checkTypes(      _context); return i; }
-            public AbstractType action(AbstractType   t, AbstractFeature outer) { return t.checkConstraints(_context);           }
-            public void         action(Cond           c, AbstractFeature outer) {        c.checkTypes();                         }
-            public void         actionBefore(Block    b, AbstractFeature outer) {        b.checkTypes();                         }
+            @Override public void         action(AbstractAssign a, AbstractFeature outer) {        a.checkTypes(res,  _context);           }
+            @Override public Call         action(Call           c, AbstractFeature outer) {        c.checkTypes(res,  _context); return c; }
+            @Override public Expr         action(If             i, AbstractFeature outer) {        i.checkTypes(      _context); return i; }
+            @Override public Expr         action(InlineArray    i, AbstractFeature outer) {        i.checkTypes(      _context); return i; }
+            @Override public AbstractType action(AbstractType   t, AbstractFeature outer) { return t.checkConstraints(_context);           }
+            @Override public void         action(Cond           c, AbstractFeature outer) {        c.checkTypes();                         }
+            @Override public void         action(Env            e, AbstractFeature outer) {        e.checkTypes();                         }
+            @Override public void         actionBefore(Block    b, AbstractFeature outer) {        b.checkTypes();                         }
           });
         checkTypes(res, context());
 

--- a/src/dev/flang/ast/FeatureVisitor.java
+++ b/src/dev/flang/ast/FeatureVisitor.java
@@ -82,6 +82,7 @@ public abstract class FeatureVisitor extends ANY
   public void         action      (Tag              b, AbstractFeature outer) { }
   public Expr         action      (This             t, AbstractFeature outer) { return t; }
   public AbstractType action      (AbstractType     t, AbstractFeature outer) { return t; }
+  public void         action      (Env              e, AbstractFeature outer) { }
 
   /**
    * Visitors that want a different treatment for visiting actual arguments of a


### PR DESCRIPTION
This check would have caught the issue with the local_mutate declared in a type feature in fallible earlier:
```
error 1: NYI: UNDER DEVELOPMENT: implementation restriction.
env type contains type feature type.
./build/lib/eff/fallible.fz:80:14:
(((eff.this (eff.this.type (in type feature))).fallible.this (eff.fallible.this.type (in type feature)) eff.fallible.type.ERROR).try.this eff.fallible.type.try.T).catch.this.lm
```

Also removed a unused method `Env.resolveTypes`


