### PR TITLE
ast: fix  check-condition in callPostCondition

### DIFF
--- a/src/dev/flang/ast/Contract.java
+++ b/src/dev/flang/ast/Contract.java
@@ -566,7 +566,7 @@ public class Contract extends ANY
       }
     var callPostCondition = new Call(p,
                                      t,
-                                     in.generics().asActuals(),
+                                     origouter.isConstructor() ? new List<>() : in.generics().asActuals(),
                                      args,
                                      origouter.postFeature(),
                                      Types.resolved.t_unit);


### PR DESCRIPTION
This occurred in jenkins runs:
```
error 1: java.lang.Error: check-condition failed: Call.java:375
	at dev.flang.util.ANY.check(ANY.java:440)
	at dev.flang.ast.Call.<init>(Call.java:375)
	at dev.flang.ast.Contract.callPostCondition(Contract.java:571)
```

A constructors post condition feature does not have generics anymore since it was changed to be an inner feature.
