### PR TITLE
win: fix build issue, patch not installed

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -51,6 +51,7 @@ jobs:
             git
             mingw-w64-ucrt-x86_64-clang
             diffutils
+            patch
 
       - name: install choco packages
         shell: powershell


### PR DESCRIPTION
This will not be sufficient to fix windows builds.

For c backend we need to link fuzion.dll but this will be another PR.
