### PR TITLE
ast: change outer ref names from `#^x.y` to `#^<x.y>`, fix #4316

### DIFF
--- a/src/dev/flang/ast/Feature.java
+++ b/src/dev/flang/ast/Feature.java
@@ -2366,7 +2366,7 @@ A ((Choice)) declaration must not contain a result type.
     if (PRECONDITIONS) require
       (_outer != null);
 
-    return FuzionConstants.OUTER_REF_PREFIX + qualifiedName();
+    return FuzionConstants.OUTER_REF_PREFIX + qualifiedName() + FuzionConstants.OUTER_REF_SUFFIX;
   }
 
 

--- a/src/dev/flang/util/FuzionConstants.java
+++ b/src/dev/flang/util/FuzionConstants.java
@@ -81,7 +81,12 @@ public class FuzionConstants extends ANY
   /**
    * Prefix of artificially generated name of outer refs.
    */
-  public static final String OUTER_REF_PREFIX = INTERNAL_NAME_PREFIX + "^";
+  public static final String OUTER_REF_PREFIX = INTERNAL_NAME_PREFIX + "^<";
+
+  /**
+   * Suffix of artificially generated name of outer refs.
+   */
+  public static final String OUTER_REF_SUFFIX = ">";
 
   /**
    * Name of Any feature, i.e., the implicit parent feature of all other


### PR DESCRIPTION
When debugging, I had run into calls like
```
  call.this.#^b.λ.call.#^b.λ.t.call
```
which now look like this
```
  call.this.#^<b.λ.call>.#^<b.λ>.t.call
```
So it is easier to see that the `.t.call` is not part of a outer ref name.
