### PR TITLE
dfa: Fully suppress the generation of EmbeddedValue if escape analysis not needed

### DIFF
--- a/src/dev/flang/fuir/analysis/dfa/DFA.java
+++ b/src/dev/flang/fuir/analysis/dfa/DFA.java
@@ -423,7 +423,7 @@ public class DFA extends ANY
               {
                 var ca = newCall(cc, s, tvalue.value(), args, _call._env, _call);
                 res = ca.result();
-                if (res != null && res != Value.UNIT && !_fuir.clazzIsRef(_fuir.clazzResultClazz(cc)))
+                if (_options.needsEscapeAnalysis() && res != null && res != Value.UNIT && !_fuir.clazzIsRef(_fuir.clazzResultClazz(cc)))
                   {
                     res = newEmbeddedValue(s, res.value());
                   }

--- a/src/dev/flang/fuir/analysis/dfa/Instance.java
+++ b/src/dev/flang/fuir/analysis/dfa/Instance.java
@@ -200,7 +200,7 @@ public class Instance extends Value
                                                 why);
           }
       }
-    else if (!dfa._fuir.clazzIsRef(dfa._fuir.clazzResultClazz(field)))
+    else if (dfa._options.needsEscapeAnalysis() && !dfa._fuir.clazzIsRef(dfa._fuir.clazzResultClazz(field)))
       {
         res = dfa.newEmbeddedValue(this, v);
       }

--- a/src/dev/flang/fuir/analysis/dfa/Val.java
+++ b/src/dev/flang/fuir/analysis/dfa/Val.java
@@ -91,8 +91,10 @@ public abstract class Val extends ANY
    */
   Val joinVal(DFA dfa, Val v, int clazz)
   {
-    return rewrap(dfa, a ->
-                  v.rewrap(dfa, b -> a.join(dfa, b, clazz)));
+    return dfa._options.needsEscapeAnalysis()
+      ? rewrap(dfa, a ->
+               v.rewrap(dfa, b -> a.join(dfa, b, clazz)))
+      : ((Value) this).join(dfa, (Value) v, clazz);
   }
 
 }


### PR DESCRIPTION
Improves DFA perfromance for JVM and interpreter backends: Time required to build the fzweb jar went down by about 5% (36.886s instead of 39.203s).
