### PR TITLE
lib: remove `map_to_option`

### DIFF
--- a/lib/String.fz
+++ b/lib/String.fz
@@ -250,11 +250,10 @@ public String ref : property.equatable, property.hashable, property.orderable is
   #
   public as_codepoints Sequence codepoint =>
     codepoints_and_errors
-      .map (x ->
+      .map x->
         match x
           c codepoint => c
           e error     => codepoint 0xFFFD # 'REPLACEMENT CHARACTER' (U+FFFD)
-      )
 
 
   # replaces invalid UTF-8 byte sequences in this string with the Unicode

--- a/lib/concur/thread_pool.fz
+++ b/lib/concur/thread_pool.fz
@@ -137,7 +137,7 @@ is
       compute =>
         compute_result.write task.call
         mtx.synchronized ()->
-          _ := fut_cnd.read.map_to_option c->
+          _ := fut_cnd.read.bind unit c->
             check concur.sync.cnd_broadcast c
             concur.sync.cnd_destroy c
 

--- a/lib/container/mutable_tree_map/Entry.fz
+++ b/lib/container/mutable_tree_map/Entry.fz
@@ -58,5 +58,5 @@ module Entry(module key KEY, module val VAL) ref is
   #
   module items Sequence (tuple KEY VAL) =>
     list (key,val) ()->
-      (left.get.map_to_option x->x.items).or_else (list (tuple KEY VAL)).empty ++
-        (right.get.map_to_option x->x.items).or_else (list (tuple KEY VAL)).empty
+      (left.get.bind (Sequence (tuple KEY VAL)) x->x.items).or_else (list (tuple KEY VAL)).empty ++
+        (right.get.bind (Sequence (tuple KEY VAL)) x->x.items).or_else (list (tuple KEY VAL)).empty

--- a/lib/container/ordered_map.fz
+++ b/lib/container/ordered_map.fz
@@ -75,7 +75,7 @@ is
   public redef index [] (k OK) =>
     sorted_entries
       .find_by_comparator (e -> ks[e.i] ⋄ k)
-      .map_to_option i->sorted_entries[i].val
+      .bind V i->sorted_entries[i].val
 
 
   # get an array of all key/value pairs in this map

--- a/lib/interval.fz
+++ b/lib/interval.fz
@@ -108,7 +108,7 @@ is
   # string representation of this interval, e.g., "1..10:2"
   #
   public redef as_string =>
-    thru := through.map_to_option ($)
+    thru := through.bind String ($)
                    .or_else ()->if step.sign < 0 then "-∞" else "∞"
     "$from..$thru{if step = T.one then "" else ":$step"}"
 

--- a/lib/option.fz
+++ b/lib/option.fz
@@ -74,13 +74,6 @@ is
     if is_nil then f() else option.this
 
 
-  # map this option using f, i.e., map nil to nil and any value v to f v
-  #
-  public map_to_option(B type, f T -> B) option B =>
-    option.this ? v T => f v
-                | nil => nil
-
-
   # converts option to a string
   #
   # returns the result of $T for an option containing an instance

--- a/modules/lock_free/src/lock_free/stack.fz
+++ b/modules/lock_free/src/lock_free/stack.fz
@@ -53,10 +53,10 @@ public stack(T type) : container.Stack T is
         n := next o
     while !o.is_nil && !top.compare_and_set o n
     else
-      o.map_to_option node->node.data
+      o.bind T node->node.data
 
 
   # peek at the top element from the stack
   #
   public redef peek option T =>
-    top.read.map_to_option node->node.data
+    top.read.bind T node->node.data


### PR DESCRIPTION
`bind` is almost the same thing but more powerful, with the  caveat that type inference is not strong enough to infer the type parameter. But this will change in the future.


