### PR TITLE
ast: refine isAssignableFrom checks

### DIFF
--- a/src/dev/flang/ast/AbstractAssign.java
+++ b/src/dev/flang/ast/AbstractAssign.java
@@ -284,7 +284,7 @@ public abstract class AbstractAssign extends Expr
           (Errors.any() || frmlT != Types.t_ERROR,
            Errors.any() || _value.type() != Types.t_ERROR);
 
-        if (_value.type() != Types.t_ERROR && !frmlT.isDirectlyAssignableFrom(_value.type(), context))
+        if (_value.type() != Types.t_ERROR && !frmlT.isAssignableFromWithoutBoxing(_value.type(), context))
           {
             AstErrors.incompatibleTypeInAssignment(pos(), f, frmlT, _value, context);
           }

--- a/src/dev/flang/ast/AbstractMatch.java
+++ b/src/dev/flang/ast/AbstractMatch.java
@@ -202,7 +202,7 @@ public abstract class AbstractMatch extends Expr
                 AstErrors.matchSubjectMustBeChoice(subject().pos(), st);
               }
           }
-        else if (!Types.resolved.t_bool.isDirectlyAssignableFrom(st, context))
+        else if (!Types.resolved.t_bool.isAssignableFromWithoutBoxing(st, context))
           {
             if (kind() == Kind.Contract)
               {

--- a/src/dev/flang/ast/AbstractType.java
+++ b/src/dev/flang/ast/AbstractType.java
@@ -352,10 +352,27 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
    *
    * @param context the source code context where this Type is used
    */
-  public boolean isDirectlyAssignableFrom(AbstractType actual, Context context)
+  public boolean isAssignableFromWithoutTagging(AbstractType actual, Context context)
   {
     return actual.isVoid()
          || (!isChoice() && isAssignableFrom(actual, context))
+         || (isChoice() && compareTo(actual) == 0);
+  }
+
+
+  /**
+   * Check if a value of static type actual can be assigned to a field of static
+   * type this without boxing. This performs static type checking, i.e.,
+   * the types may still be or depend on generic parameters.
+   *
+   * @param actual the actual type.
+   *
+   * @param context the source code context where this Type is used
+   */
+  public boolean isAssignableFromWithoutBoxing(AbstractType actual, Context context)
+  {
+    return actual.isVoid()
+         || (!isChoice() && isAssignableFrom(actual, context) && !(isRef().yes() && actual.isRef().no()))
          || (isChoice() && compareTo(actual) == 0);
   }
 
@@ -1116,8 +1133,8 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
   {
     return this.isVoid()
       || other.isVoid()
-      ||    !this .isDirectlyAssignableFrom(other, context)
-         && !other.isDirectlyAssignableFrom(this , context);
+      ||    !this .isAssignableFromWithoutTagging(other, context)
+         && !other.isAssignableFromWithoutTagging(this , context);
   }
 
 

--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -2841,7 +2841,7 @@ public class Call extends AbstractCall
                 var frmlT = _resolvedFormalArgumentTypes[count];
                 if (CHECKS) check
                   (Errors.any() || (actl != Call.ERROR && actl != Call.ERROR));
-                if (frmlT != Types.t_ERROR && actl != Call.ERROR && actl != Call.ERROR && !frmlT.isDirectlyAssignableFrom(actl.type(), context))
+                if (frmlT != Types.t_ERROR && actl != Call.ERROR && actl != Call.ERROR && !frmlT.isAssignableFromWithoutTagging(actl.type(), context))
                   {
                     AstErrors.incompatibleArgumentTypeInCall(_calledFeature, count, frmlT, actl, context);
                   }

--- a/src/dev/flang/ast/Expr.java
+++ b/src/dev/flang/ast/Expr.java
@@ -661,7 +661,7 @@ public abstract class Expr extends HasGlobalIndex implements HasSourcePosition
     else if (frmlT
              .choiceGenerics(context)
               .stream()
-             .filter(cg -> cg.isDirectlyAssignableFrom(value.type(), context))
+             .filter(cg -> cg.isAssignableFromWithoutTagging(value.type(), context))
               .count() > 1)
       {
         AstErrors.ambiguousAssignmentToChoice(frmlT, value);
@@ -673,7 +673,7 @@ public abstract class Expr extends HasGlobalIndex implements HasSourcePosition
     else if (frmlT
               .choiceGenerics(context)
               .stream()
-             .anyMatch(cg -> cg.isDirectlyAssignableFrom(value.type(), context)))
+             .anyMatch(cg -> cg.isAssignableFromWithoutTagging(value.type(), context)))
       {
         return new Tag(value, frmlT, context);
       }

--- a/src/dev/flang/ast/InlineArray.java
+++ b/src/dev/flang/ast/InlineArray.java
@@ -306,7 +306,7 @@ public class InlineArray extends ExprWithPos
 
     for (var e : _elements)
       {
-        if (!elementType.isDirectlyAssignableFrom(e.type(), context))
+        if (!elementType.isAssignableFromWithoutBoxing(e.type(), context))
           {
             AstErrors.incompatibleTypeInArrayInitialization(e.pos(), _type, elementType, e, context);
           }

--- a/src/dev/flang/ast/Tag.java
+++ b/src/dev/flang/ast/Tag.java
@@ -86,7 +86,7 @@ public class Tag extends ExprWithPos
         || taggedType
             .choiceGenerics(context)
             .stream()
-            .filter(cg -> cg.isDirectlyAssignableFrom(value.type(), context))
+            .filter(cg -> cg.isAssignableFromWithoutTagging(value.type(), context))
             .count() == 1
         // NYI why is value.type() sometimes unit
         // even though none of the choice elements is unit
@@ -97,7 +97,7 @@ public class Tag extends ExprWithPos
     this._tagNum = (int)_taggedType
       .choiceGenerics(context)
       .stream()
-      .takeWhile(cg -> !cg.isDirectlyAssignableFrom(value.type(), context))
+      .takeWhile(cg -> !cg.isAssignableFromWithoutTagging(value.type(), context))
       .count();
   }
 

--- a/src/dev/flang/be/interpreter/Instance.java
+++ b/src/dev/flang/be/interpreter/Instance.java
@@ -327,7 +327,7 @@ public class Instance extends ValueWithClazz
     if (fuir().clazzIsRef(expected))
       {
         // NYI:
-        // if (!expected.isDirectlyAssignableFrom(clazz()))
+        // if (!expected.isAssignableFromWithoutTagging(clazz()))
         //   {
         //     throw new Error("Dynamic runtime clazz "+clazz()+" does not match static "+expected);
         //   }

--- a/src/dev/flang/fe/SourceModule.java
+++ b/src/dev/flang/fe/SourceModule.java
@@ -1632,7 +1632,7 @@ A feature that is a constructor, choice or a type parameter may not redefine an 
             */
             AstErrors.cannotRedefine(f, o);
           }
-        else if (!t1.isDirectlyAssignableFrom(t2, context) &&  // we (currently) do not tag the result in a redefined feature, see testRedefine
+        else if (!t1.isAssignableFromWithoutBoxing(t2, context) &&  // we (currently) do not tag the result in a redefined feature, see testRedefine
                  !t2.isVoid() &&
                  !isLegalCovariantThisType(o, f, t1, t2, fixed, context))
           {

--- a/src/dev/flang/fuir/GeneratingFUIR.java
+++ b/src/dev/flang/fuir/GeneratingFUIR.java
@@ -3048,7 +3048,7 @@ public class GeneratingFUIR extends FUIR
         for (int tix = 0; tix < nt; tix++)
           {
             var t = f != null ? f.resultType() : ts.get(tix);
-            if (t.isDirectlyAssignableFrom(cg, Context.NONE /* NYI: CLEANUP: Context should no longer be needed during FUIR */))
+            if (t.isAssignableFromWithoutTagging(cg, Context.NONE /* NYI: CLEANUP: Context should no longer be needed during FUIR */))
               {
                 resultL.add(tag);
               }


### PR DESCRIPTION
split up into isAssignableFromWithoutTagging and isAssignableFromWithoutBoxing

In check types phase not even tagging should be necessary anymore.
