### PR TITLE
util: start numbering of warnings with 1, not 0. fix #4214, fix #4188

### DIFF
--- a/src/dev/flang/util/Errors.java
+++ b/src/dev/flang/util/Errors.java
@@ -694,24 +694,22 @@ public class Errors extends ANY
     if (PRECONDITIONS) require
       (msg != null);
 
-    Error e = new Error(pos == null ? SourcePosition.builtIn : pos, msg, detail);
-
-    if (!_shutting_down_ &&
-        (warningCount() < MAX_WARNING_MESSAGES || MAX_WARNING_MESSAGES == -1))
+    if (!_shutting_down_)
       {
-        if (warningCount()+1 == MAX_WARNING_MESSAGES)
+        Error e = new Error(pos == null ? SourcePosition.builtIn : pos, msg, detail);
+        var isnew = _warnings_.add(e);
+        if (isnew && (warningCount() <= MAX_WARNING_MESSAGES || MAX_WARNING_MESSAGES == -1))
           {
-            pos = SourcePosition.builtIn;
-            msg = "Maximum warning count reached, suppressing further warnings";
-            detail = "Maximum warning count is " + MAX_WARNING_MESSAGES + ".\n" +
-              "Change this via property '" + MAX_WARNING_MESSAGES_PROPERTY + "' or command line option '" + MAX_WARNING_MESSAGES_OPTION + "'.";
-          }
-        if (!_warnings_.contains(e))
-          {
+            if (warningCount() == MAX_WARNING_MESSAGES)
+              {
+                pos = SourcePosition.builtIn;
+                msg = "Maximum warning count reached, suppressing further warnings";
+                detail = "Maximum warning count is " + MAX_WARNING_MESSAGES + ".\n" +
+                  "Change this via property '" + MAX_WARNING_MESSAGES_PROPERTY + "' or command line option '" + MAX_WARNING_MESSAGES_OPTION + "'.";
+              }
             print(pos, warningMessage(msg), detail);
           }
       }
-    _warnings_.add(e);
   }
 
 


### PR DESCRIPTION
Also, do not create or add any new warnings once `_shutting_down_` is set. This is required to avoid race conditions when warning and error statistics haven been reported alredy by one thread while other threads may still run and, e.g., cause the compilation of some new code and reporting of new errors or warnings.
