### PR TITLE
lib: Add `ignore(T type, x T) unit` to drop a value

### DIFF
--- a/lib/id.fz
+++ b/lib/id.fz
@@ -47,9 +47,35 @@ public id(T type, x T) T => x
 #
 # or, using an intermediate field,
 #
-#   all_true(s Sequence bool) => f (bool)->bool := id;               s ∀ f
-#   all_true(s Sequence bool) => f (bool)->bool := (x -> id bool x); s ∀ f
-#   all_true(s Sequence bool) => f (bool)->bool := (x -> id x);      s ∀ f
-#   all_true(s Sequence bool) => f (bool)->bool := identity bool;    s ∀ f
+#   all_true(s Sequence bool) => { f (bool)->bool := id;               s ∀ f }
+#   all_true(s Sequence bool) => { f (bool)->bool := (x -> id bool x); s ∀ f }
+#   all_true(s Sequence bool) => { f (bool)->bool := (x -> id x);      s ∀ f }
+#   all_true(s Sequence bool) => { f (bool)->bool := identity bool;    s ∀ f }
 #
 public identity(T type) T->T => x->x
+
+
+# ignore -- function mapping any value to unit
+#
+# This can be used to ignore the result of an expression, e.g. the
+# instance returned by a constructor or the value returned by a fuction.
+#
+# Ex. with these features
+#
+#   hello is
+#     say "Hello!"
+#
+#   say_and_inc(x i32) i32 =>
+#     say x
+#     x+1
+#
+# the results can be ignored as follows
+#
+#   hello |> ignore
+#   (say_and_inc 42) |> ignore
+#   ignore hello
+#   ignore (say_and_inc 42)
+#   _ := hello
+#   _ := say_and_inc 42
+#
+public ignore(T type, x T) unit =>


### PR DESCRIPTION
`ignore xyz` or `xyz |> ignore` are maybe a nicer alternatives to `_ := xyz`.
