### PR TITLE
dfa: Add infrastructure to show values produced during DFA

### DIFF
--- a/src/dev/flang/fuir/analysis/dfa/Call.java
+++ b/src/dev/flang/fuir/analysis/dfa/Call.java
@@ -238,7 +238,7 @@ public class Call extends ANY implements Comparable<Call>, Context
       {
         var a0 = _args.get(i);
         var a1 =  args.get(i);
-        var an = a0.joinVal(_dfa, a1);
+        var an = a0.joinVal(_dfa, a1, _dfa._fuir.clazzArgClazz(_cc, i));
         if (an.value() != a0.value())
           {
             _args.set(i, an);

--- a/src/dev/flang/fuir/analysis/dfa/Env.java
+++ b/src/dev/flang/fuir/analysis/dfa/Env.java
@@ -307,7 +307,7 @@ public class Env extends ANY implements Comparable<Env>
     if (_effectType == ecl)
       {
         var oe = _actualEffectValues;
-        var ne = e.join(_dfa, oe);
+        var ne = e.join(_dfa, oe, ecl);
         if (Value.compare(oe, ne) != 0)
           {
             _actualEffectValues = ne;

--- a/src/dev/flang/fuir/analysis/dfa/Instance.java
+++ b/src/dev/flang/fuir/analysis/dfa/Instance.java
@@ -166,7 +166,7 @@ public class Instance extends Value
     var oldv = _fields.get(field);
     if (oldv != null)
       {
-        v = oldv.join(dfa, v);
+        v = oldv.join(dfa, v, dfa._fuir.clazzResultClazz(field));
       }
     if (oldv != v)
       {

--- a/src/dev/flang/fuir/analysis/dfa/NumericValue.java
+++ b/src/dev/flang/fuir/analysis/dfa/NumericValue.java
@@ -198,8 +198,16 @@ public class NumericValue extends Value
   /**
    * Create the union of the values 'this' and 'v'. This is called by join()
    * after common cases (same instance, UNDEFINED) have been handled.
+   *
+   * @param dfa the current analysis context.
+   *
+   * @param v the value this value should be joined with.
+   *
+   * @param clazz the clazz of the resulting value. This is usually the same as
+   * the clazz of `this` or `v`, unless we are joining `ref` type values.
    */
-  public Value joinInstances(DFA dfa, Value v)
+  @Override
+  public Value joinInstances(DFA dfa, Value v, int clazz)
   {
     if (v instanceof NumericValue nv)
       {
@@ -232,16 +240,16 @@ public class NumericValue extends Value
           }
         else
           {
-            return super.joinInstances(dfa, v);
+            return super.joinInstances(dfa, v, clazz);
           }
       }
     else if (v instanceof ValueSet)
       {
-        return v.join(dfa, this);
+        return v.join(dfa, this, clazz);
       }
     else
       {
-        return super.joinInstances(dfa, v);
+        return super.joinInstances(dfa, v, clazz);
       }
   }
 

--- a/src/dev/flang/fuir/analysis/dfa/SysArray.java
+++ b/src/dev/flang/fuir/analysis/dfa/SysArray.java
@@ -102,7 +102,7 @@ public class SysArray extends Value
       }
     else
       {
-        ne = _elements.join(_dfa, el);
+        ne = _elements.join(_dfa, el, _elementClazz);
       }
     if (_elements == null || Value.compare(_elements, ne) != 0)
       {
@@ -133,14 +133,22 @@ public class SysArray extends Value
   /**
    * Create the union of the values 'this' and 'v'. This is called by join()
    * after common cases (same instance, UNDEFINED) have been handled.
+   *
+   * @param dfa the current analysis context.
+   *
+   * @param v the value this value should be joined with.
+   *
+   * @param clazz the clazz of the resulting value. This is usually the same as
+   * the clazz of `this` or `v`, unless we are joining `ref` type values.
    */
-  public Value joinInstances(DFA dfa, Value v)
+  @Override
+  public Value joinInstances(DFA dfa, Value v, int cl)
   {
     if (v instanceof SysArray sv)
       {
         Value ne =
           _elements == null ? sv._elements :
-          sv._elements == null ? _elements : _elements.join(dfa, sv._elements);
+          sv._elements == null ? _elements : _elements.join(dfa, sv._elements, _elementClazz);
         return _dfa.newSysArray(ne, _elementClazz);
       }
     else

--- a/src/dev/flang/fuir/analysis/dfa/TaggedValue.java
+++ b/src/dev/flang/fuir/analysis/dfa/TaggedValue.java
@@ -120,12 +120,20 @@ public class TaggedValue extends Value implements Comparable<TaggedValue>
   /**
    * Create the union of the values 'this' and 'v'. This is called by join()
    * after common cases (same instance, UNDEFINED) have been handled.
+   *
+   * @param dfa the current analysis context.
+   *
+   * @param v the value this value should be joined with.
+   *
+   * @param clazz the clazz of the resulting value. This is usually the same as
+   * the clazz of `this` or `v`, unless we are joining `ref` type values.
    */
-  public Value joinInstances(DFA dfa, Value v)
+  @Override
+  public Value joinInstances(DFA dfa, Value v, int clazz)
   {
     if (v instanceof TaggedValue tv && _tag == tv._tag)
       {
-        return _dfa.newTaggedValue(_clazz, _original.join(dfa, tv._original), _tag);
+        return _dfa.newTaggedValue(_clazz, _original.join(dfa, tv._original, clazz), _tag);
       }
     else
       {
@@ -146,7 +154,7 @@ public class TaggedValue extends Value implements Comparable<TaggedValue>
                   }
               }
           }
-        return super.joinInstances(dfa, v);
+        return super.joinInstances(dfa, v, clazz);
       }
   }
 

--- a/src/dev/flang/fuir/analysis/dfa/Val.java
+++ b/src/dev/flang/fuir/analysis/dfa/Val.java
@@ -81,11 +81,18 @@ public abstract class Val extends ANY
 
   /**
    * Create the union of the values 'this' and 'v'.
+   *
+   * @param dfa the current analysis context.
+   *
+   * @param v the value this value should be joined with.
+   *
+   * @param clazz the clazz of the resulting value. This is usually the same as
+   * the clazz of `this` or `v`, unless we are joining `ref` type values.
    */
-  Val joinVal(DFA dfa, Val v)
+  Val joinVal(DFA dfa, Val v, int clazz)
   {
     return rewrap(dfa, a ->
-         v.rewrap(dfa, b -> a.join(dfa, b)));
+                  v.rewrap(dfa, b -> a.join(dfa, b, clazz)));
   }
 
 }

--- a/src/dev/flang/fuir/analysis/dfa/Value.java
+++ b/src/dev/flang/fuir/analysis/dfa/Value.java
@@ -335,7 +335,7 @@ public class Value extends Val
                }
              else
                {
-                 resa[0] = resa[0].joinVal(dfa, r);
+                 resa[0] = resa[0].joinVal(dfa, r, dfa._fuir.clazzResultClazz(cc));
                }
            });
     return resa[0];
@@ -359,8 +359,15 @@ public class Value extends Val
 
   /**
    * Create the union of the values 'this' and 'v'.
+   *
+   * @param dfa the current analysis context.
+   *
+   * @param v the value this value should be joined with.
+   *
+   * @param clazz the clazz of the resulting value. This is usually the same as
+   * the clazz of `this` or `v`, unless we are joining `ref` type values.
    */
-  public Value join(DFA dfa, Value v)
+  public Value join(DFA dfa, Value v, int clazz)
   {
     if (this == v)
       {
@@ -376,7 +383,7 @@ public class Value extends Val
       }
     else
       {
-        return joinInstances(dfa, v);
+        return joinInstances(dfa, v, clazz);
       }
   }
 
@@ -384,10 +391,17 @@ public class Value extends Val
   /**
    * Create the union of the values 'this' and 'v'. This is called by join()
    * after common cases (same instance, UNDEFINED) have been handled.
+   *
+   * @param dfa the current analysis context.
+   *
+   * @param v the value this value should be joined with.
+   *
+   * @param clazz the clazz of the resulting value. This is usually the same as
+   * the clazz of `this` or `v`, unless we are joining `ref` type values.
    */
-  public Value joinInstances(DFA dfa, Value v)
+  public Value joinInstances(DFA dfa, Value v, int clazz)
   {
-    return dfa.newValueSet(this, v);
+    return dfa.newValueSet(this, v, clazz);
   }
 
 

--- a/src/dev/flang/fuir/analysis/dfa/ValueSet.java
+++ b/src/dev/flang/fuir/analysis/dfa/ValueSet.java
@@ -26,6 +26,8 @@ Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
 
 package dev.flang.fuir.analysis.dfa;
 
+import dev.flang.fuir.FUIR;
+
 import dev.flang.util.IntMap;
 import dev.flang.util.List;
 
@@ -128,7 +130,7 @@ public class ValueSet extends Value
 
           var oo = _forTags.getIfExists(tv._tag);
           var no = tv._original;
-          var o = oo == null ? no : _dfa.newValueSet(oo, no);
+          var o = oo == null ? no : _dfa.newValueSet(oo, no, _dfa._fuir.clazzChoice(v._clazz, tv._tag));
           _forTags.force(tv._tag, o);
         }
       else
@@ -198,10 +200,13 @@ public class ValueSet extends Value
    * @param v1 some value
    *
    * @param v2 some value
+   *
+   * @param cl the clazz of the resulting value. This is usually the same as the
+   * clazz of `this` or `v`, unless we are joining `ref` type values.
    */
-  public ValueSet(DFA dfa, Value v1, Value v2)
+  public ValueSet(DFA dfa, Value v1, Value v2, int cl)
   {
-    super(-1);
+    super(cl);
 
     var coll = new Collect(dfa);
     coll.add(v1);
@@ -352,7 +357,7 @@ public class ValueSet extends Value
     for (var v : _componentsArray)
       {
         var u = v.box(dfa, vc, rc, context);
-        result = result == null ? u : dfa.newValueSet(result, u);
+        result = result == null ? u : dfa.newValueSet(result, u, rc);
       }
     return result;
   }
@@ -368,7 +373,7 @@ public class ValueSet extends Value
     for (var v : _componentsArray)
       {
         var u = v.unbox(dfa, vc);
-        result = result == null ? u : dfa.newValueSet(result, u);
+        result = result == null ? u : dfa.newValueSet(result, u, vc);
       }
     return result;
   }


### PR DESCRIPTION
This adds optional debug output for performance analysis.

Setting the env var

    dev_flang_fuir_analysis_dfa_DFA_SHOW_VALUES=

now results in output of the values produced by DFA, while setting

    dev_flang_fuir_analysis_dfa_DFA_SHOW_VALUES=u32

additionally prints all the values of a clazz given by name, `u32` in this case.

