### PR TITLE
analysis: Added version of AbstractInterpreter without RESULT

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,8 +41,9 @@ endif
 
 UNICODE_SOURCE = https://www.unicode.org/Public/UCD/latest/ucd/UnicodeData.txt
 
-JAVA_FILE_UTIL_VERSION_IN =  $(SRC)/dev/flang/util/Version.java.in
-JAVA_FILE_UTIL_VERSION    =  $(BUILD_DIR)/generated/src/dev/flang/util/Version.java
+JAVA_FILE_UTIL_VERSION_IN                     = $(SRC)/dev/flang/util/Version.java.in
+JAVA_FILE_UTIL_VERSION                        = $(BUILD_DIR)/generated/src/dev/flang/util/Version.java
+JAVA_FILE_FUIR_ANALYSIS_ABSTRACT_INTERPRETER2 = $(BUILD_DIR)/generated/src/dev/flang/fuir/analysis/AbstractInterpreter2.java
 
 JAVA_FILES_UTIL              = $(wildcard $(SRC)/dev/flang/util/*.java          ) $(JAVA_FILE_UTIL_VERSION)
 JAVA_FILES_UTIL_UNICODE      = $(wildcard $(SRC)/dev/flang/util/unicode/*.java  )
@@ -52,7 +53,7 @@ JAVA_FILES_IR                = $(wildcard $(SRC)/dev/flang/ir/*.java            
 JAVA_FILES_MIR               = $(wildcard $(SRC)/dev/flang/mir/*.java           )
 JAVA_FILES_FE                = $(wildcard $(SRC)/dev/flang/fe/*.java            )
 JAVA_FILES_FUIR              = $(wildcard $(SRC)/dev/flang/fuir/*.java          )
-JAVA_FILES_FUIR_ANALYSIS     = $(wildcard $(SRC)/dev/flang/fuir/analysis/*.java )
+JAVA_FILES_FUIR_ANALYSIS     = $(wildcard $(SRC)/dev/flang/fuir/analysis/*.java ) $(JAVA_FILE_FUIR_ANALYSIS_ABSTRACT_INTERPRETER2)
 JAVA_FILES_FUIR_ANALYSIS_DFA = $(wildcard $(SRC)/dev/flang/fuir/analysis/dfa/*.java )
 JAVA_FILES_FUIR_CFG          = $(wildcard $(SRC)/dev/flang/fuir/cfg/*.java      )
 JAVA_FILES_OPT               = $(wildcard $(SRC)/dev/flang/opt/*.java           )
@@ -499,6 +500,16 @@ $(CLASS_FILES_FUIR): $(JAVA_FILES_FUIR) $(CLASS_FILES_UTIL) $(CLASS_FILES_IR) $(
 	mkdir -p $(CLASSES_DIR)
 	$(JAVAC) -cp $(CLASSES_DIR) -d $(CLASSES_DIR) $(JAVA_FILES_FUIR)
 	touch $@
+
+$(JAVA_FILE_FUIR_ANALYSIS_ABSTRACT_INTERPRETER2): $(SRC)/dev/flang/fuir/analysis/AbstractInterpreter.java $(SRC)/dev/flang/fuir/analysis/AbstractInterpreter2.java.patch
+	mkdir -p $(@D)
+	patch -o $@ $^
+
+# phony target to update the .patch files used to generate sources from modified
+# version of those generated sources
+.PHONY: update-java-patches
+update-java-patches:
+	diff $(SRC)/dev/flang/fuir/analysis/AbstractInterpreter.java $(JAVA_FILE_FUIR_ANALYSIS_ABSTRACT_INTERPRETER2) >$(SRC)/dev/flang/fuir/analysis/AbstractInterpreter2.java.patch || true
 
 $(CLASS_FILES_FUIR_ANALYSIS): $(JAVA_FILES_FUIR_ANALYSIS) $(CLASS_FILES_UTIL) $(CLASS_FILES_FUIR)
 	mkdir -p $(CLASSES_DIR)

--- a/src/dev/flang/fuir/analysis/AbstractInterpreter2.java.patch
+++ b/src/dev/flang/fuir/analysis/AbstractInterpreter2.java.patch
@@ -1,0 +1,267 @@
+23c23
+<  * Source of class AbstractInterpreter
+---
+>  * Source of class AbstractInterpreter2
+40c40,54
+< import dev.flang.util.Pair;
+---
+> 
+> 
+> /*
+>  * AbstractInterpreter2 is a variant of AbstractInterpreter that does not
+>  * require code generation, i.e., the `RESULT` type parameter is `void`
+>  * and `Pair<VALUE,RESULT>` are replaced by just `VALUE`.
+>  *
+>  * To modify this file, modify
+>  *
+>  *   build/generated/src/dev/flang/fuir/analysis/AbstractInterpreter2.java
+>  *
+>  + and then run
+>  *
+>  *   make -f $(FZ_SRC)/Makefile update-java-patches
+>  */
+44c58
+<  * AbstractInterpreter provides a skeleton of an abstract interpreter
+---
+>  * AbstractInterpreter2 provides a skeleton of an abstract interpreter
+48c62
+<  * This class has two generic type parameters that specify the types of values
+---
+>  * This class has one generic type parameters that specify the type of values
+52,55d65
+<  *    for a compiler, this might be the code required to obtain that value.
+<  *
+<  *  - RESULT represents the result of the abstract interpretation. For a
+<  *    compiler, this would, e.g, be the generated code.
+59c69
+< public class AbstractInterpreter<VALUE, RESULT> extends ANY
+---
+> public class AbstractInterpreter2<VALUE> extends ANY
+70c80
+<   public static abstract class ProcessExpression<VALUE, RESULT> extends ANY
+---
+>   public static abstract class ProcessExpression<VALUE> extends ANY
+73,79d82
+<     /**
+<      * Join a List of RESULT from subsequent expressions into a compound
+<      * expression.  For a code generator, this could, e.g., join expressions "a :=
+<      * 3;" and "b(x);" into a block "{ a := 3; b(x); }".
+<      */
+<     public abstract RESULT sequence(List<RESULT> l);
+< 
+92c95
+<     public abstract RESULT expressionHeader(int s);
+---
+>     public abstract void expressionHeader(int s);
+97c100
+<     public abstract RESULT comment(String s);
+---
+>     public abstract void comment(String s);
+102c105
+<     public abstract RESULT nop();
+---
+>     public abstract void nop();
+119c122
+<     public RESULT drop(VALUE v, int type)
+---
+>     public void drop(VALUE v, int type)
+121c124
+<       return nop(); // NYI, should be implemented by BEs.
+---
+>       nop(); // NYI, should be implemented by BEs.
+141c144
+<     public abstract RESULT assignStatic(int s, int tc, int f, int rt, VALUE tvalue, VALUE val);
+---
+>     public abstract void assignStatic(int s, int tc, int f, int rt, VALUE tvalue, VALUE val);
+153c156
+<     public abstract RESULT assign(int s, VALUE tvalue, VALUE avalue);
+---
+>     public abstract void assign(int s, VALUE tvalue, VALUE avalue);
+169c172
+<     public abstract Pair<VALUE, RESULT> call(int s, VALUE tvalue, List<VALUE> args);
+---
+>     public abstract VALUE call(int s, VALUE tvalue, List<VALUE> args);
+180c183
+<     public abstract Pair<VALUE, RESULT> box(int s, VALUE v, int vc, int rc);
+---
+>     public abstract VALUE box(int s, VALUE v, int vc, int rc);
+187c190
+<     public abstract Pair<VALUE, RESULT> current(int s);
+---
+>     public abstract VALUE current(int s);
+194c197
+<     public abstract Pair<VALUE, RESULT> outer(int s);
+---
+>     public abstract VALUE outer(int s);
+214c217
+<     public abstract Pair<VALUE, RESULT> constData(int s, int constCl, byte[] d);
+---
+>     public abstract VALUE constData(int s, int constCl, byte[] d);
+225c228
+<     public abstract Pair<VALUE, RESULT> match(int s, AbstractInterpreter<VALUE, RESULT> ai, VALUE subv);
+---
+>     public abstract VALUE match(int s, AbstractInterpreter2<VALUE> ai, VALUE subv);
+239c242
+<     public abstract Pair<VALUE, RESULT> tag(int s, VALUE value, int newcl, int tagNum);
+---
+>     public abstract VALUE tag(int s, VALUE value, int newcl, int tagNum);
+248c251
+<     public abstract Pair<VALUE, RESULT> env(int s, int ecl);
+---
+>     public abstract VALUE env(int s, int ecl);
+255c258
+<     public RESULT reportErrorInCode(String msg) { return comment(msg); }
+---
+>     public void reportErrorInCode(String msg) { comment(msg); }
+314c317
+<   public final ProcessExpression<VALUE, RESULT> _processor;
+---
+>   public final ProcessExpression<VALUE> _processor;
+325c328
+<   public AbstractInterpreter(FUIR fuir, ProcessExpression<VALUE, RESULT> processor)
+---
+>   public AbstractInterpreter2(FUIR fuir, ProcessExpression<VALUE> processor)
+452c455
+<   void assignOuterAndArgFields(List<RESULT> l, int s)
+---
+>   void assignOuterAndArgFields(int s)
+460d462
+<         l.add(cur.v1());
+462,463c464
+<         l.add(out.v1());
+<         l.add(_processor.assignStatic(s, cl, or, rt, cur.v0(), out.v0()));
+---
+>         _processor.assignStatic(s, cl, or, rt, cur, out);
+470d470
+<         l.add(cur.v1());
+476c476
+<             l.add(_processor.assignStatic(s, cl, af, at, cur.v0(), ai));
+---
+>             _processor.assignStatic(s, cl, af, at, cur, ai);
+491c491
+<   public Pair<VALUE,RESULT> processClazz(int cl)
+---
+>   public VALUE processClazz(int cl)
+493d492
+<     var l = new List<RESULT>();
+497c496
+<         assignOuterAndArgFields(l, s);
+---
+>         assignOuterAndArgFields(s);
+500,502c499,500
+<     l.add(p.v1());
+<     var res = p.v0();
+<     return new Pair<>(res, _processor.sequence(l));
+---
+>     var res = p;
+>     return res;
+515c513
+<   public Pair<VALUE,RESULT> processCode(int s0)
+---
+>   public VALUE processCode(int s0)
+518d515
+<     var l = new List<RESULT>();
+522,523c519,520
+<         l.add(_processor.expressionHeader(s));
+<         l.add(process(s, stack));
+---
+>         _processor.expressionHeader(s);
+>         process(s, stack);
+532,533c529,530
+<         l.add(_processor.reportErrorInCode("Severe compiler bug! This code should be unreachable:\n" +
+<                                            _fuir.siteAsString(last_s)));
+---
+>         _processor.reportErrorInCode("Severe compiler bug! This code should be unreachable:\n" +
+>                                      _fuir.siteAsString(last_s));
+549c546
+<             l.add(_processor.drop(stack.pop(), rt));
+---
+>             _processor.drop(stack.pop(), rt);
+553c550
+<     return new Pair<>(v, _processor.sequence(l));
+---
+>     return v;
+567c564
+<   public RESULT process(int s, Stack<VALUE> stack)
+---
+>   public void process(int s, Stack<VALUE> stack)
+575d571
+<     RESULT res;
+588c584
+<               res = _processor.assign(s, tvalue, avalue);
+---
+>               _processor.assign(s, tvalue, avalue);
+592,593c588,589
+<               res = _processor.sequence(new List<>(_processor.drop(tvalue, tc),
+<                                                     _processor.drop(avalue, ft)));
+---
+>               _processor.drop(tvalue, tc);
+>               _processor.drop(avalue, ft);
+604c600
+<               res = _processor.comment("Box is a NOP, clazz is already a ref");
+---
+>               _processor.comment("Box is a NOP, clazz is already a ref");
+610,611c606
+<               push(stack, rc, r.v0());
+<               res = r.v1();
+---
+>               push(stack, rc, r);
+622c617
+<           if (r.v0() == null)  // this may happen even if rt is not void (e.g., in case of tail recursion or error)
+---
+>           if (r == null)  // this may happen even if rt is not void (e.g., in case of tail recursion or error)
+629c624
+<               push(stack, rt, r.v0());
+---
+>               push(stack, rt, r);
+631d625
+<           res = r.v1();
+636c630
+<           res = _processor.comment(_fuir.comment(s));
+---
+>           _processor.comment(_fuir.comment(s));
+643,644c637
+<           push(stack, cl, r.v0());
+<           res = r.v1();
+---
+>           push(stack, cl, r);
+653,658c646
+<           if (CHECKS) check
+<             // check that constant creation has no side effects.
+<             (r.v1() == _processor.nop());
+< 
+<           push(stack, constCl, r.v0());
+<           res = r.v1();
+---
+>           push(stack, constCl, r);
+666c654
+<           if (r.v0() == null)
+---
+>           if (r == null)
+671,672c659
+<             (r.v0() == null || r.v0() == _processor.unitValue());
+<           res = r.v1();
+---
+>             (r == null || r == _processor.unitValue());
+684,685c671
+<           push(stack, newcl, r.v0());
+<           res = r.v1();
+---
+>           push(stack, newcl, r);
+694,695c680
+<           push(stack, ecl, r.v0());
+<           res = r.v1();
+---
+>           push(stack, ecl, r);
+709c694
+<           res = _processor.drop(v, rt);
+---
+>           _processor.drop(v, rt);
+715d699
+<           res = null;
+724c708
+<         say("process done: "+_fuir.siteAsString(s) + ":\t"+_fuir.codeAtAsString(s)+" stack is "+stack+" RES "+res);
+---
+>         say("process done: "+_fuir.siteAsString(s) + ":\t"+_fuir.codeAtAsString(s)+" stack is "+stack);
+726d709
+<     return res;

--- a/src/dev/flang/fuir/analysis/dfa/DFA.java
+++ b/src/dev/flang/fuir/analysis/dfa/DFA.java
@@ -43,7 +43,7 @@ import dev.flang.fuir.FUIR;
 import dev.flang.fuir.FUIR.LifeTime;
 import dev.flang.fuir.FUIR.SpecialClazzes;
 import dev.flang.fuir.GeneratingFUIR;
-import dev.flang.fuir.analysis.AbstractInterpreter;
+import dev.flang.fuir.analysis.AbstractInterpreter2;
 import dev.flang.ir.IR.ExprKind;
 import dev.flang.ir.IR.FeatureKind;
 
@@ -56,7 +56,6 @@ import dev.flang.util.FuzionOptions;
 import dev.flang.util.List;
 import dev.flang.util.IntMap;
 import dev.flang.util.LongMap;
-import dev.flang.util.Pair;
 
 
 /**
@@ -86,14 +85,6 @@ public class DFA extends ANY
 
 
   /**
-   * Dummy unit type as type parameter for AbstractInterpreter.ProcessExpression.
-   */
-  static class Unit
-  {
-  }
-
-
-  /**
    * Record match cases that were evaluated by the DFA.
    */
   public final Set<Long> _takenMatchCases = new TreeSet<>();
@@ -102,7 +93,7 @@ public class DFA extends ANY
   /**
    * Statement processor used with AbstractInterpreter to perform DFA analysis
    */
-  class Analyze extends AbstractInterpreter.ProcessExpression<Val,Unit>
+  class Analyze extends AbstractInterpreter2.ProcessExpression<Val>
   {
 
 
@@ -123,18 +114,6 @@ public class DFA extends ANY
 
 
 
-    /**
-     * Join a List of RESULT from subsequent statements into a compound
-     * statement.  For a code generator, this could, e.g., join statements "a :=
-     * 3;" and "b(x);" into a block "{ a := 3; b(x); }".
-     */
-    @Override
-    public Unit sequence(List<Unit> l)
-    {
-      return _unit_;
-    }
-
-
     /*
      * Produce the unit type value.  This is used as a placeholder
      * for the universe instance as well as for the instance 'unit'.
@@ -151,13 +130,12 @@ public class DFA extends ANY
      * tracing code for debugging or a comment.
      */
     @Override
-    public Unit expressionHeader(int s)
+    public void expressionHeader(int s)
     {
       if (_reportResults && _options.verbose(9))
         {
           say("DFA for "+_fuir.siteAsString(s)+" at "+s+": "+_fuir.codeAtAsString(s));
         }
-      return _unit_;
     }
 
 
@@ -165,9 +143,8 @@ public class DFA extends ANY
      * A comment, adds human readable information
      */
     @Override
-    public Unit comment(String s)
+    public void comment(String s)
     {
-      return _unit_;
     }
 
 
@@ -175,9 +152,8 @@ public class DFA extends ANY
      * no operation, like comment, but without giving any comment.
      */
     @Override
-    public Unit nop()
+    public void nop()
     {
-      return _unit_;
     }
 
 
@@ -199,10 +175,9 @@ public class DFA extends ANY
      * @return resulting code of this assignment.
      */
     @Override
-    public Unit assignStatic(int s, int tc, int f, int rt, Val tvalue, Val val)
+    public void assignStatic(int s, int tc, int f, int rt, Val tvalue, Val val)
     {
       tvalue.value().setField(DFA.this, f, val.value());
-      return _unit_;
     }
 
 
@@ -217,10 +192,9 @@ public class DFA extends ANY
      * @param avalue the new value to be assigned to the field.
      */
     @Override
-    public Unit assign(int s, Val tvalue, Val avalue)
+    public void assign(int s, Val tvalue, Val avalue)
     {
       var res = access(s, tvalue, new List<>(avalue));
-      return _unit_;
     }
 
 
@@ -254,11 +228,11 @@ public class DFA extends ANY
      * (due to an error or tail recursion optimization).
      */
     @Override
-    public Pair<Val, Unit> call(int s, Val tvalue, List<Val> args)
+    public Val call(int s, Val tvalue, List<Val> args)
     {
       var res = access(s, tvalue, args);
       DFA.this.site(s).recordResult(res == null);
-      return new Pair<>(res, _unit_);
+      return res;
     }
 
 
@@ -326,7 +300,7 @@ public class DFA extends ANY
     Val accessSingleTarget(int s, Value tvalue, List<Val> args, Val res, Val original_tvalue)
     {
       if (PRECONDITIONS) require
-        (Errors.any() || tvalue != Value.UNIT || AbstractInterpreter.clazzHasUnitValue(_fuir, _fuir.accessTargetClazz(s))
+        (Errors.any() || tvalue != Value.UNIT || AbstractInterpreter2.clazzHasUnitValue(_fuir, _fuir.accessTargetClazz(s))
          // NYI: UNDER DEVELOPMENT: intrinsics create instances like
          // `fuzion.java.Array`. These intrinsics currently do not set the outer
          // refs correctly, so we handle them for now by just assuming they are
@@ -465,10 +439,10 @@ public class DFA extends ANY
      * For a given value v of value type vc create a boxed ref value of type rc.
      */
     @Override
-    public Pair<Val, Unit> box(int s, Val val, int vc, int rc)
+    public Val box(int s, Val val, int vc, int rc)
     {
       var boxed = val.value().box(DFA.this, vc, rc, _call);
-      return new Pair<>(boxed, _unit_);
+      return boxed;
     }
 
 
@@ -476,9 +450,9 @@ public class DFA extends ANY
      * Get the current instance
      */
     @Override
-    public Pair<Val, Unit> current(int s)
+    public Val current(int s)
     {
-      return new Pair<>(_call._instance, _unit_);
+      return _call._instance;
     }
 
 
@@ -486,9 +460,9 @@ public class DFA extends ANY
      * Get the outer instance
      */
     @Override
-    public Pair<Val, Unit> outer(int s)
+    public Val outer(int s)
     {
-      return new Pair<>(_call._target, _unit_);
+      return _call._target;
     }
 
     /**
@@ -505,9 +479,8 @@ public class DFA extends ANY
      * Get a constant value of type constCl with given byte data d.
      */
     @Override
-    public Pair<Val, Unit> constData(int s, int constCl, byte[] d)
+    public Val constData(int s, int constCl, byte[] d)
     {
-      var o = _unit_;
       var r = switch (_fuir.getSpecialClazz(constCl))
         {
         case c_bool -> d[0] == 1 ? True() : False();
@@ -538,7 +511,7 @@ public class DFA extends ANY
               }
           }
         };
-      return new Pair<>(r, o);
+      return r;
     }
 
 
@@ -565,7 +538,7 @@ public class DFA extends ANY
           var f = _fuir.clazzArg(constCl, index);
           var fr = _fuir.clazzArgClazz(constCl, index);
           var bytes = _fuir.deseralizeConst(fr, b);
-          var arg = constData(s, fr, bytes).v0().value();
+          var arg = constData(s, fr, bytes).value();
           args.add(arg);
           result.setField(DFA.this, f, arg);
         }
@@ -611,8 +584,8 @@ public class DFA extends ANY
         {
           var b = _fuir.deseralizeConst(elementClazz, d);
           elements = elements == null
-            ? constData(s, elementClazz, b).v0().value()
-            : elements.join(DFA.this, constData(s, elementClazz, b).v0().value(), elementClazz);
+            ? constData(s, elementClazz, b).value()
+            : elements.join(DFA.this, constData(s, elementClazz, b).value(), elementClazz);
         }
       SysArray sysArray = newSysArray(elements, elementClazz);
 
@@ -627,7 +600,7 @@ public class DFA extends ANY
      * Perform a match on value subv.
      */
     @Override
-    public Pair<Val, Unit> match(int s, AbstractInterpreter<Val,Unit> ai, Val subv)
+    public Val match(int s, AbstractInterpreter2<Val> ai, Val subv)
     {
       Val r = null; // result value null <=> does not return.  Will be set to Value.UNIT if returning case was found.
       for (var mc = 0; mc < _fuir.matchCaseCount(s); mc++)
@@ -662,14 +635,14 @@ public class DFA extends ANY
           if (taken)
             {
               var resv = ai.processCode(_fuir.matchCaseCode(s, mc));
-              if (resv.v0() != null)
+              if (resv != null)
                 { // if at least one case returns (i.e., result is not null), this match returns.
                   r = Value.UNIT;
                 }
             }
         }
       DFA.this.site(s).recordResult(r == null);
-      return new Pair<>(r, _unit_);
+      return r;
     }
 
 
@@ -715,10 +688,10 @@ public class DFA extends ANY
      * Create a tagged value of type newcl from an untagged value.
      */
     @Override
-    public Pair<Val, Unit> tag(int s, Val value, int newcl, int tagNum)
+    public Val tag(int s, Val value, int newcl, int tagNum)
     {
       Val res = value.value().tag(_call._dfa, newcl, tagNum);
-      return new Pair<>(res, _unit_);
+      return res;
     }
 
 
@@ -726,9 +699,9 @@ public class DFA extends ANY
      * Access the effect of type ecl that is installed in the environment.
      */
     @Override
-    public Pair<Val, Unit> env(int s, int ecl)
+    public Val env(int s, int ecl)
     {
-      return new Pair<>(_call.getEffectForce(s, ecl), _unit_);
+      return _call.getEffectForce(s, ecl);
     }
 
 
@@ -738,10 +711,9 @@ public class DFA extends ANY
      * @param msg a message explaining the illegal state
      */
     @Override
-    public Unit reportErrorInCode(String msg)
+    public void reportErrorInCode(String msg)
     {
       // In the DFA, ignore these errors
-      return _unit_;
     }
 
   }
@@ -819,12 +791,6 @@ public class DFA extends ANY
    *   dev_flang_fuir_analysis_dfa_DFA_USE_EMBEDDED_VALUES=false
    */
   static final boolean USE_EMBEDDED_VALUES = FuzionOptions.boolPropertyOrEnv("dev.flang.fuir.analysis.dfa.DFA.USE_EMBEDDED_VALUES", true);
-
-
-  /**
-   * singleton instance of Unit.
-   */
-  static Unit _unit_ = new Unit();
 
 
   /**
@@ -1558,9 +1524,9 @@ public class DFA extends ANY
             i.setField(this, or, c._target);
           }
 
-        var ai = new AbstractInterpreter<Val,Unit>(_fuir, new Analyze(c));
+        var ai = new AbstractInterpreter2<Val>(_fuir, new Analyze(c));
         var r = ai.processClazz(c._cc);
-        if (r.v0() != null)
+        if (r != null)
           {
             c.returns();
           }


### PR DESCRIPTION
This simplifies the DFA code and provides a slight speedup for uses of the AbstractInterpreter that use a unit type as RESULT while Java does not really provide a unit type.

When buildig `fzweb` into a JAR, I gain about 1.7% (33.14s instead of 33.70s elapsed time) and about 3% on a `say "hi"` (0.994s vs. 1.023s).

To avoid the risk that duplicated code will eventually get out of sync, I use a patch to generate the new variant of AbstractInterpreter.  Explanation on how to update the patch is given in the source code.
