### PR TITLE
jvm: add FuzionOptions to jar file when using `-jar` target

### DIFF
--- a/src/dev/flang/be/jvm/JVM.java
+++ b/src/dev/flang/be/jvm/JVM.java
@@ -616,6 +616,7 @@ should be avoided as much as possible.
               "dev/flang/util/Errors$SRCF.class",
               "dev/flang/util/Errors$SRCF$1.class",
               "dev/flang/util/FatalError.class",
+              "dev/flang/util/FuzionOptions.class",
               "dev/flang/util/HasSourcePosition.class",
               "dev/flang/util/List.class",
               "dev/flang/util/QuietThreadTermination.class",


### PR DESCRIPTION
Otherwise, I see this

     > make run_tests_jar
    rm -rf build/tests
    mkdir -p build
    cp -rf ./tests build/tests
    chmod +x build/tests/*.sh
    Exception in thread "Fuzion thread" java.lang.NoClassDefFoundError: dev/flang/util/FuzionOptions
    	at dev.flang.util.Errors.<clinit>(Errors.java:63)
    	at dev.flang.be.jvm.runtime.FuzionThread.lambda$new$2(FuzionThread.java:116)
	at java.base/java.lang.Thread.run(Thread.java:1583)
    Caused by: java.lang.ClassNotFoundException: dev.flang.util.FuzionOptions
