### PR TITLE
 ast/air: Small cleanup in logic for this-type replacement

### DIFF
--- a/src/dev/flang/air/Clazz.java
+++ b/src/dev/flang/air/Clazz.java
@@ -694,16 +694,10 @@ public class Clazz extends ANY implements Comparable<Clazz>
    */
   AbstractType replaceThisTypeForTypeFeature(AbstractType t)
   {
-    if (feature().isTypeFeature() && !t.isGenericArgument())
+    if (feature().isTypeFeature())
       {
         t = _type.generics().get(0).actualType(t, Context.NONE);
-        var g = t.generics();
-        if (t.feature().isTypeFeature())
-          {
-            var this_type = g.get(0);
-            g = g.map(x -> x == this_type ? x   // leave first type parameter unchanged
-                                          : this_type.actualType(x, Context.NONE));
-          }
+        var g = t.cotypeActualGenerics();
         var o = t.outer();
         if (o != null)
           {


### PR DESCRIPTION
Added helper methods `cotypeActualGenerics`, removed unused conditions.