### PR TITLE
ast: petter precondition for `AbstractFeature.findInheritanceChain`

### DIFF
--- a/src/dev/flang/ast/AbstractFeature.java
+++ b/src/dev/flang/ast/AbstractFeature.java
@@ -1462,7 +1462,8 @@ public abstract class AbstractFeature extends Expr implements Comparable<Abstrac
   public List<AbstractCall> findInheritanceChain(AbstractFeature ancestor)
   {
     if (PRECONDITIONS) require
-      (ancestor != null);
+      (ancestor != null,
+       this == Types.f_ERROR || ancestor == Types.f_ERROR || Errors.any() || inheritsFrom(ancestor));
 
     List<AbstractCall> result = tryFindInheritanceChain(ancestor);
 


### PR DESCRIPTION
If this is called on something that we do not inherit from, this is the caller's fault, so it should be checked in the precondition, not only in the postcondition.
