### PR TITLE
dfa: At end of DFA, no extra iterations after `_fuir.lookupDone()` was called

### DIFF
--- a/src/dev/flang/fuir/analysis/dfa/DFA.java
+++ b/src/dev/flang/fuir/analysis/dfa/DFA.java
@@ -1264,7 +1264,6 @@ public class DFA extends ANY
   void findFixPoint()
   {
     var cnt = 0;
-    var lookupDone = false;
     do
       {
         cnt++;
@@ -1278,12 +1277,6 @@ public class DFA extends ANY
         _changed = false;
         _changedSetBy = () -> "*** change not set ***";
         iteration();
-        if (!_changed && !lookupDone)
-          {
-            _fuir.lookupDone();  // once we are done, FUIR.isUnitType() will work since it can be sure nothing will be added.
-            lookupDone = true;
-            wasChanged(() -> "freezing lookup");
-          }
       }
     while (_changed && (true || cnt < 100));
 
@@ -1311,6 +1304,9 @@ public class DFA extends ANY
 
     _reportResults = true;
     iteration();
+
+    _fuir.lookupDone();  // once we are done, FUIR.clazzIsUnitType() will work since it can be sure nothing will be added.
+
     if (CHECKS) check
       (!_changed);
 


### PR DESCRIPTION
Calling `_fuir.lookupDone()` results in soem clazzes having `clazzIsUnitType(cl)` return true, which DFA turns into `Value.UNIT`.  These new values could result into several extra DFA iterations until a fixpoint is reached again.

This results in a speedup of about 20% on a Hello-World example: before

     > time ./build/bin/fz -verbose=0 -e 'say "hi"'
    hi

    real	0m1,176s
    user	0m6,102s
    sys	0m0,341s

now:

     > time ./build/bin/fz -verbose=0 -e 'say "hi"'
    hi

    real	0m0,971s
    user	0m4,805s
    sys	0m0,337s
