### PR TITLE
scripts: use any POSIX shell instead of bash

### DIFF
--- a/bin/fz
+++ b/bin/fz
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
 # This file is part of the Fuzion language implementation.
 #
@@ -36,7 +36,7 @@
 #   FUZION_JAVA_OPTIONS    options to be passed to the JAVA command (if set, will
 #                          override stack size)
 
-set -euo pipefail
+set -eu
 
 FUZION_CMD=$0
 FUZION_BIN="$(dirname "$(readlink -f "$0")")"
@@ -59,6 +59,7 @@ PATH=${PATH:+:$PATH}:$FUZION_HOME/lib
 DYLD_FALLBACK_LIBRARY_PATH=${DYLD_FALLBACK_LIBRARY_PATH:+:$DYLD_FALLBACK_LIBRARY_PATH}:$FUZION_HOME/lib
 
 # shellcheck disable=SC2086
+# shellcheck disable=SC3003
 LD_LIBRARY_PATH=$LD_LIBRARY_PATH \
   PATH=$PATH \
   DYLD_FALLBACK_LIBRARY_PATH=$DYLD_FALLBACK_LIBRARY_PATH \

--- a/bin/fzjava
+++ b/bin/fzjava
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
 # This file is part of the Fuzion language implementation.
 #
@@ -37,7 +37,7 @@
 #   FUZION_JAVA_OPTIONS    options to be passed to the JAVA command (if set, will
 #                          override stack size)
 
-set -euo pipefail
+set -eu
 
 FUZION_CMD=$0
 FUZION_BIN="$(dirname "$(readlink -f "$0")")"
@@ -56,4 +56,5 @@ fi
 : "${FUZION_JAVA_ADDITIONAL_OPTIONS=--enable-preview --enable-native-access=ALL-UNNAMED}"
 
 # shellcheck disable=SC2086
+# shellcheck disable=SC3003
 $FUZION_JAVA $FUZION_JAVA_OPTIONS $FUZION_JAVA_ADDITIONAL_OPTIONS -cp "$FUZION_JAVA_CLASSPATH" -Dline.separator=$'\n' -Dfile.encoding=UTF-8 -Dsun.stdout.encoding=UTF-8 -Dsun.stderr.encoding=UTF-8 -Dfuzion.home="$FUZION_HOME" -Dfuzion.command="$FUZION_CMD" dev.flang.tools.fzjava.FZJava "$@"

--- a/bin/run_tests.sh
+++ b/bin/run_tests.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
 # This file is part of the Fuzion language implementation.
 #
@@ -25,7 +25,7 @@
 #
 # -----------------------------------------------------------------------
 
-set -euo pipefail
+set -eu
 
 # usage: run_tests.sh <build-dir> <target>
 #

--- a/bin/windows_install_boehm_gc.sh
+++ b/bin/windows_install_boehm_gc.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
 # This file is part of the Fuzion language implementation.
 #
@@ -23,14 +23,17 @@
 #
 # -----------------------------------------------------------------------
 
-set -euo pipefail
+set -eu
+
+VERSION=8.2.4
+TAR_BALL_HASH=3d0d3cdbe077403d3106bb40f0cbb563413d6efdbb2a7e1cd6886595dec48fc2
 
 mkdir -p build
 cd build
-wget https://www.hboehm.info/gc/gc_source/gc-8.2.4.tar.gz
-echo "3d0d3cdbe077403d3106bb40f0cbb563413d6efdbb2a7e1cd6886595dec48fc2 gc-8.2.4.tar.gz" | sha256sum --check --status
-tar xf gc-8.2.4.tar.gz
-cd gc-8.2.4
+wget "https://www.hboehm.info/gc/gc_source/gc-$VERSION.tar.gz"
+echo "$TAR_BALL_HASH gc-$VERSION.tar.gz" | sha256sum --check --status
+tar xf "gc-$VERSION.tar.gz"
+cd "gc-$VERSION"
 ./configure --prefix=/ucrt64/ --enable-threads=pthreads
 make
 make install

--- a/tests/_cur_dir.sh
+++ b/tests/_cur_dir.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
 # This file is part of the Fuzion language implementation.
 #
@@ -27,7 +27,7 @@
 # -----------------------------------------------------------------------
 
 
-set -euo pipefail
+set -eu
 
 # @returns:
 #   - unix: /my/current/path

--- a/tests/_diff_err.sh
+++ b/tests/_diff_err.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
 # This file is part of the Fuzion language implementation.
 #
@@ -31,7 +31,7 @@
 SCRIPTPATH="$(dirname "$(readlink -f "$0")")"
 STRIP_ERR="$SCRIPTPATH"/_strip_err.sh
 
-set -euo pipefail
+set -eu
 
 tmp1="$(mktemp)"
 tmp2="$(mktemp)"

--- a/tests/_strip_err.sh
+++ b/tests/_strip_err.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
 # This file is part of the Fuzion language implementation.
 #
@@ -28,7 +28,7 @@
 # by dummy strings that are all the same. Result is written to stdout.
 #
 
-set -euo pipefail
+set -eu
 
 sed <&0 -E "s \.fz:[0-9]+:[0-9]+: \.fz:n:n: g" |                                                    # line numbers  \
     sed -E "s #fun[0-9]+ fun g"                | sed -E "s INTERN_fun[0-9]+ fun g "               | # lambdas       \


### PR DESCRIPTION
- `#!/usr/bin/env bash` => `#!/usr/bin/env sh`
- not all scripts are changed since some scripts use bash features
- note that shellcheck automatically detects shell of script and lints accordingly
