### PR TITLE
ast: suppress subsequent error of generated feature `λ.call`

### DIFF
--- a/src/dev/flang/ast/AstErrors.java
+++ b/src/dev/flang/ast/AstErrors.java
@@ -1055,13 +1055,21 @@ public class AstErrors extends ANY
                    "declaration of " + s(f) + ".");
   }
 
-  public static void redefineModifierDoesNotRedefine(AbstractFeature f)
+  public static void redefineModifierDoesNotRedefine(AbstractFeature af)
   {
-    error(f.pos(),
-          "Feature declared using modifier " + skw("redef") + " does not redefine another feature",
-          "Redefining feature: " + s(f) + "\n" +
-          "To solve this, check spelling and argument count against the feature you want to redefine or " +
-          "remove " + skw("redef") + " modifier in the declaration of " + s(f) + ".");
+    if (any() && af instanceof Feature f && f.isLambdaCall())
+      {
+        // suppress subsequent errors for λ.call
+        // see reg_issue3691
+      }
+    else
+      {
+        error(af.pos(),
+              "Feature declared using modifier " + skw("redef") + " does not redefine another feature",
+              "Redefining feature: " + s(af) + "\n" +
+              "To solve this, check spelling and argument count against the feature you want to redefine or " +
+              "remove " + skw("redef") + " modifier in the declaration of " + s(af) + ".");
+      }
   }
 
   static void notRedefinedContractMustNotUseElseOrThen(SourcePosition pos, AbstractFeature f, PreOrPost preOrPost)

--- a/tests/reg_issue3691/Makefile
+++ b/tests/reg_issue3691/Makefile
@@ -1,0 +1,25 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test Makefile
+#
+# -----------------------------------------------------------------------
+
+override NAME = reg_issue3691
+include ../simple.mk

--- a/tests/reg_issue3691/reg_issue3691.fz
+++ b/tests/reg_issue3691/reg_issue3691.fz
@@ -1,0 +1,28 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test reg_issue3691
+#
+# -----------------------------------------------------------------------
+
+reg_issue3691 =>
+
+  a(b ()->unit) =>
+
+  a (_ -> )

--- a/tests/reg_issue3691/reg_issue3691.fz.expected_err
+++ b/tests/reg_issue3691/reg_issue3691.fz.expected_err
@@ -1,0 +1,10 @@
+
+--CURDIR--/reg_issue3691.fz:28:5: error 1: Wrong number of arguments in lambda expression
+  a (_ -> )
+----^^^^^^^
+Lambda expression has one argument while the target type expects no arguments.
+Arguments of lambda expression: '_'
+Expected function type: Function unit
+To solve this, replace the list '_' by '()'.
+
+one error.


### PR DESCRIPTION
fixes #3691

