### PR TITLE
Dfa better joining of tagged values

### DIFF
--- a/src/dev/flang/fuir/analysis/dfa/DFA.java
+++ b/src/dev/flang/fuir/analysis/dfa/DFA.java
@@ -2608,8 +2608,42 @@ public class DFA extends ANY
         if (res == null)
           {
             res = v instanceof ValueSet vv && vv.contains(w) ? v :
-                  w instanceof ValueSet vw && vw.contains(v) ? w : cache(new ValueSet(v, w));
+                  w instanceof ValueSet ww && ww.contains(v) ? w :
+                  v instanceof TaggedValue tv ? tryJoin(tv,w) :
+                  w instanceof TaggedValue tw ? tryJoin(tw,v) : null;
+            if (res == null)
+              {
+                res = new ValueSet(v, w);
+              }
+            res = cache(res);
             _joined.put(k, res);
+          }
+      }
+    return res;
+  }
+
+
+  /**
+   * Helper for newValueSet that tries to join a TaggedValue with another Value.
+   *
+   * @return a value that covers the values of tv and w or null if we must
+   * create a ValueSet of v and w.
+   */
+  private Value tryJoin(TaggedValue tv, Value w)
+  {
+    Value res = null;
+    if (tv.contains(w))
+      {
+        res = tv;
+      }
+    else if (w instanceof ValueSet ws)
+      {
+        for (var wc : ws._componentsArray)
+          {
+            if (wc.contains(tv))
+              {
+                res = w;
+              }
           }
       }
     return res;

--- a/src/dev/flang/fuir/analysis/dfa/DFA.java
+++ b/src/dev/flang/fuir/analysis/dfa/DFA.java
@@ -2607,43 +2607,10 @@ public class DFA extends ANY
         res = _joined.get(k);
         if (res == null)
           {
-            res = v instanceof ValueSet vv && vv.contains(w) ? v :
-                  w instanceof ValueSet ww && ww.contains(v) ? w :
-                  v instanceof TaggedValue tv ? tryJoin(tv,w) :
-                  w instanceof TaggedValue tw ? tryJoin(tw,v) : null;
-            if (res == null)
-              {
-                res = new ValueSet(v, w);
-              }
+            res = v.contains(w) ? v :
+                  w.contains(v) ? w : new ValueSet(v, w);
             res = cache(res);
             _joined.put(k, res);
-          }
-      }
-    return res;
-  }
-
-
-  /**
-   * Helper for newValueSet that tries to join a TaggedValue with another Value.
-   *
-   * @return a value that covers the values of tv and w or null if we must
-   * create a ValueSet of v and w.
-   */
-  private Value tryJoin(TaggedValue tv, Value w)
-  {
-    Value res = null;
-    if (tv.contains(w))
-      {
-        res = tv;
-      }
-    else if (w instanceof ValueSet ws)
-      {
-        for (var wc : ws._componentsArray)
-          {
-            if (wc.contains(tv))
-              {
-                res = w;
-              }
           }
       }
     return res;

--- a/src/dev/flang/fuir/analysis/dfa/DFA.java
+++ b/src/dev/flang/fuir/analysis/dfa/DFA.java
@@ -2608,7 +2608,7 @@ public class DFA extends ANY
         if (res == null)
           {
             res = v.contains(w) ? v :
-                  w.contains(v) ? w : new ValueSet(v, w);
+                  w.contains(v) ? w : new ValueSet(this, v, w);
             res = cache(res);
             _joined.put(k, res);
           }

--- a/src/dev/flang/fuir/analysis/dfa/TaggedValue.java
+++ b/src/dev/flang/fuir/analysis/dfa/TaggedValue.java
@@ -105,6 +105,19 @@ public class TaggedValue extends Value implements Comparable<TaggedValue>
 
 
   /**
+   * Does this Value cover the values in other?
+   */
+  @Override
+  boolean contains(Value other)
+  {
+    return other instanceof TaggedValue ot &&
+      _clazz == ot._clazz &&
+      _tag == ot._tag &&
+      _original.contains(ot._original);
+  }
+
+
+  /**
    * Create the union of the values 'this' and 'v'. This is called by join()
    * after common cases (same instance, UNDEFINED) have been handled.
    */

--- a/src/dev/flang/fuir/analysis/dfa/Value.java
+++ b/src/dev/flang/fuir/analysis/dfa/Value.java
@@ -279,7 +279,7 @@ public class Value extends Val
    */
   boolean contains(Value other)
   {
-    return false;
+    return this == other;
   }
 
 

--- a/src/dev/flang/fuir/analysis/dfa/Value.java
+++ b/src/dev/flang/fuir/analysis/dfa/Value.java
@@ -275,6 +275,15 @@ public class Value extends Val
 
 
   /**
+   * Does this Value cover the values in other?
+   */
+  boolean contains(Value other)
+  {
+    return false;
+  }
+
+
+  /**
    * Add v to the set of values of given field within this instance.
    */
   public void setField(DFA dfa, int field, Value v)

--- a/src/dev/flang/fuir/analysis/dfa/ValueSet.java
+++ b/src/dev/flang/fuir/analysis/dfa/ValueSet.java
@@ -138,9 +138,11 @@ public class ValueSet extends Value
       }
   }
 
+
   /**
    * Is this ValueSet a superset of other?
    */
+  @Override
   boolean contains(Value other)
   {
     boolean result;

--- a/src/dev/flang/fuir/analysis/dfa/ValueSet.java
+++ b/src/dev/flang/fuir/analysis/dfa/ValueSet.java
@@ -159,7 +159,7 @@ public class ValueSet extends Value
         result = false;
         for (var tc : _componentsArray)
           {
-            result = result || tc == other;
+            result = result || tc.contains(other);
           }
       }
     return result;


### PR DESCRIPTION
dfa: Improve merging of tagged values
Before this, joining two values
```
  a[tag:0,val:v1,v2]
  a[tag:0,val:v1]
```
created a value set
```
  {a[tag:0,val:v1,v2],
   a[tag:0,val:v1]}
```
while now the result is
```
  a[tag:0,val:v1,v2]
```
