### PR TITLE
be/c: fix parameter 'fzouter' set but not used

### DIFF
--- a/src/dev/flang/be/c/C.java
+++ b/src/dev/flang/be/c/C.java
@@ -754,6 +754,7 @@ public class C extends ANY
           "-Wpedantic",
           "-Wformat=2",
           "-Wno-unused-parameter",
+          "-Wno-unused-but-set-parameter", // needed for #1777
           "-Wshadow",
           "-Wwrite-strings",
           "-Wold-style-definition",

--- a/tests/reg_issue1777/Makefile
+++ b/tests/reg_issue1777/Makefile
@@ -1,0 +1,25 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test Makefile
+#
+# -----------------------------------------------------------------------
+
+override NAME = reg_issue1777
+include ../compile.mk # infinite recursion

--- a/tests/reg_issue1777/reg_issue1777.fz
+++ b/tests/reg_issue1777/reg_issue1777.fz
@@ -1,0 +1,35 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test reg_issue1777
+#
+# -----------------------------------------------------------------------
+
+reg_issue1777 =>
+
+  Curry ref is
+    r(x Curry) i32 => abstract
+
+  my_loop i32 =>
+    c := (ref : Curry
+      redef r(x Curry) => x.r x
+    )
+    c.r c
+
+  _ := my_loop


### PR DESCRIPTION
fixes #1777

the offending code:
```c
fzT_1i32 fzC_my_u_loop_R_Hanonymous0__1r(fzT_my_u_loop_R_Hanonymous0* fzouter, fzT__RCurry* arg0)
{
  start:
  {
    // cur does not escape, alloc on stack
    fzT_my_u_loop_R_Hanonymous0__1r fzCur;
    fzE_memset(&fzCur,0,sizeof fzCur);
    // assignment to unused field `my_loop.#anonymous0.r#1.#^<my_loop.anonymous.r>`
    fzCur.fzF_0_x = (fzT__RCurry*)arg0;
    // 805306384: Current
    // 805306385: Call my_loop.#anonymous0.r#1.x(outer my_loop.#anonymous0.r#1) Curry
    // 805306386: Current
    // 805306387: Call my_loop.#anonymous0.r#1.x(outer my_loop.#anonymous0.r#1) Curry
    // 805306388: Call Curry.r#1(outer Curry, x Curry) i32
    // tail recursion with changed target
    fzouter = (fzT_my_u_loop_R_Hanonymous0*)fzCur.fzF_0_x;
    arg0 = (fzT__RCurry*)fzCur.fzF_0_x;
    goto start;
    fprintf(stderr,"*** %s:%d: %s\012",__FILE__,__LINE__,"Severe compiler bug! This code should be unreachable:\012my_loop.#anonymous0.r#1(1 args) at \033[32m/home/sam/playground/test.fz:6:25:\033[39m\012\033[34m    redef r(x Curry) => \033[4:3m\033[58;5;1mx.r x\033[24m\033[59m\012\033[0m");
    exit(1);
    return fzCur.fzF_1__Hresult;
  }
}
```
