### PR TITLE
lib: add temporary preconditions for `/` and `%` in integer types

### DIFF
--- a/lib/i16.fz
+++ b/lib/i16.fz
@@ -51,8 +51,18 @@ public i16(public val i16) : num.wrap_around, has_interval is
   public fixed redef infix *° (other i16) i16 => intrinsic
 
   # division and remainder with check for div-by-zero
-  public fixed redef infix / (other i16) => div other
-  public fixed redef infix % (other i16) => mod other
+  public fixed redef infix / (other i16)
+    pre else
+      // NYI: #3051 precondition inheritance does not work yet
+      // remove this redundant precondition once #3051 is fixed
+      safety: other != 0
+  => div other
+  public fixed redef infix % (other i16)
+    pre else
+      // NYI: #3051 precondition inheritance does not work yet
+      // remove this redundant precondition once #3051 is fixed
+      safety: other != 0
+  => mod other
 
   # division and remainder with crash in case of div-by-zero
   div (other i16) i16 => intrinsic

--- a/lib/i16.fz
+++ b/lib/i16.fz
@@ -53,14 +53,14 @@ public i16(public val i16) : num.wrap_around, has_interval is
   # division and remainder with check for div-by-zero
   public fixed redef infix / (other i16)
     pre else
-      // NYI: #3051 precondition inheritance does not work yet
-      // remove this redundant precondition once #3051 is fixed
+      # NYI: #3051 precondition inheritance does not work yet
+      # remove this redundant precondition once #3051 is fixed
       safety: other != 0
   => div other
   public fixed redef infix % (other i16)
     pre else
-      // NYI: #3051 precondition inheritance does not work yet
-      // remove this redundant precondition once #3051 is fixed
+      # NYI: #3051 precondition inheritance does not work yet
+      # remove this redundant precondition once #3051 is fixed
       safety: other != 0
   => mod other
 

--- a/lib/i32.fz
+++ b/lib/i32.fz
@@ -57,7 +57,12 @@ public i32(public val i32) : num.wrap_around, has_interval is
       // remove this redundant precondition once #3051 is fixed
       safety: other != 0
   => div other
-  public fixed redef infix % (other i32) => mod other
+  public fixed redef infix % (other i32)
+    pre else
+      // NYI: #3051 precondition inheritance does not work yet
+      // remove this redundant precondition once #3051 is fixed
+      safety: other != 0
+  => mod other
 
   # division and remainder with crash in case of div-by-zero
   div (other i32) i32 => intrinsic

--- a/lib/i32.fz
+++ b/lib/i32.fz
@@ -53,14 +53,14 @@ public i32(public val i32) : num.wrap_around, has_interval is
   # division and remainder with check for div-by-zero
   public fixed redef infix / (other i32)
     pre else
-      // NYI: #3051 precondition inheritance does not work yet
-      // remove this redundant precondition once #3051 is fixed
+      # NYI: #3051 precondition inheritance does not work yet
+      # remove this redundant precondition once #3051 is fixed
       safety: other != 0
   => div other
   public fixed redef infix % (other i32)
     pre else
-      // NYI: #3051 precondition inheritance does not work yet
-      // remove this redundant precondition once #3051 is fixed
+      # NYI: #3051 precondition inheritance does not work yet
+      # remove this redundant precondition once #3051 is fixed
       safety: other != 0
   => mod other
 

--- a/lib/i64.fz
+++ b/lib/i64.fz
@@ -53,14 +53,14 @@ public i64(public val i64) : num.wrap_around, has_interval is
   # division and remainder with check for div-by-zero
   public fixed redef infix / (other i64)
     pre else
-      // NYI: #3051 precondition inheritance does not work yet
-      // remove this redundant precondition once #3051 is fixed
+      # NYI: #3051 precondition inheritance does not work yet
+      # remove this redundant precondition once #3051 is fixed
       safety: other != 0
   => div other
   public fixed redef infix % (other i64)
     pre else
-      // NYI: #3051 precondition inheritance does not work yet
-      // remove this redundant precondition once #3051 is fixed
+      # NYI: #3051 precondition inheritance does not work yet
+      # remove this redundant precondition once #3051 is fixed
       safety: other != 0
   => mod other
 

--- a/lib/i64.fz
+++ b/lib/i64.fz
@@ -51,8 +51,18 @@ public i64(public val i64) : num.wrap_around, has_interval is
   public fixed redef infix *° (other i64) i64 => intrinsic
 
   # division and remainder with check for div-by-zero
-  public fixed redef infix / (other i64) => div other
-  public fixed redef infix % (other i64) => mod other
+  public fixed redef infix / (other i64)
+    pre else
+      // NYI: #3051 precondition inheritance does not work yet
+      // remove this redundant precondition once #3051 is fixed
+      safety: other != 0
+  => div other
+  public fixed redef infix % (other i64)
+    pre else
+      // NYI: #3051 precondition inheritance does not work yet
+      // remove this redundant precondition once #3051 is fixed
+      safety: other != 0
+  => mod other
 
   # division and remainder with crash in case of div-by-zero
   div (other i64) i64 => intrinsic

--- a/lib/i8.fz
+++ b/lib/i8.fz
@@ -53,14 +53,14 @@ public i8(public val i8) : num.wrap_around, has_interval is
   # division and remainder with check for div-by-zero
   public fixed redef infix / (other i8)
     pre else
-      // NYI: #3051 precondition inheritance does not work yet
-      // remove this redundant precondition once #3051 is fixed
+      # NYI: #3051 precondition inheritance does not work yet
+      # remove this redundant precondition once #3051 is fixed
       safety: other != 0
   => div other
   public fixed redef infix % (other i8)
     pre else
-      // NYI: #3051 precondition inheritance does not work yet
-      // remove this redundant precondition once #3051 is fixed
+      # NYI: #3051 precondition inheritance does not work yet
+      # remove this redundant precondition once #3051 is fixed
       safety: other != 0
   => mod other
 

--- a/lib/i8.fz
+++ b/lib/i8.fz
@@ -51,8 +51,18 @@ public i8(public val i8) : num.wrap_around, has_interval is
   public fixed redef infix *° (other i8) i8 => intrinsic
 
   # division and remainder with check for div-by-zero
-  public fixed redef infix / (other i8) => div other
-  public fixed redef infix % (other i8) => mod other
+  public fixed redef infix / (other i8)
+    pre else
+      // NYI: #3051 precondition inheritance does not work yet
+      // remove this redundant precondition once #3051 is fixed
+      safety: other != 0
+  => div other
+  public fixed redef infix % (other i8)
+    pre else
+      // NYI: #3051 precondition inheritance does not work yet
+      // remove this redundant precondition once #3051 is fixed
+      safety: other != 0
+  => mod other
 
   # division and remainder with crash in case of div-by-zero
   div (other i8) i8 => intrinsic

--- a/lib/u128.fz
+++ b/lib/u128.fz
@@ -81,14 +81,14 @@ public u128(public hi u64, public lo u64) : num.wrap_around, has_interval is
   # division and remainder with check for div-by-zero
   public fixed redef infix / (other u128)
     pre else
-      // NYI: #3051 precondition inheritance does not work yet
-      // remove this redundant precondition once #3051 is fixed
+      # NYI: #3051 precondition inheritance does not work yet
+      # remove this redundant precondition once #3051 is fixed
       safety: other != u128.zero
   => div other
   public fixed redef infix % (other u128)
     pre else
-      // NYI: #3051 precondition inheritance does not work yet
-      // remove this redundant precondition once #3051 is fixed
+      # NYI: #3051 precondition inheritance does not work yet
+      # remove this redundant precondition once #3051 is fixed
       safety: other != u128.zero
   => mod other
 

--- a/lib/u128.fz
+++ b/lib/u128.fz
@@ -79,8 +79,18 @@ public u128(public hi u64, public lo u64) : num.wrap_around, has_interval is
      u128 p03<<32 0         )
 
   # division and remainder with check for div-by-zero
-  public fixed redef infix / (other u128) => div other
-  public fixed redef infix % (other u128) => mod other
+  public fixed redef infix / (other u128)
+    pre else
+      // NYI: #3051 precondition inheritance does not work yet
+      // remove this redundant precondition once #3051 is fixed
+      safety: other != u128.zero
+  => div other
+  public fixed redef infix % (other u128)
+    pre else
+      // NYI: #3051 precondition inheritance does not work yet
+      // remove this redundant precondition once #3051 is fixed
+      safety: other != u128.zero
+  => mod other
 
   # division and remainder with crash in case of div-by-zero
   fixed div (other u128) u128 =>

--- a/lib/u16.fz
+++ b/lib/u16.fz
@@ -53,14 +53,14 @@ public u16(public val u16) : num.wrap_around, has_interval is
   # division and remainder with check for div-by-zero
   public fixed redef infix / (other u16)
     pre else
-      // NYI: #3051 precondition inheritance does not work yet
-      // remove this redundant precondition once #3051 is fixed
+      # NYI: #3051 precondition inheritance does not work yet
+      # remove this redundant precondition once #3051 is fixed
       safety: other != 0
   => div other
   public fixed redef infix % (other u16)
     pre else
-      // NYI: #3051 precondition inheritance does not work yet
-      // remove this redundant precondition once #3051 is fixed
+      # NYI: #3051 precondition inheritance does not work yet
+      # remove this redundant precondition once #3051 is fixed
       safety: other != 0
   => mod other
 

--- a/lib/u16.fz
+++ b/lib/u16.fz
@@ -51,8 +51,18 @@ public u16(public val u16) : num.wrap_around, has_interval is
   public fixed redef infix *° (other u16) u16 => intrinsic
 
   # division and remainder with check for div-by-zero
-  public fixed redef infix / (other u16) => div other
-  public fixed redef infix % (other u16) => mod other
+  public fixed redef infix / (other u16)
+    pre else
+      // NYI: #3051 precondition inheritance does not work yet
+      // remove this redundant precondition once #3051 is fixed
+      safety: other != 0
+  => div other
+  public fixed redef infix % (other u16)
+    pre else
+      // NYI: #3051 precondition inheritance does not work yet
+      // remove this redundant precondition once #3051 is fixed
+      safety: other != 0
+  => mod other
 
   # division and remainder with crash in case of div-by-zero
   div (other u16) u16 => intrinsic

--- a/lib/u32.fz
+++ b/lib/u32.fz
@@ -51,8 +51,18 @@ public u32(public val u32) : num.wrap_around, has_interval is
   public fixed redef infix *° (other u32) u32 => intrinsic
 
   # division and remainder with check for div-by-zero
-  public fixed redef infix / (other u32) => div other
-  public fixed redef infix % (other u32) => mod other
+  public fixed redef infix / (other u32)
+    pre else
+      // NYI: #3051 precondition inheritance does not work yet
+      // remove this redundant precondition once #3051 is fixed
+      safety: other != 0
+  => div other
+  public fixed redef infix % (other u32)
+    pre else
+      // NYI: #3051 precondition inheritance does not work yet
+      // remove this redundant precondition once #3051 is fixed
+      safety: other != 0
+  => mod other
 
   # division and remainder with crash in case of div-by-zero
   div (other u32) u32 => intrinsic

--- a/lib/u32.fz
+++ b/lib/u32.fz
@@ -53,14 +53,14 @@ public u32(public val u32) : num.wrap_around, has_interval is
   # division and remainder with check for div-by-zero
   public fixed redef infix / (other u32)
     pre else
-      // NYI: #3051 precondition inheritance does not work yet
-      // remove this redundant precondition once #3051 is fixed
+      # NYI: #3051 precondition inheritance does not work yet
+      # remove this redundant precondition once #3051 is fixed
       safety: other != 0
   => div other
   public fixed redef infix % (other u32)
     pre else
-      // NYI: #3051 precondition inheritance does not work yet
-      // remove this redundant precondition once #3051 is fixed
+      # NYI: #3051 precondition inheritance does not work yet
+      # remove this redundant precondition once #3051 is fixed
       safety: other != 0
   => mod other
 

--- a/lib/u64.fz
+++ b/lib/u64.fz
@@ -53,14 +53,14 @@ public u64(public val u64) : num.wrap_around, has_interval is
   # division and remainder with check for div-by-zero
   public fixed redef infix / (other u64)
     pre else
-      // NYI: #3051 precondition inheritance does not work yet
-      // remove this redundant precondition once #3051 is fixed
+      # NYI: #3051 precondition inheritance does not work yet
+      # remove this redundant precondition once #3051 is fixed
       safety: other != 0
   => div other
   public fixed redef infix % (other u64)
     pre else
-      // NYI: #3051 precondition inheritance does not work yet
-      // remove this redundant precondition once #3051 is fixed
+      # NYI: #3051 precondition inheritance does not work yet
+      # remove this redundant precondition once #3051 is fixed
       safety: other != 0
   => mod other
 

--- a/lib/u64.fz
+++ b/lib/u64.fz
@@ -51,8 +51,18 @@ public u64(public val u64) : num.wrap_around, has_interval is
   public fixed redef infix *° (other u64) u64 => intrinsic
 
   # division and remainder with check for div-by-zero
-  public fixed redef infix / (other u64) => div other
-  public fixed redef infix % (other u64) => mod other
+  public fixed redef infix / (other u64)
+    pre else
+      // NYI: #3051 precondition inheritance does not work yet
+      // remove this redundant precondition once #3051 is fixed
+      safety: other != 0
+  => div other
+  public fixed redef infix % (other u64)
+    pre else
+      // NYI: #3051 precondition inheritance does not work yet
+      // remove this redundant precondition once #3051 is fixed
+      safety: other != 0
+  => mod other
 
   # division and remainder with crash in case of div-by-zero
   div (other u64) u64 => intrinsic

--- a/lib/u8.fz
+++ b/lib/u8.fz
@@ -51,8 +51,18 @@ public u8(public val u8) : num.wrap_around, has_interval is
   public fixed redef infix *° (other u8) u8 => intrinsic
 
   # division and remainder with check for div-by-zero
-  public fixed redef infix / (other u8) => div other
-  public fixed redef infix % (other u8) => mod other
+  public fixed redef infix / (other u8)
+    pre else
+      // NYI: #3051 precondition inheritance does not work yet
+      // remove this redundant precondition once #3051 is fixed
+      safety: other != 0
+  => div other
+  public fixed redef infix % (other u8)
+    pre else
+      // NYI: #3051 precondition inheritance does not work yet
+      // remove this redundant precondition once #3051 is fixed
+      safety: other != 0
+  => mod other
 
   # division and remainder with crash in case of div-by-zero
   div (other u8) u8 => intrinsic

--- a/lib/u8.fz
+++ b/lib/u8.fz
@@ -53,14 +53,14 @@ public u8(public val u8) : num.wrap_around, has_interval is
   # division and remainder with check for div-by-zero
   public fixed redef infix / (other u8)
     pre else
-      // NYI: #3051 precondition inheritance does not work yet
-      // remove this redundant precondition once #3051 is fixed
+      # NYI: #3051 precondition inheritance does not work yet
+      # remove this redundant precondition once #3051 is fixed
       safety: other != 0
   => div other
   public fixed redef infix % (other u8)
     pre else
-      // NYI: #3051 precondition inheritance does not work yet
-      // remove this redundant precondition once #3051 is fixed
+      # NYI: #3051 precondition inheritance does not work yet
+      # remove this redundant precondition once #3051 is fixed
       safety: other != 0
   => mod other
 
@@ -145,12 +145,12 @@ public u8(public val u8) : num.wrap_around, has_interval is
   # is this u8 an ASCII white-space character?
   #
   public is_ascii_white_space =>
-    (val = 9  ||  // HT
-     val = 10 ||  // LF
-     val = 11 ||  // VT
-     val = 12 ||  // FF
-     val = 13 ||  // CR
-     val = 32     // SPACE
+    (val = 9  ||  # HT
+     val = 10 ||  # LF
+     val = 11 ||  # VT
+     val = 12 ||  # FF
+     val = 13 ||  # CR
+     val = 32     # SPACE
     )
 
 


### PR DESCRIPTION
required as long as precondition inheritance is not working, see #3051