### PR TITLE
cleanup: fix non existing parameters and broken references in javadocs

### DIFF
--- a/src/dev/flang/ast/AbstractCall.java
+++ b/src/dev/flang/ast/AbstractCall.java
@@ -185,8 +185,6 @@ public abstract class AbstractCall extends Expr
    *
    * @param p the source position
    *
-   * @param typeParameters the type parameters passed to the call
-   *
    * @param res Resolution instance used to resolve types in this call.
    *
    * @param that the original feature that is used to lookup types.

--- a/src/dev/flang/ast/AbstractType.java
+++ b/src/dev/flang/ast/AbstractType.java
@@ -2183,7 +2183,6 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
 
   /**
    * Return constraint if type is a generic, unmodified type otherwise
-   * @param tt the type
    * @param context the context
    * @return constraint for generics, unmodified type otherwise
    */
@@ -2195,7 +2194,6 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
 
   /**
    * Return constraint if type is a generic, unmodified type otherwise
-   * @param tt the type
    * @param res the resolution
    * @param context the context
    * @return constraint for generics, unmodified type otherwise

--- a/src/dev/flang/ast/Assign.java
+++ b/src/dev/flang/ast/Assign.java
@@ -111,7 +111,7 @@ public class Assign extends AbstractAssign
    *
    * @param v
    *
-   * @param outer the root feature that contains this expression.
+   * @param context the source code context where this assignment is used
    */
   public Assign(Resolution res, SourcePosition pos, AbstractFeature f, Expr v, Context context)
   {

--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -181,6 +181,9 @@ public class Call extends AbstractCall
   AbstractType[] _resolvedFormalArgumentTypes = null;
 
 
+  private boolean _recursiveResolveType = false;
+
+
   /**
    * Will be set to true for a call to a direct parent feature in an inheritance
    * call.
@@ -959,7 +962,7 @@ public class Call extends AbstractCall
    * called repeatedly with different outer arguments as a result of this call
    * being moved into a different feature (lambda, lazy, etc.).
    *
-   * @param re the resolution instance
+   * @param res the resolution instance
    *
    * @param context the source code context where this Call is used
    */
@@ -1286,7 +1289,7 @@ public class Call extends AbstractCall
    *
    * @param res the resolution instance.
    *
-   * @param outer the root feature that contains this expression.
+   * @param context the source code context where this assignment is used
    *
    * @return result this in case this was not an immediate call, otherwise the
    * resulting call to Function/Routine.call.
@@ -1564,7 +1567,7 @@ public class Call extends AbstractCall
    *
    * @param arg true if `t` is the type of an argument, false if `t` is the result type
    *
-   * @param the declared argument (if arg == true) or the called feature (otherwise).
+   * @param calledOrArg the declared argument (if arg == true) or the called feature (otherwise).
    *
    * @param context the source code context where this Call is used
    *
@@ -2478,7 +2481,6 @@ public class Call extends AbstractCall
    *
    * @param context the source code context where this Call is used
    */
-  private boolean _recursiveResolveType = false;
   public Call resolveTypes(Resolution res, Context context)
   {
     Call result = this;

--- a/src/dev/flang/ast/Check.java
+++ b/src/dev/flang/ast/Check.java
@@ -81,11 +81,6 @@ public class Check extends ANY
   /**
    * visit all the expressions within this feature.
    *
-   * @param v the visitor instance that defines an action to be performed on
-   * visited objects.
-   *
-   * @param outer the feature surrounding this expression.
-   *
    * @return this.
    */
   public Expr asIfs()

--- a/src/dev/flang/ast/Contract.java
+++ b/src/dev/flang/ast/Contract.java
@@ -345,7 +345,7 @@ public class Contract extends ANY
    *
    * @param f a feature with a precondition that should be called.
    *
-   * @param outer the outer feature the call will be used in.
+   * @param context the source code context where this assignment is used
    *
    * @return a call to f.preFeature() to be added to code of outer.
    */
@@ -498,7 +498,7 @@ public class Contract extends ANY
    *
    * @param res resolution instance
    *
-   * @param outer a feature with a postcondition whose body the result will be
+   * @param context the source code context where this assignment is used
    * added to
    *
    * @return a call to outer.postFeature() to be added to code of outer.

--- a/src/dev/flang/ast/Feature.java
+++ b/src/dev/flang/ast/Feature.java
@@ -98,6 +98,9 @@ public class Feature extends AbstractFeature
   private final SourcePosition _posOfReturnType;
 
 
+  Context _sourceCodeContext = Context.NONE;
+
+
   /**
    * The visibility of this feature
    */
@@ -1487,7 +1490,6 @@ public class Feature extends AbstractFeature
    * @param res this is called during type resolution, res gives the resolution
    * instance.
    */
-  Context _sourceCodeContext = Context.NONE;
   void internalResolveTypes(Resolution res)
   {
     if (PRECONDITIONS) require

--- a/src/dev/flang/ast/Impl.java
+++ b/src/dev/flang/ast/Impl.java
@@ -413,7 +413,7 @@ public class Impl extends ANY
    * @param res this is called during type resolution, res gives the resolution
    * instance.
    *
-   * @param outer the feature that contains this implementation.
+   * @param context the source code context where this assignment is used
    */
   public void resolveSyntacticSugar2(Resolution res, Context context)
   {

--- a/src/dev/flang/ast/Partial.java
+++ b/src/dev/flang/ast/Partial.java
@@ -273,7 +273,6 @@ public class Partial extends AbstractLambda
    *
    * @param res the resolution instance.
    *
-   * @param outer the root feature that contains this expression.
    */
   public Expr resolveSyntacticSugar2X(Resolution res)
   {

--- a/src/dev/flang/ast/This.java
+++ b/src/dev/flang/ast/This.java
@@ -135,8 +135,6 @@ public class This extends ExprWithPos
    *
    * @param context the source code context where this This is to be used
    *
-   * @param cur the current feature that contains this this expression
-   *
    * @param f the outer feature whose instance we want to access.
    *
    * @return the type resolved expression to access f.this.

--- a/src/dev/flang/ast/UnresolvedType.java
+++ b/src/dev/flang/ast/UnresolvedType.java
@@ -536,8 +536,7 @@ public abstract class UnresolvedType extends AbstractType implements HasSourcePo
    * @param res this is called during type resolution, res gives the resolution
    * instance.
    *
-   * @param outerfeat the outer feature this type is declared in. Lookup of
-   * unqualified types will happen in this feature.
+   * @param context the source code context where this assignment is used
    */
   @Override
   AbstractType resolve(Resolution res, Context context)

--- a/src/dev/flang/be/c/C.java
+++ b/src/dev/flang/be/c/C.java
@@ -1992,7 +1992,7 @@ public class C extends ANY
    * pointer in case _fuir.clazzIsRef(cl), or the C struct corresponding to cl
    * otherwise.
    *
-   * @param cl id of clazz we are generating code for
+   * @param s id of clazz we are generating code for
    */
   CExpr current(int s)
   {

--- a/src/dev/flang/be/interpreter/Executor.java
+++ b/src/dev/flang/be/interpreter/Executor.java
@@ -132,7 +132,6 @@ public class Executor extends ProcessExpression<Value, Object>
    * The constructor to initialize the executor
    * with a custom current, outer and args.
    *
-   * @param fuir
    * @param cur
    * @param outer
    * @param args
@@ -654,9 +653,13 @@ public class Executor extends ProcessExpression<Value, Object>
   /**
    * Helper for callStack() to show one single frame
    *
+   * @param fuir
+   *
+   * @param sb used to append the output
+   *
    * @param frame the clazz of the entry to show
    *
-   * @param call the call of the entry to show
+   * @param callSite the call of the entry to show
    */
   private static void showFrame(FUIR fuir, StringBuilder sb, int frame, int callSite)
   {
@@ -671,6 +674,8 @@ public class Executor extends ProcessExpression<Value, Object>
   /**
    * Helper for callStack() to show a repeated frame
    *
+   * @param fuir
+   *
    * @param sb used to append the output
    *
    * @param repeat how often was the previous entry repeated? >= 0 where 0 means
@@ -679,7 +684,7 @@ public class Executor extends ProcessExpression<Value, Object>
    *
    * @param frame the clazz of the previous entry
    *
-   * @param call the call of the previous entry
+   * @param callSite the call of the previous entry
    */
   private static void showRepeat(FUIR fuir, StringBuilder sb, int repeat, int frame, int callSite)
   {

--- a/src/dev/flang/be/jvm/CodeGen.java
+++ b/src/dev/flang/be/jvm/CodeGen.java
@@ -153,8 +153,6 @@ class CodeGen
    * Called before each statement is processed.  May be used to, e.g., produce
    * tracing code for debugging or a comment.
    *
-   * @param cl the clazz we are compiling
-   *
    * @param s site of the next expression
    */
   @Override
@@ -517,8 +515,6 @@ class CodeGen
    * @param isCall true if the access is a call, false if it is an assignment to
    * a field.
    *
-   * @param si site of the access
-   *
    * @return the result and code to perform the access.
    */
   Pair<Expr, Expr> staticAccess(int si, int tt, int cc, Expr tv, List<Expr> args, boolean isCall)
@@ -554,8 +550,6 @@ class CodeGen
    * @param cc clazz that is called
    *
    * @return the code to perform the call
-   *
-   * @param si site of the call
    */
   Pair<Expr, Expr> staticCall(int si, Expr tvalue, List<Expr> args, int cc)
   {
@@ -1024,7 +1018,7 @@ class CodeGen
   /**
    * Create a tagged value of type newcl from an untagged value for type valuecl.
    *
-   * @param cl the clazz we are compiling
+   * @param s site of the match
    *
    * @param value code to produce the value we are tagging
    *

--- a/src/dev/flang/be/jvm/JVM.java
+++ b/src/dev/flang/be/jvm/JVM.java
@@ -1341,9 +1341,9 @@ should be avoided as much as possible.
   /**
    * Alloc local var slots for the given routine.
    *
-   * @param cl id of clazz to generate code for
+   * @param si id of clazz to generate code for
    *
-   * @param numSlots the number of slots to be alloced
+   * @param numSlots the number of slots to be allocated
    *
    * @return the local var index of the allocated slots
    */

--- a/src/dev/flang/be/jvm/classfile/Expr.java
+++ b/src/dev/flang/be/jvm/classfile/Expr.java
@@ -2050,7 +2050,7 @@ public abstract class Expr extends ByteCode
    *
    * @param try_handler label marking the catch code
    *
-   * @param type the exception type that is to be caught, must not be null.
+   * @param exc_type the exception type that is to be caught, must not be null.
    */
   public static Expr tryCatch(Label try_end,
                               Label try_handler,

--- a/src/dev/flang/fuir/Clazz.java
+++ b/src/dev/flang/fuir/Clazz.java
@@ -1007,11 +1007,6 @@ class Clazz extends ANY implements Comparable<Clazz>
    * @param select in case f is a field of open generic type, this selects the
    * actual field.  -1 otherwise.
    *
-   * @param p if this lookup would result in the returned feature to be called,
-   * p gives the position in the source code that causes this call.  p must be
-   * null if the lookup does not cause a call, but it just done to determine
-   * the type.
-   *
    * @param isInheritanceCall true iff this is a call in an inheritance clause.  In
    * this case, the result clazz will not be marked as instantiated since the
    * call will work on the instance of the inheriting clazz.
@@ -1921,21 +1916,6 @@ class Clazz extends ANY implements Comparable<Clazz>
    * @param select in case t is an open generic, the variant of the actual type
    * that is to be chosen.  -1 otherwise.
    *
-   * @param inh the inheritance change that brought is here. This is usually an
-   * empty list, only in case this is used in a (recursively) inlined inherits
-   * call, then inh gives the sequence of inherits calls from bottom (child) to
-   * top (parent).  E.g., in
-   *
-   *    sum(T type : numeric, a, b T) is
-   *       res := a + b
-   *
-   *    sum_of_3_and_5 : sum i32 3 5 is
-   *
-   * the type `T` used in `res := a + b` gets replaced by `i32` when this code
-   * is inlined to the constructor of `sum_of_3_and_5` via the inherits call
-   * `sum i32 3 5`.
-   *
-   * @param pos a source code position, used to report errors.
    */
   Clazz handDown(AbstractType t, int select)
   {
@@ -1954,7 +1934,7 @@ class Clazz extends ANY implements Comparable<Clazz>
       {
         // iterate using `child` and `parent` over outer clazzes starting at
         // `this` where `child` is the current outer clazz and `parent` is the
-        // parent feature the previous inner clazz' feature was inherted from.
+        // parent feature the previous inner clazz' feature was inherited from.
         var child = this;
         AbstractFeature parent = feature();
         while (child != null)

--- a/src/dev/flang/fuir/FUIR.java
+++ b/src/dev/flang/fuir/FUIR.java
@@ -236,7 +236,7 @@ public abstract class FUIR extends IR
   /**
    * Check if field does not store the value directly, but a pointer to the value.
    *
-   * @param field a clazz id, not necessarily a field
+   * @param fcl a clazz id, not necessarily a field
    *
    * @return true iff the field is an outer ref field that holds an address of
    * an outer value, false for normal fields our outer ref fields that store the
@@ -993,8 +993,6 @@ public abstract class FUIR extends IR
   /**
    * Get the target (outer) clazz of a feature access
    *
-   * @param cl index of clazz containing the access
-   *
    * @param s site of the access
    *
    * @return index of the static outer clazz of the accessed feature.
@@ -1008,8 +1006,6 @@ public abstract class FUIR extends IR
    * Currently, the clazz is one of bool, i8, i16, i32, i64, u8, u16, u32, u64,
    * f32, f64, or Const_String. This will be extended by value instances without
    * refs, choice instances with tag, arrays, etc.
-   *
-   * @param cl index of clazz containing the constant
    *
    * @param s site of the constant
    */
@@ -1465,7 +1461,7 @@ public abstract class FUIR extends IR
    *
    * @param f the inner clazz that is called and that is missing an implementation
    *
-   * @param instantiationPos if known, the site where `cl` was instantiated,
+   * @param instantiationSite if known, the site where `cl` was instantiated,
    * `NO_SITE` if unknown.
    */
   public abstract void recordAbstractMissing(int cl, int f, int instantiationSite, String context, int callSite);

--- a/src/dev/flang/fuir/GeneratingFUIR.java
+++ b/src/dev/flang/fuir/GeneratingFUIR.java
@@ -2880,8 +2880,6 @@ public class GeneratingFUIR extends FUIR
   /**
    * Get the target (outer) clazz of a feature access
    *
-   * @param cl index of clazz containing the access
-   *
    * @param s site of the access
    *
    * @return index of the static outer clazz of the accessed feature.
@@ -2922,8 +2920,6 @@ public class GeneratingFUIR extends FUIR
    * Currently, the clazz is one of bool, i8, i16, i32, i64, u8, u16, u32, u64,
    * f32, f64, or Const_String. This will be extended by value instances without
    * refs, choice instances with tag, arrays, etc.
-   *
-   * @param cl index of clazz containing the constant
    *
    * @param s site of the constant
    */
@@ -3462,7 +3458,7 @@ public class GeneratingFUIR extends FUIR
    *
    * @param f the inner clazz that is called and that is missing an implementation
    *
-   * @param instantiationPos if known, the site where `cl` was instantiated,
+   * @param instantiationSite if known, the site where `cl` was instantiated,
    * `NO_SITE` if unknown.
    */
   @Override

--- a/src/dev/flang/fuir/analysis/TailCall.java
+++ b/src/dev/flang/fuir/analysis/TailCall.java
@@ -115,8 +115,6 @@ public class TailCall extends ANY
    * check if the first argument in the given call is the current instance's
    * outer reference.
    *
-   * @param cl index of clazz containing the call
-   *
    * @param s site of the call
    */
   public boolean firstArgIsOuter(int s)

--- a/src/dev/flang/fuir/analysis/dfa/DFA.java
+++ b/src/dev/flang/fuir/analysis/dfa/DFA.java
@@ -171,8 +171,6 @@ public class DFA extends ANY
      * @param tvalue the target instance
      *
      * @param val the new value to be assigned to the field.
-     *
-     * @return resulting code of this assignment.
      */
     @Override
     public void assignStatic(int s, int tc, int f, int rt, Val tvalue, Val val)

--- a/src/dev/flang/fuir/analysis/dfa/EmbeddedValue.java
+++ b/src/dev/flang/fuir/analysis/dfa/EmbeddedValue.java
@@ -80,9 +80,7 @@ public class EmbeddedValue extends Val
    *
    * @param instance the instance containing this embedded value
    *
-   * @param code code block index
-   *
-   * @param index expr index in code block
+   * @param site expr index in code block
    *
    * @param value the value of the embedded field
    */

--- a/src/dev/flang/fuir/analysis/dfa/SysArray.java
+++ b/src/dev/flang/fuir/analysis/dfa/SysArray.java
@@ -138,7 +138,7 @@ public class SysArray extends Value
    *
    * @param v the value this value should be joined with.
    *
-   * @param clazz the clazz of the resulting value. This is usually the same as
+   * @param cl the clazz of the resulting value. This is usually the same as
    * the clazz of `this` or `v`, unless we are joining `ref` type values.
    */
   @Override

--- a/src/dev/flang/ir/IR.java
+++ b/src/dev/flang/ir/IR.java
@@ -160,9 +160,9 @@ public abstract class IR extends ANY
    *
    * This also sets _siteStart in case `b` was not already added.
    *
-   * @param b a list of Exprs, might contain non-Expr values for special cases.
+   * @param code a list of Exprs, might contain non-Expr values for special cases.
    *
-   * @return the index of b
+   * @return the index of code
    */
   protected int addCode(List<Object> code)
   {
@@ -439,7 +439,7 @@ public abstract class IR extends ANY
   /**
    * Get the source code position of an expr at the given site if it is available.
    *
-   * @param site a site
+   * @param s a site
    *
    * @return the source code position or null if not available.
    */

--- a/src/dev/flang/parser/Parser.java
+++ b/src/dev/flang/parser/Parser.java
@@ -3696,10 +3696,6 @@ typeOpt     : type
    * @param allowTypeInParentheses true iff the type may be surrounded by
    * parentheses, i.e., '(i32, list bool)', '(stack f64)', '()'.
    *
-   * @param allowTypeThatIsNotExpression false to forbid types that cannot be
-   * parsed as expressions such as lambdas types with argument types that are
-   * not just argNames.
-   *
    * @return true iff the next token(s) is a onetype, otherwise no onetype was
    * found and the parser/lexer is at an undefined position.
    */

--- a/src/dev/flang/tools/docs/Html.java
+++ b/src/dev/flang/tools/docs/Html.java
@@ -192,7 +192,6 @@ public class Html extends ANY
   /**
    * summary for feature af
    * @param af
-   * @param printArgs whether or not arguments of the feature should be included in output
    * @return
    */
   private String summary(AbstractFeature af, AbstractFeature outer)
@@ -684,7 +683,7 @@ public class Html extends ANY
 
   /**
    * get full html with doctype, head and body
-   * @param af
+   * @param qualifiedName
    * @param bareHtml
    * @return
    */

--- a/src/dev/flang/util/Errors.java
+++ b/src/dev/flang/util/Errors.java
@@ -592,7 +592,7 @@ public class Errors extends ANY
   /**
    * Record the given runtime error and exit immediately with exit code 1.
    *
-   * @param k the kind of error we encountered, currently "postcondition" is the
+   * @param kind the kind of error we encountered, currently "postcondition" is the
    * only supported kind that is treated specially.
    *
    * @param msg a message to be shown

--- a/src/dev/flang/util/IntMap.java
+++ b/src/dev/flang/util/IntMap.java
@@ -27,6 +27,7 @@ Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
 package dev.flang.util;
 
 import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 
@@ -67,7 +68,7 @@ public class IntMap<T>
 
 
   /**
-   * @see java.util.Map.size
+   * @see java.util.Map#size()
    */
   public int size()
   {
@@ -76,7 +77,7 @@ public class IntMap<T>
 
 
   /**
-   * @see java.util.Map.get
+   * @see java.util.Map#get(Object)
    */
   public T get(int i)
   {
@@ -85,7 +86,7 @@ public class IntMap<T>
 
 
   /**
-   * @see java.util.Map.getOrDefault
+   * @see java.util.Map#getOrDefault(Object, Object)
    */
   public T getOrDefault(int i, T def)
   {
@@ -94,7 +95,7 @@ public class IntMap<T>
 
 
   /**
-   * @see java.util.Map.put
+   * @see java.util.Map#put(Object, Object)
    */
   public T put(int i, T v)
   {
@@ -106,7 +107,7 @@ public class IntMap<T>
    * All keys in this map.  This is sorted by the integer values to ensure
    * repeatable behaviour when iterating.
    *
-   * @see java.util.Map.keySet
+   * @see java.util.Map#keySet()
    */
   public Set<Integer> keySet()
   {

--- a/src/dev/flang/util/LongMap.java
+++ b/src/dev/flang/util/LongMap.java
@@ -67,7 +67,7 @@ public class LongMap<T>
 
 
   /**
-   * @see java.util.Map.size
+   * @see java.util.Map#size()
    */
   public int size()
   {
@@ -76,7 +76,7 @@ public class LongMap<T>
 
 
   /**
-   * @see java.util.Map.get
+   * @see java.util.Map#get(Object)
    */
   public T get(long i)
   {
@@ -85,7 +85,7 @@ public class LongMap<T>
 
 
   /**
-   * @see java.util.Map.getOrDefault
+   * @see java.util.Map#getOrDefault(Object, Object)
    */
   public T getOrDefault(long i, T def)
   {
@@ -94,7 +94,7 @@ public class LongMap<T>
 
 
   /**
-   * @see java.util.Map.put
+   * @see java.util.Map#put(Object, Object)
    */
   public T put(long i, T v)
   {
@@ -106,7 +106,7 @@ public class LongMap<T>
    * All keys in this map.  This is sorted by the long values to ensure
    * repeatable behaviour when iterating.
    *
-   * @see java.util.Map.keySet
+   * @see java.util.Map#keySet()
    */
   public Set<Long> keySet()
   {


### PR DESCRIPTION
partially solves #4358