### PR TITLE
int: Add error handling to exit after an exception in a spawned thread

### DIFF
--- a/src/dev/flang/be/interpreter/Intrinsics.java
+++ b/src/dev/flang/be/interpreter/Intrinsics.java
@@ -917,7 +917,8 @@ public class Intrinsics extends ANY
         {
           var oc   = executor.fuir().clazzArgClazz(innerClazz, 0);
           var cc = executor.fuir().lookupCall(oc);
-          var t = new Thread(() -> executor.callOnNewInstance(NO_SITE, cc, args.get(1), new List<>()));
+          var t = new Thread(() -> Errors.runAndExit
+                             (() -> executor.callOnNewInstance(NO_SITE, cc, args.get(1), new List<>())));
           t.setDaemon(true);
           t.start();
           return new i64Value(_startedThreads_.add(t));


### PR DESCRIPTION
Not doing this results in the thread terminating and the original error might get lost as in [this test run](https://github.com/tokiwa-software/fuzion/actions/runs/10970505275/job/30466861407).
