### PR TITLE
dfa: allow set field in UNIT value if field remove or of unit type, fix 4216

### DIFF
--- a/src/dev/flang/fuir/analysis/dfa/DFA.java
+++ b/src/dev/flang/fuir/analysis/dfa/DFA.java
@@ -2657,6 +2657,19 @@ public class DFA extends ANY
 
 
   /**
+   * Is this field ever read?
+   */
+  boolean isRead(int field)
+  {
+    if (PRECONDITIONS) require
+      (_fuir.clazzKind(field) == FUIR.FeatureKind.Field);
+
+    var fnum = _fuir.clazzId2num(field);
+    return _readFields.get(fnum);
+  }
+
+
+  /**
    * To reduce number of calls created for unit type values, we originally
    * assume calls to an empty constructor with no arguments and not fields as
    * all the same.

--- a/src/dev/flang/fuir/analysis/dfa/Value.java
+++ b/src/dev/flang/fuir/analysis/dfa/Value.java
@@ -146,7 +146,10 @@ public class Value extends Val
           }
         else
           {
-            super.setField(dfa, field, v);
+            // a UNIT type value may have fields that are never read (i.e.,
+            // don't exist) or that are of unit type themselves
+            if (CHECKS) check
+              (!dfa.isRead(field) || dfa._fuir.clazzIsUnitType(dfa._fuir.clazzResultClazz(field)) || Errors.any());
           }
       }
 
@@ -288,12 +291,8 @@ public class Value extends Val
    */
   public void setField(DFA dfa, int field, Value v)
   {
-    var rt = dfa._fuir.clazzResultClazz(field);
-    if (!dfa._fuir.clazzIsUnitType(rt) && !Errors.any())
-      {
-        throw new Error("Value.setField for '"+dfa._fuir.clazzAsString(field)+"' called on class " +
-                        this + " (" + getClass() + "), expected " + Instance.class);
-      }
+    throw new Error("Value.setField for '"+dfa._fuir.clazzAsString(field)+"' called on class " +
+                    this + " (" + getClass() + "), expected " + Instance.class);
   }
 
 


### PR DESCRIPTION
A field that is removed may result in the outer feature to become a unit type, which caused an error before this patch.
