### PR TITLE
fix shellcheck issues

### DIFF
--- a/bin/fz
+++ b/bin/fz
@@ -54,4 +54,5 @@ fi
 : "${FUZION_JAVA_OPTIONS="-Xss$FUZION_JAVA_STACK_SIZE"}"
 : "${FUZION_JAVA_ADDITIONAL_OPTIONS=--enable-preview --enable-native-access=ALL-UNNAMED}"
 
+# shellcheck disable=SC2086
 $FUZION_JAVA $FUZION_JAVA_OPTIONS $FUZION_JAVA_ADDITIONAL_OPTIONS -cp "$FUZION_JAVA_CLASSPATH" -Dline.separator=$'\n' -Dfile.encoding=UTF-8 -Dfuzion.home="$FUZION_HOME" -Dfuzion.command="$FUZION_CMD" dev.flang.tools.Fuzion "$@"

--- a/bin/fzjava
+++ b/bin/fzjava
@@ -55,4 +55,5 @@ fi
 : "${FUZION_JAVA_OPTIONS="-Xss$FUZION_JAVA_STACK_SIZE"}"
 : "${FUZION_JAVA_ADDITIONAL_OPTIONS=--enable-preview --enable-native-access=ALL-UNNAMED}"
 
+# shellcheck disable=SC2086
 $FUZION_JAVA $FUZION_JAVA_OPTIONS $FUZION_JAVA_ADDITIONAL_OPTIONS -cp "$FUZION_JAVA_CLASSPATH" -Dline.separator=$'\n' -Dfile.encoding=UTF-8 -Dfuzion.home="$FUZION_HOME" -Dfuzion.command="$FUZION_CMD" dev.flang.tools.fzjava.FZJava "$@"


### PR DESCRIPTION
shellcheck wants $FUZION_JAVA_ADDITIONAL_OPTIONS to be quoted to prevent globbing and word splitting. But we want to split on spaces and currently do not want to use an array, so I added a `shellcheck disable`

