### PR TITLE
be/jvm: no effect of <str> instated

### DIFF
--- a/src/dev/flang/be/jvm/Intrinsix.java
+++ b/src/dev/flang/be/jvm/Intrinsix.java
@@ -1103,19 +1103,21 @@ public class Intrinsix extends ANY implements ClassFileConstants
           Expr.invokeStatic(Names.RUNTIME_CLASS,
                             "currentThread",
                             "()" + ftCt.descriptor(),
-                            ftCt)
-          .andThen(Expr.iconst(jvm.effectId(ecl)))
-          .andThen(Expr.invokeVirtual(ftCt.className(), "effect_load", "(I)" + Names.ANYI_DESCR , Names.ANYI_TYPE))
-          .andThen(Expr.DUP)
-          .andThen(Expr.branch(O_ifnull,
-                       Expr.new0(JAVA_LANG_ERROR.className(), Names.JAVA_LANG_ERROR)
-                           .andThen(Expr.DUP)
-                           .andThen(Expr.stringconst("No effect of "+jvm._fuir.clazzAsStringHuman(ecl)+" instated."))
-                           .andThen(Expr.invokeSpecial(JAVA_LANG_ERROR.className(),
+                            ftCt)                                                                                     // FuzionThread
+          .andThen(Expr.iconst(jvm.effectId(ecl)))                                                                    // FuzionThread, int
+          .andThen(Expr.invokeVirtual(ftCt.className(), "effect_load", "(I)" + Names.ANYI_DESCR , Names.ANYI_TYPE))   // AnyI
+          .andThen(Expr.DUP)                                                                                          // AnyI, AnyI
+          .andThen(Expr.branch(O_ifnull,                                                                              // AnyI
+                       Expr.POP                                                                                       // -
+                           .andThen(Expr.new0(JAVA_LANG_ERROR.className(), Names.JAVA_LANG_ERROR) )                   // Error
+
+                           .andThen(Expr.DUP)                                                                         // Error, Error
+                           .andThen(Expr.stringconst("No effect of "+jvm._fuir.clazzAsStringHuman(ecl)+" instated.")) // Error, Error, String
+                           .andThen(Expr.invokeSpecial(JAVA_LANG_ERROR.className(),                                   // Error
                                                        "<init>",
                                                        "(" + Names.JAVA_LANG_STRING.descriptor() + ")V"))
-                           .andThen(Expr.THROW)))
-          .andThen(rt == PrimitiveType.type_void ? Expr.UNIT : Expr.checkcast(rt));
+                           .andThen(Expr.THROW)))                                                                     // -
+          .andThen(rt == PrimitiveType.type_void ? Expr.UNIT : Expr.checkcast(rt));                                   // RT
         var code = Expr.UNIT;
         return new Pair<>(val, code);
       });

--- a/src/dev/flang/be/jvm/classfile/ClassFileConstants.java
+++ b/src/dev/flang/be/jvm/classfile/ClassFileConstants.java
@@ -680,6 +680,7 @@ public interface ClassFileConstants
   static ClassType JAVA_LANG_CLASS  = new ClassType("java/lang/Class");
   static ClassType JAVA_LANG_OBJECT = new ClassType("java/lang/Object");
   static ClassType JAVA_LANG_STRING = new ClassType("java/lang/String");
+  static ClassType JAVA_LANG_ERROR  = new ClassType("java/lang/Error");
 
   static ClassType NULL_TYPE = new ClassType("java/lang/Object");
   static ClassType ERROR_TYPE = new ClassType("dev/flang/be/jvm/runtime/JavaError");

--- a/src/dev/flang/be/jvm/classfile/Expr.java
+++ b/src/dev/flang/be/jvm/classfile/Expr.java
@@ -1940,6 +1940,8 @@ public abstract class Expr extends ByteCode
           // backend does not generate redundant
           // checkcasts anymore.
           isRedundant = type().vti().compareTo(stack.peek()) == 0;
+          stack.pop();
+          stack.push(new VerificationType(type.className(), (cf)->cf.cpClass(type.className()).index()));
         }
         @Override
         public void buildLineNumberTable(ClassFile cf, List<Pair<Integer, Integer>> lnt, int[] idx)

--- a/src/dev/flang/be/jvm/runtime/FuzionThread.java
+++ b/src/dev/flang/be/jvm/runtime/FuzionThread.java
@@ -157,7 +157,7 @@ public class FuzionThread extends Thread
    *
    * @param id an effect id.
    */
-  AnyI effect_load(int id)
+  public AnyI effect_load(int id)
   {
     ensure_effect_capacity(id);
     return _installedEffects.get(id);

--- a/src/dev/flang/be/jvm/runtime/Runtime.java
+++ b/src/dev/flang/be/jvm/runtime/Runtime.java
@@ -645,29 +645,6 @@ public class Runtime extends ANY
 
 
   /**
-   * Helper method to implement `effect.env` expressions.  Returns the instated
-   * effect with the given id.  Causes an error in case no such effect exists.
-   *
-   * @param id the id of the effect that should be loaded.
-   *
-   * @return the instance that was instated for this id
-   *
-   * @throws Error in case no instance was instated.
-   */
-  public static AnyI effect_get(int id)
-  {
-    var t = currentThread();
-
-    var result = t.effect_load(id);
-    if (result == null)
-      {
-        throw new Error("No effect of "+id+" instated");
-      }
-    return result;
-  }
-
-
-  /**
    * Get the message of last exception thrown in the current thread.
    */
   public static String getException()


### PR DESCRIPTION
fixes #4270,

now output looks like this:

```
error 1: java.lang.Error: No effect of random instated.
        at fzC_ex.fzRoutine(/home/sam/playground/test.fz:3)
        at fzC_universe.fz_run(--builtin--)
        at dev.flang.be.jvm.runtime.FuzionThread.lambda$new$1(FuzionThread.java:120)
        at dev.flang.util.Errors.runAndExit(Errors.java:903)
        at dev.flang.be.jvm.runtime.FuzionThread.lambda$new$2(FuzionThread.java:132)
        at java.base/java.lang.Thread.run(Thread.java:1583)
```
