### PR TITLE
fuir: Add precondition for Clazz of `Types.t_ERROR` not to be created.

### DIFF
--- a/src/dev/flang/fuir/Clazz.java
+++ b/src/dev/flang/fuir/Clazz.java
@@ -282,7 +282,8 @@ class Clazz extends ANY implements Comparable<Clazz>
     if (PRECONDITIONS) require
       (!type.dependsOnGenerics() || true /* NYI: UNDER DEVELOPMENT: Why? */,
        !type.containsThisType(),
-       type.feature().resultType().isOpenGeneric() == (select >= 0));
+       type.feature().resultType().isOpenGeneric() == (select >= 0),
+       type != Types.t_ERROR);
 
     _fuir = fuir;
     outer = normalizeOuter(type, outer);


### PR DESCRIPTION
This would have made my life easier debugging a problem where this happened.

