### PR TITLE
makefile: adhere to `FUZION_OPTIONS` for simple_and_negative tests

### DIFF
--- a/tests/simple_and_negative.mk
+++ b/tests/simple_and_negative.mk
@@ -31,29 +31,32 @@
 # running both ensures that an update of error output cannot accidentally
 # introduce some missing errors.
 #
+
+FUZION_OPTIONS ?=
+
 all: jvm int c
 
 jvm:
-	NAME=$(NAME) make -f ../negative.mk jvm
-	NAME=$(NAME) make -f ../simple.mk jvm
+	NAME=$(NAME) FUZION_OPTIONS=$(FUZION_OPTIONS) make -f ../negative.mk jvm
+	NAME=$(NAME) FUZION_OPTIONS=$(FUZION_OPTIONS) make -f ../simple.mk jvm
 c:
-	NAME=$(NAME) make -f ../negative.mk c
-	NAME=$(NAME) make -f ../simple.mk c
+	NAME=$(NAME) FUZION_OPTIONS=$(FUZION_OPTIONS) make -f ../negative.mk c
+	NAME=$(NAME) FUZION_OPTIONS=$(FUZION_OPTIONS) make -f ../simple.mk c
 int:
-	NAME=$(NAME) make -f ../negative.mk int
-	NAME=$(NAME) make -f ../simple.mk int
+	NAME=$(NAME) FUZION_OPTIONS=$(FUZION_OPTIONS) make -f ../negative.mk int
+	NAME=$(NAME) FUZION_OPTIONS=$(FUZION_OPTIONS) make -f ../simple.mk int
 
 show:
-	NAME=$(NAME) make -f ../negative.mk show
+	NAME=$(NAME) FUZION_OPTIONS=$(FUZION_OPTIONS) make -f ../negative.mk show
 
 record:
-	NAME=$(NAME) make -f ../simple.mk record
+	NAME=$(NAME) FUZION_OPTIONS=$(FUZION_OPTIONS) make -f ../simple.mk record
 
 record_jvm:
-	NAME=$(NAME) make -f ../simple.mk record_jvm
+	NAME=$(NAME) FUZION_OPTIONS=$(FUZION_OPTIONS) make -f ../simple.mk record_jvm
 
 record_c:
-	NAME=$(NAME) make -f ../simple.mk record_c
+	NAME=$(NAME) FUZION_OPTIONS=$(FUZION_OPTIONS) make -f ../simple.mk record_c
 
 record_int:
-	NAME=$(NAME)make -f ../simple.mk record_int
+	NAME=$(NAME) FUZION_OPTIONS=$(FUZION_OPTIONS) make -f ../simple.mk record_int


### PR DESCRIPTION
Without this the fuzion options from tests Makefile would be lost, because a new instance of make is started.