### PR TITLE
parser: end expr at comma 

### DIFF
--- a/src/dev/flang/parser/Parser.java
+++ b/src/dev/flang/parser/Parser.java
@@ -2510,6 +2510,7 @@ brblock     : BRACEL exprs BRACER
     return switch (currentAtMinIndent())
       {
       case
+        t_comma,
         t_indentationLimit,
         t_lineLimit,
         t_spaceOrSemiLimit,

--- a/tests/reg_issue3761/Makefile
+++ b/tests/reg_issue3761/Makefile
@@ -1,0 +1,25 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test Makefile
+#
+# -----------------------------------------------------------------------
+
+override NAME = reg_issue3761
+include ../simple.mk

--- a/tests/reg_issue3761/reg_issue3761.fz
+++ b/tests/reg_issue3761/reg_issue3761.fz
@@ -1,0 +1,29 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test reg_issue3761
+#
+# -----------------------------------------------------------------------
+
+reg_issue3761 =>
+  # the if expression should end at the comma
+  for i := if true then "string" else "strong", "strung"
+      j in 1..3
+  do
+    say "$j: $i"

--- a/tests/reg_issue3761/reg_issue3761.fz.expected_out
+++ b/tests/reg_issue3761/reg_issue3761.fz.expected_out
@@ -1,0 +1,3 @@
+1: string
+2: strung
+3: strung


### PR DESCRIPTION
fix #3761

Example
```
for i := if true then "string" else "strong", "strung"
    j in 1..3
do
  say "$j: $i"
```

```
1: string
2: strung
3: strung
```