### PR TITLE
cleanup: type remove `typeOfConstant`

### DIFF
--- a/bin/aspell.dict
+++ b/bin/aspell.dict
@@ -1731,7 +1731,6 @@ Trigraphs
 tslot
 typeFromDescriptor
 typeinference
-typeOfConstant
 unicodes
 unresolvedGenerics
 valueOf

--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -501,7 +501,7 @@ public class Call extends AbstractCall
       .applyTypePars(_calledFeature, _generics);
 
     if (POSTCONDITIONS) ensure
-      (result != null && result != Types.resolved.t_Const_String);
+      (result != null);
 
     return result;
   }

--- a/src/dev/flang/ast/Constant.java
+++ b/src/dev/flang/ast/Constant.java
@@ -94,21 +94,6 @@ public abstract class Constant extends Expr
 
 
   /**
-   * The type of the constant.  This may be different to the the user-visible
-   * `type()` of this constant, in particular, for a constant string, `type()`
-   * returns `String`, while `typeOfConstant` is the actual child of `String`
-   * used for constants: `Const_String`.
-   *
-   * @return the type to be used to create the constant value. Is assignment
-   * compatible to `type()`.
-   */
-  public AbstractType typeOfConstant()
-  {
-    return type();
-  }
-
-
-  /**
    * visit all the expressions within this feature.
    *
    * @param v the visitor instance that defines an action to be performed on

--- a/src/dev/flang/ast/Feature.java
+++ b/src/dev/flang/ast/Feature.java
@@ -2259,9 +2259,6 @@ A ((Choice)) declaration must not contain a result type.
         result = result.resolve(res, outer().context());
       }
 
-    if (POSTCONDITIONS) ensure
-      (isCoTypesThisType() || Types.resolved == null || selfType() == Types.resolved.t_Const_String || result != Types.resolved.t_Const_String);
-
     return result;
   }
 

--- a/src/dev/flang/ast/StrConst.java
+++ b/src/dev/flang/ast/StrConst.java
@@ -99,21 +99,6 @@ public class StrConst extends Constant
 
 
   /**
-   * The type of the constant that is created is not `String`, but
-   * `Const_String`.
-   *
-   * @return Types.resolved.t_Const_String
-   */
-  @Override
-  public AbstractType typeOfConstant()
-  {
-    return isCodepointLiteral()
-      ? Types.resolved.t_codepoint
-      : Types.resolved.t_Const_String;
-  }
-
-
-  /**
    * Serialized form of the data of this constant.
    */
   public byte[] data()

--- a/src/dev/flang/ast/Types.java
+++ b/src/dev/flang/ast/Types.java
@@ -140,7 +140,6 @@ public class Types extends ANY
     public final AbstractType t_Any;
     private final AbstractType t_fuzion;
     public final AbstractType t_String;
-    public final AbstractType t_Const_String;
     public final AbstractType t_unit;
 
     /* void will be used as the initial result type of tail recursive calls of
@@ -167,7 +166,6 @@ public class Types extends ANY
     public final AbstractFeature f_bool_TERNARY;
     public final AbstractFeature f_debug;
     public final AbstractFeature f_debug_level;
-    public final AbstractFeature f_Const_String_utf8_data;
     public final AbstractFeature f_Function;
     public final AbstractFeature f_Function_call;
     public final AbstractFeature f_safety;
@@ -215,7 +213,6 @@ public class Types extends ANY
       t_bool                    = universe.get(mod, "bool", 0).selfType();
       t_fuzion                  = universe.get(mod, "fuzion", 0).selfType();
       t_String                  = universe.get(mod, FuzionConstants.STRING_NAME, 0).selfType();
-      t_Const_String            = universe.get(mod, "Const_String", 0).selfType();
       t_Any                     = universe.get(mod, FuzionConstants.ANY_NAME, 0).selfType();
       t_unit                    = universe.get(mod, FuzionConstants.UNIT_NAME, 0).selfType();
       t_void                    = universe.get(mod, "void", 0).selfType();
@@ -233,7 +230,6 @@ public class Types extends ANY
       f_bool_OR                 = forFrontEnd ? f_bool.get(mod, FuzionConstants.INFIX_OPERATOR_PREFIX + "||"   , 1) : null;
       f_bool_IMPLIES            = forFrontEnd ? f_bool.get(mod, FuzionConstants.INFIX_OPERATOR_PREFIX + ":"    , 1) : null;
       f_bool_TERNARY            = forFrontEnd ? f_bool.get(mod, FuzionConstants.TERNARY_OPERATOR_PREFIX + "? :", 3) : null;
-      f_Const_String_utf8_data  = universe.get(mod, "Const_String", 0).get(mod, "utf8_data", 0);
       f_debug                   = universe.get(mod, "debug", 0);
       f_debug_level             = universe.get(mod, "debug_level", 0);
       f_Function                = universe.get(mod, FUNCTION_NAME, 2);
@@ -313,7 +309,6 @@ public class Types extends ANY
         t_bool       ,
         t_fuzion     ,
         t_String     ,
-        t_Const_String,
         t_Any        ,
         t_unit       ,
         t_void       ,

--- a/src/dev/flang/be/c/C.java
+++ b/src/dev/flang/be/c/C.java
@@ -266,8 +266,7 @@ public class C extends ANY
           case c_u64  -> new Pair<>(primitiveExpression(SpecialClazzes.c_u64,  ByteBuffer.wrap(d).position(4).order(ByteOrder.LITTLE_ENDIAN)),CStmnt.EMPTY);
           case c_f32  -> new Pair<>(primitiveExpression(SpecialClazzes.c_f32,  ByteBuffer.wrap(d).position(4).order(ByteOrder.LITTLE_ENDIAN)),CStmnt.EMPTY);
           case c_f64  -> new Pair<>(primitiveExpression(SpecialClazzes.c_f64,  ByteBuffer.wrap(d).position(4).order(ByteOrder.LITTLE_ENDIAN)),CStmnt.EMPTY);
-          case c_String, c_Const_String
-                      -> new Pair<>(heapClone(constString(Arrays.copyOfRange(d, 4, ByteBuffer.wrap(d).order(ByteOrder.LITTLE_ENDIAN).getInt() + 4)), constCl)               ,CStmnt.EMPTY);
+          case c_String -> new Pair<>(heapClone(constString(Arrays.copyOfRange(d, 4, ByteBuffer.wrap(d).order(ByteOrder.LITTLE_ENDIAN).getInt() + 4)), constCl)               ,CStmnt.EMPTY);
           default     -> {
             if (CHECKS)
               check(!_fuir.clazzIsRef(constCl)); // NYI currently no refs
@@ -1957,7 +1956,7 @@ public class C extends ANY
         case
           c_i8, c_i16, c_i32, c_i64, c_u8,
           c_u16, c_u32, c_u64, c_f32, c_f64 -> call.ret();
-        case c_Const_String, c_String ->
+        case c_String ->
           {
             var str = new CIdent("str");
             yield CStmnt.seq(
@@ -2139,7 +2138,7 @@ public class C extends ANY
         return CExpr.seq(sideEffect, result);
       case c_unit :
         return expr;
-      case c_Const_String :
+      case c_String :
       case c_false_ :
       case c_true_ :
       case c_sys_ptr :
@@ -2199,7 +2198,7 @@ public class C extends ANY
       case c_NOT_FOUND :
       case c_unit :
         return val;
-      case c_Const_String :
+      case c_String :
       case c_false_ :
       case c_true_ :
       case c_sys_ptr :

--- a/src/dev/flang/be/interpreter/Executor.java
+++ b/src/dev/flang/be/interpreter/Executor.java
@@ -448,7 +448,7 @@ public class Executor extends ProcessExpression<Value, Object>
     // NYI: UNDERDEVELOPMENT: cache?
     var val = switch (_fuir.getSpecialClazz(constCl))
       {
-      case c_Const_String, c_String -> Interpreter
+      case c_String -> Interpreter
         .value(new String(Arrays.copyOfRange(d, 4, ByteBuffer.wrap(d).order(ByteOrder.LITTLE_ENDIAN).getInt() + 4), StandardCharsets.UTF_8));
       case c_bool -> { check(d.length == 1, d[0] == 0 || d[0] == 1); yield new boolValue(d[0] == 1); }
       case c_f32 -> new f32Value(ByteBuffer.wrap(d).position(4).order(ByteOrder.LITTLE_ENDIAN).getFloat());

--- a/src/dev/flang/be/jvm/CodeGen.java
+++ b/src/dev/flang/be/jvm/CodeGen.java
@@ -880,7 +880,7 @@ class CodeGen
         {
           var ucl = _types.classFile(_fuir.clazzUniverse());
           var f = _names.preallocatedConstantField(constCl, d);
-          var jt = _types.javaType(constCl);
+          var jt = _types.resultType(constCl);
           if (!ucl.hasField(f))
             {
               ucl.field(ACC_STATIC | ACC_PUBLIC,
@@ -942,8 +942,7 @@ class CodeGen
       case c_u64          -> new Pair<>(Expr.lconst(ByteBuffer.wrap(d).position(4).order(ByteOrder.LITTLE_ENDIAN).getLong ())                                   , Expr.UNIT);
       case c_f32          -> new Pair<>(Expr.fconst(ByteBuffer.wrap(d).position(4).order(ByteOrder.LITTLE_ENDIAN).getInt  ())                                   , Expr.UNIT);
       case c_f64          -> new Pair<>(Expr.dconst(ByteBuffer.wrap(d).position(4).order(ByteOrder.LITTLE_ENDIAN).getLong ())                                   , Expr.UNIT);
-      case c_Const_String, c_String
-                          -> _jvm.constString(Arrays.copyOfRange(d, 4, ByteBuffer.wrap(d).order(ByteOrder.LITTLE_ENDIAN).getInt()+4));
+      case c_String       -> _jvm.constString(Arrays.copyOfRange(d, 4, ByteBuffer.wrap(d).order(ByteOrder.LITTLE_ENDIAN).getInt()+4));
       default             ->
         {
           if (_fuir.clazzIsArray(constCl))

--- a/src/dev/flang/fe/LibraryOut.java
+++ b/src/dev/flang/fe/LibraryOut.java
@@ -765,7 +765,7 @@ class LibraryOut extends ANY
    *   |        | length | byte          | data of the constant                          |
    *   +--------+--------+---------------+-----------------------------------------------+
    */
-        type(c.typeOfConstant());
+        type(c.type());
         var d = c.data();
         _data.writeInt(d.length);
         _data.write(d);

--- a/src/dev/flang/fuir/Clazz.java
+++ b/src/dev/flang/fuir/Clazz.java
@@ -38,6 +38,7 @@ import java.util.function.Consumer;
 import dev.flang.ast.AbstractFeature;
 import dev.flang.ast.AbstractCall;
 import dev.flang.ast.AbstractType;
+import dev.flang.ast.AstErrors;
 import dev.flang.ast.Context;
 import dev.flang.ast.Expr;
 import dev.flang.ast.ResolvedNormalType;
@@ -52,7 +53,6 @@ import dev.flang.util.Errors;
 import dev.flang.util.FuzionConstants;
 import dev.flang.util.HasSourcePosition;
 import dev.flang.util.List;
-import dev.flang.util.SourcePosition;
 import dev.flang.util.StringHelpers;
 import dev.flang.util.YesNo;
 
@@ -1948,7 +1948,7 @@ class Clazz extends ANY implements Comparable<Clazz>
     var err = new List<Consumer<AbstractCall>>();
     var ft = t; // final variant of t to be used in lambda
     BiConsumer<AbstractType, AbstractType> foundRef = (from,to) ->
-      { err.add((c)->dev.flang.ast.AstErrors.illegalOuterRefTypeInCall(c, false, feature(), ft, from, to)); };
+      { err.add((c)->AstErrors.illegalOuterRefTypeInCall(c, false, feature(), ft, from, to)); };
 
     for (var i = 0; i<2; i++) // NYI: UNDER DEVELOPMENT: get rid for second iteration!
       {

--- a/src/dev/flang/fuir/GeneratingFUIR.java
+++ b/src/dev/flang/fuir/GeneratingFUIR.java
@@ -506,7 +506,7 @@ public class GeneratingFUIR extends FUIR
 
     else if (e instanceof Constant c)
       {
-        result = outerClazz.handDown(c.typeOfConstant(), inh);
+        result = outerClazz.handDown(c.type(), inh);
       }
 
     else if (e instanceof Tag tg)
@@ -1653,7 +1653,7 @@ public class GeneratingFUIR extends FUIR
   @Override
   public int clazzAny()
   {
-    return clazz(SpecialClazzes.c_Const_String);
+    return clazz(SpecialClazzes.c_Any);
   }
 
 
@@ -3343,7 +3343,7 @@ public class GeneratingFUIR extends FUIR
   {
     return switch (getSpecialClazz(cl))
       {
-      case c_Const_String, c_String :
+      case c_String :
         var len = bb.duplicate().order(ByteOrder.LITTLE_ENDIAN).getInt();
         yield bb.slice(bb.position(), 4+len);
       case c_bool :

--- a/src/dev/flang/fuir/analysis/dfa/Call.java
+++ b/src/dev/flang/fuir/analysis/dfa/Call.java
@@ -359,7 +359,7 @@ public class Call extends ANY implements Comparable<Call>, Context
              c_u8, c_u16, c_u32, c_u64,
              c_f32, c_f64              -> NumericValue.create(_dfa, rc);
         case c_bool                    -> _dfa.bool();
-        case c_Const_String, c_String  -> _dfa.newConstString(null, this);
+        case c_String                  -> _dfa.newConstString(null, this);
         case c_sys_ptr                 -> _dfa.newInstance(_dfa._fuir.clazz(SpecialClazzes.c_sys_ptr), _site, _context);
         default                        ->
           _dfa._fuir.clazzIsUnitType(rc)

--- a/src/dev/flang/fuir/analysis/dfa/DFA.java
+++ b/src/dev/flang/fuir/analysis/dfa/DFA.java
@@ -494,7 +494,7 @@ public class DFA extends ANY
              c_u64  ,
              c_f32  ,
              c_f64  -> NumericValue.create(DFA.this, constCl, ByteBuffer.wrap(d).position(4).order(ByteOrder.LITTLE_ENDIAN));
-        case c_Const_String, c_String -> newConstString(Arrays.copyOfRange(d, 4, ByteBuffer.wrap(d).order(ByteOrder.LITTLE_ENDIAN).getInt()+4), _call);
+        case c_String -> newConstString(Arrays.copyOfRange(d, 4, ByteBuffer.wrap(d).order(ByteOrder.LITTLE_ENDIAN).getInt()+4), _call);
         default ->
           {
             if (!_fuir.clazzIsChoice(constCl))


### PR DESCRIPTION
Removed t_Const_String from frontend. Backends decide how they want to implement constant strings.


