### PR TITLE
dfa: minor cleanup: add method to allocate `fuzion.java.Java_Object`

### DIFF
--- a/src/dev/flang/fuir/analysis/dfa/DFA.java
+++ b/src/dev/flang/fuir/analysis/dfa/DFA.java
@@ -1717,6 +1717,20 @@ public class DFA extends ANY
   static void setArrayI64ElementsToAnything(Call cl, int argnum, String intrinsicName) { setArrayElementsToAnything(cl, argnum, intrinsicName, FUIR.SpecialClazzes.c_i64); }
 
 
+  /**
+   * Allocate the result instance of an intrinsic call returning
+   * fuzion.java.Java_Object or children like fuzion.java.Array.
+   *
+   * @param cl the call to the intrinsic
+   *
+   * @return the result instance
+   */
+  static Value wrappedJavaObject(Call cl)
+  {
+    var rc   = cl._dfa._fuir.clazzResultClazz(cl._cc);
+    return cl._dfa.newInstance(rc, NO_SITE, cl._context);
+  }
+
   static
   {
     put("Type.name"                      , cl -> cl._dfa.newConstString(cl._dfa._fuir.clazzTypeName(cl._dfa._fuir.clazzOuterClazz(cl._cc)), cl) );
@@ -2250,7 +2264,7 @@ public class DFA extends ANY
         {
           var jref = cl._dfa._fuir.lookupJavaRef(cl._dfa._fuir.clazzArgClazz(cl._cc, 0));
           cl._dfa.readField(jref);
-          return cl._dfa.newInstance(cl._dfa._fuir.clazzResultClazz(cl._cc), NO_SITE, cl._context);
+          return wrappedJavaObject(cl);
         });
     put("fuzion.java.array_length"          , cl ->
       {
@@ -2261,19 +2275,19 @@ public class DFA extends ANY
     );
     put("fuzion.java.array_to_java_object0" , cl ->
         {
-          var rc = cl._dfa._fuir.clazzResultClazz(cl._cc);
+          var rc   = cl._dfa._fuir.clazzResultClazz(cl._cc);
           var jref = cl._dfa._fuir.lookupJavaRef(rc);
           var data = cl._dfa._fuir.lookup_fuzion_sys_internal_array_data  (cl._dfa._fuir.clazzArgClazz(cl._cc,0));
           var len  = cl._dfa._fuir.lookup_fuzion_sys_internal_array_length(cl._dfa._fuir.clazzArgClazz(cl._cc,0));
           cl._dfa.readField(data);
           cl._dfa.readField(len);
-          var result = cl._dfa.newInstance(cl._dfa._fuir.clazzResultClazz(cl._cc), NO_SITE, cl._context);
+          var result = wrappedJavaObject(cl);
           result.setField(cl._dfa, jref, Value.UNKNOWN_JAVA_REF); // NYI: record putfield of result.jref := args.get(0).data
           return result;
         });
-    put("fuzion.java.bool_to_java_object"   , cl -> cl._dfa.newInstance(cl._dfa._fuir.clazzResultClazz(cl._cc), NO_SITE, cl._context) );
-    put("fuzion.java.f32_to_java_object"    , cl -> cl._dfa.newInstance(cl._dfa._fuir.clazzResultClazz(cl._cc), NO_SITE, cl._context) );
-    put("fuzion.java.f64_to_java_object"    , cl -> cl._dfa.newInstance(cl._dfa._fuir.clazzResultClazz(cl._cc), NO_SITE, cl._context) );
+    put("fuzion.java.bool_to_java_object"   , cl -> wrappedJavaObject(cl) );
+    put("fuzion.java.f32_to_java_object"    , cl -> wrappedJavaObject(cl) );
+    put("fuzion.java.f64_to_java_object"    , cl -> wrappedJavaObject(cl) );
     put("fuzion.java.get_field0"            , cl ->
       {
         var jref0 = cl._dfa._fuir.lookupJavaRef(((RefValue)cl._args.get(0))._clazz);
@@ -2282,7 +2296,7 @@ public class DFA extends ANY
         cl._dfa.readField(jref0);
         cl._dfa.readField(jref1);
         // NYI: UNDER DEVELOPMENT: setField Java_Ref, see get_static_field0
-        var x = cl._dfa.newInstance(cl._dfa._fuir.clazzResultClazz(cl._cc), NO_SITE, cl._context);
+        var x = wrappedJavaObject(cl);
         // Causes Error // x.setField(cl._dfa, jrefres, Value.UNKNOWN_JAVA_REF);
         return x;
       });
@@ -2297,17 +2311,17 @@ public class DFA extends ANY
         cl._dfa.readField(jref2);
         return Value.UNIT;
       });
-    put("fuzion.java.i16_to_java_object"    , cl -> cl._dfa.newInstance(cl._dfa._fuir.clazzResultClazz(cl._cc), NO_SITE, cl._context) );
-    put("fuzion.java.i32_to_java_object"    , cl -> cl._dfa.newInstance(cl._dfa._fuir.clazzResultClazz(cl._cc), NO_SITE, cl._context) );
-    put("fuzion.java.i64_to_java_object"    , cl -> cl._dfa.newInstance(cl._dfa._fuir.clazzResultClazz(cl._cc), NO_SITE, cl._context) );
-    put("fuzion.java.i8_to_java_object"     , cl -> cl._dfa.newInstance(cl._dfa._fuir.clazzResultClazz(cl._cc), NO_SITE, cl._context) );
+    put("fuzion.java.i16_to_java_object"    , cl -> wrappedJavaObject(cl) );
+    put("fuzion.java.i32_to_java_object"    , cl -> wrappedJavaObject(cl) );
+    put("fuzion.java.i64_to_java_object"    , cl -> wrappedJavaObject(cl) );
+    put("fuzion.java.i8_to_java_object"     , cl -> wrappedJavaObject(cl) );
     put("fuzion.java.java_string_to_string" , cl -> cl._dfa.newConstString(null, cl) );
     put("fuzion.java.create_jvm", cl -> Value.UNIT);
     put("fuzion.java.string_to_java_object0", cl ->
       {
         var rc = cl._dfa._fuir.clazzResultClazz(cl._cc);
         var jref = cl._dfa._fuir.lookupJavaRef(rc);
-        var jobj = cl._dfa.newInstance(rc, NO_SITE, cl._context);
+        var jobj = wrappedJavaObject(cl);
         jobj.setField(cl._dfa, jref, Value.UNKNOWN_JAVA_REF);
         return jobj;
       });
@@ -2355,7 +2369,7 @@ public class DFA extends ANY
         case c_unit -> Value.UNIT;
         default -> {
           var jref = cl._dfa._fuir.lookupJavaRef(rc);
-          var jobj = cl._dfa.newInstance(rc, NO_SITE, cl._context);
+          var jobj = wrappedJavaObject(cl);
           jobj.setField(cl._dfa, jref, Value.UNKNOWN_JAVA_REF);
           yield jobj;
         }
@@ -2429,7 +2443,7 @@ public class DFA extends ANY
     put("fuzion.java.get_static_field0"     , cl ->
       {
         var rc = cl._dfa._fuir.clazzResultClazz(cl._cc);
-        var jobj = cl._dfa.newInstance(rc, NO_SITE, cl._context);
+        var jobj = wrappedJavaObject(cl);
         // otherwise it is a primitive like int, boolean
         if (cl._dfa._fuir.clazzIsRef(rc))
           {
@@ -2441,7 +2455,7 @@ public class DFA extends ANY
     put("fuzion.java.set_static_field0"     , cl ->
       {
         var rc = cl._dfa._fuir.clazzResultClazz(cl._cc);
-        var jobj = cl._dfa.newInstance(rc, NO_SITE, cl._context);
+        var jobj = wrappedJavaObject(cl);
         // otherwise it is a primitive like int, boolean
         if (cl._dfa._fuir.clazzIsRef(rc))
           {
@@ -2450,7 +2464,7 @@ public class DFA extends ANY
           }
           return Value.UNIT;
       });
-    put("fuzion.java.u16_to_java_object"    , cl -> cl._dfa.newInstance(cl._dfa._fuir.clazzResultClazz(cl._cc), NO_SITE, cl._context) );
+    put("fuzion.java.u16_to_java_object"    , cl -> wrappedJavaObject(cl) );
 
     put("concur.sync.mtx_init"              , cl ->
       {


### PR DESCRIPTION
This provides one central place for operations lik to initialize outer ref, which is currently not done.

