### PR TITLE
lib: ensure `Sequence.equality` with infinite sequences terminates whenever possible

### DIFF
--- a/lib/Sequence.fz
+++ b/lib/Sequence.fz
@@ -903,9 +903,18 @@ public Sequence(public T type) ref : property.equatable is
   # equality
   #
   public fixed redef type.equality(a, b Sequence T) =>
+    equality0(a1, b1 Sequence (T2 : property.equatable)) =>
+      ((a1.zip b1 x,y->x=y) ∀ x->x)
+
     if T : property.equatable
-      a.count = b.count
-        && ((a.zip b x,y->x=y) ∀ x->x)
+      if a.finite && b.finite
+        a.count = b.count && equality0 a b
+      else if a.finite
+        a.count = (b.take (a.count+1)).count && equality0 a b
+      else if b.finite
+        b.count = (a.take (b.count+1)).count && equality0 a b
+      else
+        equality0 a b
     else
       panic "***"
 

--- a/lib/interval.fz
+++ b/lib/interval.fz
@@ -122,6 +122,12 @@ is
   public fixed redef type.new (s Sequence T) interval.this => panic "not applicable"
 
 
+  # is this sequence known to be finite?  For infinite sequences, features like
+  # count diverge.
+  #
+  public redef finite =>
+    through.exists
+
 # has_interval -- feature for integers that can define an interval
 #
 public has_interval : integer is


### PR DESCRIPTION
I think comparisons with infinite sequences should terminate when it is possible to determine the result, i.e. when one is finite or when infinite ones differ.

Makes the following possible
```
> fz -e 'say ((1..10).as_seq = (1..).as_seq)'
false

> fz -e 'say ((1..).as_seq = (1..10).as_seq)'
false

> fz -e 'say ([0,0].as_seq = (1..10).as_seq)'
false

> fz -e 'say ((1..).as_seq = (2..).as_seq)'
false
```
