### PR TITLE
lib: cleanup `buffered.reader.with`

### DIFF
--- a/lib/io/buffered/reader.fz
+++ b/lib/io/buffered/reader.fz
@@ -46,7 +46,8 @@ public reader(LM type : mutate, rp Read_Provider, buf_size i32) : effect is
   # resulting 'outcome'.
   #
   public with(R type, f ()->R) outcome R =>
-    try (reader LM) R (() -> reader.this.instate R reader.this f (_ -> exit 1))
+    try (reader LM) R ()->
+      reader.this.instate_self R f
 
 
   # terminate immediately with the given error wrapped in 'option'.


### PR DESCRIPTION
The default of instate_self is to panic which is probably better than `(_ -> exit 1)` 