### PR TITLE
lib: fix sequences with finite=unknown to be falsely considered equal if one is prefix of the other

### DIFF
--- a/lib/Sequence.fz
+++ b/lib/Sequence.fz
@@ -927,7 +927,9 @@ public Sequence(public T type) ref : property.equatable is
       else if b.finite=trit.yes
         b.count = (a.take (b.count+1)).count && equality0 a b
       else
-        equality0 a b
+        equality0 a b &&
+          {zip_count := (a.zip b x,y->unit).count
+           (a.drop zip_count).is_empty && (b.drop zip_count).is_empty}
     else
       panic "***"
 


### PR DESCRIPTION
Because of the `zip` in `equals0` in the longer sequence only the first n elements are considered with n being the length of the shorter sequence.

So if for both sequences finite!=true but one sequence turns out to be finite, they might falsely be considered equal if the shorter sequence is prefix of the longer one.