### PR TITLE
lib: io.file/dir remove parameter T, used for distinguishing

### DIFF
--- a/lib/io/dir/open.fz
+++ b/lib/io/dir/open.fz
@@ -23,10 +23,8 @@
 
 
 # effect for manipulating open directories
-# T is used to distinguish several open directories
 #
-module:public open(public T type,
-                   fd i64,
+module:public open(fd i64,
                    public path String) : effect is
 
   # reads the next entry of this directory
@@ -42,24 +40,6 @@ module:public open(public T type,
 
 # short hand to get the currently
 # installed open effect
-# for type T from the environment.
-# see `use` on how to use this.
-#
-public open(T type) =>
-  (open T).env
-
-
-# unit type used internally by open- and use-
-# short hands which can be used when one does not need
-# to distinguish between several open directories.
-#
-private:public open_unique_type is
-
-
-# short hand to get the currently
-# installed open effect
-# from the environment.
-# see `use` on how to use this.
 #
 public open =>
-  (open open_unique_type).env
+  open.env

--- a/lib/io/dir/use.fz
+++ b/lib/io/dir/use.fz
@@ -25,9 +25,6 @@
 # this opens a directory and installs the (open T) effect to be used
 # in `code()`.
 #
-# type parameter T is used to distinguish between several open
-# directories.
-#
 # usage example:
 #
 #     use some_type path ()->
@@ -35,26 +32,12 @@
 #         e error => e
 #         s String => say s
 #
-public use(T, R type, path String, code ()-> outcome R) outcome R =>
+public use(R type, path String, code ()-> outcome R) outcome R =>
   (fuzion.sys.fileio.open_dir path).bind R fd->
     # install effect `open T` and run `code`
-    r := open T fd path
+    r := open fd path
        ! code
     # close file
     _ := fuzion.sys.fileio.close_dir fd
     # return result
     r
-
-
-# short hand for use when
-# it is not necessary to distinguish between opens
-#
-# usage example:
-#
-#     use path ()->
-#       match open.read
-#         e error => e
-#         s String => say s
-#
-public use(R type, path String, code ()-> outcome R) outcome R =>
-  use open_unique_type R path code

--- a/lib/io/file/delete.fz
+++ b/lib/io/file/delete.fz
@@ -39,17 +39,12 @@ public delete(dop Delete_Handler, _ unit) : effect is
     tmp
 
 
-  # the default file/dir delete operation via fuzion.sys.fileio.delete
-  #
-  type.default_delete_handler : io.file.Delete_Handler is
-    redef delete(path String) =>
-      fuzion.sys.fileio.delete path
+# the default file/dir delete operation via fuzion.sys.fileio.delete
+#
+default_delete_handler : Delete_Handler is
+  redef delete(path String) =>
+    fuzion.sys.fileio.delete path
 
-
-  # install default effect io.file.delete
-  #
-  type.install_default =>
-    (io.file.delete default_delete_handler unit).default
 
 # short-hand for accessing delete effect in current environment and performing the default delete operation using io.file.delete.delete path
 # deletes the file/dir found in the path
@@ -57,7 +52,7 @@ public delete(dop Delete_Handler, _ unit) : effect is
 # if the targeted dir has content, then the return value will be error and the deletion will not take place
 #
 public delete(path String) =>
-  delete.install_default
+  (delete default_delete_handler unit).default
   delete.env.delete path
 
 # reference to the delete operations that could take place

--- a/lib/io/file/exists.fz
+++ b/lib/io/file/exists.fz
@@ -17,12 +17,13 @@
 #
 #  Tokiwa Software GmbH, Germany
 #
-#  Source code of Fuzion standard library feature file
-#
-#  Author: Wael Youssfi (wael.youssfi@tokiwa.software)
+#  Source code of Fuzion standard library feature io.file.exists
 #
 # -----------------------------------------------------------------------
 
-# file -- a unit type that contains effects related to file I/O
+
+# Does a file or directory at path exist?
 #
-public file is
+public exists(path String) =>
+  (stat path false).ok
+

--- a/lib/io/file/move.fz
+++ b/lib/io/file/move.fz
@@ -31,7 +31,7 @@ public move(mop Move_Handler) : effect is
   # can rename the file/dir as well by changing the name of the old file/dir to a new name in the new_path
   # returns a unit type as outcome in case of success and error in case of failure
   #
-  move(
+  public move(
        # the old (relative or absolute) file name, using platform specific path separators
        old_path String,
        # the new (relative or absolute) file name, using platform specific path separators
@@ -41,17 +41,11 @@ public move(mop Move_Handler) : effect is
     tmp
 
 
-  # the default file/dir move operation via fuzion.sys.fileio.move
-  #
-  type.default_move_handler : io.file.Move_Handler is
-    redef move(old_path String, new_path String) =>
-      fuzion.sys.fileio.move old_path new_path
-
-
-  # install default effect io.file.move
-  #
-  type.install_default =>
-    (io.file.move default_move_handler).default
+# the default file/dir move operation via fuzion.sys.fileio.move
+#
+default_move_handler : Move_Handler is
+  redef move(old_path String, new_path String) =>
+    fuzion.sys.fileio.move old_path new_path
 
 
 # short-hand for accessing move effect in current environment and performing the default move operation using
@@ -65,7 +59,7 @@ public move(
      old_path String,
      # the new (relative or absolute) file name, using platform specific path separators
      new_path String) =>
-  move.install_default
+  (move default_move_handler).default
   move.env.move old_path new_path
 
 # reference to the move operations that could take place

--- a/lib/io/file/open.fz
+++ b/lib/io/file/open.fz
@@ -23,10 +23,8 @@
 
 
 # effect for manipulating open files
-# T is used to distinguish several open files
 #
-module:public open(public T type,
-                   fd i64,
+module:public open(fd i64,
                    public file_name String) : effect is
 
   # seek in file
@@ -34,13 +32,13 @@ module:public open(public T type,
   public seek(
        # the offset to seek from the beginning of the stream pointer
        offset i64) =>
-    io.file.seek.seek fd offset
+    seek.seek fd offset
 
 
   # get the current byte position in the file
   #
   public file_position =>
-    io.file.seek.file_position fd
+    seek.file_position fd
 
 
   # install mmap effect an run code
@@ -94,7 +92,7 @@ module:public open(public T type,
      # the length of this buffer
      public redef length i64
     )
-    : container.Buffer u8 (io.file.open T) is
+    : container.Buffer u8 open is
 
 
     # get byte at given index i
@@ -106,7 +104,7 @@ module:public open(public T type,
 
     # set byte at given index i to given value o
     #
-    public redef set [ ] (i i64, o u8) unit ! io.file.open T
+    public redef set [ ] (i i64, o u8) unit ! open T
     =>
       mapped_buffer_set memory i o
 
@@ -114,24 +112,7 @@ module:public open(public T type,
 
 # short hand to get the currently
 # installed open effect
-# for type T from the environment.
-# see `use` on how to use this.
-#
-public open(T type) =>
-  (open T).env
-
-
-# unit type used internally by open- and use-
-# short hands which can be used when one does not need
-# to distinguish between several open files.
-private:public open_unique_type is
-
-
-
-# short hand to get the currently
-# installed open effect
-# from the environment.
-# see `use` on how to use this.
 #
 public open =>
-  (open open_unique_type).env
+  open.env
+

--- a/lib/io/file/seek.fz
+++ b/lib/io/file/seek.fz
@@ -31,61 +31,45 @@ public seek(ps Seek_Handler) : effect is
   # returns an outcome i64 that represents the new offset
   # returns an error in case of failure
   #
-  module seek(
+  public seek(
        # the file descriptor
        fd i64,
        # the offset to seek from the beginning of the stream pointer
        offset i64) =>
-    tmp := ps.seek fd offset
     replace
-    tmp
+    ps.seek fd offset
+
 
   # returns the current file-pointer offset as an outcome i64,
   # the offset is measured from the beginning of the file indicated by the file descriptor
   # returns the current offset in success and error in failure
   #
-  module file_position(
+  public file_position(
                 # the file descriptor
                 fd i64) =>
-    tmp := ps.file_position fd
     replace
-    tmp
+    ps.file_position fd
 
 
-  # the default stream seeking
-  #
-  type.default_seek_handler : io.file.Seek_Handler is
-    redef seek(fd i64, offset i64) =>
-      fuzion.sys.fileio.seek fd offset
-
-    redef file_position(fd i64) =>
-      fuzion.sys.fileio.file_position fd
-
-
-  # install default effect io.file.seek
-  type.install_default unit =>
-    (io.file.seek default_seek_handler).default
-
-
-# short-hand for accessing seek effect in current environment and performing the default seek operation using
-# io.file.seek.seek fd offset
-# seek offset in the stream represented by fd
-# returns an outcome i64 that represents the new offset
-# returns an error in case of failure
+# the default stream seeking
 #
-seek(
-     # the file descriptor
-     fd i64,
-     # the offset to seek from the beginning of the stream pointer
-     offset i64) =>
-  seek.install_default
-  seek.env.seek fd offset
+default_seek_handler : Seek_Handler is
+  redef seek(fd i64, offset i64) =>
+    fuzion.sys.fileio.seek fd offset
+
+  redef file_position(fd i64) =>
+    fuzion.sys.fileio.file_position fd
+
+
+# install default effect seek
+install_default_seek unit =>
+  (seek default_seek_handler).default
 
 
 # short-hand for accessing seek effect in current environment
 #
 module seek =>
-  seek.install_default
+  install_default_seek
   seek.env
 
 

--- a/lib/io/file/stat.fz
+++ b/lib/io/file/stat.fz
@@ -72,25 +72,29 @@ public stat(ps Stat_Handler) : effect is
       error "lstat error {res[0]} for {path}"
 
 
-  # the default file stat provided
-  #
-  type.default_stat_handler : io.file.Stat_Handler is
-    redef stats(path fuzion.sys.Pointer, meta_data_arr fuzion.sys.Pointer) =>
-      fuzion.sys.fileio.stats path meta_data_arr
 
-    redef lstats(path fuzion.sys.Pointer, meta_data_arr fuzion.sys.Pointer) =>
-      fuzion.sys.fileio.lstats path meta_data_arr
+# install default effect io.file.stat
+#
+install_default =>
+  (stat default_stat_handler).default
 
 
-  # install default effect io.file.stat
-  type.install_default =>
-    (io.file.stat default_stat_handler).default
+
+# the default file stat provided
+#
+default_stat_handler : Stat_Handler is
+  redef stats(path fuzion.sys.Pointer, meta_data_arr fuzion.sys.Pointer) =>
+    fuzion.sys.fileio.stats path meta_data_arr
+
+  redef lstats(path fuzion.sys.Pointer, meta_data_arr fuzion.sys.Pointer) =>
+    fuzion.sys.fileio.lstats path meta_data_arr
+
 
 
 # short-hand for accessing the stat effect in current environment
 #
 public stat =>
-  stat.install_default
+  install_default
   stat.env
 
 
@@ -105,7 +109,7 @@ public stat(
      path String,
      # a boolean resolve flag to resolve symbolic links or not
      resolve bool) =>
-  stat.install_default
+  install_default
   if resolve
     stat.env.stats path
   else

--- a/lib/io/file/use.fz
+++ b/lib/io/file/use.fz
@@ -37,8 +37,6 @@ public mode is
 # this opens a file with the given mode and installs
 # effect (open T) to be used in `code()`.
 #
-# type parameter T is used to distinguish between several open files.
-#
 # usage example:
 #
 #     use some_type file_name mode.read ()->
@@ -46,7 +44,7 @@ public mode is
 #         e error => e
 #         a array => String.from_bytes a
 #
-public use(T, R type, LM type : mutate, file_name String, m mode.val, code ()-> outcome R) outcome R =>
+public use(R type, LM type : mutate, file_name String, m mode.val, code ()-> outcome R) outcome R =>
 
   # definition of read provider for file
   #
@@ -70,7 +68,7 @@ public use(T, R type, LM type : mutate, file_name String, m mode.val, code ()-> 
 
   (fuzion.sys.fileio.open file_name mode_num).bind R fd->
     # install effect `open T` and run `code`
-    r := (open T fd file_name) ! ()->
+    r := (open fd file_name) ! ()->
           (io.buffered.reader LM (read_provider fd) 1024).try ()->
             (io.buffered.writer LM (write_provider fd) 1024).with ()->
               tmp := code.call
@@ -87,17 +85,3 @@ public use(T, R type, LM type : mutate, file_name String, m mode.val, code ()-> 
       .bind (outcome R) x->x
       .bind R x->x
 
-
-
-# short hand for use when
-# it is not necessary to distinguish between opens
-#
-# usage example:
-#
-#     use file_name mode.read ()->
-#       match open.read
-#         e error => e
-#         a array => String.from_bytes a
-#
-public use(R type, LM type : mutate, file_name String, m mode.val, code ()-> outcome R) outcome R =>
-  use open_unique_type R LM file_name m code

--- a/lib/io/file/write.fz
+++ b/lib/io/file/write.fz
@@ -17,12 +17,15 @@
 #
 #  Tokiwa Software GmbH, Germany
 #
-#  Source code of Fuzion standard library feature file
-#
-#  Author: Wael Youssfi (wael.youssfi@tokiwa.software)
+#  Source code of Fuzion standard library feature io.file.write
 #
 # -----------------------------------------------------------------------
 
-# file -- a unit type that contains effects related to file I/O
+
+# write String `s` to file `f`
 #
-public file is
+public write(f String, s String) outcome unit =>
+  lm : mutate is
+  lm ! ()->
+    use unit lm f mode.write ()->
+      ((io.buffered.writer lm).write s.utf8).error

--- a/tests/lib_io_file/fileiotests.fz
+++ b/tests/lib_io_file/fileiotests.fz
@@ -36,7 +36,7 @@ fileiotests =>
 
   content := "Hello world 🌍"
 
-  f => io.file
+  f : io.file is
 
   say "$dir exists: {f.exists dir}"
   _ := (io.dir.make dir).bind unit _->
@@ -46,21 +46,21 @@ fileiotests =>
   say "$file exists: {f.exists file}"
 
   _ := f
-    .use unit lm file io.file.mode.write ()->((io.buffered.writer lm).write content.utf8).error
+    .use unit lm file f.mode.write ()->((io.buffered.writer lm).write content.utf8).error
     .bind unit (_ -> say "$file was created")
   say "$file exists: {f.exists file}"
 
   say "stat resolve=true : $file size is {(f.stat file true).val.size}"
   say "stat resolve=false: $file size is {(f.stat file false).val.size}"
 
-  _ := f.use unit lm file io.file.mode.read ()->
-    say io.file.open.file_position
-    say (io.file.open.seek 1)
-    say io.file.open.file_position
-    say (io.file.open.seek 0)
+  _ := f.use unit lm file f.mode.read ()->
+    say  f.open.file_position
+    say (f.open.seek 1)
+    say  f.open.file_position
+    say (f.open.seek 0)
 
 
-  _ := f.use (array u8) lm file io.file.mode.read (()->io.buffered.read_fully lm)
+  _ := f.use (array u8) lm file f.mode.read (()->io.buffered.read_fully lm)
     .bind unit bytes->
       filecontent := String.from_bytes bytes
       say "file content bytes: $bytes"


### PR DESCRIPTION
Inheritance can instead be used to distinguish several files. Thus in fileiotests
`f => io.file` becomes `f : io.file is`

Also moved exists/write to own files.
