### PR TITLE
fuir: Implement GeneratingFUIR.declarationPos()

### DIFF
--- a/src/dev/flang/fuir/GeneratingFUIR.java
+++ b/src/dev/flang/fuir/GeneratingFUIR.java
@@ -3181,11 +3181,14 @@ public class GeneratingFUIR extends FUIR
   /**
    * Get the position where the clazz is declared
    * in the source code.
+   *
+   * NYI: CLEANUP: This is currently used only by the interpreter backend. Maybe we should remove this?
    */
   @Override
   public SourcePosition declarationPos(int cl)
   {
-    throw new Error("NYI");
+    var c = id2clazz(cl);
+    return c._type.declarationPos();
   }
 
 


### PR DESCRIPTION
This is required by the interpreter, the missing implementation causes failures in some negative jenkins flang_dev tests.

This is redundant with PR #3994, but at least adds a comment to maybe remove this method altogether. 
