### PR TITLE
ast: optimize recording of used fields

### DIFF
--- a/src/dev/flang/ast/AbstractCall.java
+++ b/src/dev/flang/ast/AbstractCall.java
@@ -250,30 +250,6 @@ public abstract class AbstractCall extends Expr
                     tf.selfType());
   }
 
-
-  /**
-   * Collect used fields to be able to warn about unused ones.
-   * @param usages set to which the used fields should be collected to
-   */
-  public void recordUsage(Set<AbstractFeature> usages)
-  {
-    if (!(this instanceof Call c) || c.calledFeatureKnown())
-      {
-        var feat = calledFeature();
-
-        // don't collect features that should never be warned about, see Feature.java for reasons
-        if (feat.kind() == AbstractFeature.Kind.Field
-            && feat.visibility().eraseTypeVisibility() != Visi.PUB
-            && !feat.featureName().isInternal()
-            && !feat.outer().featureName().isInternal()
-            && !feat.featureName().isNameless()
-            && !feat.isArgument())
-          {
-            usages.add(feat);
-          }
-      }
-  }
-
 }
 
 /* end of file */

--- a/src/dev/flang/ast/Resolution.java
+++ b/src/dev/flang/ast/Resolution.java
@@ -136,11 +136,6 @@ public class Resolution extends ANY
 
   /*----------------------------  variables  ----------------------------*/
 
-  /*
-   * For recording usages of (non-public) fields.
-   */
-  public final Set<AbstractFeature> fieldUsages = new TreeSet<AbstractFeature>();
-
 
   /**
    * FeatureVisitor to call resolve() on all types.


### PR DESCRIPTION
store usage state inside the Feature instead of using one big set with references of all used fields
