### PR TITLE
be/int: remove skip_int in sockets

### DIFF
--- a/tests/sockets/skip_int
+++ b/tests/sockets/skip_int
@@ -1,1 +1,0 @@
-NYI: BUG: interpreter not thread safe, see #2813


### PR DESCRIPTION
worked eight times in succession on my machine.
fixes #2813
