### PR TITLE
jvm: A `staticAccess` in a stub was falsely optimized as a tail call

### DIFF
--- a/src/dev/flang/be/jvm/CodeGen.java
+++ b/src/dev/flang/be/jvm/CodeGen.java
@@ -428,7 +428,7 @@ class CodeGen
           {
             initLocals = Types.addToLocals(initLocals, _types.javaType(rc));
           }
-        addStub(si, tt, cc, dn, ds, isCall, initLocals);
+        addStub(tt, cc, dn, ds, isCall, initLocals);
       }
     return Expr.invokeInterface(intfc._name, dn, ds, dr, _fuir.sitePos(si).line());
   }
@@ -437,8 +437,6 @@ class CodeGen
   /**
    * Create a stub method, i.e., an implementation of a dynamic function defined
    * in an interface that performs a static access for the given target type.
-   *
-   * @param si site of the access expression, must be ExprKind.Assign or ExprKind.Call
    *
    * @param tt the target clazz. Note that tt may be different to
    * _fuir.clazzOuterClazz(cc), e.g., if tt is some type defining abstract
@@ -454,7 +452,7 @@ class CodeGen
    * @param isCall true if the access is a call, false if it is an assignment to
    * a field.
    */
-  private void addStub(int si, int tt, int cc, String dn, String ds, boolean isCall, List<VerificationType> initLocals)
+  private void addStub(int tt, int cc, String dn, String ds, boolean isCall, List<VerificationType> initLocals)
   {
     var cf = _types.classFile(tt);
     if (!cf.hasMethod(dn))
@@ -480,7 +478,13 @@ class CodeGen
             var t = _types.javaType(_fuir.clazzResultClazz(cc));
             na.add(t.load(1));
           }
-        var p = staticAccess(si, tt, cc, tv, na, isCall);
+        var p = staticAccess(/* *** NOTE ***: The site must be NO_SITE since we are not generating
+                              * code for `_fuir.clazzAt(si)`, but for the stub. If we would pass the
+                              * site here, the access might otherwise be optimized as a tail call
+                              * here!
+                              */
+                             FUIR.NO_SITE,
+                             tt, cc, tv, na, isCall);
         var code = p.v1()
           .andThen(p.v0() == null ? Expr.UNIT : p.v0())
           .andThen(retoern);
@@ -583,7 +587,8 @@ class CodeGen
         {
           if (_types.clazzNeedsCode(cc))
             {
-              var cl = si == NO_SITE ? -1 :_fuir.clazzAt(si);
+              var cl = si == NO_SITE ? FUIR.NO_CLAZZ
+                                     : _fuir.clazzAt(si);
 
               if (cc == cl && // calling myself
                   _jvm._tailCall.callIsTailCall(cl, si))


### PR DESCRIPTION
Stubs are used to implement dynamic binging using Java's interface calls: A call is replaced by a interface call to a stub which is implemented by all actual implementations of the call.

The stub itself then performs a static call to the actual feature.

The problem was that tail call optimization might be done by `staticAccess` if the target is the same as the current clazz.  For the code generation of a stub, however, the `site` that was provided was the first call site that causes the generation of the `stub`. If this happened to be in the same clazz as the called clazz, tail call optimization inserted a goto in the stub to the start of the method created for the called clazz, usually resulting in a class file verifier error.

This could be triggered by running tests/transducers with JVM backend:

    build/tests/transducers 16:06:47 > dev_flang_fuir_analysis_dfa_DFA_SITE_SENSITIVE=false make jvm
    ../check_simple_example_jvm.sh "../../bin/fz " transducertest.fz || exit 1
    RUN transducertest.fz 0a1,23
    >
    > error 1: java.lang.VerifyError: Expecting a stackmap frame at branch target 8
    > Exception Details:
    >   Location:
    >     fzC__L1230_transducer__lter__fun__1call__fun.fzD_1285_call(LfzI_Sequence_i32;I)LfzI_Sequence_i32; @6: goto
    >   Reason:
    >     Expected stackmap frame at this location.
    >   Bytecode:
    >     0000000: 2a4b 2b4c 1c3d a700 02
    >   Stackmap Table:
    >
    > 	at fzC__L1226_transducer__test_human__1filter__fun__1call.fzRoutine($MODULE/transducer.fz:66)
    > 	at fzC_1transducer__Sequence_i32__i32__i32__1call.fzRoutine($MODULE/transducer.fz:51)
    > 	at fzC_3interval_i32__1into_i32.fzRoutine($MODULE/Sequence.fz:540)
    > 	at fzC_transducertest.fzRoutine(--CURDIR--/transducertest.fz:39)
    > 	at fzC_universe.fz_run(--builtin--)
    > 	at dev.flang.be.jvm.runtime.FuzionThread.lambda$new$1(FuzionThread.java:120)
    > 	at dev.flang.util.Errors.runAndExit(Errors.java:897)
    > 	at dev.flang.be.jvm.runtime.FuzionThread.lambda$new$2(FuzionThread.java:132)
    > 	at java.base/java.lang.Thread.run(Thread.java:1583)
    >
    > *** fatal errors encountered, stopping.
    > one error.
    *** FAILED err on transducertest.fz
    make: *** [../simple.mk:64: jvm] Fehler 1

