### PR TITLE
lib: Add `foldr*` to `list` and `Sequence`, use `foldr` in `String.type.join`

### DIFF
--- a/modules/base/src/Sequence.fz
+++ b/modules/base/src/Sequence.fz
@@ -420,6 +420,34 @@ public Sequence(public T type) ref : property.equatable is
     as_list.foldf f e
 
 
+  # fold the elements of this list using the given monoid right-to-left.
+  #
+  # e.g., to concat the elements of a list of String, use l.foldr String.concat
+  #
+  public foldr (m Monoid T) => as_list.foldr m
+
+
+  # fold the elements of this list using the given monoid and initial value right-to-left.
+  #
+  # Used to fold a list tail-recursively
+  #
+  public foldr (s T, m Monoid T) => as_list.foldr m.e m
+
+
+  # fold the elements of this non-empty list using the given function right-to-left
+  #
+  # e.g., to concat the elements of a non-empty list of lists, use foldr1 (++)
+  #
+  public foldr1 (f (T,T)->T) => as_list.foldr1 f
+
+
+  # fold the elements of this list using the given function right-to-left.
+  #
+  # e.g., to concat the elements of a list of lists, use foldrf (++) []
+  #
+  public foldrf (B type, f (T,B)->B, e B) => as_list.foldrf f e
+
+
   # map this Sequence to a list that contains the result of folding
   # all prefixes using the given monoid.
   #

--- a/modules/base/src/String.fz
+++ b/modules/base/src/String.fz
@@ -808,7 +808,7 @@ public String ref : property.equatable, property.hashable, property.orderable is
   # sep in between its elements. In case an empty sequence is given, returns the empty string.
   #
   public type.join(elems Sequence String, sep String) String =>
-    (elems.as_list.intersperse sep).fold concat
+    (elems.as_list.intersperse sep).foldr concat
 
 
   # Takes a sequence of strings and concatenates its elements.

--- a/modules/base/src/list.fz
+++ b/modules/base/src/list.fz
@@ -235,6 +235,39 @@ public list(public A type) : choice nil (Cons A (list A)), Sequence A is
               | c Cons => c.tail.foldf f (f e c.head)
 
 
+  # fold the elements of this list using the given monoid right-to-left.
+  #
+  # e.g., to concat the elements of a list of String, use l.foldr String.concat
+  #
+  public redef foldr (m Monoid A) => foldr m.e m
+
+
+  # fold the elements of this list using the given monoid and initial value right-to-left.
+  #
+  # Used to fold a list tail-recursively
+  #
+  public redef foldr (s A, m Monoid A) =>
+    list.this ? nil    => s
+              | c Cons => m.op c.head (c.tail.foldr s m)
+
+
+  # fold the elements of this non-empty list using the given function right-to-left
+  #
+  # e.g., to concat the elements of a non-empty list of lists, use foldr1 (++)
+  #
+  public redef foldr1 (f (A,A)->A) =>
+    list.this ? nil    => panic "list.fold1 called on empty list"
+              | c Cons => f c.head (c.tail.foldr1 f)
+
+
+  # fold the elements of this list using the given function right-to-left.
+  #
+  # e.g., to concat the elements of a list of lists, use foldrf (++) []
+  #
+  public redef foldrf (B type, f (A,B)->B, e B) =>
+    list.this ? nil    => e
+              | c Cons => f c.head (c.tail.foldrf f e)
+
 
   # map this Sequence to a list that contains the result of folding
   # all prefixes using the given monoid.


### PR DESCRIPTION
This improves the performance of the first two test cases of #4505 significantly
and avoids the quadratic execution time:

     > time ./build/bin/fz -e 'say (["1"," "].cycle.take 1000 .as_string "" .split " ").count'
    501

    real	0m1,528s
    user	0m9,265s
    sys	0m0,374s
     > time ./build/bin/fz -e 'say (["1"," "].cycle.take 2000 .as_string "" .split " ").count'
    1001

    real	0m1,799s
    user	0m10,254s
    sys	0m0,550s

However, this does not improve the second example in #4505.