### PR TITLE
fz_cmd: show total warning count when output of warnings is limited

### DIFF
--- a/src/dev/flang/util/Errors.java
+++ b/src/dev/flang/util/Errors.java
@@ -688,6 +688,8 @@ public class Errors extends ANY
     if (PRECONDITIONS) require
       (msg != null);
 
+    Error e = new Error(pos == null ? SourcePosition.builtIn : pos, msg, detail);
+
     if (!_shutting_down_ &&
         (warningCount() < MAX_WARNING_MESSAGES || MAX_WARNING_MESSAGES == -1))
       {
@@ -698,13 +700,12 @@ public class Errors extends ANY
             detail = "Maximum warning count is " + MAX_WARNING_MESSAGES + ".\n" +
               "Change this via property '" + MAX_WARNING_MESSAGES_PROPERTY + "' or command line option '" + MAX_WARNING_MESSAGES_OPTION + "'.";
           }
-        Error e = new Error(pos == null ? SourcePosition.builtIn : pos, msg, detail);
         if (!_warnings_.contains(e))
           {
-            _warnings_.add(e);
             print(pos, warningMessage(msg), detail);
           }
       }
+    _warnings_.add(e);
   }
 
 


### PR DESCRIPTION
examples
```
❯ fz -XmaxErrors=0 -XmaxWarnings=0 tests/visibility_negative/visibility_negative.fz
452 errors and one warning.

❯ fz -XmaxErrors=0 -XmaxWarnings=1 tests/visibility_negative/visibility_negative.fz

<built-in>: warning 0: Maximum warning count reached, suppressing further warnings
Maximum warning count is 1.
Change this via property 'fuzion.maxWarningCount' or command line option '-XmaxWarnings'.

452 errors and one warning.
```