### PR TITLE
ast/fe: Simplify `Expr.box`, add box result type to `.fum` file

### DIFF
--- a/src/dev/flang/ast/Box.java
+++ b/src/dev/flang/ast/Box.java
@@ -74,25 +74,7 @@ public class Box extends Expr
        !(value instanceof Box));
 
     this._value = value;
-    var t = value.type();
-    this._type = needsBoxingForGenericOrThis(frmlT) ? t : t.asRef();
-  }
-
-
-  /**
-   * Constructor for Box loaded from .fum/MIR module file be front end.
-   *
-   * @param value the value to be boxed.
-   */
-  public Box(Expr value)
-  {
-    if (PRECONDITIONS) require
-      (value != null,
-       !value.type().isRef() || value.isCallToOuterRef());
-
-    this._value = value;
-    var t = value.type();
-    this._type = t.asRef();
+    this._type = frmlT;
   }
 
 

--- a/src/dev/flang/ast/Expr.java
+++ b/src/dev/flang/ast/Expr.java
@@ -628,14 +628,9 @@ public abstract class Expr extends HasGlobalIndex implements HasSourcePosition
         var rt = needsBoxing(frmlT, context);
         if (rt != null)
           {
-            if (rt.isGenericArgument() && rt.isRef())
-              {
-                System.out.println("PROBLEM for "+rt+" at "+pos().show());
-              }
             result = new Box(result, rt);
-            t = result.type();
           }
-        if (frmlT.isChoice() && frmlT.isAssignableFrom(t, context))
+        if (frmlT.isChoice() && frmlT.isAssignableFrom(result.type(), context))
           {
             result = tag(frmlT, result, context);
             if (CHECKS) check
@@ -645,7 +640,7 @@ public abstract class Expr extends HasGlobalIndex implements HasSourcePosition
 
     if (POSTCONDITIONS) ensure
       (Errors.count() > 0
-        || t.isVoid()
+        || type().isVoid()
         || frmlT.isGenericArgument()
         || frmlT.isThisType()
         || result.needsBoxing(frmlT, context) == null

--- a/src/dev/flang/ast/Expr.java
+++ b/src/dev/flang/ast/Expr.java
@@ -625,16 +625,21 @@ public abstract class Expr extends HasGlobalIndex implements HasSourcePosition
 
     if (!t.isVoid() && (frmlT.isAssignableFrom(t, context) || frmlT.isAssignableFrom(t.asRef(), context)))
       {
-        if (needsBoxing(frmlT, context))
+        var rt = needsBoxing(frmlT, context);
+        if (rt != null)
           {
-            result = new Box(result, frmlT);
+            if (rt.isGenericArgument() && rt.isRef())
+              {
+                System.out.println("PROBLEM for "+rt+" at "+pos().show());
+              }
+            result = new Box(result, rt);
             t = result.type();
           }
         if (frmlT.isChoice() && frmlT.isAssignableFrom(t, context))
           {
             result = tag(frmlT, result, context);
             if (CHECKS) check
-              (!result.needsBoxing(frmlT, context));
+              (result.needsBoxing(frmlT, context) == null);
           }
       }
 
@@ -643,7 +648,7 @@ public abstract class Expr extends HasGlobalIndex implements HasSourcePosition
         || t.isVoid()
         || frmlT.isGenericArgument()
         || frmlT.isThisType()
-        || !result.needsBoxing(frmlT, context)
+        || result.needsBoxing(frmlT, context) == null
         || !(frmlT.isAssignableFrom(t, context) || frmlT.isAssignableFrom(t.asRef(), context)));
 
     return result;
@@ -722,43 +727,50 @@ public abstract class Expr extends HasGlobalIndex implements HasSourcePosition
 
 
   /**
-   * Is boxing needed when we assign to frmlT since frmlT is generic (so it
-   * could be a ref) or frmlT is this type and the underlying feature is by
-   * default a ref?
+   * Is boxing needed when we assign to frmlT?
    *
    * @param frmlT the formal type we are assigning to.
+   *
+   * @return the type after boxing or null if boxing is not needed
    */
-  boolean needsBoxingForGenericOrThis(AbstractType frmlT)
-  {
-    return
-      frmlT.isGenericArgument() || frmlT.isThisType();
-  }
-
-
-  /**
-   * Is boxing needed when we assign to frmlT?
-   * @param frmlT the formal type we are assigning to.
-   */
-  private boolean needsBoxing(AbstractType frmlT, Context context)
+  private AbstractType needsBoxing(AbstractType frmlT, Context context)
   {
     var t = type();
-    if (needsBoxingForGenericOrThis(frmlT))
-      {
-        return true;
+    if (frmlT.isGenericArgument() || frmlT.isThisType())
+      { /* Boxing needed when we assign to frmlT since frmlT is generic (so it
+         * could be a ref) or frmlT is this type and the underlying feature is by
+         * default a ref?
+         */
+        return frmlT;
       }
     else if (t.isRef() && !isCallToOuterRef())
       {
-        return false;
+        return null;
       }
     else if (frmlT.isRef())
       {
-        return true;
+        return frmlT;
       }
     else
       {
-        return frmlT.isChoice() &&
-          !frmlT.isAssignableFrom(t, context) &&
-          frmlT.isAssignableFrom(t.asRef(), context);
+        var tr = t.asRef();
+        if (frmlT.isChoice() &&
+            !frmlT.isAssignableFrom(t , context) &&
+             frmlT.isAssignableFrom(tr, context))
+          { // we do both, box and then tag:
+            for (var cg : frmlT.choiceGenerics(context))
+              {
+                if (cg.isAssignableFrom(tr, context))
+                  {
+                    return cg;
+                  }
+              }
+            throw new Error("Expr.needsBoxing confused for choice type "+frmlT+" which is assignable from "+t.asRef()+" but not from "+t);
+          }
+        else
+          {
+            return null;
+          }
       }
   }
 

--- a/src/dev/flang/fe/LibraryFeature.java
+++ b/src/dev/flang/fe/LibraryFeature.java
@@ -615,8 +615,11 @@ public class LibraryFeature extends AbstractFeature
             }
           case Box:
             {
-              x = new Box(s.pop())
-                { public SourcePosition pos() { return LibraryFeature.this.pos(fpos, fposEnd); } };
+              var t = _libModule.boxType(iat);
+              x = new Box(s.pop(), t)
+                {
+                  public SourcePosition pos() { return LibraryFeature.this.pos(fpos, fposEnd); }
+                };
               break;
             }
           case Const:

--- a/src/dev/flang/fe/LibraryModule.java
+++ b/src/dev/flang/fe/LibraryModule.java
@@ -1601,7 +1601,7 @@ Expression
     return switch (k)
       {
       case Assign      -> assignNextPos(eAt);
-      case Box         -> eAt;
+      case Box         -> boxNextPos  (eAt);
       case Const       -> constNextPos(eAt);
       case Current     -> eAt;
       case Match       -> matchNextPos(eAt);
@@ -1661,6 +1661,54 @@ Assign
       expressionKindRaw(at-9) == (MirExprKind.Assign.ordinal() | 0x80)     );
 
     return assignFieldPos(at) + 4;
+  }
+
+
+  /*
+--asciidoc--
+
+Box
+^^^
+
+[options="header",cols="1,1,2,5"]
+|====
+   |cond.     | repeat | type          | what
+
+.3+| true  .2+| 1      | Type          | box result type
+|====
+
+--asciidoc--
+   *   +---------------------------------------------------------------------------------+
+   *   | Box                                                                             |
+   *   +--------+--------+---------------+-----------------------------------------------+
+   *   | cond.  | repeat | type          | what                                          |
+   *   +--------+--------+---------------+-----------------------------------------------+
+   *   | true   | 1      | Type          | box result type                               |
+   *   +--------+--------+---------------+-----------------------------------------------+
+   */
+  int boxTypePos(int at)
+  {
+    if (PRECONDITIONS) require
+     (expressionKindRaw(at-1) ==  MirExprKind.Box.ordinal()         ||
+      expressionKindRaw(at-9) == (MirExprKind.Box.ordinal() | 0x80)     );
+
+    return at;
+  }
+  AbstractType boxType(int at)
+  {
+    if (PRECONDITIONS) require
+     (expressionKindRaw(at-1) ==  MirExprKind.Box.ordinal()         ||
+      expressionKindRaw(at-9) == (MirExprKind.Box.ordinal() | 0x80)     );
+
+    return type(boxTypePos(at));
+  }
+  int boxNextPos(int at)
+  {
+    if (PRECONDITIONS) require
+     (expressionKindRaw(at-1) ==  MirExprKind.Box.ordinal()         ||
+      expressionKindRaw(at-9) == (MirExprKind.Box.ordinal() | 0x80)     );
+
+    return typeNextPos(boxTypePos(at));
   }
 
 

--- a/src/dev/flang/fe/LibraryOut.java
+++ b/src/dev/flang/fe/LibraryOut.java
@@ -703,8 +703,18 @@ class LibraryOut extends ANY
       }
     else if (e instanceof Box b)
       {
+  /*
+   *   +---------------------------------------------------------------------------------+
+   *   | Box                                                                             |
+   *   +--------+--------+---------------+-----------------------------------------------+
+   *   | cond.  | repeat | type          | what                                          |
+   *   +--------+--------+---------------+-----------------------------------------------+
+   *   | true   | 1      | Type          | box result type                               |
+   *   +--------+--------+---------------+-----------------------------------------------+
+   */
         lastPos = expressions(b._value, lastPos);
         lastPos = exprKindAndPos(MirExprKind.Box, lastPos, e.sourceRange());
+        type(e.type());
       }
     else if (e instanceof AbstractBlock b)
       {


### PR DESCRIPTION
Makes the code a little less confusing and, in a next step, having the type in the `.fum` file should help getting rid for `Clazzes.propagateExpectedClazz`.

