### PR TITLE
fe: fix check condition failure

### DIFF
--- a/src/dev/flang/fe/SourceModule.java
+++ b/src/dev/flang/fe/SourceModule.java
@@ -729,7 +729,7 @@ part of the (((inner features))) declarations of the corresponding
     if (doi != null)
       {
         if (CHECKS) check
-          (!doi.containsKey(fn) || doi.get(fn).size() == 1 && doi.get(fn).getFirst() == typeParameter);
+          (Errors.any() || !doi.containsKey(fn) || doi.get(fn).size() == 1 && doi.get(fn).getFirst() == typeParameter);
         add(doi, fn, typeParameter);
       }
   }
@@ -1010,7 +1010,7 @@ A post-condition of a feature that does not redefine an inherited feature must s
           }
         else
           {
-            if (existing instanceof Feature ef && ef.isArgument() && f.isArgument())
+            if (existing instanceof Feature ef && ef.isArgument() && f.isArgument() && !f.isTypeParameter())
               {
                 // NYI: CLEANUP: there should not be two places where
                 // similar error is raised.

--- a/tests/reg_issue3647/Makefile
+++ b/tests/reg_issue3647/Makefile
@@ -1,0 +1,25 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test Makefile
+#
+# -----------------------------------------------------------------------
+
+override NAME = reg_issue3647
+include ../simple.mk

--- a/tests/reg_issue3647/reg_issue3647.fz
+++ b/tests/reg_issue3647/reg_issue3647.fz
@@ -1,0 +1,30 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test reg_issue3647
+#
+# -----------------------------------------------------------------------
+
+# NYI: BUG: should not display error twice.
+
+reg_issue3647 =>
+
+  Node(T Type, a Node T) ref is
+
+  say (type_as_value (Node i32))

--- a/tests/reg_issue3647/reg_issue3647.fz.expected_err
+++ b/tests/reg_issue3647/reg_issue3647.fz.expected_err
@@ -1,0 +1,21 @@
+
+--CURDIR--/reg_issue3647.fz:28:23: error 1: Duplicate feature declaration
+  Node(T Type, a Node T) ref is
+----------------------^
+Feature that was declared repeatedly: 'reg_issue3647.Node.T'
+originally declared at --CURDIR--/reg_issue3647.fz:28:8:
+  Node(T Type, a Node T) ref is
+-------^
+To solve this, consider renaming one of these two features, e.g., as 'Tʼ' (using a unicode modifier letter apostrophe 'ʼ' U+02BC) or adding an additional argument (e.g. '_ unit' for an ignored unit argument used only to disambiguate these two).
+
+
+--CURDIR--/reg_issue3647.fz:28:8: error 2: Duplicate feature declaration
+  Node(T Type, a Node T) ref is
+-------^
+Feature that was declared repeatedly: 'reg_issue3647.Node.T'
+originally declared at --CURDIR--/reg_issue3647.fz:28:23:
+  Node(T Type, a Node T) ref is
+----------------------^
+To solve this, consider renaming one of these two features, e.g., as 'Tʼ' (using a unicode modifier letter apostrophe 'ʼ' U+02BC) or adding an additional argument (e.g. '_ unit' for an ignored unit argument used only to disambiguate these two).
+
+2 errors.


### PR DESCRIPTION
The check condition expects duplicate arg names error to have been raised but in this case the duplicate feature sneaks in via free type.

fixes #3647


