### PR TITLE
be/jvm: get_field fix ClassCastException

### DIFF
--- a/src/dev/flang/be/jvm/Intrinsix.java
+++ b/src/dev/flang/be/jvm/Intrinsix.java
@@ -414,9 +414,7 @@ public class Intrinsix extends ANY implements ClassFileConstants
             .andThen(Expr.invokeStatic(Names.RUNTIME_CLASS,
                                        "fuzion_java_get_field0",
                                        "(Ljava/lang/Object;Ljava/lang/String;)Ljava/lang/Object;",
-                                       Names.JAVA_LANG_OBJECT));
-
-          res = (rt.isPrimitive() ? res : res.andThen(Expr.checkcast(rt)))
+                                       Names.JAVA_LANG_OBJECT))
             .is(rt);
 
           return new Pair<>(res.andThen(returnNewJavaObject(jvm, rc)), Expr.UNIT);


### PR DESCRIPTION
this now works:
```
ex_verifyerror =>
  addr array i8 := [0, 0, 0, 0]
  client Java.java.net.InetAddress := (Java.java.net.InetAddress_static.getByAddress addr).val
  s := Java.dev.flang.Session_static.get "" "" client
  c := Java.dev.flang.Content_static.getContents s "/news"
  s.setCurrent c.__simplePath
```
result:
```
0: new session 1 EA3VfjpPKJUF9odRP_yTfA for /0.0.0.0 user --none--
```
