### PR TITLE
tests: add reg test #929

### DIFF
--- a/tests/reg_issue929/Makefile
+++ b/tests/reg_issue929/Makefile
@@ -1,0 +1,25 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test Makefile
+#
+# -----------------------------------------------------------------------
+
+override NAME = reg_issue929
+include ../simple.mk

--- a/tests/reg_issue929/reg_issue929.fz
+++ b/tests/reg_issue929/reg_issue929.fz
@@ -1,0 +1,32 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test reg_issue929
+#
+# -----------------------------------------------------------------------
+
+reg_issue929 =>
+
+  listX(A type, h A, t ()->list A) list A => nil
+
+  infix :: (A type, val A, l ()->list A) => listX val l
+
+  # NYI: UNDER DEVELOPMENT, needs support for nullary-lambda inference incl. cylces
+  fibs => ()->(0 :: ()->fibs.zip 1:()->fibs a,b->a+b)
+  fib(n i32) => (fibs().drop n).head

--- a/tests/reg_issue929/reg_issue929.fz.expected_err
+++ b/tests/reg_issue929/reg_issue929.fz.expected_err
@@ -1,0 +1,10 @@
+
+--CURDIR--/reg_issue929.fz:31:11: error 1: No type information can be inferred from a lambda expression
+  fibs => ()->(0 :: ()->fibs.zip 1:()->fibs a,b->a+b)
+----------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+A lambda expression can only be used if assigned to a field or argument of type 'Function'
+with argument count of the lambda expression equal to the number of type parameters of the type.  The type of the
+assigned field must be given explicitly.
+To solve this, declare an explicit type for the target field, e.g., 'f (i32, i32) -> bool := x, y -> x > y'.
+
+one error.


### PR DESCRIPTION
fixes #929

(there is no _confusing_ error message anymore.)
