### PR TITLE
ast/parser: fix scoping for blocks in braces

### DIFF
--- a/src/dev/flang/ast/Block.java
+++ b/src/dev/flang/ast/Block.java
@@ -68,7 +68,7 @@ public class Block extends AbstractBlock
    * @param s the list of expressions
    *
    */
-  private Block(boolean newScope,
+  public Block(boolean newScope,
                List<Expr> s)
   {
     super(s);

--- a/src/dev/flang/parser/Parser.java
+++ b/src/dev/flang/parser/Parser.java
@@ -1848,7 +1848,7 @@ bracketTerm : brblock
     var c = current();
     switch (c)
       {
-      case t_lbrace  : return block();
+      case t_lbrace  : return block(true);
       case t_lparen  : return klammer();
       case t_lbracket: return inlineArray();
       default: throw new Error("Unexpected case: "+c);
@@ -2538,11 +2538,12 @@ block       : exprs
 brblock     : BRACEL exprs BRACER
             ;
    */
-  Block block()
+  Block block() { return block(false); }
+  Block block(boolean newScope)
   {
     var p0 = lastTokenEndPos();
     var p1 = tokenPos();
-    var b = optionalBrackets(BRACES, "block", () -> new Block(exprs()));
+    var b = optionalBrackets(BRACES, "block", () -> new Block(newScope, exprs()));
     var p2 = lastTokenEndPos();
     b.setSourceRange(sourceRange(p0, p1, p2));
     return b;

--- a/tests/choice_negative/choice_negative.fz.expected_err
+++ b/tests/choice_negative/choice_negative.fz.expected_err
@@ -2,19 +2,19 @@
 --CURDIR--/choice_negative.fz:137:30: error 1: Syntax error: expected 'is', or '=>' in routine declaration, found operator ':='
     x bool : choice i64 bool := true  // 27. should flag an error, choice feature must not be field
 -----------------------------^
-While parsing: implRout, parse stack: implRout, routOrField, feature, expr, exprs, block, implRout, implFldOrRout, routOrField, feature, expr, exprs, block, implRout, implFldOrRout, routOrField, feature, expr, exprs, block, unit
+While parsing: implRout, parse stack: implRout, routOrField, feature, expr, exprs, block (twice), implRout, implFldOrRout, routOrField, feature, expr, exprs, block (twice), implRout, implFldOrRout, routOrField, feature, expr, exprs, block (twice), unit
 
 
 --CURDIR--/choice_negative.fz:140:25: error 2: Syntax error: expected 'is', or '=>' in routine declaration, found operator ':='
     x : choice i64 bool := true  // 28. should flag an error, choice feature must not be field
 ------------------------^
-While parsing: implRout, parse stack: implRout, routOrField, feature, expr, exprs, block, implRout, implFldOrRout, routOrField, feature, expr, exprs, block, implRout, implFldOrRout, routOrField, feature, expr, exprs, block, unit
+While parsing: implRout, parse stack: implRout, routOrField, feature, expr, exprs, block (twice), implRout, implFldOrRout, routOrField, feature, expr, exprs, block (twice), implRout, implFldOrRout, routOrField, feature, expr, exprs, block (twice), unit
 
 
 --CURDIR--/choice_negative.fz:142:30: error 3: Syntax error: expected 'is', or '=>' in routine declaration, found operator ':='
     x bool : choice i64 bool := any  // 29. should flag an error, choice feature must not be field
 -----------------------------^
-While parsing: implRout, parse stack: implRout, routOrField, feature, expr, exprs, block, implRout, implFldOrRout, routOrField, feature, expr, exprs, block, implRout, implFldOrRout, routOrField, feature, expr, exprs, block, unit
+While parsing: implRout, parse stack: implRout, routOrField, feature, expr, exprs, block (twice), implRout, implFldOrRout, routOrField, feature, expr, exprs, block (twice), implRout, implFldOrRout, routOrField, feature, expr, exprs, block (twice), unit
 
 
 --CURDIR--/choice_negative.fz:61:26: error 4: Repeated inheritance of choice is not permitted

--- a/tests/indentation_negative/indentation_negative.fz.expected_err
+++ b/tests/indentation_negative/indentation_negative.fz.expected_err
@@ -5,7 +5,7 @@
 Indentation reference point is --CURDIR--/indentation_negative.fz:45:7:
       say "1ba"
 ------^
-While parsing: exprs, parse stack: exprs, block, implRout, implFldOrRout, routOrField, feature, expr, exprs, block, implRout, implFldOrRout, routOrField, feature, expr, exprs, block, implRout, implFldOrRout, routOrField, feature, expr, exprs, block, unit
+While parsing: exprs, parse stack: exprs, block (twice), implRout, implFldOrRout, routOrField, feature, expr, exprs, block (twice), implRout, implFldOrRout, routOrField, feature, expr, exprs, block (twice), implRout, implFldOrRout, routOrField, feature, expr, exprs, block (twice), unit
 
 
 --CURDIR--/indentation_negative.fz:56:6: error 2: Inconsistent indentation
@@ -14,7 +14,7 @@ While parsing: exprs, parse stack: exprs, block, implRout, implFldOrRout, routOr
 Indentation reference point is --CURDIR--/indentation_negative.fz:53:5:
     feature1 is
 ----^
-While parsing: exprs, parse stack: exprs, block, implRout, implFldOrRout, routOrField, feature, expr, exprs, block, implRout, implFldOrRout, routOrField, feature, expr, exprs, block, unit
+While parsing: exprs, parse stack: exprs, block (twice), implRout, implFldOrRout, routOrField, feature, expr, exprs, block (twice), implRout, implFldOrRout, routOrField, feature, expr, exprs, block (twice), unit
 
 
 --CURDIR--/indentation_negative.fz:72:18: error 3: Inconsistent indentation
@@ -23,7 +23,7 @@ While parsing: exprs, parse stack: exprs, block, implRout, implFldOrRout, routOr
 Indentation reference point is --CURDIR--/indentation_negative.fz:70:17:
     feature2 is say "2ba"
 ----------------^
-While parsing: exprs, parse stack: exprs, block, implRout, implFldOrRout, routOrField, feature, expr, exprs, block, implRout, implFldOrRout, routOrField, feature, expr, exprs, block, implRout, implFldOrRout, routOrField, feature, expr, exprs, block, unit
+While parsing: exprs, parse stack: exprs, block (twice), implRout, implFldOrRout, routOrField, feature, expr, exprs, block (twice), implRout, implFldOrRout, routOrField, feature, expr, exprs, block (twice), implRout, implFldOrRout, routOrField, feature, expr, exprs, block (twice), unit
 
 
 --CURDIR--/indentation_negative.fz:80:16: error 4: Inconsistent indentation
@@ -32,7 +32,7 @@ While parsing: exprs, parse stack: exprs, block, implRout, implFldOrRout, routOr
 Indentation reference point is --CURDIR--/indentation_negative.fz:78:5:
     feature2 is say "2ca"
 ----^
-While parsing: exprs, parse stack: exprs, block, implRout, implFldOrRout, routOrField, feature, expr, exprs, block, implRout, implFldOrRout, routOrField, feature, expr, exprs, block, unit
+While parsing: exprs, parse stack: exprs, block (twice), implRout, implFldOrRout, routOrField, feature, expr, exprs, block (twice), implRout, implFldOrRout, routOrField, feature, expr, exprs, block (twice), unit
 
 
 --CURDIR--/indentation_negative.fz:87:18: error 5: Inconsistent indentation
@@ -41,7 +41,7 @@ While parsing: exprs, parse stack: exprs, block, implRout, implFldOrRout, routOr
 Indentation reference point is --CURDIR--/indentation_negative.fz:86:17:
     feature2 is say "2da"
 ----------------^
-While parsing: exprs, parse stack: exprs, block, implRout, implFldOrRout, routOrField, feature, expr, exprs, block, implRout, implFldOrRout, routOrField, feature, expr, exprs, block, implRout, implFldOrRout, routOrField, feature, expr, exprs, block, unit
+While parsing: exprs, parse stack: exprs, block (twice), implRout, implFldOrRout, routOrField, feature, expr, exprs, block (twice), implRout, implFldOrRout, routOrField, feature, expr, exprs, block (twice), implRout, implFldOrRout, routOrField, feature, expr, exprs, block (twice), unit
 
 
 --CURDIR--/indentation_negative.fz:88:18: error 6: Inconsistent indentation
@@ -50,7 +50,7 @@ While parsing: exprs, parse stack: exprs, block, implRout, implFldOrRout, routOr
 Indentation reference point is --CURDIR--/indentation_negative.fz:86:17:
     feature2 is say "2da"
 ----------------^
-While parsing: exprs, parse stack: exprs, block, implRout, implFldOrRout, routOrField, feature, expr, exprs, block, implRout, implFldOrRout, routOrField, feature, expr, exprs, block, implRout, implFldOrRout, routOrField, feature, expr, exprs, block, unit
+While parsing: exprs, parse stack: exprs, block (twice), implRout, implFldOrRout, routOrField, feature, expr, exprs, block (twice), implRout, implFldOrRout, routOrField, feature, expr, exprs, block (twice), implRout, implFldOrRout, routOrField, feature, expr, exprs, block (twice), unit
 
 
 --CURDIR--/indentation_negative.fz:95:16: error 7: Inconsistent indentation
@@ -59,7 +59,7 @@ While parsing: exprs, parse stack: exprs, block, implRout, implFldOrRout, routOr
 Indentation reference point is --CURDIR--/indentation_negative.fz:94:5:
     feature2 is say "2ea"
 ----^
-While parsing: exprs, parse stack: exprs, block, implRout, implFldOrRout, routOrField, feature, expr, exprs, block, implRout, implFldOrRout, routOrField, feature, expr, exprs, block, unit
+While parsing: exprs, parse stack: exprs, block (twice), implRout, implFldOrRout, routOrField, feature, expr, exprs, block (twice), implRout, implFldOrRout, routOrField, feature, expr, exprs, block (twice), unit
 
 
 --CURDIR--/indentation_negative.fz:96:16: error 8: Inconsistent indentation
@@ -68,7 +68,7 @@ While parsing: exprs, parse stack: exprs, block, implRout, implFldOrRout, routOr
 Indentation reference point is --CURDIR--/indentation_negative.fz:94:5:
     feature2 is say "2ea"
 ----^
-While parsing: exprs, parse stack: exprs, block, implRout, implFldOrRout, routOrField, feature, expr, exprs, block, implRout, implFldOrRout, routOrField, feature, expr, exprs, block, unit
+While parsing: exprs, parse stack: exprs, block (twice), implRout, implFldOrRout, routOrField, feature, expr, exprs, block (twice), implRout, implFldOrRout, routOrField, feature, expr, exprs, block (twice), unit
 
 
 --CURDIR--/indentation_negative.fz:110:17: error 9: Inconsistent indentation
@@ -77,7 +77,7 @@ While parsing: exprs, parse stack: exprs, block, implRout, implFldOrRout, routOr
 Indentation reference point is --CURDIR--/indentation_negative.fz:109:18:
     feature3 is {say "3ba"; say "3bb"
 -----------------^
-While parsing: block, parse stack: block, implRout, implFldOrRout, routOrField, feature, expr, exprs, block, implRout, implFldOrRout, routOrField, feature, expr, exprs, block, implRout, implFldOrRout, routOrField, feature, expr, exprs, block, unit
+While parsing: block, parse stack: block (twice), implRout, implFldOrRout, routOrField, feature, expr, exprs, block (twice), implRout, implFldOrRout, routOrField, feature, expr, exprs, block (twice), implRout, implFldOrRout, routOrField, feature, expr, exprs, block (twice), unit
 
 
 --CURDIR--/indentation_negative.fz:117:22: error 10: Inconsistent indentation
@@ -86,7 +86,7 @@ While parsing: block, parse stack: block, implRout, implFldOrRout, routOrField, 
 Indentation reference point is --CURDIR--/indentation_negative.fz:116:18:
     feature3 is {say "3ca"; say "3cb"
 -----------------^
-While parsing: exprs, parse stack: exprs, block, implRout, implFldOrRout, routOrField, feature, expr, exprs, block, implRout, implFldOrRout, routOrField, feature, expr, exprs, block, implRout, implFldOrRout, routOrField, feature, expr, exprs, block, unit
+While parsing: exprs, parse stack: exprs, block (twice), implRout, implFldOrRout, routOrField, feature, expr, exprs, block (twice), implRout, implFldOrRout, routOrField, feature, expr, exprs, block (twice), implRout, implFldOrRout, routOrField, feature, expr, exprs, block (twice), unit
 
 
 --CURDIR--/indentation_negative.fz:170:7: error 11: Inconsistent indentation
@@ -95,6 +95,6 @@ While parsing: exprs, parse stack: exprs, block, implRout, implFldOrRout, routOr
 Indentation reference point is --CURDIR--/indentation_negative.fz:168:5:
     if callWith2Args arg
 ----^
-While parsing: exprs, parse stack: exprs, block, implRout, implFldOrRout, routOrField, feature, expr, exprs, block, implRout, implFldOrRout, routOrField, feature, expr, exprs, block, unit
+While parsing: exprs, parse stack: exprs, block (twice), implRout, implFldOrRout, routOrField, feature, expr, exprs, block (twice), implRout, implFldOrRout, routOrField, feature, expr, exprs, block (twice), unit
 
 11 errors.

--- a/tests/reg_issue2371/reg_issue2371.fz.expected_err
+++ b/tests/reg_issue2371/reg_issue2371.fz.expected_err
@@ -5,6 +5,6 @@
 Indentation reference point is --CURDIR--/reg_issue2371.fz:24:1:
 _ := for i := 0, i+1
 ^
-While parsing: exprs, parse stack: exprs, block, unit
+While parsing: exprs, parse stack: exprs, block (twice), unit
 
 one error.

--- a/tests/reg_issue2691_b/reg_issue2691_b.fz.expected_err
+++ b/tests/reg_issue2691_b/reg_issue2691_b.fz.expected_err
@@ -2,7 +2,7 @@
 --CURDIR--/reg_issue2691_b.fz:34:9: error 1: Syntax error: expected 'is', or '=>' in routine declaration, found keyword 'else'
         else true       # causes a syntax error NYI: an indentation error would be nicer
 --------^
-While parsing: implRout, parse stack: implRout, routOrField, feature, expr, exprs, block, implRout, routOrField, feature, expr, exprs, block, implRout, implFldOrRout, routOrField, feature, expr, exprs, block, unit
+While parsing: implRout, parse stack: implRout, routOrField, feature, expr, exprs, block (twice), implRout, routOrField, feature, expr, exprs, block (twice), implRout, implFldOrRout, routOrField, feature, expr, exprs, block (twice), unit
 
 
 --CURDIR--/reg_issue2691_b.fz:33:14: error 2: Incompatible types in branches of if expression

--- a/tests/reg_issue3406/reg_issue3406.fz.expected_err
+++ b/tests/reg_issue3406/reg_issue3406.fz.expected_err
@@ -2,6 +2,6 @@
 --CURDIR--/reg_issue3406.fz:25:3: error 1: Syntax error: expected term (lbrace, lparen, lbracket, fun, string, integer, old, match, or name), found end-of-file
 (#
 --^
-While parsing: term, parse stack: term, opTail, opExpr, operatorExpr (twice), klammer, bracketTerm, term, opTail, opExpr, operatorExpr (twice), expr, exprs, block, unit
+While parsing: term, parse stack: term, opTail, opExpr, operatorExpr (twice), klammer, bracketTerm, term, opTail, opExpr, operatorExpr (twice), expr, exprs, block (twice), unit
 
 one error.

--- a/tests/reg_issue3493/reg_issue3493.fz.expected_err
+++ b/tests/reg_issue3493/reg_issue3493.fz.expected_err
@@ -1,7 +1,7 @@
 
 --CURDIR--/reg_issue3493.fz:25:1: error 1: Syntax error: expected 'is', ':=' or '{', found end-of-file
 ^
-While parsing: impl, parse stack: implFldOrRout, routOrField, feature, expr, exprs, block, unit
+While parsing: impl, parse stack: implFldOrRout, routOrField, feature, expr, exprs, block (twice), unit
 
 
 --CURDIR--/reg_issue3493.fz:24:1: error 2: Missing result type in field declaration with initialization

--- a/tests/reg_issue3754/reg_issue3754.fz.expected_err
+++ b/tests/reg_issue3754/reg_issue3754.fz.expected_err
@@ -5,7 +5,7 @@
 Indentation reference point is --CURDIR--/reg_issue3754.fz:26:15:
   my_feat is {say "a"
 --------------^
-While parsing: block, parse stack: block, implRout, implFldOrRout, routOrField, feature, expr, exprs, block, implRout, implFldOrRout, routOrField, feature, expr, exprs, block, unit
+While parsing: block, parse stack: block (twice), implRout, implFldOrRout, routOrField, feature, expr, exprs, block (twice), implRout, implFldOrRout, routOrField, feature, expr, exprs, block (twice), unit
 
 
 --CURDIR--/reg_issue3754.fz:29:3: error 2: Could not find called feature

--- a/tests/reg_issue4272/Makefile
+++ b/tests/reg_issue4272/Makefile
@@ -1,0 +1,25 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test Makefile
+#
+# -----------------------------------------------------------------------
+
+override NAME = reg_issue4272
+include ../simple.mk

--- a/tests/reg_issue4272/reg_issue4272.fz
+++ b/tests/reg_issue4272/reg_issue4272.fz
@@ -1,0 +1,24 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test reg_issue4272
+#
+# -----------------------------------------------------------------------
+
+ex is {{x:=42}}; say ex.x

--- a/tests/reg_issue4272/reg_issue4272.fz.expected_err
+++ b/tests/reg_issue4272/reg_issue4272.fz.expected_err
@@ -1,0 +1,9 @@
+
+--CURDIR--/reg_issue4272.fz:24:25: error 1: Could not find called feature
+ex is {{x:=42}}; say ex.x
+------------------------^
+Feature not found: 'x' (no arguments)
+Target feature: 'ex'
+In call: 'ex.x'
+
+one error.

--- a/tests/reg_issue627/reg_issue627.fz.expected_err
+++ b/tests/reg_issue627/reg_issue627.fz.expected_err
@@ -2,12 +2,12 @@
 --CURDIR--/reg_issue627.fz:25:3: error 1: Syntax error: expected '[ ]' after 'set', found left parenthesis '('
   set(a string) unit is
 --^
-While parsing: name, parse stack: name (twice), call (twice), callOrFeatOrThis, term, opTail, opExpr, operatorExpr (twice), expr, exprs, block, implRout, implFldOrRout, routOrField, feature, expr, exprs, block, unit
+While parsing: name, parse stack: name (twice), call (twice), callOrFeatOrThis, term, opTail, opExpr, operatorExpr (twice), expr, exprs, block (twice), implRout, implFldOrRout, routOrField, feature, expr, exprs, block (twice), unit
 
 
 --CURDIR--/reg_issue627.fz:25:17: error 2: Syntax error: expected semicolon ';', found identifier 'unit'
   set(a string) unit is
 ----------------^
-While parsing: semicolon or flat line break, parse stack: semiOrFlatLF, exprs, block, implRout, implFldOrRout, routOrField, feature, expr, exprs, block, unit
+While parsing: semicolon or flat line break, parse stack: semiOrFlatLF, exprs, block (twice), implRout, implFldOrRout, routOrField, feature, expr, exprs, block (twice), unit
 
 2 errors.


### PR DESCRIPTION
fixes #4272
