### PR TITLE
makefile: use asciidoctor-web-pdf

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1140,7 +1140,7 @@ $(BUILD_DIR)/generated/doc/stringEscapes.adoc: $(CLASS_FILES_PARSER)
 
 $(REF_MANUAL_PDF): $(REF_MANUAL_SOURCES) $(BUILD_DIR)/generated/doc/fum_file.adoc $(FUZION_EBNF)
 	mkdir -p $(@D)
-	asciidoctor-pdf $(REF_MANUAL_ATTRIBUTES) --out-file $@ $(REF_MANUAL_SOURCE)
+	asciidoctor-web-pdf $(REF_MANUAL_ATTRIBUTES) --out-file $@ $(REF_MANUAL_SOURCE)
 
 $(REF_MANUAL_HTML): $(REF_MANUAL_SOURCES) $(BUILD_DIR)/generated/doc/fum_file.adoc $(FUZION_EBNF)
 	mkdir -p $(@D)


### PR DESCRIPTION
> WARN: `asciidoctor-pdf` is deprecated and will be removed in a future version, please use `asciidoctor-web-pdf` instead
