### PR TITLE
lib: `Sequence.sort` should require elements to be `orderable`

### DIFF
--- a/modules/base/src/Sequence.fz
+++ b/modules/base/src/Sequence.fz
@@ -467,9 +467,14 @@ public Sequence(public T type) ref : property.equatable is
   #
   public sort
   pre
-    T : property.partially_orderable
+    T : property.orderable
+  post
+    # NYI: BUG: #4346 constraint from pre-condition is not propagated to post-condition
+    #
+    # result.map_pairs (<=)
+    #       .reduce true (&&)
   =>
-    sort_by ((a,b) -> T.lteq a b)
+    sort_by (<=)
 
 
   # create a new list from the result of applying 'f' to the


### PR DESCRIPTION
`partially_orderable` does not seem to make any sense sense, what should be the postcondition of the ordered result?

Also adding a post-conditions for this, which requires a repeated type constraint due to #4346.
