### PR TITLE
makefile: use installed java version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,8 @@
 # -----------------------------------------------------------------------
 
 JAVA = java --enable-preview --enable-native-access=ALL-UNNAMED
-JAVA_VERSION = 21
+MIN_JAVA_VERSION = 21
+JAVA_VERSION = $(shell v=$$(java -version 2>&1 | grep 'version' | cut -d '"' -f2 | cut -d. -f1); [ $$v -lt $(MIN_JAVA_VERSION) ] && echo $(MIN_JAVA_VERSION) || echo $$v)
 JAVAC = javac -encoding UTF8 --release $(JAVA_VERSION) --enable-preview
 FZ_SRC = $(patsubst %/,%,$(dir $(lastword $(MAKEFILE_LIST))))
 SRC = $(FZ_SRC)/src


### PR DESCRIPTION
`javac` option `--enable-preview` can not be used if installed java version is newer than what is specified in `--release`

```
❯ make base-only
mkdir -p ./build/classes
javac -encoding UTF8 --release 21 --enable-preview -d ./build/classes ./src/dev/flang/util/ANY.java ./src/dev/flang/util/BiGraph.java ./src/dev/flang/util/BoolArray.java ./src/dev/flang/util/Callable.java ./src/dev/flang/util/DataOut.java ./src/dev/flang/util/Errors.java ./src/dev/flang/util/FatalError.java ./src/dev/flang/util/FuzionConstants.java ./src/dev/flang/util/FuzionOptions.java ./src/dev/flang/util/Graph.java ./src/dev/flang/util/HasSourcePosition.java ./src/dev/flang/util/HexDump.java ./src/dev/flang/util/IntArray.java ./src/dev/flang/util/Intervals.java ./src/dev/flang/util/IntMap.java ./src/dev/flang/util/JavaInterface.java ./src/dev/flang/util/List.java ./src/dev/flang/util/LongMap.java ./src/dev/flang/util/Map2Int.java ./src/dev/flang/util/MapComparable2Int.java ./src/dev/flang/util/MapToN.java ./src/dev/flang/util/package-info.java ./src/dev/flang/util/Pair.java ./src/dev/flang/util/Profiler.java ./src/dev/flang/util/QuietThreadTermination.java ./src/dev/flang/util/SourceDir.java ./src/dev/flang/util/SourceFile.java ./src/dev/flang/util/SourcePosition.java ./src/dev/flang/util/SourceRange.java ./src/dev/flang/util/StringHelpers.java ./src/dev/flang/util/Terminal.java ./src/dev/flang/util/UnicodeData.java ./src/dev/flang/util/YesNo.java ./build/generated/src/dev/flang/util/Version.java
error: invalid source release 21 with --enable-preview
  (preview language features are only supported for release 22)
make: *** [Makefile:466: build/classes/dev/flang/util/__marker_for_make__] Error 2
```