### PR TITLE
make: add .DELETE_ON_ERROR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -427,6 +427,11 @@ FZ_MODULES = \
 
 C_FILES = $(shell find $(FZ_SRC) \( -path ./build -o -path ./.git \) -prune -o -name '*.c' -print)
 
+# make sure that any rule failing will result in the created file being
+# deleted. This helps in case a failing rule creates a broken result file, which
+# would prevent a second run of `make` from re-applying the failing rule.
+.DELETE_ON_ERROR:
+
 .PHONY: all
 all: $(FUZION_BASE) $(FUZION_JAVA_MODULES) $(FUZION_FILES) $(MOD_FZ_CMD)
 


### PR DESCRIPTION
I ran into a problme building fuzion.ebnf, but strangely, running `make` again did not show any error since it was happy with the empty `fuzion.ebnf` created by the failed make.

This should delete targets if the rules failed, so we cannot just continue by running make again.

If the original behaviour is desired, you can do
```
  > make
  *** fails for fuzion.ebnf ***
  > touch build/fuzion.ebnf
  > make
  --- will run to completion now, leaving the empty fuzion.ebnf untouched
```