### PR TITLE
lib: add `String.chunk` to split a string in parts of fixed length

### DIFF
--- a/lib/String.fz
+++ b/lib/String.fz
@@ -400,6 +400,15 @@ public String ref : property.equatable, property.hashable, property.orderable is
     substring from codepoint_length
 
 
+  # splits this string in chunks of codepoint length n, the last part might be shorter
+  #
+  public chunk(n i32)
+    pre n>0
+  =>
+    as_codepoints.chunk n
+                 .map (.as_string "")
+
+
   # check if this string starts with given prefix
   #
   public starts_with(prefx String) =>

--- a/lib/String.fz
+++ b/lib/String.fz
@@ -406,7 +406,7 @@ public String ref : property.equatable, property.hashable, property.orderable is
     pre n>0
   =>
     as_codepoints.chunk n
-                 .map (.as_string "")
+                 .map String.type.from_codepoints
 
 
   # check if this string starts with given prefix


### PR DESCRIPTION
I think this could be useful sometimes, e.g. to format some output.

```
> fz -e 'say ("abababababab".chunk 2)'
[ab, ab, ab, ab, ab, ab]

> fz -e 'say ("abababababab".chunk 3)'
[aba, bab, aba, bab]

> fz -e 'say ("abababababab".chunk 5)'
[ababa, babab, ab]

> fz -e 'say ((u64 42).bin(64).chunk(8).as_string "_")'
00000000_00000000_00000000_00000000_00000000_00000000_00000000_00101010
```