### PR TITLE
dfa: Env, fix logic bug in env merging code

### DIFF
--- a/src/dev/flang/fuir/analysis/dfa/Env.java
+++ b/src/dev/flang/fuir/analysis/dfa/Env.java
@@ -150,7 +150,7 @@ public class Env extends ANY implements Comparable<Env>
             _types              [i] = insert ? et : ot[j];
             _initialEffectValues[i] = insert ? ev : oi[j];
             j = j + (insert ? 0 : 1);
-            left = insert && left;
+            left = !insert && left;
           }
       }
     _outer = outer;


### PR DESCRIPTION
was debugging some code and came across this, same effect in the env twice:
```
equals#3 u32 a0=u32:1 a1=u32:0 => *** VOID *** ENV: 'try_unit, try_unit'
```


