### PR TITLE
ast: fix inconsistency in AbstractType.toString, ResolvedNormalType.t…

### DIFF
--- a/src/dev/flang/ast/AbstractType.java
+++ b/src/dev/flang/ast/AbstractType.java
@@ -1877,7 +1877,7 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
           }
 
         result = outer
-              + (isRef() != feature().isRef() ? (isRef() ? "ref " : "value ") : "" )
+              + (!isThisType() && isRef() != feature().isRef() ? (isRef() ? "ref " : "value ") : "" )
               + fname;
         if (isThisType())
           {


### PR DESCRIPTION
…oString

this confused me... led to strange output like: "value Any.this"
