### PR TITLE
ast: Don't let co-type inherit from `Type` in case of earlier errors

### DIFF
--- a/src/dev/flang/ast/AbstractFeature.java
+++ b/src/dev/flang/ast/AbstractFeature.java
@@ -925,8 +925,10 @@ public abstract class AbstractFeature extends Expr implements Comparable<Abstrac
                 typeArgs.add(ta);
               }
 
-            if (inh.isEmpty())
-              {
+            if (inh.isEmpty() && !Errors.any())
+              { // let `Any.type`, inherit from `Type`
+                if (CHECKS) check
+                  (this instanceof Feature tf && featureName().baseName().equals("Any"));
                 inh.add(new Call(pos(), "Type"));
               }
             existingOrNewTypeFeature(res, name, typeArgs, inh);

--- a/src/dev/flang/ast/AbstractFeature.java
+++ b/src/dev/flang/ast/AbstractFeature.java
@@ -926,9 +926,9 @@ public abstract class AbstractFeature extends Expr implements Comparable<Abstrac
               }
 
             if (inh.isEmpty() && !Errors.any())
-              { // let `Any.type`, inherit from `Type`
+              { // let `Any.type` inherit from `Type`
                 if (CHECKS) check
-                  (this instanceof Feature tf && featureName().baseName().equals("Any"));
+                  (this instanceof Feature && featureName().baseName().equals("Any"));
                 inh.add(new Call(pos(), "Type"));
               }
             existingOrNewTypeFeature(res, name, typeArgs, inh);


### PR DESCRIPTION
Only `Any.type` should implicitly inherit `Type`. Doing this whenever the `inh` list is empty due to other errors would result in confusing errors.

