### PR TITLE
c/jvm: in error created in the backends, output clazz names in quotes

### DIFF
--- a/src/dev/flang/be/c/C.java
+++ b/src/dev/flang/be/c/C.java
@@ -534,7 +534,7 @@ public class C extends ANY
     public Pair<CExpr, CStmnt> env(int s, int ecl)
     {
       CExpr res = null;
-      var o = CStmnt.seq(CExpr.fprintfstderr("*** effect %s not present in current environment\n",
+      var o = CStmnt.seq(CExpr.fprintfstderr("*** effect `%s` not present in current environment\n",
                                              CExpr.string(_fuir.clazzAsString(ecl))),
                          CExpr.exit(1));
       if (Arrays.binarySearch(_effectClazzes, ecl) >= 0)
@@ -1277,7 +1277,7 @@ public class C extends ANY
       {
         if (isCall && (_fuir.hasData(rt) || _fuir.clazzIsVoidType(rt)))
           {
-            ol.add(reportErrorInCode0("no targets for access of %s within %s",
+            ol.add(reportErrorInCode0("no targets for access of `%s` within %s",
                                       CExpr.string(_fuir.clazzAsString(cc0)),
                                       CExpr.string(_fuir.siteAsString(s))));
             res = null;
@@ -1360,7 +1360,7 @@ public class C extends ANY
           {
             var id = tvalue.deref().field(CNames.CLAZZ_ID);
             acc = CStmnt.suitch(id, cazes,
-                                reportErrorInCode0("unhandled dynamic target %d in access of %s within %s",
+                                reportErrorInCode0("unhandled dynamic target %d in access of `%s` within %s",
                                                    id,
                                                    CExpr.string(_fuir.clazzAsString(cc0)),
                                                    CExpr.string(_fuir.siteAsString(s))));

--- a/src/dev/flang/be/jvm/CodeGen.java
+++ b/src/dev/flang/be/jvm/CodeGen.java
@@ -340,7 +340,7 @@ class CodeGen
           }
         if (isCall && (_fuir.hasData(rt) || _fuir.clazzIsVoidType(rt)))  // we need a non-unit result and do not know what to do with this call, so flag an error
           {
-            s = s.andThen(_jvm.reportErrorInCode("no targets for access of " + _fuir.clazzAsString(cc0) + " within " + _fuir.siteAsString(si)));
+            s = s.andThen(_jvm.reportErrorInCode("no targets for access of " + clazzInQuotes(cc0) + " within `" + _fuir.siteAsString(si) + "`"));
             res = null;
           }
         else  // an assignment to an unused field or unit-type call, that is fine to remove, just add a comment
@@ -355,7 +355,7 @@ class CodeGen
            _fuir.accessIsDynamic(si));                  // or call is not dynamic
 
         var dynCall = args(true, tvalue, args, cc0, isCall ? _fuir.clazzArgCount(cc0) : 1)
-          .andThen(Expr.comment("Dynamic access of " + _fuir.clazzAsString(cc0)))
+          .andThen(Expr.comment("Dynamic access of " + clazzInQuotes(cc0)))
           .andThen(addDynamicFunctionAndStubs(si, cc0, ccs, isCall));
         if (AbstractInterpreter.clazzHasUnitValue(_fuir, rt))
           {
@@ -484,7 +484,7 @@ class CodeGen
         var code = p.v1()
           .andThen(p.v0() == null ? Expr.UNIT : p.v0())
           .andThen(retoern);
-        var ca = cf.codeAttribute(dn + "in class for " + _fuir.clazzAsString(tt),
+        var ca = cf.codeAttribute(dn + "in class for " + clazzInQuotes(tt),
                                   code, new List<>(), ClassFile.StackMapTable.empty(cf, initLocals, code));
         cf.method(ACC_PUBLIC, dn, ds, new List<>(ca));
       }
@@ -525,7 +525,7 @@ class CodeGen
                                 // this special handling could be removed.
         )
       { // in case we access the value in a boxed target, unbox it first:
-        tv = Expr.comment("UNBOXING , boxed type "+_fuir.clazzAsString(tt)+" desired type "+_fuir.clazzAsString(cco))
+        tv = Expr.comment("UNBOXING , boxed type " + clazzInQuotes(tt) + " desired type " + clazzInQuotes(cco))
           .andThen(tv.getFieldOrUnit(_names.javaClass(tt),    // note that tv.getfield works vor unit type (resulting in tv.drop()).
                                      Names.BOXED_VALUE_FIELD_NAME,
                                      _types.javaType(cco)));
@@ -562,7 +562,7 @@ class CodeGen
       {
       case Abstract :
         Errors.error("Call to abstract feature encountered.",
-                     "Found call to  " + _fuir.clazzAsString(cc));
+                     "Found call to " + clazzInQuotes(cc));
       case Intrinsic:
         {
           if (_fuir.clazzTypeParameterActualType(cc) != -1)  /* type parameter is also of Kind Intrinsic, NYI: CLEANUP: should better have its own kind?  */
@@ -673,7 +673,7 @@ class CodeGen
     if (!_fuir.clazzIsRef(vc) && _fuir.clazzIsRef(rc))  // NYI: CLEANUP: would be good if the AbstractInterpreter would not call box() in this case
       {
         var n = _names.javaClass(rc);
-        res = Expr.comment("box from "+_fuir.clazzAsString(vc)+" to "+_fuir.clazzAsString(rc))
+        res = Expr.comment("box from " + clazzInQuotes(vc) + " to " + clazzInQuotes(rc))
           .andThen(val)
           .andThen(Expr.invokeStatic(n, Names.BOX_METHOD_NAME,
                                      _types.boxSignature(rc),
@@ -899,7 +899,7 @@ class CodeGen
           else
             {
               Errors.error("Unsupported constant in JVM backend.",
-                           "Backend cannot handle constant of clazz '" + _fuir.clazzAsString(constCl) + "' ");
+                           "Backend cannot handle constant of clazz " + clazzInQuotes(constCl));
               yield null;
             }
         }
@@ -985,6 +985,17 @@ class CodeGen
       ( et == NULL_TYPE                                                                 ||
         _fuir.clazzIsRef(type) /* we do not check exact reference assignability here */ ||
         et.sameAs(ct)          /* but value or choice types must be the same!        */ );
+  }
+
+
+  /**
+   * For debugging output
+   *
+   * @return "`<clazz c>`".
+   */
+  private String clazzInQuotes(int c)
+  {
+    return "`" + _fuir.clazzAsString(c) + "`";
   }
 
 


### PR DESCRIPTION
Makes this easier to read for clazz names like `a`.

