### PR TITLE
ast: return null for `asType` of partialargs

### DIFF
--- a/src/dev/flang/ast/Partial.java
+++ b/src/dev/flang/ast/Partial.java
@@ -110,7 +110,14 @@ public class Partial extends AbstractLambda
    */
   static ParsedCall argName(SourcePosition pos)
   {
-    return new ParsedCall(new ParsedName(pos, argName()));
+    return new ParsedCall(new ParsedName(pos, argName()))
+      {
+        @Override
+        public AbstractType asType()
+        {
+          return null;
+        }
+      };
   }
 
 

--- a/tests/reg_issue4420/Makefile
+++ b/tests/reg_issue4420/Makefile
@@ -1,0 +1,25 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test Makefile
+#
+# -----------------------------------------------------------------------
+
+override NAME = reg_issue4420
+include ../simple.mk

--- a/tests/reg_issue4420/reg_issue4420.fz
+++ b/tests/reg_issue4420/reg_issue4420.fz
@@ -1,0 +1,24 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test reg_issue4420
+#
+# -----------------------------------------------------------------------
+
+[""].reduce unit unit id

--- a/tests/reg_issue4420/reg_issue4420.fz.expected_err
+++ b/tests/reg_issue4420/reg_issue4420.fz.expected_err
@@ -1,0 +1,10 @@
+
+--CURDIR--/reg_issue4420.fz:24:23: error 1: Wrong number of type parameters
+[""].reduce unit unit id
+----------------------^^
+Wrong number of actual type parameters in call:
+Called feature: id
+expected one generic argument for 'T'
+found none.
+
+one error.


### PR DESCRIPTION
fixes #4420
