### PR TITLE
tests: fix "result is not used" error

### DIFF
--- a/tests/visibility_negative/visibility_negative.fz
+++ b/tests/visibility_negative/visibility_negative.fz
@@ -112,7 +112,7 @@ visibility_negative is
   visi2 =>
     count := 0
     expr => set count := count + 11; count
-    use(i i32) is
+    use(i i32) =>
 
     a1 is
       f1 := expr


### PR DESCRIPTION
error was:
```
Expression produces result of type 'visibility_negative.this.visi2.this.use' but result is not used.
To solve this, use the result, explicitly ignore the result '_ := <expression>' or change 'visibility_negative.visi2.use' from constructor to routine by replacing'is' by '=>'.
```