### PR TITLE
be/interpreter: fix check-condition

### DIFF
--- a/src/dev/flang/be/interpreter/ChoiceIdAsRef.java
+++ b/src/dev/flang/be/interpreter/ChoiceIdAsRef.java
@@ -151,7 +151,8 @@ public class ChoiceIdAsRef extends Value
       {
         if (CHECKS) check
           (idAsRef instanceof ValueWithClazz ||
-           idAsRef instanceof JavaRef          );
+           idAsRef instanceof JavaRef        ||
+           idAsRef instanceof ArrayData  );
 
         var cl = (idAsRef instanceof ValueWithClazz id) ? id._clazz
                                                         : fuir().clazz(FUIR.SpecialClazzes.c_sys_ptr);


### PR DESCRIPTION
There was just a case missing. see also lib_region PR.

