### PR TITLE
cleanup: fix javadoc errors not recognized by linter

### DIFF
--- a/src/dev/flang/ast/ParsedName.java
+++ b/src/dev/flang/ast/ParsedName.java
@@ -110,7 +110,7 @@ public class ParsedName extends ANY implements HasSourcePosition
   /**
    * toString creates a string representation for debug output.
    *
-   * @retur just the name.
+   * @return just the name.
    */
   public String toString()
   {

--- a/src/dev/flang/ast/UnresolvedType.java
+++ b/src/dev/flang/ast/UnresolvedType.java
@@ -51,7 +51,7 @@ public abstract class UnresolvedType extends AbstractType implements HasSourcePo
 
   /**
    * Pre-allocated empty type list. NOTE: There is a specific empty type List
-   * {@code Call.NO_GENERICS} which is used to distinguish {@code a.b<>()} (using {@codeUnresolvedType.NONE})
+   * {@code Call.NO_GENERICS} which is used to distinguish {@code a.b<>()} (using {@code UnresolvedType.NONE})
    * from {@code a.b()} (using {@code Call.NO_GENERICS}).
    */
   public static final List<AbstractType> NONE = new List<AbstractType>();

--- a/src/dev/flang/be/interpreter/Interpreter.java
+++ b/src/dev/flang/be/interpreter/Interpreter.java
@@ -120,7 +120,7 @@ public class Interpreter extends FUIRContext
   /**
    * Create runtime value of given String constant.
    *
-   * @bytes the string in UTF-16
+   * @param bytes the string in UTF-16
    */
   public static Value value(byte[] bytes)
   {

--- a/src/dev/flang/be/jvm/runtime/Runtime.java
+++ b/src/dev/flang/be/jvm/runtime/Runtime.java
@@ -538,7 +538,7 @@ public class Runtime extends ANY
    *
    * @param id an effect type id.
    *
-   * @instance a new instance to replace the old one
+   * @param instance a new instance to replace the old one
    */
   public static void effect_replace(int id, Any instance)
   {

--- a/src/dev/flang/fe/SourceModule.java
+++ b/src/dev/flang/fe/SourceModule.java
@@ -1973,7 +1973,7 @@ A feature that is a constructor, choice or a type parameter may not redefine an 
    * arguments, result field, outer refs or case fields (in case condition uses
    * a {@code match}). Produce AstErrors if needed.
    *
-   * @parm f the feature whose contract should be checked.
+   * @param f the feature whose contract should be checked.
    */
   private void checkContractAccesses(AbstractFeature f)
   { //NYI: CLEANUP:  remove, has no effect.

--- a/src/dev/flang/fuir/FUIR.java
+++ b/src/dev/flang/fuir/FUIR.java
@@ -448,7 +448,7 @@ public abstract class FUIR extends IR
   /**
    * Is the given clazz a ref clazz?
    *
-   * @parm cl a constructor clazz id
+   * @param cl a constructor clazz id
    *
    * @return true for non-value-type clazzes
    */
@@ -1061,7 +1061,7 @@ public abstract class FUIR extends IR
    *
    * @param s site of the match
    *
-   * @paramc cix index of the case in the match
+   * @param cix index of the case in the match
    *
    * @return clazz id of field the value in this case is assigned to, -1 if this
    * case does not have a field or the field is unused.
@@ -1086,7 +1086,7 @@ public abstract class FUIR extends IR
    *
    * @param s site of the match
    *
-   * @paramc cix index of the case in the match
+   * @param cix index of the case in the match
    *
    * @return array of tag numbers this case matches
    */
@@ -1098,7 +1098,7 @@ public abstract class FUIR extends IR
    *
    * @param s site of the match
    *
-   * @paramc cix index of the case in the match
+   * @param cix index of the case in the match
    *
    * @return code block for the case
    */

--- a/src/dev/flang/fuir/GeneratingFUIR.java
+++ b/src/dev/flang/fuir/GeneratingFUIR.java
@@ -1405,7 +1405,7 @@ public class GeneratingFUIR extends FUIR
   /**
    * Is the given clazz a ref clazz?
    *
-   * @parm cl a constructor clazz id
+   * @param cl a constructor clazz id
    *
    * @return true for non-value-type clazzes
    */
@@ -2960,7 +2960,7 @@ public class GeneratingFUIR extends FUIR
    *
    * @param s site of the match
    *
-   * @paramc cix index of the case in the match
+   * @param cix index of the case in the match
    *
    * @return clazz id of field the value in this case is assigned to, -1 if this
    * case does not have a field or the field is unused.
@@ -3023,7 +3023,7 @@ public class GeneratingFUIR extends FUIR
    *
    * @param s site of the match
    *
-   * @paramc cix index of the case in the match
+   * @param cix index of the case in the match
    *
    * @return array of tag numbers this case matches
    */
@@ -3073,7 +3073,7 @@ public class GeneratingFUIR extends FUIR
    *
    * @param s site of the match
    *
-   * @paramc cix index of the case in the match
+   * @param cix index of the case in the match
    *
    * @return code block for the case
    */

--- a/src/dev/flang/util/SourceFile.java
+++ b/src/dev/flang/util/SourceFile.java
@@ -865,7 +865,7 @@ The end of a source code line is marked by one of the code points LF 0x000a, VT 
    * @param end the byte position of first code point after the desired portion
    * of the file
    *
-   * @pram s a String
+   * @param s a String
    *
    * @return -1, 0, +1 if the string in the file is smaller, equal or larger
    * than s comparing each single code point until the end. If all are equal,


### PR DESCRIPTION
fix #4358
