### PR TITLE
c: fix `ArrayIndexOutOfBounds` in `tutorial/examples/match_example1.fz`

### DIFF
--- a/src/dev/flang/be/c/CTypes.java
+++ b/src/dev/flang/be/c/CTypes.java
@@ -245,7 +245,7 @@ public class CTypes extends ANY
         if (!isScalar(cl)) // special handling of stdlib clazzes known to the compiler
           {
             // first, make sure structs used for inner fields are declared:
-            for (int i = 0; i < _fuir.clazzNumFields(cl); i++)
+            for (int i = 0; _fuir.clazzNeedsCode(cl) && i < _fuir.clazzNumFields(cl); i++)
               {
                 var fcl = _fuir.clazzField(cl, i);
                 var rcl = _fuir.clazzResultClazz(fcl);

--- a/src/dev/flang/fuir/GeneratingFUIR.java
+++ b/src/dev/flang/fuir/GeneratingFUIR.java
@@ -1672,7 +1672,9 @@ public class GeneratingFUIR extends FUIR
   @Override
   public int clazz_Const_String()
   {
-    return clazz(SpecialClazzes.c_Const_String);
+    var res = clazz(SpecialClazzes.c_Const_String);
+    doesNeedCode(clazzAsValue(res));
+    return res;
   }
 
 


### PR DESCRIPTION
First, the C backend must not use the result types of fields in routines with `!FUIR.clazzNeedsCode(cl)` since these might not be set be DFA.

Then, `FUIR.clazzNeedsCode(cl)` for the value clazz created from `Const_String` was false while its fields have to be taken into account be the C backend, so changed that.