### PR TITLE
dfa: Improve the fixpoint loop: run one more iteration after `lookupDone`

### DIFF
--- a/src/dev/flang/fuir/analysis/dfa/DFA.java
+++ b/src/dev/flang/fuir/analysis/dfa/DFA.java
@@ -1276,6 +1276,7 @@ public class DFA extends ANY
   void findFixPoint()
   {
     var cnt = 0;
+    var lookupDone = false;
     do
       {
         cnt++;
@@ -1289,6 +1290,12 @@ public class DFA extends ANY
         _changed = false;
         _changedSetBy = () -> "*** change not set ***";
         iteration();
+        if (!_changed && !lookupDone)
+          {
+            _fuir.lookupDone();  // once we are done, FUIR.isUnitType() will work since it can be sure nothing will be added.
+            lookupDone = true;
+            wasChanged(() -> "freezing lookup");
+          }
       }
     while (_changed && (true || cnt < 100));
     if (_options.verbose(4))
@@ -1301,9 +1308,11 @@ public class DFA extends ANY
             _options.verbosePrintln(4, "  call: " + c);
           }
       }
+
     _reportResults = true;
-    _fuir.lookupDone();  // once we are done, FUIR.isUnitType() will work since it can be sure nothing will be added.
     iteration();
+    if (CHECKS) check
+      (!_changed);
 
     showCallStatistics();
   }


### PR DESCRIPTION
After `lookupDone` was called, some values will be turned into unit type values. This may have the effect that new clazzes are created if these unit types are boxed.

So we run one more iteration before we report the results and check that the result reporting perfomed no more changes to the reached fix point.
