### PR TITLE
scripts: fix line.separator

### DIFF
--- a/bin/fz
+++ b/bin/fz
@@ -58,9 +58,22 @@ LD_LIBRARY_PATH=${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}:$FUZION_HOME/lib
 PATH=${PATH:+:$PATH}:$FUZION_HOME/lib
 DYLD_FALLBACK_LIBRARY_PATH=${DYLD_FALLBACK_LIBRARY_PATH:+:$DYLD_FALLBACK_LIBRARY_PATH}:$FUZION_HOME/lib
 
+LINE_SEPARATOR="
+"
+
 # shellcheck disable=SC2086
-# shellcheck disable=SC3003
 LD_LIBRARY_PATH=$LD_LIBRARY_PATH \
   PATH=$PATH \
   DYLD_FALLBACK_LIBRARY_PATH=$DYLD_FALLBACK_LIBRARY_PATH \
-  $FUZION_JAVA $FUZION_JAVA_OPTIONS $FUZION_JAVA_ADDITIONAL_OPTIONS -cp "$FUZION_JAVA_CLASSPATH" -Dline.separator=$'\n' -Dfile.encoding=UTF-8 -Dsun.stdout.encoding=UTF-8 -Dsun.stderr.encoding=UTF-8 -Dfuzion.home="$FUZION_HOME" -Dfuzion.command="$FUZION_CMD" dev.flang.tools.Fuzion "$@"
+  $FUZION_JAVA \
+  $FUZION_JAVA_OPTIONS \
+  $FUZION_JAVA_ADDITIONAL_OPTIONS \
+  -cp "$FUZION_JAVA_CLASSPATH" \
+  -Dline.separator="$LINE_SEPARATOR" \
+  -Dfile.encoding=UTF-8 \
+  -Dsun.stdout.encoding=UTF-8 \
+  -Dsun.stderr.encoding=UTF-8 \
+  -Dfuzion.home="$FUZION_HOME" \
+  -Dfuzion.command="$FUZION_CMD" \
+  dev.flang.tools.Fuzion \
+  "$@"

--- a/bin/fzjava
+++ b/bin/fzjava
@@ -55,6 +55,19 @@ fi
 : "${FUZION_JAVA_OPTIONS="-Xss$FUZION_JAVA_STACK_SIZE"}"
 : "${FUZION_JAVA_ADDITIONAL_OPTIONS=--enable-preview --enable-native-access=ALL-UNNAMED}"
 
+LINE_SEPARATOR="
+"
+
 # shellcheck disable=SC2086
-# shellcheck disable=SC3003
-$FUZION_JAVA $FUZION_JAVA_OPTIONS $FUZION_JAVA_ADDITIONAL_OPTIONS -cp "$FUZION_JAVA_CLASSPATH" -Dline.separator=$'\n' -Dfile.encoding=UTF-8 -Dsun.stdout.encoding=UTF-8 -Dsun.stderr.encoding=UTF-8 -Dfuzion.home="$FUZION_HOME" -Dfuzion.command="$FUZION_CMD" dev.flang.tools.fzjava.FZJava "$@"
+$FUZION_JAVA \
+  $FUZION_JAVA_OPTIONS \
+  $FUZION_JAVA_ADDITIONAL_OPTIONS \
+  -cp "$FUZION_JAVA_CLASSPATH" \
+  -Dline.separator="$LINE_SEPARATOR" \
+  -Dfile.encoding=UTF-8 \
+  -Dsun.stdout.encoding=UTF-8 \
+  -Dsun.stderr.encoding=UTF-8 \
+  -Dfuzion.home="$FUZION_HOME" \
+  -Dfuzion.command="$FUZION_CMD" \
+  dev.flang.tools.fzjava.FZJava \
+  "$@"


### PR DESCRIPTION
`$'\n'` works only in bash. I tried multiple options including: $(printf '%b' '\n') but this one seems to be the only one that works...