### PR TITLE
fz_cmd: check for invalid values in provided options

### DIFF
--- a/src/dev/flang/tools/Fuzion.java
+++ b/src/dev/flang/tools/Fuzion.java
@@ -958,7 +958,7 @@ public class Fuzion extends Tool
             else if (a.startsWith("-XdumpModules="           )) { _dumpModules             = parseStringListArg(a);     }
             else if (a.startsWith("-sourceDirs="             )) { _sourceDirs = new List<>(); _sourceDirs.addAll(parseStringListArg(a)); }
             else if (a.startsWith("-moduleDirs="             )) {                             _moduleDirs.addAll(parseStringListArg(a)); }
-            else if (_backend.runsCode() && a.matches("-debug(=\\d+|)"       )) { _debugLevel              = parsePositiveIntArg(a, 1); }
+            else if (_backend.runsCode() && a.matches("-debug(=\\d+|)"       )) { _debugLevel              = parseIntArg(a, 1); }
             else if (_backend.runsCode() && a.startsWith("-safety="          )) { _safety                  = parseOnOffArg(a);          }
             else if (_backend.runsCode() && a.startsWith("-unsafeIntrinsics=")) { _enableUnsafeIntrinsics  = parseOnOffArg(a);          }
             else if (_backend.handleOption(this, a))

--- a/src/dev/flang/tools/Tool.java
+++ b/src/dev/flang/tools/Tool.java
@@ -255,31 +255,13 @@ public abstract class Tool extends ANY
         else
           { Profiler.start(); }
       }
-    else if (a.equals(Errors.MAX_ERROR_MESSAGES_OPTION))
+    else if (a.equals(Errors.MAX_ERROR_MESSAGES_OPTION) || a.startsWith(Errors.MAX_ERROR_MESSAGES_OPTION + "="))
       {
-        Errors.MAX_ERROR_MESSAGES = -1;
+        Errors.MAX_ERROR_MESSAGES = parseIntArg(a, -1);
       }
-    else if (a.startsWith(Errors.MAX_ERROR_MESSAGES_OPTION + "="))
+    else if (a.equals(Errors.MAX_WARNING_MESSAGES_OPTION) || a.startsWith(Errors.MAX_WARNING_MESSAGES_OPTION + "="))
       {
-        try {
-          Errors.MAX_ERROR_MESSAGES = Integer.parseInt(a.substring(a.indexOf("=")+1));
-        } catch (NumberFormatException e) {
-          fatal("'" + a.substring(a.indexOf("=")+1) + "' is not a valid argument to option '" + Errors.MAX_ERROR_MESSAGES_OPTION + "'. "
-                + "Please provide a integer value or use the option without an argument for unlimited errors.");
-        }
-      }
-    else if (a.equals(Errors.MAX_WARNING_MESSAGES_OPTION))
-      {
-        Errors.MAX_WARNING_MESSAGES = -1;
-      }
-    else if (a.startsWith(Errors.MAX_WARNING_MESSAGES_OPTION + "="))
-      {
-        try {
-          Errors.MAX_WARNING_MESSAGES = Integer.parseInt(a.substring(a.indexOf("=")+1));
-        } catch (NumberFormatException e) {
-          fatal("'" + a.substring(a.indexOf("=")+1) + "' is not a valid argument to option '" + Errors.MAX_WARNING_MESSAGES_OPTION + "'. "
-                + "Please provide a integer value or use the option without an argument for unlimited warnings.");
-        }
+        Errors.MAX_WARNING_MESSAGES = parseIntArg(a, -1);;
       }
     else if (a.equals("-noANSI"))
       {
@@ -287,7 +269,7 @@ public abstract class Tool extends ANY
       }
     else if (a.matches("-verbose(=\\d+|)"))
       {
-        _verbose = parsePositiveIntArg(a, 1);
+        _verbose = parseIntArg(a, 1);
       }
     else if (a.equals("-XenableSetKeyword"))
       {
@@ -341,7 +323,7 @@ public abstract class Tool extends ANY
    *
    * @return defawlt or the values specified in a after '='.
    */
-  protected int parsePositiveIntArg(String a, int defawlt)
+  protected int parseIntArg(String a, int defawlt)
   {
     if (PRECONDITIONS) require
       (a.split("=").length == 1 || a.split("=").length == 2);

--- a/src/dev/flang/tools/Tool.java
+++ b/src/dev/flang/tools/Tool.java
@@ -249,15 +249,37 @@ public abstract class Tool extends ANY
       }
     else if (a.startsWith("-XjavaProf="))
       {
-        Profiler.start(a.substring(a.indexOf("=")+1));
+        var file = a.substring(a.indexOf("=")+1);
+        if (file.equals(""))
+          { fatal("Please provide a file name to option '-XjavaProf=<file>'."); }
+        else
+          { Profiler.start(); }
       }
-    else if (a.startsWith(Errors.MAX_ERROR_MESSAGES_OPTION) && a.startsWith(Errors.MAX_ERROR_MESSAGES_OPTION + "="))
+    else if (a.equals(Errors.MAX_ERROR_MESSAGES_OPTION))
       {
-        Errors.MAX_ERROR_MESSAGES = Integer.parseInt(a.substring(a.indexOf("=")+1));
+        Errors.MAX_ERROR_MESSAGES = -1;
       }
-    else if (a.startsWith(Errors.MAX_WARNING_MESSAGES_OPTION) && a.startsWith(Errors.MAX_WARNING_MESSAGES_OPTION + "="))
+    else if (a.startsWith(Errors.MAX_ERROR_MESSAGES_OPTION + "="))
       {
-        Errors.MAX_WARNING_MESSAGES = Integer.parseInt(a.substring(a.indexOf("=")+1));
+        try {
+          Errors.MAX_ERROR_MESSAGES = Integer.parseInt(a.substring(a.indexOf("=")+1));
+        } catch (NumberFormatException e) {
+          fatal("'" + a.substring(a.indexOf("=")+1) + "' is not a valid argument to option '" + Errors.MAX_ERROR_MESSAGES_OPTION + "'. "
+                + "Please provide a integer value or use the option without an argument for unlimited errors.");
+        }
+      }
+    else if (a.equals(Errors.MAX_WARNING_MESSAGES_OPTION))
+      {
+        Errors.MAX_WARNING_MESSAGES = -1;
+      }
+    else if (a.startsWith(Errors.MAX_WARNING_MESSAGES_OPTION + "="))
+      {
+        try {
+          Errors.MAX_WARNING_MESSAGES = Integer.parseInt(a.substring(a.indexOf("=")+1));
+        } catch (NumberFormatException e) {
+          fatal("'" + a.substring(a.indexOf("=")+1) + "' is not a valid argument to option '" + Errors.MAX_WARNING_MESSAGES_OPTION + "'. "
+                + "Please provide a integer value or use the option without an argument for unlimited warnings.");
+        }
       }
     else if (a.equals("-noANSI"))
       {


### PR DESCRIPTION
fix #4156

examples
```
❯ fz -XmaxErrors -e 'say "ok"' 
ok

❯ fz -XmaxErrors=twenty -e 'say "ok"'

error 1: 'twenty' is not a valid argument to option '-XmaxErrors'. Please provide a integer value or use the option without an argument for unlimited errors.
Usage: /home/simon/fuzion/build/bin/fz [-h|--help|-version]  --or--
       /home/simon/fuzion/build/bin/fz [-c|-classes|-dfa|-effects|-frontend-only|-interpreter|-jar|-java|-jvm|-llvm|-no-backend|-saveLib=<file>] [-h|--help|-version] [<backend specific options>]  --or--
       /home/simon/fuzion/build/bin/fz -pretty [-noANSI] [-verbose[=<n>]]  ({<file>} | - | -e <code> | -execute <code>)  --or--
       /home/simon/fuzion/build/bin/fz -latex [-noANSI] [-verbose[=<n>]]   --or--
       /home/simon/fuzion/build/bin/fz -acemode [-noANSI] [-verbose[=<n>]]   --or--

*** fatal errors encountered, stopping.
one error.

❯ fz -XmaxWarnings=5.0 -e 'say "ok"'

error 1: '5.0' is not a valid argument to option '-XmaxWarnings'. Please provide a integer value or use the option without an argument for unlimited warnings.
Usage: /home/simon/fuzion/build/bin/fz [-h|--help|-version]  --or--
       /home/simon/fuzion/build/bin/fz [-c|-classes|-dfa|-effects|-frontend-only|-interpreter|-jar|-java|-jvm|-llvm|-no-backend|-saveLib=<file>] [-h|--help|-version] [<backend specific options>]  --or--
       /home/simon/fuzion/build/bin/fz -pretty [-noANSI] [-verbose[=<n>]]  ({<file>} | - | -e <code> | -execute <code>)  --or--
       /home/simon/fuzion/build/bin/fz -latex [-noANSI] [-verbose[=<n>]]   --or--
       /home/simon/fuzion/build/bin/fz -acemode [-noANSI] [-verbose[=<n>]]   --or--

*** fatal errors encountered, stopping.
one error.

❯ fz -XjavaProf= -e 'say "ok"'      

error 1: Please provide a file name to option '-XjavaProf=<file>'.
Usage: /home/simon/fuzion/build/bin/fz [-h|--help|-version]  --or--
       /home/simon/fuzion/build/bin/fz [-c|-classes|-dfa|-effects|-frontend-only|-interpreter|-jar|-java|-jvm|-llvm|-no-backend|-saveLib=<file>] [-h|--help|-version] [<backend specific options>]  --or--
       /home/simon/fuzion/build/bin/fz -pretty [-noANSI] [-verbose[=<n>]]  ({<file>} | - | -e <code> | -execute <code>)  --or--
       /home/simon/fuzion/build/bin/fz -latex [-noANSI] [-verbose[=<n>]]   --or--
       /home/simon/fuzion/build/bin/fz -acemode [-noANSI] [-verbose[=<n>]]   --or--

*** fatal errors encountered, stopping.
one error.
```
