### PR TITLE
ast/Feature: fix call to `selfOrConstraint`

### DIFF
--- a/src/dev/flang/ast/Feature.java
+++ b/src/dev/flang/ast/Feature.java
@@ -1502,8 +1502,8 @@ public class Feature extends AbstractFeature
             {
               var t = e.resolve(res, context());
 
-              if (t != Types.t_ERROR && (!(AbstractType.selfOrConstraint(t, res, context()))
-                                                       .feature().inheritsFrom(Types.resolved.f_effect)))
+              if (t != Types.t_ERROR && (!(t.selfOrConstraint(res, context()))
+                                            .feature().inheritsFrom(Types.resolved.f_effect)))
                 {
                   AstErrors.notAnEffect(t, ((UnresolvedType) e).pos());
                 }


### PR DESCRIPTION
This call was not updated because #4138 was merged after #4140 was created. This caused a merge incongruence.