### PR TITLE
fz_cmd: don't consider option value when checking for duplicate options

### DIFF
--- a/src/dev/flang/tools/Tool.java
+++ b/src/dev/flang/tools/Tool.java
@@ -219,11 +219,11 @@ public abstract class Tool extends ANY
    */
   protected boolean parseGenericArg(String a)
   {
-    if (_duplicates.contains(a))
+    if (_duplicates.contains(stripValue(a)))
       {
-        fatal("duplicate argument: '" + a + "'");
+        fatal("duplicate argument: '" + stripValue(a) + "'");
       }
-    _duplicates.add(a);
+    _duplicates.add(stripValue(a));
     if (a.equals("-h"    ) ||
         a.equals("-help" ) ||
         a.equals("--help")    )
@@ -276,6 +276,11 @@ public abstract class Tool extends ANY
         return false;
       }
     return true;
+  }
+
+  private String stripValue(String option)
+  {
+    return option.contains("=") ? option.substring(0, option.indexOf("=")) : option;
   }
 
 


### PR DESCRIPTION
fix #4154
