### PR TITLE
ast: add debug option to Resolution

### DIFF
--- a/src/dev/flang/ast/Resolution.java
+++ b/src/dev/flang/ast/Resolution.java
@@ -128,6 +128,9 @@ import dev.flang.util.FuzionOptions;
 public class Resolution extends ANY
 {
 
+  /* flag to control debug output */
+  private static final boolean DEBUG = "true".equals(FuzionOptions.propertyOrEnv("dev.flang.ast.Resolution.DEBUG"));
+
 
   /*----------------------------  variables  ----------------------------*/
 
@@ -404,11 +407,19 @@ public class Resolution extends ANY
     if (!forInheritance.isEmpty())
       {
         Feature f = forInheritance.removeFirst();
+        if (DEBUG)
+          {
+            sayDebug("resolve inheritance: " + f);
+          }
         f.resolveInheritance(this);
       }
     else if (!forDeclarations.isEmpty())
       {
         Feature f = forDeclarations.removeFirst();
+        if (DEBUG)
+          {
+            sayDebug("resolve declarations: " + f);
+          }
         f.resolveDeclarations(this);
       }
     else if (!forType.isEmpty())
@@ -419,6 +430,10 @@ public class Resolution extends ANY
           }
 
         Feature f = forType.removeFirst();
+        if (DEBUG)
+          {
+            sayDebug("resolve types: " + f);
+          }
         f.internalResolveTypes(this);
       }
     else if (!moreThanTypes)
@@ -428,11 +443,19 @@ public class Resolution extends ANY
     else if (!forSyntacticSugar1.isEmpty())
       {
         Feature f = forSyntacticSugar1.removeFirst();
+        if (DEBUG)
+          {
+            sayDebug("resolve syntax sugar 1: " + f);
+          }
         f.resolveSyntacticSugar1(this);
       }
     else if (!forTypeInference.isEmpty())
       {
         Feature f = forTypeInference.removeFirst();
+        if (DEBUG)
+          {
+            sayDebug("resolve type inference: " + f);
+          }
         f.typeInference(this);
       }
     else if (!_waitingForCalls.isEmpty())
@@ -447,17 +470,29 @@ public class Resolution extends ANY
         Feature f = forSyntacticSugar2.removeFirst();
         if (!_options.isLanguageServer())
           {
+            if (DEBUG)
+              {
+                sayDebug("resolve syntax sugar 2: " + f);
+              }
             f.resolveSyntacticSugar2(this);
           }
       }
     else if (!forBoxing.isEmpty())
       {
         Feature f = forBoxing.removeFirst();
+        if (DEBUG)
+          {
+            sayDebug("resolve boxing: " + f);
+          }
         f.box(this);
       }
     else if (!forCheckTypes.isEmpty())
       {
         Feature f = forCheckTypes.removeFirst();
+        if (DEBUG)
+          {
+            sayDebug("resolve check types: " + f);
+          }
         f.checkTypes(this);
       }
     else if (false && Errors.any())  // NYI: We could give up here in case of errors, we do not to make the next phases more robust and to find more errors at once

--- a/src/dev/flang/util/ANY.java
+++ b/src/dev/flang/util/ANY.java
@@ -780,6 +780,13 @@ public class ANY
     say_err("");
   }
 
+  /**
+   * say but to be used for printing debug output in color
+   */
+  public static void sayDebug(String str)
+  {
+    say(Terminal.BLUE + str + Terminal.REGULAR_COLOR);
+  }
 
   /* ----------------------------------------------------------------------------- */
 


### PR DESCRIPTION
for HelloWorld it looks like this:
```
resolve inheritance: public universe ***not yet known*** is Routine
resolve declarations: public universe ***not yet known*** is Routine
resolve inheritance: private HelloWorld ***not yet known*** : Any 🤝 is Routine
resolve declarations: private HelloWorld ***not yet known*** : Any 🤝 is Routine
resolve types: public universe ***not yet known*** is Routine
resolve types: private HelloWorld ***not yet known*** : Any 🤝 is Routine
resolve syntax sugar 1: public universe universe is Routine
resolve syntax sugar 1: private HelloWorld HelloWorld : Any 🤝 is Routine
resolve inheritance: private type.HelloWorld(private THIS#TYPE ***not yet known*** : Any is TypeParameter) ***not yet known*** : Any.#type (HelloWorld.this.type (in type feature)) is Routine
resolve inheritance: private THIS#TYPE ***not yet known*** : Any is TypeParameter
resolve declarations: private type.HelloWorld(private THIS#TYPE ***not yet known*** : Any is TypeParameter) ***not yet known*** : Any.#type (HelloWorld.this.type (in type feature)) is Routine
resolve declarations: private THIS#TYPE ***not yet known*** : Any is TypeParameter
resolve inheritance: private #^HelloWorld.this.type ***not yet known*** is Field
resolve declarations: private #^HelloWorld.this.type ***not yet known*** is Field
resolve types: private type.HelloWorld(private THIS#TYPE ***not yet known*** : Any is TypeParameter) ***not yet known*** : Any.#type (HelloWorld.this.type (in type feature)) is Routine
resolve types: private THIS#TYPE ***not yet known*** : Any is TypeParameter
resolve types: private #^HelloWorld.this.type ***not yet known*** is Field
resolve syntax sugar 1: private type.HelloWorld(private THIS#TYPE HelloWorld : Any is TypeParameter) HelloWorld (HelloWorld.this.type (in type feature)) : Any.#type (HelloWorld.this.type (in type feature)) is Routine
resolve syntax sugar 1: private THIS#TYPE HelloWorld : Any is TypeParameter
resolve syntax sugar 1: private #^HelloWorld.this.type --ADDRESS-- is Field
resolve type inference: public universe universe is Routine
resolve type inference: private HelloWorld HelloWorld : Any 🤝 is Routine
resolve type inference: private type.HelloWorld(private THIS#TYPE HelloWorld : Any is TypeParameter) HelloWorld (HelloWorld.this.type (in type feature)) : Any.#type (HelloWorld.this.type (in type feature)) is Routine
resolve type inference: private THIS#TYPE HelloWorld : Any is TypeParameter
resolve type inference: private #^HelloWorld.this.type --ADDRESS-- is Field
resolve syntax sugar 2: public universe universe is Routine
resolve syntax sugar 2: private HelloWorld HelloWorld : Any 🤝 is Routine
resolve syntax sugar 2: private type.HelloWorld(private THIS#TYPE HelloWorld : Any is TypeParameter) HelloWorld (HelloWorld.this.type (in type feature)) : Any.#type (HelloWorld.this.type (in type feature)) is Routine
resolve syntax sugar 2: private THIS#TYPE HelloWorld : Any is TypeParameter
resolve syntax sugar 2: private #^HelloWorld.this.type --ADDRESS-- is Field
resolve boxing: public universe universe is Routine
resolve boxing: private HelloWorld HelloWorld : Any 🤝 is Routine
resolve boxing: private type.HelloWorld(private THIS#TYPE HelloWorld : Any is TypeParameter) HelloWorld (HelloWorld.this.type (in type feature)) : Any.#type (HelloWorld.this.type (in type feature)) is Routine
resolve boxing: private THIS#TYPE HelloWorld : Any is TypeParameter
resolve boxing: private #^HelloWorld.this.type --ADDRESS-- is Field
resolve check types: public universe universe is Routine
resolve check types: private HelloWorld HelloWorld : Any 🤝 is Routine
resolve check types: private type.HelloWorld(private THIS#TYPE HelloWorld : Any is TypeParameter) HelloWorld (HelloWorld.this.type (in type feature)) : Any.#type (HelloWorld.this.type (in type feature)) is Routine
resolve check types: private THIS#TYPE HelloWorld : Any is TypeParameter
resolve check types: private #^HelloWorld.this.type --ADDRESS-- is Field
```
