### PR TITLE
lib: correct result type of fzE_file_close

### DIFF
--- a/modules/base/src/fuzion/sys/fileio.fz
+++ b/modules/base/src/fuzion/sys/fileio.fz
@@ -217,7 +217,7 @@ module fileio is
   #
   fzE_file_close(
                 # file descriptor
-                fd fuzion.sys.Pointer) i8 => native
+                fd fuzion.sys.Pointer) i32 => native
 
 
   # seek offset in the stream represented by fd

--- a/tests/lib_fileio_mmap/mmap_test.fz
+++ b/tests/lib_fileio_mmap/mmap_test.fz
@@ -60,4 +60,4 @@ mmap_test =>
     String.from_bytes ((io.buffered.read_fully lm).drop page_size)
   )
 
-  _ := io.file.delete testfile
+  say (io.file.delete testfile)

--- a/tests/lib_fileio_mmap/mmap_test.fz.expected_out
+++ b/tests/lib_fileio_mmap/mmap_test.fz.expected_out
@@ -2,3 +2,4 @@ unit
 --error: mmap failed--
 unit
 hallo!
+unit


### PR DESCRIPTION
Discovered this while investigating the windows test failure. Also changed mmap_test slightly, to detect file deletion failure early.
