### PR TITLE
tools: Fix handling for `file` argument to of `-XjavaProf=` option.

### DIFF
--- a/src/dev/flang/tools/Tool.java
+++ b/src/dev/flang/tools/Tool.java
@@ -251,9 +251,13 @@ public abstract class Tool extends ANY
       {
         var file = a.substring(a.indexOf("=")+1);
         if (file.equals(""))
-          { fatal("Please provide a file name to option '-XjavaProf=<file>'."); }
+          {
+            fatal("Please provide a file name to option '-XjavaProf=<file>'.");
+          }
         else
-          { Profiler.start(); }
+          {
+            Profiler.start(file);
+          }
       }
     else if (a.equals(Errors.MAX_ERROR_MESSAGES_OPTION) || a.startsWith(Errors.MAX_ERROR_MESSAGES_OPTION + "="))
       {


### PR DESCRIPTION
The file name was forgotten when the profiler was started.

Also fixed formatting to conform to our / GNU style guides.

fix #4201.