### PR TITLE
lib: Add `Sequence.as_*tuple[s]`, fix #4501

### DIFF
--- a/modules/base/src/Sequence.fz
+++ b/modules/base/src/Sequence.fz
@@ -759,7 +759,6 @@ public Sequence(public T type) ref : property.equatable is
     r.val
 
 
-
   # convert a Sequence's head into a 4-tuple.
   #
   # ex.

--- a/modules/base/src/Sequence.fz
+++ b/modules/base/src/Sequence.fz
@@ -622,6 +622,243 @@ public Sequence(public T type) ref : property.equatable is
       (take chunk_size) : ((drop chunk_size).chunk chunk_size).as_list
 
 
+  # chop this Sequence into tuples of size 2.  In case
+  # the number of elements is not a multiple of 2,
+  # the last count % 2 elements will be dropped silently.
+  #
+  # ex.
+  #
+  #   [1,2,3,4,5].tuples produces [(1,2),(3,4)]
+  #
+  public tuples Sequence (T, T)
+  =>
+    h := take 2
+    t := drop 2
+    if h.count < 2
+      (Sequence (T,T)).empty
+    else
+      h.as_tuple : t.tuples.as_list
+
+
+  # chop this Sequence into tuples of size 3.  In case
+  # the number of elements is not a multiple of 3,
+  # the last count % 3 elements will be dropped silently.
+  #
+  # ex.
+  #
+  #   [1,2,3,4,5,6,7].tuples3 produces [(1,2,3),(4,5,6)]
+  #
+  public tuples3 Sequence (T, T, T)
+  =>
+    h := take 3
+    t := drop 3
+    if h.count < 3
+      (Sequence (T,T,T)).empty
+    else
+      h.as_3tuple : t.tuples3.as_list
+
+
+  # chop this Sequence into tuples of size 4.  In case
+  # the number of elements is not a multiple of 4,
+  # the last count % 4 elements will be dropped silently.
+  #
+  # ex.
+  #
+  #   [1,2,3,4,5].tuples4 produces [(1,2,3,4)]
+  #
+  public tuples4 Sequence (T, T, T, T)
+  =>
+    h := take 4
+    t := drop 4
+    if h.count < 4
+      (Sequence (T,T,T,T)).empty
+    else
+      h.as_4tuple : t.tuples4.as_list
+
+
+  # chop this Sequence into tuples of size 5.  In case
+  # the number of elements is not a multiple of 5,
+  # the last count % 5 elements will be dropped silently.
+  #
+  # ex.
+  #
+  #   [1,2,3,4,5,6].tuples5 produces [(1,2,3,4,5)]
+  #
+  public tuples5 Sequence (T, T, T, T, T)
+  =>
+    h := take 5
+    t := drop 5
+    if h.count < 5
+      (Sequence (T,T,T,T,T)).empty
+    else
+      h.as_5tuple : t.tuples5.as_list
+
+
+  # chop this Sequence into tuples of size 6.  In case
+  # the number of elements is not a multiple of 6,
+  # the last count % 6 elements will be dropped silently.
+  #
+  # ex.
+  #
+  #   [1,2,3,4,5,6,7].tuples6 produces [(1,2,3,4,5,6)]
+  #
+  public tuples6 Sequence (T,T, T, T, T, T)
+  =>
+    h := take 6
+    t := drop 6
+    if h.count < 6
+      (Sequence (T,T,T,T,T,T)).empty
+    else
+      h.as_6tuple : t.tuples6.as_list
+
+
+  # convert a Sequence's head into a 2-tuple.
+  #
+  # ex.
+  #
+  #   [1,2,3,4,5].as_tuple  produces (1,2)
+  #   [1,2].as_tuple        produces (1,2)
+  #   [1].as_tuple          breaks the pre condition
+  #   [].as_tuple           breaks the pre condition
+  #
+  public as_tuple() (T, T)
+    pre
+      debug: take 2 .count = 2
+  =>
+    match as_list
+      c1 Cons =>
+        match c1.tail
+          c2 Cons => (c1.head, c2.head)
+          nil => panic "as_tuple called on single element Sequence"
+      nil => panic "as_tuple called on empty Sequence"
+
+
+  # convert a Sequence's head into a 3-tuple.
+  #
+  # ex.
+  #
+  #   [1,2,3,4,5].as_3tuple  produces (1,2,3)
+  #   [1,2,3].as_3tuple      produces (1,2,3)
+  #   [1,2].as_3tuple        breaks the pre condition
+  #   [1].as_3tuple          breaks the pre condition
+  #   [].as_3tuple           breaks the pre condition
+  #
+  public as_3tuple() (T, T, T)
+    pre
+      debug: take 3 .count = 3
+  =>
+    r option (T, T, T) := match as_list
+                            c1 Cons =>
+                              match c1.tail
+                                c2 Cons =>
+                                  match c2.tail
+                                    c3 Cons => (c1.head, c2.head, c3.head)
+                                    nil => nil
+                                nil => nil
+                            nil => nil
+    r.val
+
+
+
+  # convert a Sequence's head into a 4-tuple.
+  #
+  # ex.
+  #
+  #   [1,2,3,4,5].as_4tuple  produces (1,2,3,4)
+  #   [1,2,3,4].as_4tuple    produces (1,2,3,4)
+  #   [1,2,3].as_4tuple      breaks the pre condition
+  #   [1,2].as_4tuple        breaks the pre condition
+  #   [1].as_4tuple          breaks the pre condition
+  #   [].as_4tuple           breaks the pre condition
+  #
+  public as_4tuple() (T, T, T, T)
+    pre
+      debug: take 4 .count = 4
+  =>
+    r option (T, T, T, T) := match as_list
+                               c1 Cons =>
+                                 match c1.tail
+                                   c2 Cons =>
+                                     match c2.tail
+                                       c3 Cons =>
+                                         match c3.tail
+                                           c4 Cons => (c1.head, c2.head, c3.head, c4.head)
+                                           nil => nil
+                                       nil => nil
+                                   nil => nil
+                               nil => nil
+    r.val
+
+
+  # convert a Sequence's head into a 5-tuple.
+  #
+  # ex.
+  #
+  #   [1,2,3,4,5,6].as_5tuple  produces (1,2,3,4,5)
+  #   [1,2,3,4,5].as_5tuple    produces (1,2,3,4,5)
+  #   [1,2,3,4].as_5tuple      breaks the pre condition
+  #   [1,2,3].as_5tuple        breaks the pre condition
+  #    ...
+  #   [].as_5tuple             breaks the pre condition
+  #
+  public as_5tuple() (T, T, T, T, T)
+    pre
+      debug: take 5 .count = 5
+  =>
+    r option (T, T, T, T, T) := match as_list
+                                  c1 Cons =>
+                                    match c1.tail
+                                      c2 Cons =>
+                                        match c2.tail
+                                          c3 Cons =>
+                                            match c3.tail
+                                              c4 Cons =>
+                                                match c4.tail
+                                                  c5 Cons => (c1.head, c2.head, c3.head, c4.head, c5.head)
+                                                  nil => nil
+                                              nil => nil
+                                          nil => nil
+                                      nil => nil
+                                  nil => nil
+    r.val
+
+
+  # convert a Sequence's head into a 6-tuple.
+  #
+  # ex.
+  #
+  #   [1,2,3,4,5,6,7].as_6tuple  produces (1,2,3,4,5,6)
+  #   [1,2,3,4,5,6].as_6tuple    produces (1,2,3,4,5,6)
+  #   [1,2,3,4,5].as_6tuple      breaks the pre condition
+  #   [1,2,3,4].as_6tuple        breaks the pre condition
+  #    ...
+  #   [].as_6tuple               breaks the pre condition
+  #
+  public as_6tuple() (T, T, T, T, T, T)
+    pre
+      debug: take 6 .count = 6
+  =>
+    r option (T, T, T, T, T, T) := match as_list
+                                     c1 Cons =>
+                                       match c1.tail
+                                         c2 Cons =>
+                                           match c2.tail
+                                             c3 Cons =>
+                                               match c3.tail
+                                                 c4 Cons =>
+                                                   match c4.tail
+                                                     c5 Cons =>
+                                                       match c5.tail
+                                                         c6 Cons => (c1.head, c2.head, c3.head, c4.head, c5.head, c6.head)
+                                                         nil => nil
+                                                     nil => nil
+                                                 nil => nil
+                                             nil => nil
+                                         nil => nil
+                                     nil => nil
+    r.val
+
+
   # does this sequence start with l?
   #
   public starts_with(l Sequence T) bool

--- a/modules/base/src/Sequence.fz
+++ b/modules/base/src/Sequence.fz
@@ -630,14 +630,14 @@ public Sequence(public T type) ref : property.equatable is
   #
   #   [1,2,3,4,5].tuples produces [(1,2),(3,4)]
   #
-  public tuples Sequence (T, T)
+  public as_tuples Sequence (T, T)
   =>
     h := take 2
     t := drop 2
     if h.count < 2
       (Sequence (T,T)).empty
     else
-      h.as_tuple : t.tuples.as_list
+      h.as_tuple : t.as_tuples.as_list
 
 
   # chop this Sequence into tuples of size 3.  In case
@@ -648,14 +648,14 @@ public Sequence(public T type) ref : property.equatable is
   #
   #   [1,2,3,4,5,6,7].tuples3 produces [(1,2,3),(4,5,6)]
   #
-  public tuples3 Sequence (T, T, T)
+  public as_3tuples Sequence (T, T, T)
   =>
     h := take 3
     t := drop 3
     if h.count < 3
       (Sequence (T,T,T)).empty
     else
-      h.as_3tuple : t.tuples3.as_list
+      h.as_3tuple : t.as_3tuples.as_list
 
 
   # chop this Sequence into tuples of size 4.  In case
@@ -666,14 +666,14 @@ public Sequence(public T type) ref : property.equatable is
   #
   #   [1,2,3,4,5].tuples4 produces [(1,2,3,4)]
   #
-  public tuples4 Sequence (T, T, T, T)
+  public as_4tuples Sequence (T, T, T, T)
   =>
     h := take 4
     t := drop 4
     if h.count < 4
       (Sequence (T,T,T,T)).empty
     else
-      h.as_4tuple : t.tuples4.as_list
+      h.as_4tuple : t.as_4tuples.as_list
 
 
   # chop this Sequence into tuples of size 5.  In case
@@ -684,14 +684,14 @@ public Sequence(public T type) ref : property.equatable is
   #
   #   [1,2,3,4,5,6].tuples5 produces [(1,2,3,4,5)]
   #
-  public tuples5 Sequence (T, T, T, T, T)
+  public as_5tuples Sequence (T, T, T, T, T)
   =>
     h := take 5
     t := drop 5
     if h.count < 5
       (Sequence (T,T,T,T,T)).empty
     else
-      h.as_5tuple : t.tuples5.as_list
+      h.as_5tuple : t.as_5tuples.as_list
 
 
   # chop this Sequence into tuples of size 6.  In case
@@ -702,14 +702,14 @@ public Sequence(public T type) ref : property.equatable is
   #
   #   [1,2,3,4,5,6,7].tuples6 produces [(1,2,3,4,5,6)]
   #
-  public tuples6 Sequence (T,T, T, T, T, T)
+  public as_6tuples Sequence (T,T, T, T, T, T)
   =>
     h := take 6
     t := drop 6
     if h.count < 6
       (Sequence (T,T,T,T,T,T)).empty
     else
-      h.as_6tuple : t.tuples6.as_list
+      h.as_6tuple : t.as_6tuples.as_list
 
 
   # convert a Sequence's head into a 2-tuple.


### PR DESCRIPTION
These convert a sequence into a sequence of tuples and into a single tuple, respectively.
