### PR TITLE
lib: outcome, redef as_outcome

### DIFF
--- a/lib/outcome.fz
+++ b/lib/outcome.fz
@@ -129,6 +129,15 @@ is
                  | e error => e
 
 
+  # convert this to an outcome
+  #
+  # this is essentially a no-op.
+  #
+  public redef as_outcome outcome T
+  =>
+    outcome.this
+
+
   # return function
   #
   public fixed redef type.return (a T) => outcome a


### PR DESCRIPTION
as suggested by previous review.