### PR TITLE
be/jvm/runtime: handle `null` message in `getException`

### DIFF
--- a/src/dev/flang/be/jvm/runtime/Runtime.java
+++ b/src/dev/flang/be/jvm/runtime/Runtime.java
@@ -667,7 +667,12 @@ public class Runtime extends ANY
    */
   public static String getException()
   {
-    return ((FuzionThread)Thread.currentThread())._thrownException.getMessage();
+    var result = ((FuzionThread)Thread.currentThread())._thrownException.getMessage();
+    if (result == null)
+      {
+        result = "";
+      }
+    return result;
   }
 
 


### PR DESCRIPTION
This would previously cause errors such as
```
error 1: java.lang.NullPointerException: Cannot invoke "String.getBytes(java.nio.charset.Charset)" because the return value of "dev.flang.be.jvm.runtime.Runtime.getException()" is null
	at fzC_fuzion__java__5call_virtual_Java_java_lang_Object.fzRoutine($MODULE/fuzion/java.fz:155)
[...]
```