### PR TITLE
util: highlight that `-XmaxErrors` requires a value in max error warning

### DIFF
--- a/src/dev/flang/util/Errors.java
+++ b/src/dev/flang/util/Errors.java
@@ -435,7 +435,7 @@ public class Errors extends ANY
                 warning(SourcePosition.builtIn,
                         "Maximum error count reached, stop error output.",
                         "Maximum error count is " + MAX_ERROR_MESSAGES + ".\n" +
-                        "Change this via property '" + MAX_ERROR_MESSAGES_PROPERTY + "' or command line option '" + MAX_ERROR_MESSAGES_OPTION + "'.");
+                        "Change this via property '" + MAX_ERROR_MESSAGES_PROPERTY + "' or command line option '" + MAX_ERROR_MESSAGES_OPTION + "=<n>'.");
               }
           }
       }


### PR DESCRIPTION
The old warning
```
<built-in>: warning 1: Maximum error count reached, stop error output.
Maximum error count is 10.
Change this via property 'fuzion.maxErrorCount' or command line option '-XmaxErrors'.
```

This is what happens when you simply copy paste the option with the intention to show all errors
```
fz -XmaxErrors tests/visibility_negative/visibility_negative.fz

error 1: unknown argument: '-XmaxErrors'
Usage: /home/simon/fuzion/build/bin/fz [-h|--help|-version]  --or--
       /home/simon/fuzion/build/bin/fz [-c|-classes|-dfa|-effects|-frontend-only|-interpreter|-jar|-java|-jvm|-llvm|-no-backend|-saveLib=<file>] [-h|--help|-version] [<backend specific options>]  --or--
       /home/simon/fuzion/build/bin/fz -pretty [-noANSI] [-verbose[=<n>]]  ({<file>} | - | -e <code> | -execute <code>)  --or--
       /home/simon/fuzion/build/bin/fz -latex [-noANSI] [-verbose[=<n>]]   --or--
       /home/simon/fuzion/build/bin/fz -acemode [-noANSI] [-verbose[=<n>]]   --or--

*** fatal errors encountered, stopping.
one error.
```