### PR TITLE
be/int: add tail call optimization

### DIFF
--- a/src/dev/flang/be/interpreter/Executor.java
+++ b/src/dev/flang/be/interpreter/Executor.java
@@ -255,7 +255,7 @@ public class Executor extends ProcessExpression<Value, Object>
         // NYI change call to pass in ai as in match expression?
         var cur = new Instance(cc);
 
-        callOnInstance(s, cc, cur, tvalue, args);
+        cur = callOnInstance(s, cc, cur, tvalue, args);
 
         Value rres = cur;
         if (!_fuir.isConstructor(cc))
@@ -570,20 +570,21 @@ public class Executor extends ProcessExpression<Value, Object>
    *
    * @param args the arguments to be passed to this call.
    *
-   * @return
+   * @return the (new) instance (might have been replaced due to tail call optimization).
    */
-  Value callOnInstance(int s, int cc, Instance cur, Value outer, List<Value> args)
+  Instance callOnInstance(int s, int cc, Instance cur, Value outer, List<Value> args)
   {
     FuzionThread.current()._callStackFrames.push(cc);
     FuzionThread.current()._callStack.push(s);
 
     var o = outer;
     var a = args;
+    var c = cur;
     while (o != null)
       {
         try
           {
-            new AbstractInterpreter<>(_fuir, new Executor(cur, o, a))
+            new AbstractInterpreter<>(_fuir, new Executor(c, o, a))
               .processClazz(cc);
             o = null;
           }
@@ -591,6 +592,7 @@ public class Executor extends ProcessExpression<Value, Object>
           {
             check(fuir().clazzAt(s) != cc);
 
+            c = new Instance(cc);
             o = tce.tvalue;
             a = tce.args;
           }
@@ -599,7 +601,7 @@ public class Executor extends ProcessExpression<Value, Object>
     FuzionThread.current()._callStack.pop();
     FuzionThread.current()._callStackFrames.pop();
 
-    return null;
+    return c;
   }
 
 

--- a/src/dev/flang/be/interpreter/Intrinsics.java
+++ b/src/dev/flang/be/interpreter/Intrinsics.java
@@ -916,8 +916,8 @@ public class Intrinsics extends ANY
     put("fuzion.sys.thread.spawn0", (executor, innerClazz) -> args ->
         {
           var oc   = executor.fuir().clazzArgClazz(innerClazz, 0);
-          var call = executor.fuir().lookupCall(oc);
-          var t = new Thread(() -> executor.callOnInstance(NO_SITE, call, new Instance(call), args.get(1), new List<>()));
+          var cc = executor.fuir().lookupCall(oc);
+          var t = new Thread(() -> executor.callOnNewInstance(NO_SITE, cc, args.get(1), new List<>()));
           t.setDaemon(true);
           t.start();
           return new i64Value(_startedThreads_.add(t));
@@ -1594,10 +1594,10 @@ public class Intrinsics extends ANY
               var prev = effects.get(ecl);
               effects.put(ecl, ev);
               var oc   = executor.fuir().clazzActualGeneric(innerClazz, 0);
-              var call = executor.fuir().lookupCall(oc);
+              var cc = executor.fuir().lookupCall(oc);
               try
                 {
-                  var ignore = executor.callOnInstance(NO_SITE, call, new Instance(call), args.get(2), new List<>());
+                  var ignore = executor.callOnNewInstance(NO_SITE, cc, args.get(2), new List<>());
                   return new boolValue(true);
                 }
               catch (Abort a)

--- a/src/dev/flang/be/interpreter/TailCallException.java
+++ b/src/dev/flang/be/interpreter/TailCallException.java
@@ -1,0 +1,41 @@
+/*
+
+This file is part of the Fuzion language implementation.
+
+The Fuzion language implementation is free software: you can redistribute it
+and/or modify it under the terms of the GNU General Public License as published
+by the Free Software Foundation, version 3 of the License.
+
+The Fuzion language implementation is distributed in the hope that it will be
+useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+License for more details.
+
+You should have received a copy of the GNU General Public License along with The
+Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+*/
+
+/*-----------------------------------------------------------------------
+ *
+ * Tokiwa Software GmbH, Germany
+ *
+ * Source of class TailCallException
+ *
+ *---------------------------------------------------------------------*/
+
+package dev.flang.be.interpreter;
+
+import dev.flang.util.List;
+
+public class TailCallException extends RuntimeException {
+
+  public final Value tvalue;
+  public final List<Value> args;
+
+  public TailCallException(Value tvalue, List<Value> args)
+  {
+    this.tvalue = tvalue;
+    this.args = args;
+  }
+}

--- a/tests/catch_postcondition/catch_postcondition.fz.expected_err
+++ b/tests/catch_postcondition/catch_postcondition.fz.expected_err
@@ -27,28 +27,68 @@ public postcondition_fault(msg String) => post_fault.cause msg
 (catch_postcondition.test#1 i32).loop: --CURDIR--/catch_postcondition.fz:43:21:
     for v := T.one, double v
 --------------------^^^^^^
-(catch_postcondition.test#1 i32).loop: --CURDIR--/catch_postcondition.fz:43:5:
-    for v := T.one, double v
-----^
-... repeated 29 times ...
-
 catch_postcondition.test#1 i32: --CURDIR--/catch_postcondition.fz:43:5:
     for v := T.one, double v
 ----^
-(catch_postcondition.test#1 i16).loop: --CURDIR--/catch_postcondition.fz:291:8:
+catch_postcondition.λ.call: --CURDIR--/catch_postcondition.fz:291:8:
   say (test i32)
 -------^^^^
-(catch_postcondition.test#1 i16).loop: --CURDIR--/catch_postcondition.fz:43:5:
-    for v := T.one, double v
-----^
-... repeated 10 times ...
+catch_postcondition.loop.λ.call: --CURDIR--/catch_postcondition.fz:276:28:
+           option tries[c].call
+---------------------------^^^^
+(fuzion.type.runtime.type.fault.type.try (option String)).catch#1.λ.call.λ.call: $MODULE/eff/fallible.fz:84:35:
+        fallible.this.instate T v code_try (()->code_catch m.get.get)
+----------------------------------^^^^^^^^
+(fuzion.type.runtime.type.fault.type.instate#4 (option String)).λ.call: $MODULE/effect.fz:119:25:
+    cf := e.Effect_Call code
+------------------------^^^^
+(fuzion.runtime.fault.Effect_Call (option String)).call: $MODULE/effect.fz:210:18:
+      set res := f()
+-----------------^
+fuzion.type.runtime.type.fault.type.instate#4 (option String): <source position not available>:
 
-catch_postcondition.test#1 i16: --CURDIR--/catch_postcondition.fz:43:5:
-    for v := T.one, double v
-----^
-catch_postcondition.λ.call: --CURDIR--/catch_postcondition.fz:146:56:
+(fuzion.type.runtime.type.fault.type.try (option String)).catch#1.λ.call: $MODULE/eff/fallible.fz:84:9:
+        fallible.this.instate T v code_try (()->code_catch m.get.get)
+--------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+(eff.lm.instate_self#2 (option String)).λ.call: $MODULE/effect.fz:164:39:
+    effect.this.instate R effect.this code
+--------------------------------------^^^^
+(eff.type.lm.type.instate#3 (option String)).λ.call: $MODULE/effect.fz:143:17:
+    instate R e code (panic "unexpected abort in {effect.this.type}")
+----------------^^^^
+(eff.type.lm.type.instate#4 (option String)).λ.call: $MODULE/effect.fz:119:25:
+    cf := e.Effect_Call code
+------------------------^^^^
+(eff.lm.Effect_Call (option String)).call: $MODULE/effect.fz:210:18:
+      set res := f()
+-----------------^
+eff.type.lm.type.instate#4 (option String): <source position not available>:
+
+eff.type.lm.type.instate#3 (option String): $MODULE/effect.fz:143:5:
+    instate R e code (panic "unexpected abort in {effect.this.type}")
+----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+eff.lm.instate_self#2 (option String): $MODULE/effect.fz:164:5:
+    effect.this.instate R effect.this code
+----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+(fuzion.type.runtime.type.fault.type.try (option String)).catch#1: $MODULE/eff/fallible.fz:79:7:
+      eff.lm.instate_self ()->
+------^^^^^^^^^^^^^^^^^^^^^^^^
+        m := eff.lm.env.new (option ERROR nil)
+--------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+        v := fallible.this.new e->
+--------^^^^^^^^^^^^^^^^^^^^^^^^^^
+               m <- e
+---------------^^^^^^
+               fallible.this.type.abort
+---------------^^^^^^^^^^^^^^^^^^^^^^^^
+        fallible.this.instate T v code_try (()->code_catch m.get.get)
+--------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+catch_postcondition.test#1 i32: --CURDIR--/catch_postcondition.fz:277:11:
+         .catch s->
+----------^^^^^
+catch_postcondition.λ.call: --CURDIR--/catch_postcondition.fz:146:38:
   tries array ()->String := [ (() -> test i32), (() -> test i16), (() -> test i64) ]
--------------------------------------------------------^^^^
+-------------------------------------^^^^
 catch_postcondition.loop.λ.call: --CURDIR--/catch_postcondition.fz:276:28:
            option tries[c].call
 ---------------------------^^^^
@@ -102,35 +142,18 @@ eff.lm.instate_self#2 (option String): $MODULE/effect.fz:164:5:
 catch_postcondition.loop: --CURDIR--/catch_postcondition.fz:277:11:
          .catch s->
 ----------^^^^^
-(catch_postcondition.test#1 i32).loop: --CURDIR--/catch_postcondition.fz:272:3:
+(fuzion.type.runtime.type.post_fault.type.try (option String)).catch#1.λ.call.λ.call: --CURDIR--/catch_postcondition.fz:272:3:
   for
 --^
-(catch_postcondition.test#1 i32).loop: --CURDIR--/catch_postcondition.fz:43:5:
-    for v := T.one, double v
-----^
-... repeated 28 times ...
-
-catch_postcondition.test#1 i32: --CURDIR--/catch_postcondition.fz:43:5:
-    for v := T.one, double v
-----^
-catch_postcondition.λ.call: --CURDIR--/catch_postcondition.fz:146:38:
-  tries array ()->String := [ (() -> test i32), (() -> test i16), (() -> test i64) ]
--------------------------------------^^^^
-catch_postcondition.loop.λ.call: --CURDIR--/catch_postcondition.fz:276:28:
-           option tries[c].call
----------------------------^^^^
-(fuzion.type.runtime.type.fault.type.try (option String)).catch#1.λ.call.λ.call: $MODULE/eff/fallible.fz:84:35:
-        fallible.this.instate T v code_try (()->code_catch m.get.get)
-----------------------------------^^^^^^^^
-(fuzion.type.runtime.type.fault.type.instate#4 (option String)).λ.call: $MODULE/effect.fz:119:25:
+(fuzion.type.runtime.type.post_fault.type.instate#4 (option String)).λ.call: $MODULE/effect.fz:119:25:
     cf := e.Effect_Call code
 ------------------------^^^^
-(fuzion.runtime.fault.Effect_Call (option String)).call: $MODULE/effect.fz:210:18:
+(fuzion.runtime.post_fault.Effect_Call (option String)).call: $MODULE/effect.fz:210:18:
       set res := f()
 -----------------^
-fuzion.type.runtime.type.fault.type.instate#4 (option String): <source position not available>:
+fuzion.type.runtime.type.post_fault.type.instate#4 (option String): <source position not available>:
 
-(fuzion.type.runtime.type.fault.type.try (option String)).catch#1.λ.call: $MODULE/eff/fallible.fz:84:9:
+(fuzion.type.runtime.type.post_fault.type.try (option String)).catch#1.λ.call: $MODULE/eff/fallible.fz:84:9:
         fallible.this.instate T v code_try (()->code_catch m.get.get)
 --------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 (eff.lm.instate_self#2 (option String)).λ.call: $MODULE/effect.fz:164:39:
@@ -153,7 +176,7 @@ eff.type.lm.type.instate#3 (option String): $MODULE/effect.fz:143:5:
 eff.lm.instate_self#2 (option String): $MODULE/effect.fz:164:5:
     effect.this.instate R effect.this code
 ----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-(fuzion.type.runtime.type.fault.type.try (option String)).catch#1: $MODULE/eff/fallible.fz:79:7:
+(fuzion.type.runtime.type.post_fault.type.try (option String)).catch#1: $MODULE/eff/fallible.fz:79:7:
       eff.lm.instate_self ()->
 ------^^^^^^^^^^^^^^^^^^^^^^^^
         m := eff.lm.env.new (option ERROR nil)
@@ -166,26 +189,9 @@ eff.lm.instate_self#2 (option String): $MODULE/effect.fz:164:5:
 ---------------^^^^^^^^^^^^^^^^^^^^^^^^
         fallible.this.instate T v code_try (()->code_catch m.get.get)
 --------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-catch_postcondition.loop: --CURDIR--/catch_postcondition.fz:277:11:
+catch_postcondition.loop.λ.call: --CURDIR--/catch_postcondition.fz:258:11:
          .catch s->
 ----------^^^^^
-(catch_postcondition.test#1 i16).loop: --CURDIR--/catch_postcondition.fz:272:3:
-  for
---^
-(catch_postcondition.test#1 i16).loop: --CURDIR--/catch_postcondition.fz:43:5:
-    for v := T.one, double v
-----^
-... repeated 8 times ...
-
-catch_postcondition.test#1 i16: --CURDIR--/catch_postcondition.fz:43:5:
-    for v := T.one, double v
-----^
-catch_postcondition.λ.call: --CURDIR--/catch_postcondition.fz:146:56:
-  tries array ()->String := [ (() -> test i32), (() -> test i16), (() -> test i64) ]
--------------------------------------------------------^^^^
-catch_postcondition.loop.λ.call: --CURDIR--/catch_postcondition.fz:257:28:
-           option tries[c].call
----------------------------^^^^
 (fuzion.type.runtime.type.post_fault.type.try (option String)).catch#1.λ.call.λ.call: $MODULE/eff/fallible.fz:84:35:
         fallible.this.instate T v code_try (()->code_catch m.get.get)
 ----------------------------------^^^^^^^^
@@ -236,26 +242,9 @@ eff.lm.instate_self#2 (option String): $MODULE/effect.fz:164:5:
 catch_postcondition.loop: --CURDIR--/catch_postcondition.fz:258:11:
          .catch s->
 ----------^^^^^
-(catch_postcondition.test#1 i32).loop: --CURDIR--/catch_postcondition.fz:253:3:
+(catch_postcondition.try_post (option String)).catch#1.h.λ.call.λ.call: --CURDIR--/catch_postcondition.fz:253:3:
   for
 --^
-(catch_postcondition.test#1 i32).loop: --CURDIR--/catch_postcondition.fz:43:5:
-    for v := T.one, double v
-----^
-... repeated 26 times ...
-
-catch_postcondition.test#1 i32: --CURDIR--/catch_postcondition.fz:43:5:
-    for v := T.one, double v
-----^
-catch_postcondition.λ.call: --CURDIR--/catch_postcondition.fz:146:38:
-  tries array ()->String := [ (() -> test i32), (() -> test i16), (() -> test i64) ]
--------------------------------------^^^^
-catch_postcondition.loop.λ.call: --CURDIR--/catch_postcondition.fz:257:28:
-           option tries[c].call
----------------------------^^^^
-(fuzion.type.runtime.type.post_fault.type.try (option String)).catch#1.λ.call.λ.call: $MODULE/eff/fallible.fz:84:35:
-        fallible.this.instate T v code_try (()->code_catch m.get.get)
-----------------------------------^^^^^^^^
 (fuzion.type.runtime.type.post_fault.type.instate#4 (option String)).λ.call: $MODULE/effect.fz:119:25:
     cf := e.Effect_Call code
 ------------------------^^^^
@@ -264,65 +253,38 @@ catch_postcondition.loop.λ.call: --CURDIR--/catch_postcondition.fz:257:28:
 -----------------^
 fuzion.type.runtime.type.post_fault.type.instate#4 (option String): <source position not available>:
 
-(fuzion.type.runtime.type.post_fault.type.try (option String)).catch#1.λ.call: $MODULE/eff/fallible.fz:84:9:
-        fallible.this.instate T v code_try (()->code_catch m.get.get)
---------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-(eff.lm.instate_self#2 (option String)).λ.call: $MODULE/effect.fz:164:39:
+(catch_postcondition.try_post (option String)).catch#1.h.λ.call: --CURDIR--/catch_postcondition.fz:107:36:
+        (fuzion.runtime.post_fault.instate
+-----------------------------------^^^^^^^
+((catch_postcondition.try_post (option String)).catch#1.h.lm.instate_self#2 (option String)).λ.call: $MODULE/effect.fz:164:39:
     effect.this.instate R effect.this code
 --------------------------------------^^^^
-(eff.type.lm.type.instate#3 (option String)).λ.call: $MODULE/effect.fz:143:17:
+((catch_postcondition.type.try_post.type (option String)).catch#1.type.h.type.lm.type.instate#3 (option String)).λ.call: $MODULE/effect.fz:143:17:
     instate R e code (panic "unexpected abort in {effect.this.type}")
 ----------------^^^^
-(eff.type.lm.type.instate#4 (option String)).λ.call: $MODULE/effect.fz:119:25:
+((catch_postcondition.type.try_post.type (option String)).catch#1.type.h.type.lm.type.instate#4 (option String)).λ.call: $MODULE/effect.fz:119:25:
     cf := e.Effect_Call code
 ------------------------^^^^
-(eff.lm.Effect_Call (option String)).call: $MODULE/effect.fz:210:18:
+((catch_postcondition.try_post (option String)).catch#1.h.lm.Effect_Call (option String)).call: $MODULE/effect.fz:210:18:
       set res := f()
 -----------------^
-eff.type.lm.type.instate#4 (option String): <source position not available>:
+(catch_postcondition.type.try_post.type (option String)).catch#1.type.h.type.lm.type.instate#4 (option String): <source position not available>:
 
-eff.type.lm.type.instate#3 (option String): $MODULE/effect.fz:143:5:
+(catch_postcondition.type.try_post.type (option String)).catch#1.type.h.type.lm.type.instate#3 (option String): $MODULE/effect.fz:143:5:
     instate R e code (panic "unexpected abort in {effect.this.type}")
 ----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-eff.lm.instate_self#2 (option String): $MODULE/effect.fz:164:5:
+(catch_postcondition.try_post (option String)).catch#1.h.lm.instate_self#2 (option String): $MODULE/effect.fz:164:5:
     effect.this.instate R effect.this code
 ----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-(fuzion.type.runtime.type.post_fault.type.try (option String)).catch#1: $MODULE/eff/fallible.fz:79:7:
-      eff.lm.instate_self ()->
-------^^^^^^^^^^^^^^^^^^^^^^^^
-        m := eff.lm.env.new (option ERROR nil)
---------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-        v := fallible.this.new e->
---------^^^^^^^^^^^^^^^^^^^^^^^^^^
-               m <- e
----------------^^^^^^
-               fallible.this.type.abort
----------------^^^^^^^^^^^^^^^^^^^^^^^^
-        fallible.this.instate T v code_try (()->code_catch m.get.get)
---------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-catch_postcondition.loop: --CURDIR--/catch_postcondition.fz:258:11:
+(catch_postcondition.try_post (option String)).catch#1.h: --CURDIR--/catch_postcondition.fz:105:15:
+    res := lm.instate_self ()->
+--------------^^^^^^^^^^^^
+(catch_postcondition.try_post (option String)).catch#1: --CURDIR--/catch_postcondition.fz:195:7:
+      h.res
+------^
+(catch_postcondition.try_post (option String)).catch#1.h.try: --CURDIR--/catch_postcondition.fz:239:11:
          .catch s->
 ----------^^^^^
-(catch_postcondition.test#1 i16).loop: --CURDIR--/catch_postcondition.fz:253:3:
-  for
---^
-(catch_postcondition.test#1 i16).loop: --CURDIR--/catch_postcondition.fz:43:5:
-    for v := T.one, double v
-----^
-... repeated 7 times ...
-
-catch_postcondition.test#1 i16: --CURDIR--/catch_postcondition.fz:43:5:
-    for v := T.one, double v
-----^
-catch_postcondition.λ.call: --CURDIR--/catch_postcondition.fz:146:56:
-  tries array ()->String := [ (() -> test i32), (() -> test i16), (() -> test i64) ]
--------------------------------------------------------^^^^
-catch_postcondition.loop.λ.call: --CURDIR--/catch_postcondition.fz:238:28:
-           option tries[c].call
----------------------------^^^^
-(catch_postcondition.try_post (option String)).catch#1.h.try: --CURDIR--/catch_postcondition.fz:193:34:
-        redef try             => code_try()
----------------------------------^^^^^^^^
 (catch_postcondition.try_post (option String)).catch#1.h.λ.call.λ.call: --CURDIR--/catch_postcondition.fz:112:11:
           try
 ----------^^^
@@ -366,95 +328,9 @@ fuzion.type.runtime.type.post_fault.type.instate#4 (option String): <source posi
 catch_postcondition.loop: --CURDIR--/catch_postcondition.fz:239:11:
          .catch s->
 ----------^^^^^
-(catch_postcondition.test#1 i32).loop: --CURDIR--/catch_postcondition.fz:234:3:
+(fuzion.runtime.post_fault.Effect_Call String).call: --CURDIR--/catch_postcondition.fz:234:3:
   for
 --^
-(catch_postcondition.test#1 i32).loop: --CURDIR--/catch_postcondition.fz:43:5:
-    for v := T.one, double v
-----^
-... repeated 25 times ...
-
-catch_postcondition.test#1 i32: --CURDIR--/catch_postcondition.fz:43:5:
-    for v := T.one, double v
-----^
-catch_postcondition.λ.call: --CURDIR--/catch_postcondition.fz:146:38:
-  tries array ()->String := [ (() -> test i32), (() -> test i16), (() -> test i64) ]
--------------------------------------^^^^
-catch_postcondition.loop.λ.call: --CURDIR--/catch_postcondition.fz:238:28:
-           option tries[c].call
----------------------------^^^^
-(catch_postcondition.try_post (option String)).catch#1.h.try: --CURDIR--/catch_postcondition.fz:193:34:
-        redef try             => code_try()
----------------------------------^^^^^^^^
-(catch_postcondition.try_post (option String)).catch#1.h.λ.call.λ.call: --CURDIR--/catch_postcondition.fz:112:11:
-          try
-----------^^^
-(fuzion.type.runtime.type.post_fault.type.instate#4 (option String)).λ.call: $MODULE/effect.fz:119:25:
-    cf := e.Effect_Call code
-------------------------^^^^
-(fuzion.runtime.post_fault.Effect_Call (option String)).call: $MODULE/effect.fz:210:18:
-      set res := f()
------------------^
-fuzion.type.runtime.type.post_fault.type.instate#4 (option String): <source position not available>:
-
-(catch_postcondition.try_post (option String)).catch#1.h.λ.call: --CURDIR--/catch_postcondition.fz:107:36:
-        (fuzion.runtime.post_fault.instate
------------------------------------^^^^^^^
-((catch_postcondition.try_post (option String)).catch#1.h.lm.instate_self#2 (option String)).λ.call: $MODULE/effect.fz:164:39:
-    effect.this.instate R effect.this code
---------------------------------------^^^^
-((catch_postcondition.type.try_post.type (option String)).catch#1.type.h.type.lm.type.instate#3 (option String)).λ.call: $MODULE/effect.fz:143:17:
-    instate R e code (panic "unexpected abort in {effect.this.type}")
-----------------^^^^
-((catch_postcondition.type.try_post.type (option String)).catch#1.type.h.type.lm.type.instate#4 (option String)).λ.call: $MODULE/effect.fz:119:25:
-    cf := e.Effect_Call code
-------------------------^^^^
-((catch_postcondition.try_post (option String)).catch#1.h.lm.Effect_Call (option String)).call: $MODULE/effect.fz:210:18:
-      set res := f()
------------------^
-(catch_postcondition.type.try_post.type (option String)).catch#1.type.h.type.lm.type.instate#4 (option String): <source position not available>:
-
-(catch_postcondition.type.try_post.type (option String)).catch#1.type.h.type.lm.type.instate#3 (option String): $MODULE/effect.fz:143:5:
-    instate R e code (panic "unexpected abort in {effect.this.type}")
-----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-(catch_postcondition.try_post (option String)).catch#1.h.lm.instate_self#2 (option String): $MODULE/effect.fz:164:5:
-    effect.this.instate R effect.this code
-----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-(catch_postcondition.try_post (option String)).catch#1.h: --CURDIR--/catch_postcondition.fz:105:15:
-    res := lm.instate_self ()->
---------------^^^^^^^^^^^^
-(catch_postcondition.try_post (option String)).catch#1: --CURDIR--/catch_postcondition.fz:195:7:
-      h.res
-------^
-catch_postcondition.loop: --CURDIR--/catch_postcondition.fz:239:11:
-         .catch s->
-----------^^^^^
-(catch_postcondition.test#1 i32).loop: --CURDIR--/catch_postcondition.fz:234:3:
-  for
---^
-(catch_postcondition.test#1 i32).loop: --CURDIR--/catch_postcondition.fz:43:5:
-    for v := T.one, double v
-----^
-... repeated 23 times ...
-
-catch_postcondition.test#1 i32: --CURDIR--/catch_postcondition.fz:43:5:
-    for v := T.one, double v
-----^
-catch_postcondition.res2.λ.call: --CURDIR--/catch_postcondition.fz:225:21:
-  res2 => try_post (test i32) || (s->say "*** failed: $s ***"; test u64)
---------------------^^^^
-(catch_postcondition.try_post String).catch#1.h.try: --CURDIR--/catch_postcondition.fz:193:34:
-        redef try             => code_try()
----------------------------------^^^^^^^^
-(catch_postcondition.try_post String).catch#1.h.λ.call.λ.call: --CURDIR--/catch_postcondition.fz:112:11:
-          try
-----------^^^
-(fuzion.type.runtime.type.post_fault.type.instate#4 String).λ.call: $MODULE/effect.fz:119:25:
-    cf := e.Effect_Call code
-------------------------^^^^
-(fuzion.runtime.post_fault.Effect_Call String).call: $MODULE/effect.fz:210:18:
-      set res := f()
------------------^
 fuzion.type.runtime.type.post_fault.type.instate#4 String: <source position not available>:
 
 (catch_postcondition.try_post String).catch#1.h.λ.call: --CURDIR--/catch_postcondition.fz:107:36:
@@ -492,29 +368,9 @@ fuzion.type.runtime.type.post_fault.type.instate#4 String: <source position not 
 catch_postcondition.res2: --CURDIR--/catch_postcondition.fz:225:31:
   res2 => try_post (test i32) || (s->say "*** failed: $s ***"; test u64)
 ------------------------------^^
-(catch_postcondition.test#1 i32).loop: --CURDIR--/catch_postcondition.fz:226:7:
+(fuzion.type.runtime.type.post_fault.type.instate#4 String).λ.call: --CURDIR--/catch_postcondition.fz:226:7:
   say res2
 ------^^^^
-(catch_postcondition.test#1 i32).loop: --CURDIR--/catch_postcondition.fz:43:5:
-    for v := T.one, double v
-----^
-... repeated 24 times ...
-
-catch_postcondition.test#1 i32: --CURDIR--/catch_postcondition.fz:43:5:
-    for v := T.one, double v
-----^
-catch_postcondition.res.λ.call: --CURDIR--/catch_postcondition.fz:213:12:
-           test i32
------------^^^^
-(catch_postcondition.try_post String).catch#1.h.try: --CURDIR--/catch_postcondition.fz:193:34:
-        redef try             => code_try()
----------------------------------^^^^^^^^
-(catch_postcondition.try_post String).catch#1.h.λ.call.λ.call: --CURDIR--/catch_postcondition.fz:112:11:
-          try
-----------^^^
-(fuzion.type.runtime.type.post_fault.type.instate#4 String).λ.call: $MODULE/effect.fz:119:25:
-    cf := e.Effect_Call code
-------------------------^^^^
 (fuzion.runtime.post_fault.Effect_Call String).call: $MODULE/effect.fz:210:18:
       set res := f()
 -----------------^
@@ -552,23 +408,46 @@ fuzion.type.runtime.type.post_fault.type.instate#4 String: <source position not 
 catch_postcondition.res: --CURDIR--/catch_postcondition.fz:214:11:
          .catch s->
 ----------^^^^^
-(catch_postcondition.test#1 i16).loop: --CURDIR--/catch_postcondition.fz:217:7:
+catch_postcondition.loop.h.λ.call.λ.call: --CURDIR--/catch_postcondition.fz:217:7:
   say res
 ------^^^
-(catch_postcondition.test#1 i16).loop: --CURDIR--/catch_postcondition.fz:43:5:
-    for v := T.one, double v
-----^
-... repeated 8 times ...
+(fuzion.type.runtime.type.post_fault.type.instate#4 (option String)).λ.call: $MODULE/effect.fz:119:25:
+    cf := e.Effect_Call code
+------------------------^^^^
+(fuzion.runtime.post_fault.Effect_Call (option String)).call: $MODULE/effect.fz:210:18:
+      set res := f()
+-----------------^
+fuzion.type.runtime.type.post_fault.type.instate#4 (option String): <source position not available>:
 
-catch_postcondition.test#1 i16: --CURDIR--/catch_postcondition.fz:43:5:
-    for v := T.one, double v
-----^
-catch_postcondition.λ.call: --CURDIR--/catch_postcondition.fz:146:56:
-  tries array ()->String := [ (() -> test i32), (() -> test i16), (() -> test i64) ]
--------------------------------------------------------^^^^
-catch_postcondition.loop.h.try: --CURDIR--/catch_postcondition.fz:164:44:
-      redef try option String  => tries[c].call
--------------------------------------------^^^^
+catch_postcondition.loop.h.λ.call: --CURDIR--/catch_postcondition.fz:107:36:
+        (fuzion.runtime.post_fault.instate
+-----------------------------------^^^^^^^
+(catch_postcondition.loop.h.lm.instate_self#2 (option String)).λ.call: $MODULE/effect.fz:164:39:
+    effect.this.instate R effect.this code
+--------------------------------------^^^^
+(catch_postcondition.type.loop.type.h.type.lm.type.instate#3 (option String)).λ.call: $MODULE/effect.fz:143:17:
+    instate R e code (panic "unexpected abort in {effect.this.type}")
+----------------^^^^
+(catch_postcondition.type.loop.type.h.type.lm.type.instate#4 (option String)).λ.call: $MODULE/effect.fz:119:25:
+    cf := e.Effect_Call code
+------------------------^^^^
+(catch_postcondition.loop.h.lm.Effect_Call (option String)).call: $MODULE/effect.fz:210:18:
+      set res := f()
+-----------------^
+catch_postcondition.type.loop.type.h.type.lm.type.instate#4 (option String): <source position not available>:
+
+catch_postcondition.type.loop.type.h.type.lm.type.instate#3 (option String): $MODULE/effect.fz:143:5:
+    instate R e code (panic "unexpected abort in {effect.this.type}")
+----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+catch_postcondition.loop.h.lm.instate_self#2 (option String): $MODULE/effect.fz:164:5:
+    effect.this.instate R effect.this code
+----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+catch_postcondition.loop.h: --CURDIR--/catch_postcondition.fz:105:15:
+    res := lm.instate_self ()->
+--------------^^^^^^^^^^^^
+catch_postcondition.loop.h.try: --CURDIR--/catch_postcondition.fz:166:10:
+    r := h.res
+---------^
 catch_postcondition.loop.h.λ.call.λ.call: --CURDIR--/catch_postcondition.fz:112:11:
           try
 ----------^^^
@@ -609,106 +488,9 @@ catch_postcondition.loop.h: --CURDIR--/catch_postcondition.fz:105:15:
 catch_postcondition.loop: --CURDIR--/catch_postcondition.fz:166:10:
     r := h.res
 ---------^
-(catch_postcondition.test#1 i32).loop: --CURDIR--/catch_postcondition.fz:162:3:
+catch_postcondition.z.lm.instate_self#2 (option String): --CURDIR--/catch_postcondition.fz:162:3:
   for c in tries.indices do
 --^
-(catch_postcondition.test#1 i32).loop: --CURDIR--/catch_postcondition.fz:43:5:
-    for v := T.one, double v
-----^
-... repeated 26 times ...
-
-catch_postcondition.test#1 i32: --CURDIR--/catch_postcondition.fz:43:5:
-    for v := T.one, double v
-----^
-catch_postcondition.λ.call: --CURDIR--/catch_postcondition.fz:146:38:
-  tries array ()->String := [ (() -> test i32), (() -> test i16), (() -> test i64) ]
--------------------------------------^^^^
-catch_postcondition.loop.h.try: --CURDIR--/catch_postcondition.fz:164:44:
-      redef try option String  => tries[c].call
--------------------------------------------^^^^
-catch_postcondition.loop.h.λ.call.λ.call: --CURDIR--/catch_postcondition.fz:112:11:
-          try
-----------^^^
-(fuzion.type.runtime.type.post_fault.type.instate#4 (option String)).λ.call: $MODULE/effect.fz:119:25:
-    cf := e.Effect_Call code
-------------------------^^^^
-(fuzion.runtime.post_fault.Effect_Call (option String)).call: $MODULE/effect.fz:210:18:
-      set res := f()
------------------^
-fuzion.type.runtime.type.post_fault.type.instate#4 (option String): <source position not available>:
-
-catch_postcondition.loop.h.λ.call: --CURDIR--/catch_postcondition.fz:107:36:
-        (fuzion.runtime.post_fault.instate
------------------------------------^^^^^^^
-(catch_postcondition.loop.h.lm.instate_self#2 (option String)).λ.call: $MODULE/effect.fz:164:39:
-    effect.this.instate R effect.this code
---------------------------------------^^^^
-(catch_postcondition.type.loop.type.h.type.lm.type.instate#3 (option String)).λ.call: $MODULE/effect.fz:143:17:
-    instate R e code (panic "unexpected abort in {effect.this.type}")
-----------------^^^^
-(catch_postcondition.type.loop.type.h.type.lm.type.instate#4 (option String)).λ.call: $MODULE/effect.fz:119:25:
-    cf := e.Effect_Call code
-------------------------^^^^
-(catch_postcondition.loop.h.lm.Effect_Call (option String)).call: $MODULE/effect.fz:210:18:
-      set res := f()
------------------^
-catch_postcondition.type.loop.type.h.type.lm.type.instate#4 (option String): <source position not available>:
-
-catch_postcondition.type.loop.type.h.type.lm.type.instate#3 (option String): $MODULE/effect.fz:143:5:
-    instate R e code (panic "unexpected abort in {effect.this.type}")
-----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-catch_postcondition.loop.h.lm.instate_self#2 (option String): $MODULE/effect.fz:164:5:
-    effect.this.instate R effect.this code
-----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-catch_postcondition.loop.h: --CURDIR--/catch_postcondition.fz:105:15:
-    res := lm.instate_self ()->
---------------^^^^^^^^^^^^
-catch_postcondition.loop: --CURDIR--/catch_postcondition.fz:166:10:
-    r := h.res
----------^
-catch_postcondition.test#1 i16: --CURDIR--/catch_postcondition.fz:162:3:
-  for c in tries.indices do
---^
-catch_postcondition.λ.call: --CURDIR--/catch_postcondition.fz:146:56:
-  tries array ()->String := [ (() -> test i32), (() -> test i16), (() -> test i64) ]
--------------------------------------------------------^^^^
-catch_postcondition.z.try: --CURDIR--/catch_postcondition.fz:151:43:
-    redef try option String  => tries[c0].call
-------------------------------------------^^^^
-catch_postcondition.z.λ.call.λ.call: --CURDIR--/catch_postcondition.fz:112:11:
-          try
-----------^^^
-(fuzion.type.runtime.type.post_fault.type.instate#4 (option String)).λ.call: $MODULE/effect.fz:119:25:
-    cf := e.Effect_Call code
-------------------------^^^^
-(fuzion.runtime.post_fault.Effect_Call (option String)).call: $MODULE/effect.fz:210:18:
-      set res := f()
------------------^
-fuzion.type.runtime.type.post_fault.type.instate#4 (option String): <source position not available>:
-
-catch_postcondition.z.λ.call: --CURDIR--/catch_postcondition.fz:107:36:
-        (fuzion.runtime.post_fault.instate
------------------------------------^^^^^^^
-(catch_postcondition.z.lm.instate_self#2 (option String)).λ.call: $MODULE/effect.fz:164:39:
-    effect.this.instate R effect.this code
---------------------------------------^^^^
-(catch_postcondition.type.z.type.lm.type.instate#3 (option String)).λ.call: $MODULE/effect.fz:143:17:
-    instate R e code (panic "unexpected abort in {effect.this.type}")
-----------------^^^^
-(catch_postcondition.type.z.type.lm.type.instate#4 (option String)).λ.call: $MODULE/effect.fz:119:25:
-    cf := e.Effect_Call code
-------------------------^^^^
-(catch_postcondition.z.lm.Effect_Call (option String)).call: $MODULE/effect.fz:210:18:
-      set res := f()
------------------^
-catch_postcondition.type.z.type.lm.type.instate#4 (option String): <source position not available>:
-
-catch_postcondition.type.z.type.lm.type.instate#3 (option String): $MODULE/effect.fz:143:5:
-    instate R e code (panic "unexpected abort in {effect.this.type}")
-----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-catch_postcondition.z.lm.instate_self#2 (option String): $MODULE/effect.fz:164:5:
-    effect.this.instate R effect.this code
-----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 catch_postcondition.z: --CURDIR--/catch_postcondition.fz:105:15:
     res := lm.instate_self ()->
 --------------^^^^^^^^^^^^
@@ -748,11 +530,6 @@ public postcondition_fault(msg String) => post_fault.cause msg
 (catch_postcondition.test#1 i32).loop: --CURDIR--/catch_postcondition.fz:43:21:
     for v := T.one, double v
 --------------------^^^^^^
-(catch_postcondition.test#1 i32).loop: --CURDIR--/catch_postcondition.fz:43:5:
-    for v := T.one, double v
-----^
-... repeated 29 times ...
-
 catch_postcondition.test#1 i32: --CURDIR--/catch_postcondition.fz:43:5:
     for v := T.one, double v
 ----^
@@ -799,23 +576,9 @@ catch_postcondition.z.lm.instate_self#2 (option String): $MODULE/effect.fz:164:5
 catch_postcondition.z: --CURDIR--/catch_postcondition.fz:105:15:
     res := lm.instate_self ()->
 --------------^^^^^^^^^^^^
-(catch_postcondition.test#1 i32).loop: --CURDIR--/catch_postcondition.fz:154:7:
+(catch_postcondition.ref handle_post String).λ.call.λ.call: --CURDIR--/catch_postcondition.fz:154:7:
   say z.res
 ------^
-(catch_postcondition.test#1 i32).loop: --CURDIR--/catch_postcondition.fz:43:5:
-    for v := T.one, double v
-----^
-... repeated 26 times ...
-
-catch_postcondition.test#1 i32: --CURDIR--/catch_postcondition.fz:43:5:
-    for v := T.one, double v
-----^
-catch_postcondition.anonymous.try: --CURDIR--/catch_postcondition.fz:134:7:
-      test i32
-------^^^^
-(catch_postcondition.ref handle_post String).λ.call.λ.call: --CURDIR--/catch_postcondition.fz:112:11:
-          try
-----------^^^
 (fuzion.type.runtime.type.post_fault.type.instate#4 String).λ.call: $MODULE/effect.fz:119:25:
     cf := e.Effect_Call code
 ------------------------^^^^
@@ -850,23 +613,9 @@ fuzion.type.runtime.type.post_fault.type.instate#4 String: <source position not 
 catch_postcondition.anonymous: --CURDIR--/catch_postcondition.fz:105:15:
     res := lm.instate_self ()->
 --------------^^^^^^^^^^^^
-(catch_postcondition.test#1 i32).loop: --CURDIR--/catch_postcondition.fz:132:8:
+catch_postcondition.y.λ.call.λ.call: --CURDIR--/catch_postcondition.fz:132:8:
   say (ref : handle_post String
 -------^
-(catch_postcondition.test#1 i32).loop: --CURDIR--/catch_postcondition.fz:43:5:
-    for v := T.one, double v
-----^
-... repeated 26 times ...
-
-catch_postcondition.test#1 i32: --CURDIR--/catch_postcondition.fz:43:5:
-    for v := T.one, double v
-----^
-catch_postcondition.y.try: --CURDIR--/catch_postcondition.fz:121:30:
-    redef try             => test i32
------------------------------^^^^
-catch_postcondition.y.λ.call.λ.call: --CURDIR--/catch_postcondition.fz:112:11:
-          try
-----------^^^
 (fuzion.type.runtime.type.post_fault.type.instate#4 String).λ.call: $MODULE/effect.fz:119:25:
     cf := e.Effect_Call code
 ------------------------^^^^
@@ -924,11 +673,6 @@ public postcondition_fault(msg String) => post_fault.cause msg
 (catch_postcondition.test#1 i32).loop: --CURDIR--/catch_postcondition.fz:43:21:
     for v := T.one, double v
 --------------------^^^^^^
-(catch_postcondition.test#1 i32).loop: --CURDIR--/catch_postcondition.fz:43:5:
-    for v := T.one, double v
-----^
-... repeated 29 times ...
-
 catch_postcondition.test#1 i32: --CURDIR--/catch_postcondition.fz:43:5:
     for v := T.one, double v
 ----^

--- a/tests/reg_issue1588/skip_int
+++ b/tests/reg_issue1588/skip_int
@@ -1,2 +1,0 @@
-results in:
-> error 1: *** java.lang.StackOverflowError

--- a/tests/reg_issue2194/reg_issue2194.fz.expected_err
+++ b/tests/reg_issue2194/reg_issue2194.fz.expected_err
@@ -25,12 +25,6 @@ pre a < 3
 loop: --CURDIR--/reg_issue2194.fz:32:3:
   y i
 --^
-loop: --CURDIR--/reg_issue2194.fz:31:1:
-for i in 0..10 do
-^
-loop: --CURDIR--/reg_issue2194.fz:31:1:
-for i in 0..10 do
-^
 universe: --CURDIR--/reg_issue2194.fz:31:1:
 for i in 0..10 do
 ^

--- a/tests/reg_issue3429/skip_int
+++ b/tests/reg_issue3429/skip_int
@@ -1,1 +1,1 @@
-NYI: UNDER DEVELOPMENT: interpreter does not do tail call optimzation yet.
+NYI: UNDER DEVELOPMENT: too slow.

--- a/tests/tail_call_optimization/Makefile
+++ b/tests/tail_call_optimization/Makefile
@@ -1,0 +1,25 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test Makefile
+#
+# -----------------------------------------------------------------------
+
+override NAME = tail_call_optimization
+include ../simple.mk

--- a/tests/tail_call_optimization/tail_call_optimization.fz
+++ b/tests/tail_call_optimization/tail_call_optimization.fz
@@ -1,0 +1,32 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test tail_call_optimization
+#
+# -----------------------------------------------------------------------
+
+tail_call_optimization =>
+
+  tco(i i16) =>
+    if i = i16.max
+      say "reached i16 max"
+      exit 0
+    tco i+1
+
+  tco 0

--- a/tests/tail_call_optimization/tail_call_optimization.fz.expected_out
+++ b/tests/tail_call_optimization/tail_call_optimization.fz.expected_out
@@ -1,0 +1,1 @@
+reached i16 max


### PR DESCRIPTION
Adds TCO to the interpreter via simple exception throwing and a while loop. The exceptions payload being the next target+args.