### PR TITLE
lib: concur.sync, change cnd.wait

### DIFF
--- a/lib/concur/sync.fz
+++ b/lib/concur/sync.fz
@@ -60,6 +60,11 @@ public sync is
 
     public is_locked := concur.atomic false
 
+
+    # lock the mutex that belongs to this condition
+    # run the code
+    # unlock the mutex
+    #
     public synchronized(T type, code ()->T) T =>
       check mtx_lock mtx
       is_locked.write true
@@ -68,14 +73,37 @@ public sync is
       check mtx_unlock mtx
       res
 
+
+    # send signal to one thread
+    # waiting on this condition
+    #
     public signal
-    pre is_locked.read
+      pre is_locked.read
     => cnd_signal cnd
+
+
+    # send signal to all threads
+    # waiting on this condition
+    #
     public broadcast
-    pre is_locked.read
+      pre is_locked.read
     => cnd_broadcast cnd
-    public wait
-    pre is_locked.read
-    => cnd_wait cnd mtx
+
+
+    # make this thread wait for being signaled
+    # while cnd_met returns false.
+    #
+    public wait(cnd_met ()->bool)
+    =>
+      synchronized ()->
+        wait0 cnd_met
+
+
+    wait0(cnd_met ()->bool)
+    =>
+      if !cnd_met()
+        _ := cnd_wait cnd mtx
+        wait0 cnd_met
+
 
     # NYI destroy

--- a/lib/concur/thread_pool.fz
+++ b/lib/concur/thread_pool.fz
@@ -60,13 +60,11 @@ Blocking_Queue(T type, cnd concur.sync.condition) ref is
       if is_closed.read
         nil
       else
-        cnd.synchronized ()->
-          # check the two conditions again, otherwise we MUST NOT wait
-          if !is_closed.read && data.read.is_empty
-            # NYI: BUG: possible dead lock? what if we write to data in the meantime?
-            # we should use TLA+ or similar to prove correctness
-            # https://www.hillelwayne.com/post/list-of-tla-examples/
-            check cnd.wait
+        # NYI: BUG: possible dead lock? what if we write to data in the meantime?
+        # we should use TLA+ or similar to prove correctness
+        # https://www.hillelwayne.com/post/list-of-tla-examples/
+        cnd.wait ()->
+          is_closed.read || !data.read.is_empty
         dequeue
     else
       res := o[0]
@@ -142,10 +140,7 @@ is
       redef is_done => compute_result.read.exists
 
       redef get T =>
-        if !is_done
-          fut_cnd.synchronized ()->
-            if !is_done
-              check fut_cnd.wait
+        fut_cnd.wait ()->is_done
 
         compute_result.read.val
 

--- a/tests/lib_concur_sync/lib_concur_sync.fz
+++ b/tests/lib_concur_sync/lib_concur_sync.fz
@@ -28,9 +28,11 @@ lib_concur_sync =>
     mtx_res := concur.sync.mutex.new.bind unit mtx->
       cnd_res := mtx.condition.bind unit cnd->
 
+        cnd_met := concur.atomic false
+
         a := concur.threads.spawn ()->
           cnd.synchronized ()->
-            check cnd.wait
+            cnd.wait ()->cnd_met.read
             say "Thread proceeding after signal"
 
         b := concur.threads.spawn ()->
@@ -38,6 +40,7 @@ lib_concur_sync =>
           time.nano.sleep (time.duration.ms 100)
           cnd.synchronized ()->
             say "Thread sending signal"
+            cnd_met.write true
             check cnd.signal
 
         a.join
@@ -55,9 +58,11 @@ lib_concur_sync =>
     mtx_res := concur.sync.mutex.new.bind unit mtx->
       cnd_res := mtx.condition.bind unit cnd->
 
+        cnd_met := concur.atomic false
+
         a := concur.threads.spawn ()->
           cnd.synchronized ()->
-            check cnd.wait
+            cnd.wait ()->cnd_met.read
             say "Thread proceeding after broadcast"
 
         b := concur.threads.spawn ()->
@@ -65,6 +70,7 @@ lib_concur_sync =>
           time.nano.sleep (time.duration.ms 100)
           cnd.synchronized ()->
             say "Thread sending broadcast"
+            cnd_met.write true
             check cnd.broadcast
 
         a.join


### PR DESCRIPTION
`wait` add argument cnd_met to detect spurious wakeups. 
The idea is to make it harder to misuse `wait`.

