### PR TITLE
docs: show type features inherited by and redefined in `Type`

### DIFF
--- a/src/dev/flang/tools/docs/Docs.java
+++ b/src/dev/flang/tools/docs/Docs.java
@@ -304,7 +304,7 @@ public class Docs extends ANY
         feature,
         Stream
           .concat(s, st)
-          .collect(Collectors.groupingBy(x -> x.kind(), Collectors.toCollection(() -> new TreeSet<>(byFeatureName))))
+          .collect(Collectors.groupingBy(x -> x.kind(), Collectors.toCollection(TreeSet::new)))
       );
 
     }, universe);


### PR DESCRIPTION
This shows features, that `Type` inherits from `Any` **and** redefines, in the  type feature section. They were not shown before because of the name collision. Does not solve the problem of type features inherited from Any which are never redefined.

I'm not quite sure whether this might have any side effects.

related to #3716