### PR TITLE
docs: hide non public arguments in section 'Fields'

### DIFF
--- a/src/dev/flang/tools/docs/Html.java
+++ b/src/dev/flang/tools/docs/Html.java
@@ -287,7 +287,7 @@ public class Html extends ANY
    */
   private String annotatePrivateConstructor(AbstractFeature af)
   {
-    return af.visibility() == Visi.PRIVPUB
+    return af.visibility().eraseTypeVisibility() != Visi.PUB && af.visibility().typeVisibility() == Visi.PUB
              ? "&nbsp;<div class='fd-parent' title='This feature can not be called to construct a new instance of itself, " +
                "only the type it defines is visible.'>[Private constructor]</div>" // NYI: replace title attribute with proper tooltip
              : "";
@@ -382,7 +382,7 @@ public class Html extends ANY
     TreeSet<AbstractFeature> fields =  new TreeSet<AbstractFeature>();
     fields.addAll(map.getOrDefault(AbstractFeature.Kind.Field, new TreeSet<AbstractFeature>()));
     var normalArguments = outer.arguments().clone();
-    normalArguments.removeIf(a->a.isTypeParameter());
+    normalArguments.removeIf(a->a.isTypeParameter() || a.visibility().eraseTypeVisibility() != Visi.PUB);
     fields.addAll(normalArguments);
 
     // Constructors

--- a/src/dev/flang/tools/docs/Html.java
+++ b/src/dev/flang/tools/docs/Html.java
@@ -287,7 +287,7 @@ public class Html extends ANY
    */
   private String annotatePrivateConstructor(AbstractFeature af)
   {
-    return af.visibility().eraseTypeVisibility() != Visi.PUB && af.visibility().typeVisibility() == Visi.PUB
+    return af.visibility().eraseTypeVisibility() != Visi.PUB
              ? "&nbsp;<div class='fd-parent' title='This feature can not be called to construct a new instance of itself, " +
                "only the type it defines is visible.'>[Private constructor]</div>" // NYI: replace title attribute with proper tooltip
              : "";


### PR DESCRIPTION
fix  #3886
