### PR TITLE
lib: remove intrinsics mapped_buffer_get/set

### DIFF
--- a/lib/fuzion/sys/fileio.fz
+++ b/lib/fuzion/sys/fileio.fz
@@ -305,31 +305,6 @@ module fileio is
   module munmap(address fuzion.sys.Pointer, size i64) i32 => intrinsic
 
 
-  # get a byte from a given mapped buffer
-  #
-  module mapped_buffer_get
-    (# memory address obtained by `mmap`
-     m fuzion.sys.Pointer,
-
-     # index of the byte
-     i i64
-    ) u8 => intrinsic
-
-
-  # set a byte of a given mapped buffer to a new value
-  #
-  module mapped_buffer_set
-    (# memory address obtained by `mmap`
-     m fuzion.sys.Pointer,
-
-     # index of the byte
-     i i64,
-
-     # new value to be written at m[i]
-     o u8
-    ) unit => intrinsic
-
-
   # open the directory given by path
   #
   # accepts as arguments a path (processed by fuzion.sys.c_string) and a pointer to

--- a/lib/fuzion/sys/internal_array.fz
+++ b/lib/fuzion/sys/internal_array.fz
@@ -33,11 +33,13 @@ module internal_array_init(T type, length i32) =>
   internal_array T (alloc T length) length
 
 
+module getel(X type, d fuzion.sys.Pointer, i i32)      X    => intrinsic
+module setel(X type, d fuzion.sys.Pointer, i i32, o X) unit => intrinsic
+
+
 # fuzion.sys.internal_array_init -- one-dimensional low-level array
 module internal_array(T type, module data fuzion.sys.Pointer, module length i32) is
 
-  get  (X type, d fuzion.sys.Pointer, i i32) X => intrinsic
-  setel(X type, d fuzion.sys.Pointer, i i32, o X) unit => intrinsic
 
   # make sure that this internal array will no longer be modified.  This is just for
   # debugging and will be a NOP in case internal checks are disabled or in case the
@@ -64,7 +66,7 @@ module internal_array(T type, module data fuzion.sys.Pointer, module length i32)
     pre
       safety: 0 ≤ i < length
   =>
-    get T data i
+    fuzion.sys.getel T data i
 
   module set [ ] (i i32, o T) unit
     pre
@@ -72,4 +74,4 @@ module internal_array(T type, module data fuzion.sys.Pointer, module length i32)
   # post   NYI
     # debug: array.this[i] == o
   =>
-    setel data i o
+    fuzion.sys.setel data i o

--- a/lib/io/file/mapped_buffer.fz
+++ b/lib/io/file/mapped_buffer.fz
@@ -40,7 +40,8 @@ module:public mapped_buffer
   public redef index [ ] (i i64) u8
   =>
     replace
-    fuzion.sys.fileio.mapped_buffer_get memory i
+    # NYI: UNDER DEVELOPMENT: as_i32 ugly, change array index
+    fuzion.sys.getel u8 memory i.as_i32
 
 
   # set byte at given index i to given value o
@@ -48,7 +49,8 @@ module:public mapped_buffer
   public redef set [ ] (i i64, o u8) unit
   =>
     replace
-    fuzion.sys.fileio.mapped_buffer_set memory i o
+    # NYI: UNDER DEVELOPMENT: as_i32 ugly, change array index
+    fuzion.sys.setel u8 memory i.as_i32 o
 
 
   # cleanup

--- a/src/dev/flang/be/c/Intrinsics.java
+++ b/src/dev/flang/be/c/Intrinsics.java
@@ -442,8 +442,6 @@ public class Intrinsics extends ANY
       A0.castTo("void *"),    // address
       A1.castTo("size_t")     // size
     )).ret());
-    put("fuzion.sys.fileio.mapped_buffer_get", (c,cl,outer,in) -> A0.castTo("int8_t*").index(A1).ret());
-    put("fuzion.sys.fileio.mapped_buffer_set", (c,cl,outer,in) -> A0.castTo("int8_t*").index(A1).assign(A2.castTo("int8_t")));
     put("fuzion.sys.fileio.open_dir", (c,cl,outer,in) -> CExpr.call("fzE_opendir", new List<CExpr>(
       A0.castTo("char *"),
       A1.castTo("int64_t *")
@@ -756,14 +754,14 @@ public class Intrinsics extends ANY
           return CExpr.call(c.malloc(),
                             new List<>(CExpr.sizeOfType(c._types.clazz(gc)).mul(A0))).ret();
         });
-    put("fuzion.sys.internal_array.setel", (c,cl,outer,in) ->
+    put("fuzion.sys.setel", (c,cl,outer,in) ->
         {
           var gc = c._fuir.clazzActualGeneric(cl, 0);
           return c._fuir.hasData(gc)
             ? A0.castTo(c._types.clazz(gc) + "*").index(A1).assign(A2)
             : CStmnt.EMPTY;
         });
-    put("fuzion.sys.internal_array.get", (c,cl,outer,in) ->
+    put("fuzion.sys.getel", (c,cl,outer,in) ->
         {
           var gc = c._fuir.clazzActualGeneric(cl, 0);
           return c._fuir.hasData(gc)

--- a/src/dev/flang/be/interpreter/Intrinsics.java
+++ b/src/dev/flang/be/interpreter/Intrinsics.java
@@ -690,21 +690,6 @@ public class Intrinsics extends ANY
           _openStreams_.remove(args.get(1).i64Value());
           return new i64Value(0);
         });
-    put("fuzion.sys.fileio.mapped_buffer_get", (executor, innerClazz) -> args ->
-        {
-          return ((ArrayData)args.get(1)).get(/* index */ (int) args.get(2).i64Value(),
-                                              executor.fuir(),
-                                              /* type  */ executor.fuir().clazz(FUIR.SpecialClazzes.c_u8));
-        });
-    put("fuzion.sys.fileio.mapped_buffer_set", (executor, innerClazz) -> args ->
-        {
-          ((ArrayData)args.get(1)).set(/* index */ (int) args.get(2).i64Value(),
-                                       /* value */ args.get(3),
-                                       executor.fuir(),
-                                       /* type  */ executor.fuir().clazz(FUIR.SpecialClazzes.c_u8));
-          return Value.EMPTY_VALUE;
-        });
-
     put("fuzion.std.exit", (executor, innerClazz) -> args ->
         {
           int rc = args.get(1).i32Value();
@@ -886,19 +871,17 @@ public class Intrinsics extends ANY
                                  executor.fuir(),
                                  /* type */ et);
         });
-    put("fuzion.sys.internal_array.get", (executor, innerClazz) -> args ->
+    put("fuzion.sys.getel", (executor, innerClazz) -> args ->
         {
-          var at = executor.fuir().clazzOuterClazz(innerClazz); // array type
-          var et = executor.fuir().clazzActualGeneric(at, 0); // element type
+          var et = executor.fuir().clazzActualGeneric(innerClazz, 0); // element type
           return ((ArrayData)args.get(1)).get(
                                    /* index */ args.get(2).i32Value(),
                                    executor.fuir(),
                                    /* type  */ et);
         });
-    put("fuzion.sys.internal_array.setel", (executor, innerClazz) -> args ->
+    put("fuzion.sys.setel", (executor, innerClazz) -> args ->
         {
-          var at = executor.fuir().clazzOuterClazz(innerClazz); // array type
-          var et = executor.fuir().clazzActualGeneric(at, 0); // element type
+          var et = executor.fuir().clazzActualGeneric(innerClazz, 0); // element type
           ((ArrayData)args.get(1)).set(
                               /* index */ args.get(2).i32Value(),
                               /* value */ args.get(3),

--- a/src/dev/flang/be/jvm/Intrinsix.java
+++ b/src/dev/flang/be/jvm/Intrinsix.java
@@ -741,15 +741,14 @@ public class Intrinsix extends ANY implements ClassFileConstants
                                                             PrimitiveType.type_byte.array())));
         });
 
-    put("fuzion.sys.internal_array.get",
-        "fuzion.sys.internal_array.setel",
+    put("fuzion.sys.getel",
+        "fuzion.sys.setel",
         "fuzion.sys.internal_array_init.alloc",
 
         (jvm, si, cc, tvalue, args) ->
         {
           var in = jvm._fuir.clazzOriginalName(cc);
-          var at = jvm._fuir.clazzOuterClazz(cc); // array type
-          var et = jvm._fuir.clazzActualGeneric(at, 0); // element type
+          var et = jvm._fuir.clazzActualGeneric(cc, 0); // element type
           var jt = jvm._types.resultType(et);
           var val = Expr.UNIT;
           var code = Expr.UNIT;
@@ -760,14 +759,14 @@ public class Intrinsix extends ANY implements ClassFileConstants
             }
           else
             {
-              if (in.equals("fuzion.sys.internal_array.get"))
+              if (in.equals("fuzion.sys.getel"))
                 {
                   val = args.get(0)
                     .andThen(Expr.checkcast(jt.array()))
                     .andThen(args.get(1))
                     .andThen(jt.xaload());
                 }
-              else if (in.equals("fuzion.sys.internal_array.setel"))
+              else if (in.equals("fuzion.sys.setel"))
                 {
                   var check_frozen = Expr.UNIT;
                   if (CHECKS)

--- a/src/dev/flang/be/jvm/runtime/Intrinsics.java
+++ b/src/dev/flang/be/jvm/runtime/Intrinsics.java
@@ -820,17 +820,6 @@ public class Intrinsics extends ANY
     return 0;
   }
 
-  public static byte fuzion_sys_fileio_mapped_buffer_get(Object buf, long i)
-  {
-    Runtime.unsafeIntrinsic();
-    return ((ByteBuffer)buf).get((int) i);
-  }
-  public static void fuzion_sys_fileio_mapped_buffer_set(Object buf, long i, byte b)
-  {
-    Runtime.unsafeIntrinsic();
-    ((ByteBuffer)buf).put((int) i, b);
-  }
-
   public static void fuzion_sys_fileio_open_dir(Object s, Object res)
   {
     Runtime.unsafeIntrinsic();

--- a/src/dev/flang/fuir/analysis/dfa/DFA.java
+++ b/src/dev/flang/fuir/analysis/dfa/DFA.java
@@ -1804,35 +1804,6 @@ public class DFA extends ANY
           return cl._dfa.newSysArray(NumericValue.create(cl._dfa, c_u8), c_u8); // NYI: length wrong, get from arg
         });
     put("fuzion.sys.fileio.munmap"       , cl -> NumericValue.create(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc)) );
-    put("fuzion.sys.fileio.mapped_buffer_get", cl ->
-        {
-          var array = cl._args.get(0).value();
-          var index = cl._args.get(1).value();
-          if (array instanceof SysArray sa)
-            {
-              return sa.get(index);
-            }
-          else
-            {
-              throw new Error("intrinsic fuzion.sys.internal_array.gel: Expected class SysArray, found "+array.getClass()+" "+array);
-            }
-        });
-    put("fuzion.sys.fileio.mapped_buffer_set", cl ->
-        {
-          var array = cl._args.get(0).value();
-          var index = cl._args.get(1).value();
-          var value = cl._args.get(2).value();
-          if (array instanceof SysArray sa)
-            {
-              sa.setel(index, value);
-              return Value.UNIT;
-            }
-          else
-            {
-              throw new Error("intrinsic fuzion.sys.internal_array.setel: Expected class SysArray, found "+array.getClass()+" "+array);
-            }
-        });
-
     put("fuzion.sys.fatal_fault0"        , cl-> null                                                              );
     put("fuzion.sys.stdin.stdin0"        , cl -> NumericValue.create(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc)) );
     put("fuzion.sys.out.stdout"          , cl -> NumericValue.create(cl._dfa, cl._dfa._fuir.clazzResultClazz(cl._cc)) );
@@ -2069,7 +2040,7 @@ public class DFA extends ANY
           var ec = cl._dfa._fuir.clazzActualGeneric(oc, 0);
           return cl._dfa.newSysArray(null, ec); // NYI: get length from args
         });
-    put("fuzion.sys.internal_array.setel", cl ->
+    put("fuzion.sys.setel", cl ->
         {
           var array = cl._args.get(0).value();
           var index = cl._args.get(1).value();
@@ -2081,10 +2052,10 @@ public class DFA extends ANY
             }
           else
             {
-              throw new Error("intrinsic fuzion.sys.internal_array.setel: Expected class SysArray, found "+array.getClass()+" "+array);
+              throw new Error("intrinsic fuzion.sys.setel: Expected class SysArray, found "+array.getClass()+" "+array);
             }
         });
-    put("fuzion.sys.internal_array.get"  , cl ->
+    put("fuzion.sys.getel"  , cl ->
         {
           var array = cl._args.get(0).value();
           var index = cl._args.get(1).value();

--- a/src/dev/flang/fuir/cfg/CFG.java
+++ b/src/dev/flang/fuir/cfg/CFG.java
@@ -241,8 +241,6 @@ public class CFG extends ANY
     put("fuzion.sys.fileio.file_position", (cfg, cl) -> { } );
     put("fuzion.sys.fileio.mmap"         , (cfg, cl) -> { } );
     put("fuzion.sys.fileio.munmap"       , (cfg, cl) -> { } );
-    put("fuzion.sys.fileio.mapped_buffer_get", (cfg, cl) -> { } );
-    put("fuzion.sys.fileio.mapped_buffer_set", (cfg, cl) -> { } );
     put("fuzion.sys.fatal_fault0"        , (cfg, cl) -> { } );
     put("fuzion.sys.stdin.stdin0"        , (cfg, cl) -> { } );
     put("fuzion.sys.out.stdout"          , (cfg, cl) -> { } );
@@ -455,8 +453,8 @@ public class CFG extends ANY
     put("f64.type.epsilon"               , (cfg, cl) -> { } );
 
     put("fuzion.sys.internal_array_init.alloc", (cfg, cl) -> { } );
-    put("fuzion.sys.internal_array.setel", (cfg, cl) -> { } );
-    put("fuzion.sys.internal_array.get"  , (cfg, cl) -> { } );
+    put("fuzion.sys.setel", (cfg, cl) -> { } );
+    put("fuzion.sys.getel"  , (cfg, cl) -> { } );
     put("fuzion.sys.internal_array.freeze"
                                          , (cfg, cl) -> { } );
     put("fuzion.sys.internal_array.ensure_not_frozen"


### PR DESCRIPTION
We already have getel/setel from internal_array.
Only ugliness is that index is i64 in one case i32 in the other but that should be changed in the future.

