### PR TITLE
lib/ast: add `Nullary` and `Binary` functions

### DIFF
--- a/lib/Binary.fz
+++ b/lib/Binary.fz
@@ -17,18 +17,12 @@
 #
 #  Tokiwa Software GmbH, Germany
 #
-#  Source code of Fuzion standard library feature Lazy
+#  Source code of Fuzion standard library feature Binary
 #
 # -----------------------------------------------------------------------
 
-# Lazy has special compiler support.
-# It can be used to require lazy evaluation of arguments.
+# Binary -- function that takes exactly two arguments and returns a result
 #
-# A good example is `or` in bool:
-#     infix || (other Lazy bool) bool =>
+# T is the result type of the function, U1 and U2 are the argument types of the function
 #
-# In the following example the expression
-# `4+5>10` will never be executed:
-#     true || 4+5>10
-#
-public Lazy(public T type) ref : Nullary T is
+public Binary(public T, U1 type, U2 type) ref : Function T U1 U2 is

--- a/lib/Nullary.fz
+++ b/lib/Nullary.fz
@@ -17,18 +17,12 @@
 #
 #  Tokiwa Software GmbH, Germany
 #
-#  Source code of Fuzion standard library feature Lazy
+#  Source code of Fuzion standard library feature Nullary
 #
 # -----------------------------------------------------------------------
 
-# Lazy has special compiler support.
-# It can be used to require lazy evaluation of arguments.
+# Nullary -- function that takes no argument and returns a result
 #
-# A good example is `or` in bool:
-#     infix || (other Lazy bool) bool =>
+# T is the result type of the function
 #
-# In the following example the expression
-# `4+5>10` will never be executed:
-#     true || 4+5>10
-#
-public Lazy(public T type) ref : Nullary T is
+public Nullary(public T type) ref : Function T is

--- a/src/dev/flang/ast/AbstractType.java
+++ b/src/dev/flang/ast/AbstractType.java
@@ -1148,7 +1148,7 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
    * isFunctionType checks if this is a function type used for lambda expressions,
    * e.g., "(i32, i32) -> String".
    *
-   * @return true iff this is a function type based on `Function` or `Unary`.
+   * @return true iff this is a function type based on `Function`, `Unary` or `Binary`.
    */
   public boolean isFunctionType()
   {
@@ -1156,7 +1156,8 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
       this != Types.t_ERROR &&
       !isGenericArgument() &&
       (feature() == Types.resolved.f_Function ||
-       feature() == Types.resolved.f_Unary);
+       feature() == Types.resolved.f_Unary    ||
+       feature() == Types.resolved.f_Binary);
   }
 
 

--- a/src/dev/flang/ast/Function.java
+++ b/src/dev/flang/ast/Function.java
@@ -84,13 +84,13 @@ public class Function extends AbstractLambda
    * will be used put the correct return type in case of a fun declaration using
    * => that requires type inference.
    *
-   * I.e. a call to (Function/Unary/Lazy <generics>)
+   * I.e. a call to (Function/Unary/Binary/Nullary/Lazy <generics>)
    */
   Call _inheritsCall;
 
 
   /**
-   * The feature that inherits from `Function/Unary/Lazy/...` that implements this lambda in
+   * The feature that inherits from `Function/Unary/Binary/Nullary/Lazy/...` that implements this lambda in
    * its `call` feature.
    */
   Feature _wrapper;
@@ -309,9 +309,11 @@ public class Function extends AbstractLambda
             feature._sourceCodeContext = context;
 
             var inheritsName =
-              (t.feature() == Types.resolved.f_Unary && gs.size() == 2) ? Types.UNARY_NAME :
-              (t.feature() == Types.resolved.f_Lazy  && gs.size() == 1) ? Types.LAZY_NAME
-                                                                        : Types.FUNCTION_NAME;
+              (t.feature() == Types.resolved.f_Unary   && gs.size() == 2) ? Types.UNARY_NAME   :
+              (t.feature() == Types.resolved.f_Binary  && gs.size() == 3) ? Types.BINARY_NAME  :
+              (t.feature() == Types.resolved.f_Nullary && gs.size() == 1) ? Types.NULLARY_NAME :
+              (t.feature() == Types.resolved.f_Lazy    && gs.size() == 1) ? Types.LAZY_NAME
+                                                                          : Types.FUNCTION_NAME;
 
             // inherits clause for wrapper feature: Function<R,A,B,C,...>
             _inheritsCall = new Call(pos(), null, inheritsName);

--- a/src/dev/flang/ast/Types.java
+++ b/src/dev/flang/ast/Types.java
@@ -57,6 +57,11 @@ public class Types extends ANY
   public static final String FUNCTION_NAME = "Function";
 
   /**
+   * Name of abstract features for Nullary types:
+   */
+  public static final String NULLARY_NAME = "Nullary";
+
+  /**
    * Name of abstract features for lazy types:
    */
   public static final String LAZY_NAME = "Lazy";
@@ -65,6 +70,11 @@ public class Types extends ANY
    * Name of abstract features for unary function types:
    */
   public static final String UNARY_NAME = "Unary";
+
+  /**
+   * Name of abstract features for binary function types:
+   */
+  public static final String BINARY_NAME = "Binary";
 
   public static Resolved resolved = null;
 
@@ -183,8 +193,10 @@ public class Types extends ANY
     public final AbstractFeature f_Type_infix_colon_true;
     public final AbstractFeature f_Type_infix_colon_false;
     public final AbstractFeature f_type_as_value;
+    public final AbstractFeature f_Nullary;
     public final AbstractFeature f_Lazy;
     public final AbstractFeature f_Unary;
+    public final AbstractFeature f_Binary;
     public final AbstractFeature f_auto_unwrap;
     public final Set<AbstractType> numericTypes;
     public Resolved(AbstractModule mod, AbstractFeature universe, boolean forFrontEnd)
@@ -249,8 +261,10 @@ public class Types extends ANY
       f_Type_infix_colon_true   = f_Type.get(mod, "infix_colon_true", 1);
       f_Type_infix_colon_false  = f_Type.get(mod, "infix_colon_false", 1);
       f_type_as_value           = universe.get(mod, "type_as_value", 1);
+      f_Nullary                 = universe.get(mod, NULLARY_NAME, 1);
       f_Lazy                    = universe.get(mod, LAZY_NAME, 1);
       f_Unary                   = universe.get(mod, UNARY_NAME, 2);
+      f_Binary                  = universe.get(mod, BINARY_NAME, 3);
       f_auto_unwrap             = universe.get(mod, "auto_unwrap", 2);
       numericTypes = new TreeSet<AbstractType>(new List<>(
         t_i8,

--- a/src/dev/flang/ast/UnresolvedType.java
+++ b/src/dev/flang/ast/UnresolvedType.java
@@ -429,7 +429,8 @@ public abstract class UnresolvedType extends AbstractType implements HasSourcePo
 
     // This is called during parsing, so Types.resolved.f_function is not set yet.
     return new ParsedType(pos,
-                          arguments.size() == 1 ? Types.UNARY_NAME : Types.FUNCTION_NAME,
+                          arguments.size() == 1 ? Types.UNARY_NAME  :
+                          arguments.size() == 2 ? Types.BINARY_NAME : Types.FUNCTION_NAME,
                           new List<AbstractType>(returnType, arguments),
                           null);
   }

--- a/tests/asParsedType/test_asParsedType.fz.expected_out
+++ b/tests/asParsedType/test_asParsedType.fz.expected_out
@@ -30,12 +30,12 @@ GOT: x Type of 'Unary a a.b'
 GOT: x Type of 'Unary a a.b'
 
 EXP: x Type of 'Function String i32 u64'
-GOT: x Type of 'Function String i32 u64'
-GOT: x Type of 'Function String i32 u64'
+GOT: x Type of 'Binary String i32 u64'
+GOT: x Type of 'Binary String i32 u64'
 
 EXP: x Type of 'Function String (Sequence u64) a.b'
-GOT: x Type of 'Function String (Sequence u64) a.b'
-GOT: x Type of 'Function String (Sequence u64) a.b'
+GOT: x Type of 'Binary String (Sequence u64) a.b'
+GOT: x Type of 'Binary String (Sequence u64) a.b'
 
 EXP: x Type of 'choice a.b i32 (Unary (choice i32 A) String)'
 GOT: x Type of 'choice a.b i32 (Unary (choice i32 A) String)'

--- a/tests/functions/functions.fz
+++ b/tests/functions/functions.fz
@@ -69,13 +69,13 @@ functions is
     x ((o, i) -> { o.hash_code + i })  // implicit assignment to result from last expression
 
     say "here 1c---------------"
-    x (ref : Function i32 Any i32 {
+    x (ref : Binary i32 Any i32 {
         redef call(o Any, i i32) i32 =>
           say "in anonymous function: $o"
           o.hash_code + i
        })
 
-    F ref : Function i32 Any i32 is
+    F ref : Binary i32 Any i32 is
         redef call(o Any, i i32) i32 =>
           say "here F.call---------------"
           res := o.hash_code + i

--- a/tests/partial_application/partial_application.fz
+++ b/tests/partial_application/partial_application.fz
@@ -96,13 +96,13 @@ partial_application is
   test "data.zip data x,y->x*y" (data.zip data x,y->x*y) "[1, 4, 9, 16, 25, 36, 49, 64, 81, 100]"
   test "data.zip data (+)" (data.zip data (+)) "[2, 4, 6, 8, 10, 12, 14, 16, 18, 20]"
   test "data.zip data (*)" (data.zip data (*)) "[1, 4, 9, 16, 25, 36, 49, 64, 81, 100]"
-  z00 Function i32 i32 i32 := +
+  z00 Binary i32 i32 i32 := +
   test "data.zip data +  " (data.zip data z00) "[2, 4, 6, 8, 10, 12, 14, 16, 18, 20]"
-  z01 Function i32 i32 i32 := -
+  z01 Binary i32 i32 i32 := -
   test "data.zip data -  " (data.zip data z01) "[0, 0, 0, 0, 0, 0, 0, 0, 0, 0]"
-  z02 Function i32 i32 i32 => *
+  z02 Binary i32 i32 i32 => *
   test "data.zip data *  " (data.zip data z02) "[1, 4, 9, 16, 25, 36, 49, 64, 81, 100]"
-  z03 Function i32 i32 i32 => /
+  z03 Binary i32 i32 i32 => /
   test "data.zip data *  " (data.zip data z03) "[1, 1, 1, 1, 1, 1, 1, 1, 1, 1]"
 
   easy(f i32->i32) =>


### PR DESCRIPTION
`Nullary` as parent of `Lazy` and `Binary` as a child of `Function`

fix #2704

