### PR TITLE
dfa: Site-insensitive analysis for non-constructors, improve #4028

### DIFF
--- a/src/dev/flang/fuir/analysis/dfa/Call.java
+++ b/src/dev/flang/fuir/analysis/dfa/Call.java
@@ -29,6 +29,7 @@ package dev.flang.fuir.analysis.dfa;
 
 import dev.flang.fuir.FUIR;
 
+
 import dev.flang.ir.IR;
 
 import dev.flang.util.ANY;
@@ -36,8 +37,6 @@ import dev.flang.util.Errors;
 import static dev.flang.util.FuzionConstants.EFFECT_INSTATE_NAME;
 import dev.flang.util.HasSourcePosition;
 import dev.flang.util.List;
-
-import java.util.TreeSet;
 
 
 /**
@@ -345,47 +344,31 @@ public class Call extends ANY implements Comparable<Call>, Context
 
 
   /**
-   * toString() might end up in a complex recursion if it is used for careless
-   * debug output, so we try to catch recursion and stop it.
-   */
-  static TreeSet<Call> _toStringRecursion_ = new TreeSet<>();
-
-
-  /**
    * Create human-readable string from this call.
    */
   public String toString()
   {
-    if (_toStringRecursion_.contains(this))
+    var sb = new StringBuilder();
+    sb.append(_dfa._fuir.clazzAsString(_cc));
+    if (_target != Value.UNIT)
       {
-        return "*** recursive Call.toString() ***";
+        sb.append(" target=")
+          .append(_target);
       }
-    else
+    for (var i = 0; i < _args.size(); i++)
       {
-        _toStringRecursion_.add(this);
-        var sb = new StringBuilder();
-        sb.append(_dfa._fuir.clazzAsString(_cc));
-        if (_target != Value.UNIT)
-          {
-            sb.append(" target=")
-              .append(_target);
-          }
-        for (var i = 0; i < _args.size(); i++)
-          {
-            var a = _args.get(i);
-            sb.append(" a")
-              .append(i)
-              .append("=")
-              .append(a);
-          }
-        var r = result();
-        sb.append(" => ")
-          .append(r == null ? "*** VOID ***" : r)
-          .append(" ENV: ")
-          .append(Errors.effe(Env.envAsString(env())));
-        _toStringRecursion_.remove(this);
-        return sb.toString();
+        var a = _args.get(i);
+        sb.append(" a")
+          .append(i)
+          .append("=")
+          .append(a);
       }
+    var r = result();
+    sb.append(" => ")
+      .append(r == null ? "*** VOID ***" : r)
+      .append(" ENV: ")
+      .append(Errors.effe(Env.envAsString(env())));
+    return sb.toString();
   }
 
 

--- a/src/dev/flang/fuir/analysis/dfa/DFA.java
+++ b/src/dev/flang/fuir/analysis/dfa/DFA.java
@@ -781,9 +781,9 @@ public class DFA extends ANY
    * equals calls `t.f args` if they occur at different sites, i.e., location in
    * the source code.
    *
-   * To disable, use fz with
+   * To enable, use fz with
    *
-   *   dev_flang_fuir_analysis_dfa_DFA_SITE_SENSITIVE=false
+   *   dev_flang_fuir_analysis_dfa_DFA_SITE_SENSITIVE=true
    */
   static final boolean SITE_SENSITIVE = FuzionOptions.boolPropertyOrEnv("dev.flang.fuir.analysis.dfa.DFA.SITE_SENSITIVE", false);
 

--- a/src/dev/flang/fuir/analysis/dfa/DFA.java
+++ b/src/dev/flang/fuir/analysis/dfa/DFA.java
@@ -789,7 +789,7 @@ public class DFA extends ANY
    * overhead. However, some tests like fuzion/tests/transducers require this to
    * work properly.
    */
-  static final boolean SITE_SENSITIVE = FuzionOptions.boolPropertyOrEnv("dev.flang.fuir.analysis.dfa.DFA.SITE_SENSITIVE", true);
+  static final boolean SITE_SENSITIVE = FuzionOptions.boolPropertyOrEnv("dev.flang.fuir.analysis.dfa.DFA.SITE_SENSITIVE", !true);
 
 
   /**
@@ -2133,7 +2133,8 @@ public class DFA extends ANY
           var ev = cl.getEffectForce(cl._cc, ecl); // report an error if effect is missing
           if (ev != null)
             {
-              cl._env.aborted(ecl);
+              if (cl._env != null)
+                cl._env.aborted(ecl);
             }
           return null;
         });
@@ -2832,13 +2833,9 @@ public class DFA extends ANY
    */
   Call newCall(int cl, int site, Value tvalue, List<Val> args, Env env, Context context)
   {
-    if (!SITE_SENSITIVE)
-      {
-        site = FUIR.NO_SITE;
-      }
     var k1 = _fuir.clazzId2num(cl);
     var k2 = tvalue._id;
-    var k3 = siteIndex(site);
+    var k3 = SITE_SENSITIVE ? siteIndex(site) : 0;
     var k4 = env == null ? 0 : env._id + 1;
     Call e, r;
     // We use a LongMap in case we manage to fiddle k1..k4 into a long

--- a/src/dev/flang/fuir/analysis/dfa/DFA.java
+++ b/src/dev/flang/fuir/analysis/dfa/DFA.java
@@ -2129,10 +2129,7 @@ public class DFA extends ANY
           var ev = cl.getEffectForce(cl._cc, ecl); // report an error if effect is missing
           if (ev != null)
             {
-              if (cl._env != null)  // NYI: UNDER DEVELOPMENT: What if cl._env is null? Ignoring the abort seems wrong
-                {
-                  cl._env.aborted(ecl);
-                }
+              cl._env.aborted(ecl);
             }
           return null;
         });

--- a/src/dev/flang/fuir/analysis/dfa/Env.java
+++ b/src/dev/flang/fuir/analysis/dfa/Env.java
@@ -370,7 +370,7 @@ public class Env extends ANY implements Comparable<Env>
       }
     else
       {
-        throw new Error("DFA: Aborted effect not found in current environment");
+        throw new Error("DFA: Aborted effect `" + _dfa._fuir.clazzAsString(ecl) + "` not found in current environment");
       }
   }
 

--- a/src/dev/flang/fuir/analysis/dfa/Env.java
+++ b/src/dev/flang/fuir/analysis/dfa/Env.java
@@ -370,7 +370,7 @@ public class Env extends ANY implements Comparable<Env>
       }
     else
       {
-        throw new Error("DFA: Aborted effect `" + _dfa._fuir.clazzAsString(ecl) + "` not found in current environment");
+        throw new Error("DFA: Aborted effect not found in current environment");
       }
   }
 


### PR DESCRIPTION
Improve #4028: This might bring a significant speedup by reducing the number of calls sites the DFA checks. Calls to constructors need more accuracy since the resulting values may be used later and, e.g., become instated effects where different calls sites may results in losing accuracy, e.g., about the installed effects. 

This reduces the time required to build the Fuzion webserver by 29%: From 1:46.54 down to 1:16.59 elapsed  time when running
```
time ./build/bin/fz -jar -o=fzweb -verbose=0 -unsafeIntrinsics=on -modules=lock_free,java.base,java.desktop,java.datatransfer,java.xml,java.logging,java.security.sasl,webserver -sourceDirs=/home/fridi/fuzion/work/fzweb/src run
```
as benchmark
