### PR TITLE
Revert "ast: Move call to  `NumLiteral.checkRange` to the CHECK_TYPES phase"

### DIFF
--- a/src/dev/flang/ast/Constant.java
+++ b/src/dev/flang/ast/Constant.java
@@ -128,16 +128,6 @@ public abstract class Constant extends Expr
 
 
   /**
-   * Check that this constant is in the range allowed for its type().
-   *
-   * This is redefined by NumLiteral to check the range of the constant.
-   */
-  void checkRange()
-  {
-  }
-
-
-  /**
    * This expression as a compile time constant.
    */
   @Override

--- a/src/dev/flang/ast/Feature.java
+++ b/src/dev/flang/ast/Feature.java
@@ -1927,16 +1927,15 @@ A ((Choice)) declaration must not contain a result type.
         _resultType = _resultType.checkChoice(_posOfReturnType, context());
         visit(new ContextVisitor(context()) {
             /* if an error is reported in a call it might no longer make sense to check the actuals: */
-            @Override public boolean visitActualsLate() { return true; }
+            public boolean visitActualsLate() { return true; }
 
-            @Override public void         action(AbstractAssign a, AbstractFeature outer) {        a.checkTypes(res,  _context);           }
-            @Override public Call         action(Call           c, AbstractFeature outer) {        c.checkTypes(res,  _context); return c; }
-            @Override public void         action(Constant       c                       ) {        c.checkRange();                         }
-            @Override public Expr         action(If             i, AbstractFeature outer) {        i.checkTypes(      _context); return i; }
-            @Override public Expr         action(InlineArray    i, AbstractFeature outer) {        i.checkTypes(      _context); return i; }
-            @Override public AbstractType action(AbstractType   t, AbstractFeature outer) { return t.checkConstraints(_context);           }
-            @Override public void         action(Cond           c, AbstractFeature outer) {        c.checkTypes();                         }
-            @Override public void         actionBefore(Block    b, AbstractFeature outer) {        b.checkTypes();                         }
+            public void         action(AbstractAssign a, AbstractFeature outer) {        a.checkTypes(res,  _context);           }
+            public Call         action(Call           c, AbstractFeature outer) {        c.checkTypes(res,  _context); return c; }
+            public Expr         action(If             i, AbstractFeature outer) {        i.checkTypes(      _context); return i; }
+            public Expr         action(InlineArray    i, AbstractFeature outer) {        i.checkTypes(      _context); return i; }
+            public AbstractType action(AbstractType   t, AbstractFeature outer) { return t.checkConstraints(_context);           }
+            public void         action(Cond           c, AbstractFeature outer) {        c.checkTypes();                         }
+            public void         actionBefore(Block    b, AbstractFeature outer) {        b.checkTypes();                         }
           });
         checkTypes(res, context());
 

--- a/src/dev/flang/ast/NumLiteral.java
+++ b/src/dev/flang/ast/NumLiteral.java
@@ -419,6 +419,7 @@ public class NumLiteral extends Constant
     if (_type == null)
       {
         _type = typeForCallTarget();
+        checkRange();
       }
     return _type;
   }
@@ -713,7 +714,6 @@ public class NumLiteral extends Constant
   /**
    * Check that this constant is in the range allowed for its type_.
    */
-  @Override
   void checkRange()
   {
     if (PRECONDITIONS) require
@@ -866,6 +866,7 @@ public class NumLiteral extends Constant
         if (_type == null && findConstantType(t) != null)
           {
             _type = t;
+            checkRange();
           }
       }
     return result;


### PR DESCRIPTION
Reverts tokiwa-software/fuzion#3662