### PR TITLE
dfa: catch endless recursion in Call.toString, better env debug output

### DIFF
--- a/src/dev/flang/fuir/analysis/dfa/Call.java
+++ b/src/dev/flang/fuir/analysis/dfa/Call.java
@@ -29,7 +29,6 @@ package dev.flang.fuir.analysis.dfa;
 
 import dev.flang.fuir.FUIR;
 
-
 import dev.flang.ir.IR;
 
 import dev.flang.util.ANY;
@@ -37,6 +36,8 @@ import dev.flang.util.Errors;
 import static dev.flang.util.FuzionConstants.EFFECT_INSTATE_NAME;
 import dev.flang.util.HasSourcePosition;
 import dev.flang.util.List;
+
+import java.util.TreeSet;
 
 
 /**
@@ -344,31 +345,47 @@ public class Call extends ANY implements Comparable<Call>, Context
 
 
   /**
+   * toString() might end up in a complex recursion if it is used for careless
+   * debug output, so we try to catch recursion and stop it.
+   */
+  static TreeSet<Call> _toStringRecursion_ = new TreeSet<>();
+
+
+  /**
    * Create human-readable string from this call.
    */
   public String toString()
   {
-    var sb = new StringBuilder();
-    sb.append(_dfa._fuir.clazzAsString(_cc));
-    if (_target != Value.UNIT)
+    if (_toStringRecursion_.contains(this))
       {
-        sb.append(" target=")
-          .append(_target);
+        return "*** recursive Call.toString() ***";
       }
-    for (var i = 0; i < _args.size(); i++)
+    else
       {
-        var a = _args.get(i);
-        sb.append(" a")
-          .append(i)
-          .append("=")
-          .append(a);
+        _toStringRecursion_.add(this);
+        var sb = new StringBuilder();
+        sb.append(_dfa._fuir.clazzAsString(_cc));
+        if (_target != Value.UNIT)
+          {
+            sb.append(" target=")
+              .append(_target);
+          }
+        for (var i = 0; i < _args.size(); i++)
+          {
+            var a = _args.get(i);
+            sb.append(" a")
+              .append(i)
+              .append("=")
+              .append(a);
+          }
+        var r = result();
+        sb.append(" => ")
+          .append(r == null ? "*** VOID ***" : r)
+          .append(" ENV: ")
+          .append(Errors.effe(Env.envAsString(env())));
+        _toStringRecursion_.remove(this);
+        return sb.toString();
       }
-    var r = result();
-    sb.append(" => ")
-      .append(r == null ? "*** VOID ***" : r)
-      .append(" ENV: ")
-      .append(Errors.effe(Env.envAsString(env())));
-    return sb.toString();
   }
 
 

--- a/src/dev/flang/fuir/analysis/dfa/Env.java
+++ b/src/dev/flang/fuir/analysis/dfa/Env.java
@@ -370,7 +370,7 @@ public class Env extends ANY implements Comparable<Env>
       }
     else
       {
-        throw new Error("DFA: Aborted effect not found in current environment");
+        throw new Error("DFA: Aborted effect `" + _dfa._fuir.clazzAsString(ecl) + "` not found in current environment");
       }
   }
 


### PR DESCRIPTION
`Call.toString` could result in endless recursion if debug output calling this is added in code reachable from `Call.result`. To aovoid this, this patch adds a check for recursion and stop it.

Also improve the error message if an aborted effect is not found.

Both these changes helpd me woking in #4148.
