### PR TITLE
ast: Supress follow-up errors in jenkin's `man_or_boy2` and `tya_field` tests

### DIFF
--- a/tests/choice_negative/choice_negative.fz.expected_err
+++ b/tests/choice_negative/choice_negative.fz.expected_err
@@ -61,25 +61,19 @@ Target feature: 'choice_negative.instantiate2'
 In call: 'MyChoice'
 
 
---CURDIR--/choice_negative.fz:140:5: error 10: Failed to infer result type for feature 'choice_negative.impl2.x'.
-    x : choice i64 bool := true  // 28. should flag an error, choice feature must not be field
-----^
-To solve this, please specify a result type explicitly.
-
-
---CURDIR--/choice_negative.fz:170:22: error 11: Ambiguous assignment to 'choice choice_negative.this.ambiguous_assignment_to_choice_via_subtype.this.A choice_negative.this.ambiguous_assignment_to_choice_via_subtype.this.B' from 'choice_negative.this.ambiguous_assignment_to_choice_via_subtype.this.C'
+--CURDIR--/choice_negative.fz:170:22: error 10: Ambiguous assignment to 'choice choice_negative.this.ambiguous_assignment_to_choice_via_subtype.this.A choice_negative.this.ambiguous_assignment_to_choice_via_subtype.this.B' from 'choice_negative.this.ambiguous_assignment_to_choice_via_subtype.this.C'
     t1 choice A B := C  // 36. should flag an error, Ambiguous assignment to ...
 ---------------------^
 'choice_negative.this.ambiguous_assignment_to_choice_via_subtype.this.C' is assignable to 'choice_negative.this.ambiguous_assignment_to_choice_via_subtype.this.A', 'choice_negative.this.ambiguous_assignment_to_choice_via_subtype.this.B'
 
 
---CURDIR--/choice_negative.fz:171:22: error 12: Ambiguous assignment to 'choice choice_negative.this.ambiguous_assignment_to_choice_via_subtype.this.A choice_negative.this.ambiguous_assignment_to_choice_via_subtype.this.B' from 'choice_negative.this.ambiguous_assignment_to_choice_via_subtype.this.C'
+--CURDIR--/choice_negative.fz:171:22: error 11: Ambiguous assignment to 'choice choice_negative.this.ambiguous_assignment_to_choice_via_subtype.this.A choice_negative.this.ambiguous_assignment_to_choice_via_subtype.this.B' from 'choice_negative.this.ambiguous_assignment_to_choice_via_subtype.this.C'
     t2 choice A B => C  // 37. should flag an error, Ambiguous assignment to ...
 ---------------------^
 'choice_negative.this.ambiguous_assignment_to_choice_via_subtype.this.C' is assignable to 'choice_negative.this.ambiguous_assignment_to_choice_via_subtype.this.A', 'choice_negative.this.ambiguous_assignment_to_choice_via_subtype.this.B'
 
 
---CURDIR--/choice_negative.fz:137:30: error 13: Could not find called feature
+--CURDIR--/choice_negative.fz:137:30: error 12: Could not find called feature
     x bool : choice i64 bool := true  // 27. should flag an error, choice feature must not be field
 -----------------------------^^
 Feature not found: 'prefix :=' (no arguments)
@@ -87,7 +81,7 @@ Target feature: 'bool'
 In call: ':= true'
 
 
---CURDIR--/choice_negative.fz:140:25: error 14: Could not find called feature
+--CURDIR--/choice_negative.fz:140:25: error 13: Could not find called feature
     x : choice i64 bool := true  // 28. should flag an error, choice feature must not be field
 ------------------------^^
 Feature not found: 'prefix :=' (no arguments)
@@ -95,64 +89,64 @@ Target feature: 'bool'
 In call: ':= true'
 
 
---CURDIR--/choice_negative.fz:158:11: error 15: 'match' subject type must be a choice type
+--CURDIR--/choice_negative.fz:158:11: error 14: 'match' subject type must be a choice type
     match 42   // 34. should flag an error, match subject must be choice
 ----------^^
 Matched type: 'i32', which is not a choice type
 
 
---CURDIR--/choice_negative.fz:162:11: error 16: 'match' subject type must be a choice type
+--CURDIR--/choice_negative.fz:162:11: error 15: 'match' subject type must be a choice type
     j := (42 ? true_ => true   // 35. should flag an error, match subject must be choice
 ----------^^
 Matched type: 'i32', which is not a choice type
 
 
---CURDIR--/choice_negative.fz:32:5: error 17: Choice cannot refer to its own value type as one of the choice alternatives
+--CURDIR--/choice_negative.fz:32:5: error 16: Choice cannot refer to its own value type as one of the choice alternatives
     A : choice A i32 String is       // 1. should flag an error: cyclic choice
 ----^
 Embedding a choice type in itself would result in an infinitely large type.
 Faulty type parameter: 'choice_negative.this.cyclic1.this.A'
 
 
---CURDIR--/choice_negative.fz:35:5: error 18: choice feature must not be ref
+--CURDIR--/choice_negative.fz:35:5: error 17: choice feature must not be ref
     A ref : choice A i32 String is  // 1a. should flag an error: choice feature must not be re
 ----^
 A choice feature must be a value type since it is not constructed 
 
 
---CURDIR--/choice_negative.fz:38:5: error 19: Choice cannot refer to its own value type as one of the choice alternatives
+--CURDIR--/choice_negative.fz:38:5: error 18: Choice cannot refer to its own value type as one of the choice alternatives
     A : choice i32 A String is      // 2. should flag an error: cyclic choice
 ----^
 Embedding a choice type in itself would result in an infinitely large type.
 Faulty type parameter: 'choice_negative.this.cyclic3.this.A'
 
 
---CURDIR--/choice_negative.fz:41:5: error 20: choice feature must not be ref
+--CURDIR--/choice_negative.fz:41:5: error 19: choice feature must not be ref
     A ref : choice i32 A String is  // 2a. should flag an error: choice feature must not be re
 ----^
 A choice feature must be a value type since it is not constructed 
 
 
---CURDIR--/choice_negative.fz:44:5: error 21: Choice cannot refer to its own value type as one of the choice alternatives
+--CURDIR--/choice_negative.fz:44:5: error 20: Choice cannot refer to its own value type as one of the choice alternatives
     A : choice i32 String A is      // 3. should flag an error: cyclic choice
 ----^
 Embedding a choice type in itself would result in an infinitely large type.
 Faulty type parameter: 'choice_negative.this.cyclic5.this.A'
 
 
---CURDIR--/choice_negative.fz:47:5: error 22: choice feature must not be ref
+--CURDIR--/choice_negative.fz:47:5: error 21: choice feature must not be ref
     A ref : choice i32 String A is  // 3a. should flag an error: choice feature must not be re
 ----^
 A choice feature must be a value type since it is not constructed 
 
 
---CURDIR--/choice_negative.fz:77:5: error 23: Choice feature must not contain any code
+--CURDIR--/choice_negative.fz:77:5: error 22: Choice feature must not contain any code
     A : choice i32 String bool is // 13. should flag an error: choice type must not have any fields
 ----^
 A choice feature must be a normal feature with empty code section
 
 
---CURDIR--/choice_negative.fz:77:5: error 24: Choice must not contain any fields
+--CURDIR--/choice_negative.fz:77:5: error 23: Choice must not contain any fields
     A : choice i32 String bool is // 13. should flag an error: choice type must not have any fields
 ----^
 Field 'choice_negative.nofields1.A.x' is not permitted.
@@ -161,7 +155,7 @@ Field declared at --CURDIR--/choice_negative.fz:78:7:
 ------^
 
 
---CURDIR--/choice_negative.fz:81:5: error 25: Choice must not contain any fields
+--CURDIR--/choice_negative.fz:81:5: error 24: Choice must not contain any fields
     A (x i32) : choice i32 String bool is  // 14. should flag an error: choice type must not have any fields
 ----^
 Field 'choice_negative.nofields2.A.x' is not permitted.
@@ -170,7 +164,7 @@ Field declared at --CURDIR--/choice_negative.fz:81:8:
 -------^
 
 
---CURDIR--/choice_negative.fz:85:5: error 26: Choice must not contain any fields
+--CURDIR--/choice_negative.fz:85:5: error 25: Choice must not contain any fields
     B : A, choice i32 String bool is // 15. should flag an error: choice type must not have any fields
 ----^
 Field 'choice_negative.nofields3.A.x' is not permitted.
@@ -179,7 +173,7 @@ Field declared at --CURDIR--/choice_negative.fz:84:10:
 ---------^
 
 
---CURDIR--/choice_negative.fz:89:5: error 27: Choice must not contain any fields
+--CURDIR--/choice_negative.fz:89:5: error 26: Choice must not contain any fields
     B : choice i32 String bool, A is // 16. should flag an error: choice type must not have any fields
 ----^
 Field 'choice_negative.nofields4.A.x' is not permitted.
@@ -188,7 +182,7 @@ Field declared at --CURDIR--/choice_negative.fz:88:10:
 ---------^
 
 
---CURDIR--/choice_negative.fz:94:5: error 28: Choice must not contain any fields
+--CURDIR--/choice_negative.fz:94:5: error 27: Choice must not contain any fields
     C : B, choice i32 String bool is // 17. should flag an error: choice type must not have any fields
 ----^
 Field 'choice_negative.nofields5.A.x' is not permitted.
@@ -197,7 +191,7 @@ Field declared at --CURDIR--/choice_negative.fz:92:8:
 -------^
 
 
---CURDIR--/choice_negative.fz:99:5: error 29: Choice must not contain any fields
+--CURDIR--/choice_negative.fz:99:5: error 28: Choice must not contain any fields
     C : choice i32 String bool, B is // 18. should flag an error: choice type must not have any fields
 ----^
 Field 'choice_negative.nofields6.A.x' is not permitted.
@@ -206,7 +200,7 @@ Field declared at --CURDIR--/choice_negative.fz:97:8:
 -------^
 
 
---CURDIR--/choice_negative.fz:102:5: error 30: Actual type parameters to choice type must be disjoint types
+--CURDIR--/choice_negative.fz:102:5: error 29: Actual type parameters to choice type must be disjoint types
     A : choice i32 i32 is // 19. should flag an error: generic args to choice must be different
 ----^
 The following types have overlapping values:
@@ -214,7 +208,7 @@ The following types have overlapping values:
 'i32'
 
 
---CURDIR--/choice_negative.fz:105:7: error 31: Actual type parameters to choice type must be disjoint types
+--CURDIR--/choice_negative.fz:105:7: error 30: Actual type parameters to choice type must be disjoint types
     x choice i32 i32 := any // 20. should flag an error: generic args to choice must be different
 ------^^^^^^
 The following types have overlapping values:
@@ -222,7 +216,7 @@ The following types have overlapping values:
 'i32'
 
 
---CURDIR--/choice_negative.fz:108:7: error 32: Actual type parameters to choice type must be disjoint types
+--CURDIR--/choice_negative.fz:108:7: error 31: Actual type parameters to choice type must be disjoint types
     x i32 | i32 := any  // 21. should flag an error: generic args to choice must be different
 ------^^^
 The following types have overlapping values:
@@ -230,7 +224,7 @@ The following types have overlapping values:
 'i32'
 
 
---CURDIR--/choice_negative.fz:113:5: error 33: Actual type parameters to choice type must be disjoint types
+--CURDIR--/choice_negative.fz:113:5: error 32: Actual type parameters to choice type must be disjoint types
     A : choice R S is // 22. should flag an error: generic args to choice must be different
 ----^
 The following types have overlapping values:
@@ -238,7 +232,7 @@ The following types have overlapping values:
 'choice_negative.args4.S'
 
 
---CURDIR--/choice_negative.fz:118:7: error 34: Actual type parameters to choice type must be disjoint types
+--CURDIR--/choice_negative.fz:118:7: error 33: Actual type parameters to choice type must be disjoint types
     x choice R S := any  // 23. should flag an error: generic args to choice must be different
 ------^^^^^^
 The following types have overlapping values:
@@ -246,7 +240,7 @@ The following types have overlapping values:
 'choice_negative.this.args5.this.S'
 
 
---CURDIR--/choice_negative.fz:123:7: error 35: Actual type parameters to choice type must be disjoint types
+--CURDIR--/choice_negative.fz:123:7: error 34: Actual type parameters to choice type must be disjoint types
     x R | S := any  // 24. should flag an error: generic args to choice must be different
 ------^
 The following types have overlapping values:
@@ -254,7 +248,7 @@ The following types have overlapping values:
 'choice_negative.this.args6.this.S'
 
 
---CURDIR--/choice_negative.fz:126:5: error 36: Choice type must not access fields of surrounding scope.
+--CURDIR--/choice_negative.fz:126:5: error 35: Choice type must not access fields of surrounding scope.
     A : choice i64 f32 is
 ----^
 A closure cannot be built for a choice type. Forbidden accesses occur at 
@@ -265,7 +259,7 @@ A closure cannot be built for a choice type. Forbidden accesses occur at
 To solve this, you might move the accessed fields outside of the common outer feature.
 
 
---CURDIR--/choice_negative.fz:134:9: error 37: Choice type must not access fields of surrounding scope.
+--CURDIR--/choice_negative.fz:134:9: error 36: Choice type must not access fields of surrounding scope.
     B : A, choice i64 f32 is
 --------^
 A closure cannot be built for a choice type. Forbidden accesses occur at 
@@ -276,13 +270,13 @@ A closure cannot be built for a choice type. Forbidden accesses occur at
 To solve this, you might move the accessed fields outside of the common outer feature.
 
 
---CURDIR--/choice_negative.fz:137:5: error 38: Choice feature must not be intrinsic
+--CURDIR--/choice_negative.fz:137:5: error 37: Choice feature must not be intrinsic
     x bool : choice i64 bool := true  // 27. should flag an error, choice feature must not be field
 ----^
 A choice feature must be a normal feature with empty code section
 
 
---CURDIR--/choice_negative.fz:137:5: error 39: Choice feature must not have a result type
+--CURDIR--/choice_negative.fz:137:5: error 38: Choice feature must not have a result type
     x bool : choice i64 bool := true  // 27. should flag an error, choice feature must not be field
 ----^
 A choice feature cannot be called, so it does not make sense to define a result type of a choice.
@@ -291,19 +285,19 @@ Result type 'bool' at --CURDIR--/choice_negative.fz:137:7:
 ------^^^^
 
 
---CURDIR--/choice_negative.fz:140:5: error 40: Choice feature must not be intrinsic
+--CURDIR--/choice_negative.fz:140:5: error 39: Choice feature must not be intrinsic
     x : choice i64 bool := true  // 28. should flag an error, choice feature must not be field
 ----^
 A choice feature must be a normal feature with empty code section
 
 
---CURDIR--/choice_negative.fz:142:5: error 41: Choice feature must not be intrinsic
+--CURDIR--/choice_negative.fz:142:5: error 40: Choice feature must not be intrinsic
     x bool : choice i64 bool := any  // 29. should flag an error, choice feature must not be field
 ----^
 A choice feature must be a normal feature with empty code section
 
 
---CURDIR--/choice_negative.fz:142:5: error 42: Choice feature must not have a result type
+--CURDIR--/choice_negative.fz:142:5: error 41: Choice feature must not have a result type
     x bool : choice i64 bool := any  // 29. should flag an error, choice feature must not be field
 ----^
 A choice feature cannot be called, so it does not make sense to define a result type of a choice.
@@ -312,25 +306,25 @@ Result type 'bool' at --CURDIR--/choice_negative.fz:142:7:
 ------^^^^
 
 
---CURDIR--/choice_negative.fz:144:5: error 43: Choice feature must not be defined as a routine
+--CURDIR--/choice_negative.fz:144:5: error 42: Choice feature must not be defined as a routine
     x : choice i64 bool => 3  // 30. should flag an error, choice feature must not contain code
 ----^
 To solve this, replace '=>' by 'is'
 
 
---CURDIR--/choice_negative.fz:146:5: error 44: Choice feature must not contain any code
+--CURDIR--/choice_negative.fz:146:5: error 43: Choice feature must not contain any code
     x : choice i64 bool is say "Hello" // 31. should flag an error, choice feature must not contain code
 ----^
 A choice feature must be a normal feature with empty code section
 
 
---CURDIR--/choice_negative.fz:148:5: error 45: Choice feature must not be abstract
+--CURDIR--/choice_negative.fz:148:5: error 44: Choice feature must not be abstract
     x unit : choice i64 bool => abstract  // 32. should flag an error, choice feature must not be abstract
 ----^
 A choice feature must be a normal feature with empty code section
 
 
---CURDIR--/choice_negative.fz:148:5: error 46: Choice feature must not have a result type
+--CURDIR--/choice_negative.fz:148:5: error 45: Choice feature must not have a result type
     x unit : choice i64 bool => abstract  // 32. should flag an error, choice feature must not be abstract
 ----^
 A choice feature cannot be called, so it does not make sense to define a result type of a choice.
@@ -339,13 +333,13 @@ Result type 'unit' at --CURDIR--/choice_negative.fz:148:7:
 ------^^^^
 
 
---CURDIR--/choice_negative.fz:150:6: error 47: Choice feature must not be intrinsic
+--CURDIR--/choice_negative.fz:150:6: error 46: Choice feature must not be intrinsic
      x unit : choice i64 bool => intrinsic  // 33. should flag an error, choice feature must not be intrinsic
 -----^
 A choice feature must be a normal feature with empty code section
 
 
---CURDIR--/choice_negative.fz:150:6: error 48: Choice feature must not have a result type
+--CURDIR--/choice_negative.fz:150:6: error 47: Choice feature must not have a result type
      x unit : choice i64 bool => intrinsic  // 33. should flag an error, choice feature must not be intrinsic
 -----^
 A choice feature cannot be called, so it does not make sense to define a result type of a choice.
@@ -353,4 +347,4 @@ Result type 'unit' at --CURDIR--/choice_negative.fz:150:8:
      x unit : choice i64 bool => intrinsic  // 33. should flag an error, choice feature must not be intrinsic
 -------^^^^
 
-48 errors.
+47 errors.

--- a/tests/reg_issue2691_b/reg_issue2691_b.fz.expected_err
+++ b/tests/reg_issue2691_b/reg_issue2691_b.fz.expected_err
@@ -17,23 +17,7 @@ block returns value of type 'unit' at --CURDIR--/reg_issue2691_b.fz:33:14:
 -------------^
 
 
---CURDIR--/reg_issue2691_b.fz:33:5: error 3: Illegal forward or cyclic type inference
-    pre else if x < -10 then false
-----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-The definition of a field using ':=', or of a feature or function
-using '=>' must not create cyclic type dependencies.
-Referenced feature: 'reg_issue2691_b.h.chk' at --CURDIR--/reg_issue2691_b.fz:32:11:
-    redef chk(x i32)
-----------^^^
-
-
---CURDIR--/reg_issue2691_b.fz:32:11: error 4: Failed to infer result type for feature 'reg_issue2691_b.h.chk'.
-    redef chk(x i32)
-----------^^^
-To solve this, please specify a result type explicitly.
-
-
---CURDIR--/reg_issue2691_b.fz:33:14: error 5: Incompatible types in assignment
+--CURDIR--/reg_issue2691_b.fz:33:14: error 3: Incompatible types in assignment
     pre else if x < -10 then false
 -------------^
 assignment to field : 'reg_issue2691_b.h.pre chk.result'
@@ -43,4 +27,4 @@ assignable to       : 'unit'
 for value assigned  : ''
 To solve this, you could change the type of the target 'reg_issue2691_b.h.pre chk.result' to 'unit' or convert the type of the assigned value to 'bool'.
 
-5 errors.
+3 errors.

--- a/tests/visibility_negative/visibility_negative.fz.expected_err
+++ b/tests/visibility_negative/visibility_negative.fz.expected_err
@@ -2312,17 +2312,7 @@ Target feature: 'visibility_negative.visi1.a2.b3.c6'
 In call: 'b2'
 
 
-<built-in>: error 290: Incompatible types when passing argument in a call
-Actual type for argument #1 'b' does not match expected type.
-In call to          : 'visibility_negative.chck'
-expected formal type: 'bool'
-actual type found   : '**error**'
-assignable to       : '**error**'
-for value assigned  : ''
-To solve this, you could change the type of 'b' to a 'ref' type like 'ref bool'.
-
-
---CURDIR--/visibility_negative.fz:526:5: error 291: Could not find called feature
+--CURDIR--/visibility_negative.fz:526:5: error 290: Could not find called feature
     b // 273. should flag an error: feature not visible
 ----^
 Feature not found: 'b' (no arguments)
@@ -2330,7 +2320,7 @@ Target feature: 'visibility_negative.visi8'
 In call: 'b'
 
 
---CURDIR--/visibility_negative.fz:527:5: error 292: Could not find called feature
+--CURDIR--/visibility_negative.fz:527:5: error 291: Could not find called feature
     c // 274. should flag an error: feature not visible
 ----^
 Feature not found: 'c' (no arguments)
@@ -2338,7 +2328,7 @@ Target feature: 'visibility_negative.visi8'
 In call: 'c'
 
 
---CURDIR--/visibility_negative.fz:530:9: error 293: Could not find called feature
+--CURDIR--/visibility_negative.fz:530:9: error 292: Could not find called feature
         c // 275. should flag an error: feature not visible
 --------^
 Feature not found: 'c' (no arguments)
@@ -2346,7 +2336,7 @@ Target feature: 'visibility_negative.visi8'
 In call: 'c'
 
 
---CURDIR--/visibility_negative.fz:533:9: error 294: Could not find called feature
+--CURDIR--/visibility_negative.fz:533:9: error 293: Could not find called feature
         c // 276. should flag an error: feature not visible
 --------^
 Feature not found: 'c' (no arguments)
@@ -2354,7 +2344,7 @@ Target feature: 'visibility_negative.visi8'
 In call: 'c'
 
 
---CURDIR--/visibility_negative.fz:536:9: error 295: Could not find called feature
+--CURDIR--/visibility_negative.fz:536:9: error 294: Could not find called feature
         b // 277. should flag an error: feature not visible
 --------^
 Feature not found: 'b' (no arguments)
@@ -2362,7 +2352,7 @@ Target feature: 'visibility_negative.visi8'
 In call: 'b'
 
 
---CURDIR--/visibility_negative.fz:539:9: error 296: Could not find called feature
+--CURDIR--/visibility_negative.fz:539:9: error 295: Could not find called feature
         b // 278. should flag an error: feature not visible
 --------^
 Feature not found: 'b' (no arguments)
@@ -2370,11 +2360,11 @@ Target feature: 'visibility_negative.visi8'
 In call: 'b'
 
 
---CURDIR--/visibility_negative.fz:541:5: error 297: Could not find called feature
+--CURDIR--/visibility_negative.fz:541:5: error 296: Could not find called feature
     b // 279. should flag an error: feature not visible
 ----^
 Feature not found: 'b' (no arguments)
 Target feature: 'visibility_negative.visi8'
 In call: 'b'
 
-297 errors.
+296 errors.


### PR DESCRIPTION
Types that are `t_ERROR`, `t_UNDEFINED` or `Impl` that is `Impl.ERROR` in combination with previous errors reuslt in this suppression.

