### PR TITLE
fe: refine check, legal qual this type

### DIFF
--- a/src/dev/flang/fe/SourceModule.java
+++ b/src/dev/flang/fe/SourceModule.java
@@ -1676,7 +1676,9 @@ A feature that is a constructor, choice or a type parameter may not redefine an 
               }
             o = o.outer();
           }
-        if (!found)
+        if (!found &&
+          // okay for post condition features result field
+          !(f.isResultField() && f.outer().featureName().baseName().startsWith(FuzionConstants.POSTCONDITION_FEATURE_PREFIX)))
           {
             AstErrors.illegalResultTypeThisType(f);
           }


### PR DESCRIPTION
For the passed in result field to a post condition feature it is okay to have a this type that is not found in its outer.

fixes #3741

