### PR TITLE
fuir: better error output in case of cyclic value fields

### DIFF
--- a/src/dev/flang/fuir/Clazz.java
+++ b/src/dev/flang/fuir/Clazz.java
@@ -773,15 +773,11 @@ class Clazz extends ANY implements Comparable<Clazz>
     if (cycle != null && Errors.count() <= FuirErrors.count())
       {
         StringBuilder cycleString = new StringBuilder();
-        var tp = _type.declarationPos();
-        for (SourcePosition p : cycle)
+        for (var s: cycle.reversed())
           {
-            if (!p.equals(tp))
-              {
-                cycleString.append(p.show()).append("\n");
-              }
+            cycleString.append(s).append("\n");
           }
-        FuirErrors.error(tp,
+        FuirErrors.error(_type.declarationPos(),
                         "Cyclic field nesting is not permitted",
                         "Cyclic value field nesting would result in infinitely large objects.\n" +
                         "Cycle of nesting found during clazz layout:\n" +
@@ -798,14 +794,14 @@ class Clazz extends ANY implements Comparable<Clazz>
    * @return null in case of success, a list of source code positions that shows
    * the recursively nested value types otherwise.
    */
-  private TreeSet<SourcePosition> layout()
+  private List<String> layout()
   {
-    TreeSet<SourcePosition> result = null;
+    List<String> result = null;
     switch (_layouting)
       {
       case During:
-        result = new TreeSet<>();
-        result.add(this.feature().pos());
+        result = new List<>();
+        result.add("Requires layout of "+ Errors.sqn(this.toString()) + ": " + this.feature().pos().show());
         break;
       case Before:
         {
@@ -819,7 +815,7 @@ class Clazz extends ANY implements Comparable<Clazz>
                       result = c.layout();
                       if (result != null)
                         {
-                          result.add(c.feature().pos());
+                          result.add("Choice variant " + Errors.sqn(c.toString()) + ": " + c.feature().pos().show());
                         }
                     }
                 }
@@ -829,6 +825,10 @@ class Clazz extends ANY implements Comparable<Clazz>
               if (result == null && !fc.feature().isOuterRef())
                 {
                   result = layoutFieldType(fc);
+                  if (result != null)
+                    {
+                      result.add("Layout " + Errors.sqn(this.toString()) + ": " + fc.feature().pos().show());
+                    }
                 }
             }
           _layouting = LayoutStatus.After;
@@ -844,9 +844,9 @@ class Clazz extends ANY implements Comparable<Clazz>
    *
    * @param field to be added to this.
    */
-  private TreeSet<SourcePosition> layoutFieldType(Clazz field)
+  private List<String> layoutFieldType(Clazz field)
   {
-    TreeSet<SourcePosition> result = null;
+    List<String> result = null;
     var fieldClazz = field.resultClazz();
     if (!fieldClazz.isRef() &&
         !fieldClazz.feature().isBuiltInPrimitive() &&
@@ -855,7 +855,7 @@ class Clazz extends ANY implements Comparable<Clazz>
         result = fieldClazz.layout();
         if (result != null)
           {
-            result.add(field.feature().pos());
+            result.add("Field: " + Errors.sqn(field.toString()) + " of type " + Errors.sqn(fieldClazz.toString())+": " + field.feature().pos().show());
           }
       }
     return result;

--- a/tests/choice_negative2/choice_negative.fz.expected_err
+++ b/tests/choice_negative2/choice_negative.fz.expected_err
@@ -4,9 +4,18 @@
 ----^
 Cyclic value field nesting would result in infinitely large objects.
 Cycle of nesting found during clazz layout:
---CURDIR--/choice_negative.fz:30:7:
+Layout 'choice_negative.cyclic7.A': --CURDIR--/choice_negative.fz:30:7:
       x A | i32 | String := "Hello"  // 4. should flag an error: cyclic choice
 ------^
+Field: 'choice_negative.cyclic7.A.x' of type 'choice choice_negative.cyclic7.A i32 String': --CURDIR--/choice_negative.fz:30:7:
+      x A | i32 | String := "Hello"  // 4. should flag an error: cyclic choice
+------^
+Choice variant 'choice_negative.cyclic7.A': --CURDIR--/choice_negative.fz:29:5:
+    A is
+----^
+Requires layout of 'choice_negative.cyclic7.A': --CURDIR--/choice_negative.fz:29:5:
+    A is
+----^
 
 To solve this, you could change one or several of the fields involved to a reference type by adding 'ref' before the type.
 
@@ -16,9 +25,18 @@ To solve this, you could change one or several of the fields involved to a refer
 ----^
 Cyclic value field nesting would result in infinitely large objects.
 Cycle of nesting found during clazz layout:
---CURDIR--/choice_negative.fz:53:7:
+Layout 'choice_negative.cyclic9.A': --CURDIR--/choice_negative.fz:53:7:
       x i32 | A | String := "Hello"  // 5. should flag an error: cyclic choice
 ------^
+Field: 'choice_negative.cyclic9.A.x' of type 'choice i32 choice_negative.cyclic9.A String': --CURDIR--/choice_negative.fz:53:7:
+      x i32 | A | String := "Hello"  // 5. should flag an error: cyclic choice
+------^
+Choice variant 'choice_negative.cyclic9.A': --CURDIR--/choice_negative.fz:52:5:
+    A is
+----^
+Requires layout of 'choice_negative.cyclic9.A': --CURDIR--/choice_negative.fz:52:5:
+    A is
+----^
 
 To solve this, you could change one or several of the fields involved to a reference type by adding 'ref' before the type.
 
@@ -28,9 +46,18 @@ To solve this, you could change one or several of the fields involved to a refer
 ----^
 Cyclic value field nesting would result in infinitely large objects.
 Cycle of nesting found during clazz layout:
---CURDIR--/choice_negative.fz:76:7:
+Layout 'choice_negative.cyclic11.A': --CURDIR--/choice_negative.fz:76:7:
       x i32 | String | A := "Hello"  // 6. should flag an error: cyclic choice
 ------^
+Field: 'choice_negative.cyclic11.A.x' of type 'choice i32 String choice_negative.cyclic11.A': --CURDIR--/choice_negative.fz:76:7:
+      x i32 | String | A := "Hello"  // 6. should flag an error: cyclic choice
+------^
+Choice variant 'choice_negative.cyclic11.A': --CURDIR--/choice_negative.fz:75:5:
+    A is
+----^
+Requires layout of 'choice_negative.cyclic11.A': --CURDIR--/choice_negative.fz:75:5:
+    A is
+----^
 
 To solve this, you could change one or several of the fields involved to a reference type by adding 'ref' before the type.
 


### PR DESCRIPTION
The original error was confusing when I dubugged a cyclic layout via the `#result` field of a routine, so I added more detail.

