### PR TITLE
fuir/be/c: fix Index out of bounds

### DIFF
--- a/src/dev/flang/fuir/analysis/dfa/DFA.java
+++ b/src/dev/flang/fuir/analysis/dfa/DFA.java
@@ -1269,6 +1269,14 @@ public class DFA extends ANY
 
 
         @Override
+        public int matchCaseField(int s, int cix)
+        {
+          var key = ((long)s<<32)|((long)cix);
+          return _takenMatchCases.contains(key) ?  super.matchCaseField(s, cix) : -1;
+        }
+
+
+        @Override
         public boolean clazzIsUnitType(int cl)
         {
           return super.clazzIsUnitType(cl) || isUnitType(cl);


### PR DESCRIPTION
```
error 1: java.lang.ArrayIndexOutOfBoundsException: Index 6912 out of bounds for length 6912
	at dev.flang.fuir.GeneratingFUIR.clazzResultClazz(GeneratingFUIR.java:676)
	at dev.flang.fuir.FUIR.codeAtAsString(FUIR.java:1182)
	at dev.flang.be.c.C$CodeGen.expressionHeader(C.java:98)
	at dev.flang.be.c.C$CodeGen.expressionHeader(C.java:64)
```

occurs in branch:
turn-`env`-into-a-simple-call
