### PR TITLE
ast: fix nested tuples

### DIFF
--- a/src/dev/flang/ast/ParsedCall.java
+++ b/src/dev/flang/ast/ParsedCall.java
@@ -670,7 +670,7 @@ public class ParsedCall extends Call
   Call resolveImplicitSelect(Resolution res, Context context, AbstractType t)
   {
     Call result = this;
-    if (_select >= 0 && !t.isGenericArgument())
+    if (_select >= 0 && !t.isGenericArgument() && !calledFeature().resultType().isOpenGeneric())
       {
         var f = res._module.lookupOpenTypeParameterResult(t.feature(), this);
         if (f != null)

--- a/tests/reg_issue4386/Makefile
+++ b/tests/reg_issue4386/Makefile
@@ -1,0 +1,25 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test Makefile
+#
+# -----------------------------------------------------------------------
+
+override NAME = reg_issue4386
+include ../simple.mk

--- a/tests/reg_issue4386/reg_issue4386.fz
+++ b/tests/reg_issue4386/reg_issue4386.fz
@@ -1,0 +1,27 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test reg_issue4386
+#
+# -----------------------------------------------------------------------
+
+reg_issue4386 =>
+  x := tuple 1 (tuple 2 3)
+  say x.values.1
+  say x.1.values.1

--- a/tests/reg_issue4386/reg_issue4386.fz.expected_out
+++ b/tests/reg_issue4386/reg_issue4386.fz.expected_out
@@ -1,0 +1,2 @@
+instance[tuple i32 i32]
+3


### PR DESCRIPTION
Do not push call if called features result type already is an open generic.

fixes #4386
