### PR TITLE
makefile: fix target debug_api_docs not working on first run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1167,7 +1167,7 @@ debug_api_docs: $(FUZION_BASE) $(CLASS_FILES_TOOLS_DOCS)
 	mkdir -p $(BUILD_DIR)/debugdocs
 	cp assets/docs/style.css $(BUILD_DIR)/debugdocs/
 	$(JAVA) -cp $(CLASSES_DIR) -Xss64m -Dfuzion.home=$(BUILD_DIR) dev.flang.tools.docs.Docs $(BUILD_DIR)/debugdocs
-	jwebserver --port 15306 --directory $(realpath $(BUILD_DIR)/debugdocs)
+	jwebserver --port 15306 --directory $$(realpath $(BUILD_DIR)/debugdocs)
 
 # phony target to regenerate UnicodeData.java using the latest UnicodeData.txt.
 # This must be phony since $(SRC)/dev/flang/util/UnicodeData.java would


### PR DESCRIPTION
Did not work on first run if folder `build/debugdocs` does not exist.