### PR TITLE
docs: reorganize content of navigation panel on the left side

### DIFF
--- a/src/dev/flang/tools/docs/Html.java
+++ b/src/dev/flang/tools/docs/Html.java
@@ -780,8 +780,7 @@ public class Html extends ANY
     var f =  spacer + "<a href='" + featureAbsoluteURL(start) + "'>" + htmlEncodedBasename(start) + args(start) + "</a>";
 
     var constructors = declaredFeatures.values().stream()
-                        .filter(ft->ft.isConstructor()
-                                    && !ft.isTypeFeature()
+                        .filter(ft -> ft.definesType()
                                     && ft.visibility().typeVisibility() == Visi.PUB)
                         .collect(Collectors.toList());
 

--- a/src/dev/flang/tools/docs/Html.java
+++ b/src/dev/flang/tools/docs/Html.java
@@ -29,11 +29,13 @@ package dev.flang.tools.docs;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.LinkedList;
 import java.util.Map;
 import java.util.TreeSet;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collector;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -63,8 +65,8 @@ public class Html extends ANY
   {
     this.config = config;
     this.mapOfDeclaredFeatures = mapOfDeclaredFeatures;
-    this.navigation = navigation(universe, 0);
     this.lm = lm;
+    this.navigation = navigation(universe, 0);
   }
 
 
@@ -766,8 +768,8 @@ public class Html extends ANY
    */
   private String navigation(AbstractFeature start, int depth)
   {
-    var declaredFeatures = mapOfDeclaredFeatures.get(start);
-    if (declaredFeatures == null || Util.isArgument(start))
+    var declaredFeatures = lm.declaredFeatures(start);
+    if (declaredFeatures == null || start.isArgument())
       {
         return "";
       }
@@ -776,24 +778,26 @@ public class Html extends ANY
         .collect(Collectors.joining())
         .replaceAll("\s$", "―");
     var f =  spacer + "<a href='" + featureAbsoluteURL(start) + "'>" + htmlEncodedBasename(start) + args(start) + "</a>";
+
+    var constructors = declaredFeatures.values().stream()
+                        .filter(ft->ft.isConstructor()
+                                    && !ft.isTypeFeature()
+                                    && ft.visibility().typeVisibility() == Visi.PUB)
+                        .collect(Collectors.toList());
+
     return """
       <ul class="white-space-no-wrap">
         <li>
+          <div>$0</div>
           $1
         </li>
       </ul>"""
+        .replace("$0", f)
         .replace("$1",
-            (declaredFeatures.get(Kind.ValConstructor) == null
+            (constructors.isEmpty()
               ? ""
-              : "<div>" + f + "<small class=\"fd-feat-kind\"> Constructors</small></div>" + declaredFeatures.get(Kind.ValConstructor).stream()
-                .map(af -> navigation(af, depth + 1))
-                .collect(Collectors.joining(System.lineSeparator())))
-            + (declaredFeatures.get(Kind.ValConstructor) == null && declaredFeatures.get(Kind.Type) == null
-              ? "<div>" + f + "</div>"
-              : "")
-            + (declaredFeatures.get(Kind.Type) == null
-              ? ""
-              : "<div>" + f + "<small class=\"fd-feat-kind\"> Types</small></div>" + declaredFeatures.get(Kind.Type).stream()
+              : constructors.stream()
+                .sorted(Comparator.comparing(ft -> ft.featureName().baseName(), String.CASE_INSENSITIVE_ORDER))
                 .map(af -> navigation(af, depth + 1))
                 .collect(Collectors.joining(System.lineSeparator()))));
   }


### PR DESCRIPTION
Follow up of #3808, only show constructors in the navigation panel. Remove "Types" and "Constructors" annotations.

fix #3837
