### PR TITLE
base: rename `log` feature as `io.log`

### DIFF
--- a/modules/base/src/io/log.fz
+++ b/modules/base/src/io/log.fz
@@ -17,7 +17,7 @@
 #
 #  Tokiwa Software GmbH, Germany
 #
-#  Source code of Fuzion standard library feature log
+#  Source code of Fuzion standard library feature io.log
 #
 # -----------------------------------------------------------------------
 


### PR DESCRIPTION
The `log` feature conflicts with other definitions of a `log` feature, which is particularly annoying if you are implementing an application in Fuzion and want a `log` short-hand with custom behavior.

`redef` will only help in cases where the short-hand is to be defined in the universe, if it is defined in another feature, then fully qualifying the call would be necessary without this change.

It has been previously proposed to remove the `log` feature entirely, but this proposed change is a different viable option.