### PR TITLE
lib: introduce `switch`, parent of choices with success and failure

### DIFF
--- a/lib/num_option.fz
+++ b/lib/num_option.fz
@@ -30,54 +30,9 @@
 # numeric result or false for a boolean result.
 #
 public num_option(public T type : numeric)
-  : choice T nil,
+  : switch T nil,
     monad T (num_option T)
 is
-
-  # Does this option contain a value of type T?
-  #
-  public exists => (num_option.this ? T   => true
-                                    | nil => false)
-
-
-  # short-hand postfix operator for 'exists'
-  #
-  public postfix ?? => exists
-
-
-  # Does this option contain no value of type T?
-  #
-  public is_nil => !exists
-
-
-  # short-hand postfix operator for 'is_nil'
-  #
-  public postfix !! => is_nil
-
-
-  # short-hand prefix operator for 'is_nil'
-  #
-  public prefix ! => is_nil
-
-
-  # value of an option that is known to contain a value
-  #
-  # this can only be called in cases where it is known for sure that this option
-  # is not nil.  A runtime error will be created otherwise.
-  #
-  public val T
-    pre
-      safety: (num_option.this??)
-  =>
-    num_option.this ? v T => v
-                    | nil => fuzion.std.panic "num_option.val called on nil"
-
-
-  # unwrap value or get default
-  #
-  public get (default Lazy T) =>
-    num_option.this ? v T => v
-                    | nil => default
 
 
   # monadic operator
@@ -136,15 +91,6 @@ is
 
   public abs num_option T =>
     num_option.this >>= v -> if v.sign ≥ 0 v else -?v
-
-
-  # converts num_option into a list of either a single element in case
-  # num_option.this.exists or `nil`otherwise
-  #
-  public as_list list T
-  =>
-    num_option.this ? v T => v : nil
-                    | nil => nil
 
 
   public redef as_string String =>

--- a/lib/option.fz
+++ b/lib/option.fz
@@ -28,49 +28,15 @@
 # option represents an optional value of type T
 #
 public option(public T type)
-  : choice T nil,
-    monad T (option T),
-    Sequence T,
-    auto_unwrap T (try (option T)) /* NYI: BUG #3355: auto_unwrap T (try option.this) */
+  : switch T nil,
+    monad T (option T)
 is
 
-  # Does this option contain a value of type T?
-  #
-  public exists => (option.this ? T   => true
-                                | nil => false)
-
-
-  # short-hand postfix operator for 'exists'
-  #
-  public postfix ?? => exists
 
 
   # Does this option contain no value of type T?
   #
   public is_nil => !exists
-
-
-  # short-hand postfix operator for 'is_nil'
-  #
-  public postfix !! => is_nil
-
-
-  # short-hand prefix operator for 'is_nil'
-  #
-  public prefix ! => is_nil
-
-
-  # value of an option that is known to contain a value
-  #
-  # this can only be called in cases where it is known for sure that this option
-  # is not nil.  A runtime error will be created otherwise.
-  #
-  public val T
-    pre
-      safety: (option.this??) # NYI: REGRESSION: parantheses currently necessary, due to PR #2572
-  =>
-    option.this ? v T => v
-                | nil => fuzion.std.panic "option.val called on nil"
 
 
   # monadic operator
@@ -124,18 +90,6 @@ is
                 | nil => $nil
 
 
-  # unwraps an option that is known to contain a value
-  #
-  # this can only be called in cases where it is known for sure that this option
-  # is not nil.  A runtime error will be created otherwise.
-  #
-  public get
-  pre
-    safety: (option.this??)
-  =>
-    option.this ? v T => v
-                | nil => fuzion.std.panic "option.get called on nil"
-
 
   # unwraps an option if it exists, returns default value otherwise.
   #
@@ -145,20 +99,7 @@ is
                 | nil => default
 
 
-  # converts option into a list of either a single element in case
-  # option.this.exists or `nil`otherwise
-  #
-  public redef as_list list T
-  =>
-    option.this ? v T => v : nil
-                | nil => nil
 
-
-  # unwrap this option
-  #
-  public redef unwrap ! try option.this =>
-    option.this ? v T => v
-                | nil => (try option.this).env.raise (error "error unwrapping option: {option.this}")
 
 
   # return function

--- a/lib/outcome.fz
+++ b/lib/outcome.fz
@@ -49,57 +49,13 @@
 # compatible to  'outcome data IO_Error Permission_Error', so everything
 # is fine.
 #
-public outcome(public T type) :
-  choice T error, /* ...  NYI: this should be open generic! */
-  monad T (outcome T),
-  auto_unwrap T (try (outcome T)) /* NYI: BUG #3355: auto_unwrap T (try outcome.this) */
+public outcome(public T type) : switch T error,
+                                monad T (outcome T)
 is
-
-  # Does this outcome contain a value of type T?
-  #
-  public ok => (outcome.this ? T     => true
-                             | error => false)
-
-
-  # short-hand postfix operator for 'ok'
-  #
-  public postfix ?? => ok
-
 
   # Does this outcome contain an error
   #
   public is_error => !ok
-
-
-  # short-hand postfix operator for 'is_error'
-  #
-  public postfix !! => is_error
-
-
-  # short-hand prefix operator for 'is_error'
-  #
-  public prefix ! => is_error
-
-
-  # value of an outcome that is known to contain a value
-  #
-  # This can only be called in cases where it is known for sure that this
-  # outcomee is not an error.  A runtime error will be created otherwise.
-  #
-  public val T
-    pre
-      safety: (outcome.this??)
-  =>
-    outcome.this ? v T   => v
-                 | error => panic "outcome.val called on error"
-
-
-  # value of an outcome or default if outcome contains err
-  #
-  public val(default T) T
-  =>
-    outcome.this ? v T   => v
-                 | error => default
 
 
   # error of an outcome that is known to contain an error
@@ -179,13 +135,6 @@ is
   public bind(B type, f T -> outcome B) outcome B =>
     outcome.this ? v T => f v
                  | e error => e
-
-
-  # unwrap this outcome
-  #
-  redef unwrap ! try outcome.this =>
-    outcome.this ? v T     => v
-                 | e error => (try outcome.this).env.raise e
 
 
   # return function

--- a/lib/switch.fz
+++ b/lib/switch.fz
@@ -1,0 +1,127 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion standard library feature switch
+#
+# -----------------------------------------------------------------------
+
+# switch is the parent feature of all choices
+# that encode success and failure,
+# e.g.    option  (something/nil)
+#      or outcome (something/error)
+#
+public switch(A type, B type /* NYI: B should be open generic */) :
+  choice A B,
+  # monad A (switch A B) NYI: does not work,
+  auto_unwrap A (try (switch A B)), /* NYI: BUG #3355: auto_unwrap T (try switch.this) */
+  Sequence A
+is
+
+  # NYI: CLEANUP: decide name: exists/ok, get/val?
+
+  # Does this switch contain a value of type A?
+  #
+  public exists => (switch.this ? A => true
+                                | B => false)
+
+
+  # Does this switch contain a value of type A?
+  #
+  public ok => exists
+
+
+  # short-hand postfix operator for 'exists'
+  #
+  public postfix ?? => exists
+
+
+  # short-hand postfix operator for '!exists'
+  #
+  public postfix !! => !exists
+
+
+  # short-hand prefix operator for '!exists'
+  #
+  public prefix ! => !exists
+
+
+  # unwraps a switch that is known to contain a value
+  #
+  # this can only be called in cases where it is known for sure that this switch
+  # is not nil.  A runtime error will be created otherwise.
+  #
+  public get
+  pre
+    safety: (switch.this??) # NYI: REGRESSION: parantheses currently necessary, due to PR #2572
+  =>
+    switch.this ? a A => a
+                | B   => fuzion.std.panic "switch.get called on B"
+
+
+
+  # unwrap value or get default
+  #
+  public get (default Lazy A) =>
+    switch.this ? a A => a
+                | B => default
+
+
+  # value of a switch that is known to contain a value
+  #
+  # This can only be called in cases where it is known for sure that this
+  # switch is not a B.  A runtime error will be created otherwise.
+  #
+  public val A
+    pre
+      safety: (switch.this??) # NYI: REGRESSION: parantheses currently necessary, due to PR #2572
+  =>
+    switch.this ? a A => a
+                | B   => panic "switch.val called on B"
+
+
+  # value of a switch or default if switch contains B
+  #
+  public val(default A) A
+  =>
+    switch.this ? a A => a
+                | B   => default
+
+
+  # converts switch into a list of either a single element in case
+  # switch.this.exists or `nil`otherwise
+  #
+  public redef as_list list A
+  =>
+    switch.this ? a A => a : nil
+                | B => nil
+
+  # unwrap this switch
+  #
+  public redef unwrap ! try switch.this =>
+    match switch.this
+      a A => a
+      b B => (try switch.this).env.raise (error $b)
+
+
+  # converts switch to a string
+  #
+  public redef as_string =>
+    match switch.this
+      a A => a.as_string
+      b B => b.as_string

--- a/src/dev/flang/ast/Expr.java
+++ b/src/dev/flang/ast/Expr.java
@@ -781,8 +781,7 @@ public abstract class Expr extends HasGlobalIndex implements HasSourcePosition
       && !expectedType.isAssignableFrom(t, context)
       && expectedType.compareTo(Types.resolved.t_Any) != 0
       && !t.isGenericArgument()
-      && t.feature()
-          .inherits()
+      && allInherited(t.feature())
           .stream()
           .anyMatch(c ->
             c.calledFeature().equals(Types.resolved.f_auto_unwrap)
@@ -790,6 +789,17 @@ public abstract class Expr extends HasGlobalIndex implements HasSourcePosition
                     && expectedType.isAssignableFrom(c.actualTypeParameters().get(0).applyTypePars(t), context))
       ? new ParsedCall(this, new ParsedName(pos(), "unwrap")).resolveTypes(res, context)
       : this;
+  }
+
+
+  /**
+   * @param f
+   *
+   * @return the whole tree of inherited features flattened to a list.
+   */
+  private List<AbstractCall> allInherited(AbstractFeature f)
+  {
+    return f.inherits().flatMap(x -> new List<>(x, allInherited(x.calledFeature())));
   }
 
 

--- a/src/dev/flang/fuir/analysis/AbstractInterpreter.java
+++ b/src/dev/flang/fuir/analysis/AbstractInterpreter.java
@@ -535,7 +535,10 @@ public class AbstractInterpreter<VALUE, RESULT> extends ANY
           case Call:
             var cc0 = _fuir.accessedClazz(last_s);
             var rt = _fuir.clazzResultClazz(cc0);
-            l.add(_processor.drop(stack.pop(), rt));
+            if (!clazzHasUnitValue(rt))
+              {
+                l.add(_processor.drop(stack.pop(), rt));
+              }
             break;
           default:
             break; // NYI: ignore this case for now, this occurs infrequently, one example is tests/reg_issue1294.

--- a/tests/atomic/test_atomic.fz
+++ b/tests/atomic/test_atomic.fz
@@ -89,15 +89,15 @@ test_atomic is
 
   # test bool-like choice
   on, off.
-  switch : choice on off is
-    ord => match switch.this
+  my_switch : choice on off is
+    ord => match my_switch.this
       on => 0
       off => 1
-    redef as_string => match switch.this
+    redef as_string => match my_switch.this
       on => "on"
       off => "off"
-    type.equality(a, b switch.this) => a.ord = b.ord
-  test0 switch on on off off ((a,b)-> a.ord=b.ord)
+    type.equality(a, b my_switch.this) => a.ord = b.ord
+  test0 my_switch on on off off ((a,b)-> a.ord=b.ord)
 
   # test int-like choice
   red, yellow, green.

--- a/tests/reg_issue2111/reg_issue2111.fz
+++ b/tests/reg_issue2111/reg_issue2111.fz
@@ -26,6 +26,6 @@ test(T type : property.equatable, a T) =>
   _ := a1.read = a
 
   on, off.
-  switch : choice on off is
-    type.equality(a, b switch.this) => true
-  test switch on
+  my_switch : choice on off is
+    type.equality(a, b my_switch.this) => true
+  test my_switch on

--- a/tests/reg_issue2111/reg_issue2111.fz.expected_err
+++ b/tests/reg_issue2111/reg_issue2111.fz.expected_err
@@ -1,8 +1,8 @@
 
 --CURDIR--/reg_issue2111.fz:31:3: error 1: Incompatible type parameter
-  test switch on
+  test my_switch on
 --^^^^
 formal type parameter 'T' with constraint 'property.equatable'
-actual type parameter '(test.this test.T).switch'
+actual type parameter '(test.this test.T).my_switch'
 
 one error.


### PR DESCRIPTION
- outcome(public T type) : switch T error,
- public option(public T type) : switch T nil,
- public num_option(public T type : numeric) : switch T nil,

moved exists, ok, postfix ??, postfix !!, prefix !, get, get#1, val, val#1 and unwrap to switch.

