### PR TITLE
lib: Make sure that instance of `mutate` gets a unique id for each instate, fix #4218

### DIFF
--- a/lib/effect.fz
+++ b/lib/effect.fz
@@ -160,7 +160,7 @@ public effect is
                       ) R
   =>
     x := instate_helper R effect.this e code def
-    instate0 e x.call_code x.call_def
+    instate0 e.make_unique_at_instate x.call_code x.call_def
     x.res.get
 
 
@@ -254,6 +254,11 @@ public effect is
   #
   type.unsafe_get =>
     effect.this.env
+
+
+  # make sure this effect instance has a unique value when it is instated
+  #
+  module make_unique_at_instate => effect.this
 
 
   # --------------------  replacing effect instances  --------------------

--- a/lib/mutate.fz
+++ b/lib/mutate.fz
@@ -69,7 +69,18 @@ public mutate : effect is
   # an id used for runtime checks to verify that mutation made with the same effect
   # the mutable value was created with
   #
-  id := fuzion.sys.misc.unique_id
+  id := u64 0
+
+
+  # make sure this effect instance has a unique value when it is instated.  This
+  # is used, e.g., by `mutate` to ensure that the same instance of `mutate` is
+  # not instated repeatedly to mutate state created by an earlier call to
+  # `instate`.
+  #
+  module redef make_unique_at_instate
+  =>
+    set id := fuzion.sys.misc.unique_id
+    mutate.this
 
 
   # panic operation to be used in case of a severe problem.  This is redefined within the
@@ -102,7 +113,10 @@ public mutate : effect is
     module check_and_replace
     =>
       if !is_currently_instated
-        mpanic "*** invalid mutate for {mutate.this.type}"
+        msg := match mutate.this.get_if_instated
+          x mutate.this => "mutatable created by different instate: {my_id.hex} != {x.id.hex}"
+          nil           => "not instated"
+        mpanic "*** mutate of type {mutate.this.type}: $msg"
       mutate.this.env.replace
 
 

--- a/src/dev/flang/be/jvm/runtime/Runtime.java
+++ b/src/dev/flang/be/jvm/runtime/Runtime.java
@@ -44,6 +44,7 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.TreeMap;
 import java.util.WeakHashMap;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
 
@@ -214,12 +215,10 @@ public class Runtime extends ANY
   };
 
 
-  static long _next_unique_id = 0xf0015feedbadf00dL;
-
-  static final long UNIQUE_ID_INCREMENT = 1000000000000223L; // large prime generated using https://www.browserling.com/tools/prime-numbers
-
-
-  static final Object UNIQUE_ID_LOCK = new Object() {};
+  /**
+   * The unique id to be returned by unique_id();
+   */
+  static AtomicLong _next_unique_id = new AtomicLong(1l);
 
 
   public static final Object LOCK_FOR_ATOMIC = new Object();
@@ -1257,13 +1256,7 @@ public class Runtime extends ANY
 
   static long unique_id()
   {
-    long result;
-    synchronized (UNIQUE_ID_LOCK)
-      {
-        result = _next_unique_id;
-        _next_unique_id = result + UNIQUE_ID_INCREMENT;
-      }
-    return result;
+    return _next_unique_id.getAndIncrement();
   }
 
 

--- a/tests/reg_issue4218/Makefile
+++ b/tests/reg_issue4218/Makefile
@@ -1,0 +1,25 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test Makefile
+#
+# -----------------------------------------------------------------------
+
+override NAME = reg_issue4218
+include ../simple.mk

--- a/tests/reg_issue4218/reg_issue4218.fz
+++ b/tests/reg_issue4218/reg_issue4218.fz
@@ -1,0 +1,50 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test reg_issue4180
+#
+# -----------------------------------------------------------------------
+
+
+# This attempts to instate a local mutate instance to create a mutable
+# variable and then, re-instating this instance to secretly update that
+# variable.
+#
+# This should fail with a panic.
+#
+repeated_mutate is
+  m : mutate is
+  m1 := m
+
+  v := m1.instate_self ()->
+    say "start"
+    r := m.env.new 42
+    say "r = $r"
+    r
+
+  # f uses no effects, but mutates `v`
+  f ! io.out =>
+    _ := m1.instate_self ()->
+      v <- 4711 + v
+      say "updated v via m1: $v"
+
+  panic.try ()->
+             f; f; f
+       .catch msg->
+             say msg

--- a/tests/reg_issue4218/reg_issue4218.fz.expected_out
+++ b/tests/reg_issue4218/reg_issue4218.fz.expected_out
@@ -1,0 +1,3 @@
+start
+r = 42
+*** mutate of type Type of 'repeated_mutate.m': mutatable created by different instate: 1 != 6


### PR DESCRIPTION
This is then used to check that mutations are performed within the same `instate` call, i.e., we cannot hide a mutation by just temporarily instating the corresponding `mutate` effect.

Also add a regression test and fix the strange behavior of `fuzion.sys.misc.uniq_id` with the JVM backend. 

This currently breaks some code using `io.buffered.write` that needs to be checked. 