### PR TITLE
be/jvm: fix "VerifyError: Instruction type does not match stack map"

### DIFF
--- a/src/dev/flang/be/jvm/Choices.java
+++ b/src/dev/flang/be/jvm/Choices.java
@@ -526,8 +526,8 @@ public class Choices extends ANY implements ClassFileConstants
         }
       case nullable:
         {
-          var pos = jvm.reportErrorInCode("As per data flow analysis this code should be unreachable.");
-          var neg = jvm.reportErrorInCode("As per data flow analysis this code should be unreachable.");
+          var pos = Expr.POP.andThen(jvm.reportErrorInCode("As per data flow analysis this code should be unreachable."));
+          var neg = Expr.POP.andThen(jvm.reportErrorInCode("As per data flow analysis this code should be unreachable."));
 
           for (var mc = 0; mc < _fuir.matchCaseCount(s); mc++)
             {


### PR DESCRIPTION
broken via PR #3700
this broke (noticed in Jenkins):
- idiom119
- idiom34
- idiom40
- mandelbrot
