### PR TITLE
fuir/jvm: remove hard-coded Java name for `fuzion.java.Java_Object.Java_Ref`

### DIFF
--- a/src/dev/flang/be/jvm/Intrinsix.java
+++ b/src/dev/flang/be/jvm/Intrinsix.java
@@ -389,15 +389,17 @@ public class Intrinsix extends ANY implements ClassFileConstants
         {
           var rc = jvm._fuir.clazzResultClazz(cc);
           var rt = jvm._types.javaType(rc);
+          var jO = jvm._fuir.clazz_fuzionJavaObject_Ref();
+          var javaRefFieldName = jvm._names.field(jO);
           var res = args
             .get(0)
-            .andThen(Expr.stringconst(javaRefFieldName()))
+            .andThen(Expr.stringconst(javaRefFieldName))
             .andThen(Expr.invokeStatic(Names.RUNTIME_CLASS,
                                        "fuzion_java_get_field0",
                                        "(Ljava/lang/Object;Ljava/lang/String;)Ljava/lang/Object;",
                                        Names.JAVA_LANG_OBJECT))
             .andThen(args.get(1))
-            .andThen(Expr.stringconst(javaRefFieldName()))
+            .andThen(Expr.stringconst(javaRefFieldName))
             .andThen(Expr.invokeStatic(Names.RUNTIME_CLASS,
                                        "fuzion_java_get_field0",
                                        "(Ljava/lang/Object;Ljava/lang/String;)Ljava/lang/Object;",
@@ -411,16 +413,6 @@ public class Intrinsix extends ANY implements ClassFileConstants
 
           return new Pair<>(res.andThen(returnNewJavaObject(jvm, rc)), Expr.UNIT);
         });
-  }
-
-
-  /**
-   * get name of Java_Ref field
-   */
-  private static String javaRefFieldName()
-  {
-    // NYI: CLEANUP: get name programmatically
-    return "fzF_0_Java_Ref";
   }
 
 

--- a/src/dev/flang/be/jvm/Names.java
+++ b/src/dev/flang/be/jvm/Names.java
@@ -242,8 +242,10 @@ public class Names extends ANY implements ClassFileConstants
     {
       String rawName(int field)
       {
-        var index = _fuir.fieldIndex(field);
-        return _prefix + index + "_" + baseName(field);
+        var index = _fuir.isJavaRef(field)
+          ? ""
+          : _fuir.fieldIndex(field) + "_";
+        return _prefix + index + baseName(field);
       }
     };
 

--- a/src/dev/flang/fuir/AirFUIR.java
+++ b/src/dev/flang/fuir/AirFUIR.java
@@ -1191,6 +1191,19 @@ public class AirFUIR extends FUIR
 
 
   /**
+   * Check if the given clazz is a --possibly inherited--
+   * `fuzion.java.Java_Object.Java_Ref` field.
+   *
+   * @param cl a clazz id that should be checked, must not be NO_CLAZZ.
+   */
+  @Override
+  public boolean isJavaRef(int cl)
+  {
+    return clazz(cl).feature() == Types.resolved.f_fuzion_Java_Object_Ref;
+  }
+
+
+  /**
    * Get the id of the given special clazz.
    *
    * @param c the id of clazz c or -1 if that clazz was not created.

--- a/src/dev/flang/fuir/FUIR.java
+++ b/src/dev/flang/fuir/FUIR.java
@@ -633,6 +633,15 @@ public abstract class FUIR extends IR
 
 
   /**
+   * Check if the given clazz is a --possibly inherited--
+   * `fuzion.java.Java_Object.Java_Ref` field.
+   *
+   * @param cl a clazz id that should be checked, must not be NO_CLAZZ.
+   */
+  public abstract boolean isJavaRef(int cl);
+
+
+  /**
    * For a clazz that is an heir of 'Function', find the corresponding inner
    * clazz for 'call'.  This is used for code generation of intrinsic
    * 'abortable' that has to create code to call 'call'.


### PR DESCRIPTION
This hack will no longer work any longer with GeneratingFUIR, see branch `fum_to_fuir`.
