### PR TITLE
be: Added `break` to avoid accidental fall through in switch statements

### DIFF
--- a/src/dev/flang/be/c/C.java
+++ b/src/dev/flang/be/c/C.java
@@ -1642,6 +1642,7 @@ public class C extends ANY
       case Abstract :
         Errors.error("Call to abstract feature encountered.",
                      "Found call to  " + _fuir.clazzAsString(cc));
+        break;
       case Routine  :
       case Intrinsic:
       case Native   :

--- a/src/dev/flang/be/jvm/CodeGen.java
+++ b/src/dev/flang/be/jvm/CodeGen.java
@@ -561,8 +561,11 @@ class CodeGen
     switch (_fuir.clazzKind(cc))
       {
       case Abstract :
+        res = new Pair<>(null,  // result is void, we do not return from this path.
+                         Expr.UNIT);
         Errors.error("Call to abstract feature encountered.",
                      "Found call to " + clazzInQuotes(cc));
+        break;
       case Intrinsic:
         {
           if (_fuir.clazzTypeParameterActualType(cc) != -1)  /* type parameter is also of Kind Intrinsic, NYI: CLEANUP: should better have its own kind?  */


### PR DESCRIPTION
The code just worked by accident before.
