### PR TITLE
dfa: Do not cache `TaggedValue` twice

### DIFF
--- a/src/dev/flang/fuir/analysis/dfa/DFA.java
+++ b/src/dev/flang/fuir/analysis/dfa/DFA.java
@@ -2681,7 +2681,9 @@ public class DFA extends ANY
             if (r == null)
               {
                 r = new TaggedValue(this, nc, original, tag);
-                r = (TaggedValue) cache(r);
+                if (CHECKS) check
+                  (_cachedValues.get(r) == null);
+                makeUnique(r);
                 _tagged.put(k, r);
               }
           }
@@ -2714,9 +2716,13 @@ public class DFA extends ANY
         res = _joined.get(k);
         if (res == null)
           {
-            res = v.contains(w) ? v :
-                  w.contains(v) ? w : new ValueSet(this, v, w);
-            res = cache(res);
+            if      (v.contains(w)) { res = v; }
+            else if (w.contains(v)) { res = w; }
+            else
+              {
+                res = new ValueSet(this, v, w);
+                res = cache(res);
+              }
             _joined.put(k, res);
           }
       }


### PR DESCRIPTION
Most of these are cached in `_tagged`, so we do not need to add them to `_cachedValues`.

This also removes redundant calls to `cache` in `newValueSet` if one of the values contains the other.

This brings an insignificant performance improvement, but is IMHO cleaner. 
