### PR TITLE
util: always show total error count with `-XmaxErrors`

### DIFF
--- a/src/dev/flang/util/Errors.java
+++ b/src/dev/flang/util/Errors.java
@@ -422,18 +422,20 @@ public class Errors extends ANY
         if (!_errors_.contains(e) && (pos == null || !_syntaxErrorPositions_.contains(pos)))
           {
             _errors_.add(e);
-            print(pos, errorMessage(msg), detail);
-            if (count() >= MAX_ERROR_MESSAGES && MAX_ERROR_MESSAGES != -1)
+            if (count() <= MAX_ERROR_MESSAGES || MAX_ERROR_MESSAGES == -1)
+              {
+                print(pos, errorMessage(msg), detail);
+                if (STACK_TRACE_ON_ERROR)
+                  {
+                    Thread.dumpStack();
+                  }
+              }
+            else if (count() == (MAX_ERROR_MESSAGES + 1) && MAX_ERROR_MESSAGES != -1)
               {
                 warning(SourcePosition.builtIn,
-                        "Maximum error count reached, terminating.",
+                        "Maximum error count reached, stop error output.",
                         "Maximum error count is " + MAX_ERROR_MESSAGES + ".\n" +
                         "Change this via property '" + MAX_ERROR_MESSAGES_PROPERTY + "' or command line option '" + MAX_ERROR_MESSAGES_OPTION + "'.");
-                showAndExit();
-              }
-            if (STACK_TRACE_ON_ERROR)
-              {
-                Thread.dumpStack();
               }
           }
       }


### PR DESCRIPTION
```
❯ fz -XmaxErrors=0 tests/typeinference_negative/typeinference_negative.fz

<built-in>: warning 1: Maximum error count reached, stop error output.
Maximum error count is 0.
Change this via property 'fuzion.maxErrorCount' or command line option '-XmaxErrors'.

41 errors and one warning.
```

fix #4083