### PR TITLE
dfa/be: remove `fz` option `-Xdfa=on/off`

### DIFF
--- a/src/dev/flang/be/c/C.java
+++ b/src/dev/flang/be/c/C.java
@@ -662,7 +662,6 @@ public class C extends ANY
            FUIR fuir)
   {
     _options = opt;
-    fuir = opt._Xdfa ?  new DFA(opt, fuir).new_fuir() : fuir;
     _fuir = fuir;
     _tailCall = new TailCall(fuir);
     _ai = new AbstractInterpreter<>(fuir, new CodeGen());

--- a/src/dev/flang/be/c/COptions.java
+++ b/src/dev/flang/be/c/COptions.java
@@ -55,12 +55,6 @@ public class COptions extends FuzionOptions
 
 
   /**
-   * Should we use the DFA analysis to improve the generated code?
-   */
-  final boolean _Xdfa;
-
-
-  /**
    * Name of the C compiler to use.
    */
   final String _cCompiler;
@@ -94,13 +88,12 @@ public class COptions extends FuzionOptions
    * Constructor initializing fields as given.
    * @param keepGeneratedCode
    */
-  public COptions(FuzionOptions fo, String binaryName, boolean useBoehmGC, boolean Xdfa, String cCompiler, String cFlags, String cTarget, boolean keepGeneratedCode)
+  public COptions(FuzionOptions fo, String binaryName, boolean useBoehmGC, String cCompiler, String cFlags, String cTarget, boolean keepGeneratedCode)
   {
     super(fo);
 
     _binaryName = binaryName;
     _useBoehmGC = useBoehmGC;
-    _Xdfa = Xdfa;
     _cCompiler = cCompiler;
     _cFlags = cFlags;
     _cTarget = cTarget;

--- a/src/dev/flang/be/jvm/JVM.java
+++ b/src/dev/flang/be/jvm/JVM.java
@@ -802,7 +802,6 @@ should be avoided as much as possible.
              FUIR fuir)
   {
     _options = opt;
-    fuir = opt._Xdfa ?  new DFA(opt, fuir).new_fuir() : fuir;
     _fuir = fuir;
     _names = new Names(fuir);
     _types = new Types(opt, fuir, _names);

--- a/src/dev/flang/be/jvm/JVMOptions.java
+++ b/src/dev/flang/be/jvm/JVMOptions.java
@@ -76,12 +76,6 @@ public class JVMOptions extends FuzionOptions
 
 
   /**
-   * Should we use the DFA analysis to improve the generated code?
-   */
-  final boolean _Xdfa;
-
-
-  /**
    * Should the generated JVM bytecode be run immediately?
    */
   final boolean _run;
@@ -124,7 +118,6 @@ public class JVMOptions extends FuzionOptions
    * Constructor initializing fields as given.
    */
   public JVMOptions(FuzionOptions fo,
-                    boolean Xdfa,
                     boolean run,
                     boolean saveClasses,
                     boolean saveJAR,
@@ -132,7 +125,6 @@ public class JVMOptions extends FuzionOptions
   {
     super(fo);
 
-    this._Xdfa        = Xdfa;
     this._run         = run;
     this._saveClasses = saveClasses;
     this._saveJAR     = saveJAR;

--- a/src/dev/flang/tools/Fuzion.java
+++ b/src/dev/flang/tools/Fuzion.java
@@ -85,7 +85,6 @@ public class Fuzion extends Tool
 
   static String  _binaryName_ = null;
   static boolean _useBoehmGC_ = true;
-  static boolean _xdfa_ = true;
   static String _cCompiler_ = null;
   static String _cFlags_ = null;
   static String _cTarget_ = null;
@@ -106,9 +105,7 @@ public class Fuzion extends Tool
       }
       void process(FuzionOptions options, FUIR fuir)
       {
-        var new_fuir = _xdfa_ ? new DFA(options, fuir).new_fuir() : fuir;
-
-        new Interpreter(options, new_fuir).run();
+        new Interpreter(options, fuir).run();
       }
     },
 
@@ -116,7 +113,7 @@ public class Fuzion extends Tool
     {
       String usage()
       {
-        return "[-o=<file>] [-Xgc=(on|off)] [-Xdfa=(on|off)] [-XkeepGeneratedCode=(on|off)] [-CC=<c compiler>] [-CFlags=\"list of c compiler flags\"] [-CTarget=\"e.g. x86_64-pc-linux-gnu\"] ";
+        return "[-o=<file>] [-Xgc=(on|off)] [-XkeepGeneratedCode=(on|off)] [-CC=<c compiler>] [-CFlags=\"list of c compiler flags\"] [-CTarget=\"e.g. x86_64-pc-linux-gnu\"] ";
       }
       boolean handleOption(Fuzion f, String o)
       {
@@ -129,11 +126,6 @@ public class Fuzion extends Tool
         else if (o.startsWith("-Xgc="))
           {
             _useBoehmGC_ = parseOnOffArg(o);
-            result = true;
-          }
-        else if (o.startsWith("-Xdfa="))
-          {
-            _xdfa_ = parseOnOffArg(o);
             result = true;
           }
         else if (o.startsWith("-CC="))
@@ -160,7 +152,7 @@ public class Fuzion extends Tool
       }
       void process(FuzionOptions options, FUIR fuir)
       {
-        new C(new COptions(options, _binaryName_, _useBoehmGC_, _xdfa_, _cCompiler_, _cFlags_, _cTarget_, _keepGeneratedCode_), fuir).compile();
+        new C(new COptions(options, _binaryName_, _useBoehmGC_, _cCompiler_, _cFlags_, _cTarget_, _keepGeneratedCode_), fuir).compile();
       }
     },
 
@@ -170,23 +162,18 @@ public class Fuzion extends Tool
     {
       String usage()
       {
-        return "[-Xdfa=(on|off)] ";
+        return "";
       }
       boolean handleOption(Fuzion f, String o)
       {
         boolean result = false;
-        if (o.startsWith("-Xdfa="))
-          {
-            _xdfa_ = parseOnOffArg(o);
-            result = true;
-          }
         return result;
       }
       void process(FuzionOptions options, FUIR fuir)
       {
         try
           {
-            new JVM(new JVMOptions(options, _xdfa_, /* run */ true, /* save classes */ false, /* save JAR */ false, Optional.empty()), fuir).compile();
+            new JVM(new JVMOptions(options, /* run */ true, /* save classes */ false, /* save JAR */ false, Optional.empty()), fuir).compile();
           }
         catch (QuietThreadTermination e)
           {
@@ -202,16 +189,11 @@ public class Fuzion extends Tool
     {
       String usage()
       {
-        return "[-o=<outputName>] [-Xdfa=(on|off)] ";
+        return "[-o=<outputName>] ";
       }
       boolean handleOption(Fuzion f, String o)
       {
         boolean result = false;
-        if (o.startsWith("-Xdfa="))
-          {
-            _xdfa_ = parseOnOffArg(o);
-            result = true;
-          }
         if (o.startsWith("-o="))
           {
             _jvmOutName_ = o.substring(3);
@@ -221,7 +203,7 @@ public class Fuzion extends Tool
       }
       void process(FuzionOptions options, FUIR fuir)
       {
-        new JVM(new JVMOptions(options, _xdfa_, /* run */ false, /* save classes */ true, /* save JAR */ false, Optional.ofNullable(_jvmOutName_)), fuir).compile();
+        new JVM(new JVMOptions(options, /* run */ false, /* save classes */ true, /* save JAR */ false, Optional.ofNullable(_jvmOutName_)), fuir).compile();
       }
     },
 
@@ -229,16 +211,11 @@ public class Fuzion extends Tool
     {
       String usage()
       {
-        return "[-o=<outputName>] [-Xdfa=(on|off)] ";
+        return "[-o=<outputName>] ";
       }
       boolean handleOption(Fuzion f, String o)
       {
         boolean result = false;
-        if (o.startsWith("-Xdfa="))
-          {
-            _xdfa_ = parseOnOffArg(o);
-            result = true;
-          }
         if (o.startsWith("-o="))
           {
             _jvmOutName_ = o.substring(3);
@@ -248,7 +225,7 @@ public class Fuzion extends Tool
       }
       void process(FuzionOptions options, FUIR fuir)
       {
-        new JVM(new JVMOptions(options, _xdfa_, /* run */ false, /* save classes */ false, /* save JAR */ true, Optional.ofNullable(_jvmOutName_)), fuir).compile();
+        new JVM(new JVMOptions(options, /* run */ false, /* save classes */ false, /* save JAR */ true, Optional.ofNullable(_jvmOutName_)), fuir).compile();
       }
     },
 
@@ -258,7 +235,7 @@ public class Fuzion extends Tool
     {
       void process(FuzionOptions options, FUIR fuir)
       {
-        new DFA(options, fuir).dfa();
+        // nothing to be done, DFA was already run by processFrontEnd which calls us.
       }
     },
 
@@ -388,7 +365,6 @@ public class Fuzion extends Tool
     {
       void process(FuzionOptions options, FUIR fuir)
       {
-        new DFA(options, fuir).new_fuir();
         Errors.showAndExit();
       }
     },
@@ -499,9 +475,10 @@ public class Fuzion extends Tool
      */
     void processFrontEnd(Fuzion f, FrontEnd fe)
     {
+      var o    = fe._options;
       var mir  = fe.createMIR();                             f.timer("createMIR");
-      var fuir = new Optimizer(fe._options, fe, mir).fuir(); f.timer("ir");
-      process(fe._options, fuir);
+      var fuir = new Optimizer(o, fe, mir).fuir();           f.timer("ir");
+      process(o, new DFA(o, fuir).new_fuir());
     }
 
     void process(FuzionOptions options, FUIR fuir)


### PR DESCRIPTION
It is no longer possible to run a backend without first performing DFA, so we do not need this option any more.

