### PR TITLE
dfa: fix type of valueset of original of TaggedValue

### DIFF
--- a/src/dev/flang/fuir/analysis/dfa/TaggedValue.java
+++ b/src/dev/flang/fuir/analysis/dfa/TaggedValue.java
@@ -54,7 +54,7 @@ public class TaggedValue extends Value implements Comparable<TaggedValue>
   /**
    * The original, un-tagged value.
    */
-  Value _original;
+  final Value _original;
 
 
   /**
@@ -81,6 +81,8 @@ public class TaggedValue extends Value implements Comparable<TaggedValue>
   public TaggedValue(DFA dfa, int nc, Value original, int tag)
   {
     super(nc);
+    if (PRECONDITIONS) require
+      (nc != original._clazz);
 
     _dfa = dfa;
     _original = original;
@@ -133,7 +135,11 @@ public class TaggedValue extends Value implements Comparable<TaggedValue>
   {
     if (v instanceof TaggedValue tv && _tag == tv._tag)
       {
-        return _dfa.newTaggedValue(_clazz, _original.join(dfa, tv._original, clazz), _tag);
+        if (CHECKS) check
+          (tv._clazz == clazz);
+
+        var oc = dfa._fuir.clazzChoice(tv._clazz, tv._tag);
+        return _dfa.newTaggedValue(_clazz, _original.join(dfa, tv._original, oc), _tag);
       }
     else
       {

--- a/src/dev/flang/fuir/analysis/dfa/Value.java
+++ b/src/dev/flang/fuir/analysis/dfa/Value.java
@@ -220,7 +220,7 @@ public class Value extends Val
   /**
    * The clazz this is an instance of.
    */
-  int _clazz;
+  final int _clazz;
 
 
   /**


### PR DESCRIPTION
A TaggedValue may have a whole set of values as original values. When joining two TaggedValue instances of the same tag, the _clazz of the joined original values was falses set the the type of the tagged value, it has to be the type of the original value.

Also marked some fields final since that help me debugging by making sure these are immutable.

This bug broke the DFA optimizations I am working on (#4401)