### PR TITLE
be/c: add -CInclude, -CLink options

### DIFF
--- a/src/dev/flang/be/c/C.java
+++ b/src/dev/flang/be/c/C.java
@@ -876,6 +876,16 @@ public class C extends ANY
         command.addAll("-lgc");
       }
 
+
+    if (_options._cLink != null)
+      {
+        var libraries = Arrays
+          .stream(_options._cLink.split(" "))
+          .map(x -> "-l" + x)
+          .iterator();
+        command.addAll(libraries);
+      }
+
     return command;
   }
 
@@ -1192,6 +1202,13 @@ public class C extends ANY
     var fzH = _options.pathOf("include/fz.h");
     cf.println("#include \"" + fzH + "\"");
     cf.println("#include \"" + hf.fileName() + "\"");
+
+    if (_options._cLink != null)
+      {
+        Arrays
+          .stream(_options._cInclude.split(" "))
+          .forEach(x -> cf.println("#include <" + x + ">"));
+      }
 
     var o = new CIdent("of");
     var s = new CIdent("sz");

--- a/src/dev/flang/be/c/COptions.java
+++ b/src/dev/flang/be/c/COptions.java
@@ -81,6 +81,18 @@ public class COptions extends FuzionOptions
   final boolean _keepGeneratedCode;
 
 
+  /**
+   * additional includes to include
+   */
+  final String _cInclude;
+
+
+  /**
+   * additional libraries to link
+   */
+  final String _cLink;
+
+
   /*--------------------------  constructors  ---------------------------*/
 
 
@@ -88,7 +100,7 @@ public class COptions extends FuzionOptions
    * Constructor initializing fields as given.
    * @param keepGeneratedCode
    */
-  public COptions(FuzionOptions fo, String binaryName, boolean useBoehmGC, String cCompiler, String cFlags, String cTarget, boolean keepGeneratedCode)
+  public COptions(FuzionOptions fo, String binaryName, boolean useBoehmGC, String cCompiler, String cFlags, String cTarget, String cInclude, String cLink, boolean keepGeneratedCode)
   {
     super(fo);
 
@@ -97,6 +109,8 @@ public class COptions extends FuzionOptions
     _cCompiler = cCompiler;
     _cFlags = cFlags;
     _cTarget = cTarget;
+    _cInclude = cInclude;
+    _cLink = cLink;
     _keepGeneratedCode = keepGeneratedCode;
   }
 

--- a/src/dev/flang/tools/Fuzion.java
+++ b/src/dev/flang/tools/Fuzion.java
@@ -88,6 +88,8 @@ public class Fuzion extends Tool
   static String _cCompiler_ = null;
   static String _cFlags_ = null;
   static String _cTarget_ = null;
+  static String _cInclude_ = null;
+  static String _cLink_ = null;
   static boolean _keepGeneratedCode_ = false;
   static String  _jvmOutName_ = null;
 
@@ -113,7 +115,7 @@ public class Fuzion extends Tool
     {
       String usage()
       {
-        return "[-o=<file>] [-Xgc=(on|off)] [-XkeepGeneratedCode=(on|off)] [-CC=<c compiler>] [-CFlags=\"list of c compiler flags\"] [-CTarget=\"e.g. x86_64-pc-linux-gnu\"] ";
+        return "[-o=<file>] [-Xgc=(on|off)] [-XkeepGeneratedCode=(on|off)] [-CC=<c compiler>] [-CFlags=\"list of c compiler flags\"] [-CTarget=\"e.g. x86_64-pc-linux-gnu\"] [-CInclude=\"list of header files to include\"] [-CLink=\"list libraries to link\"] ";
       }
       boolean handleOption(Fuzion f, String o)
       {
@@ -143,6 +145,16 @@ public class Fuzion extends Tool
             _cTarget_ = o.substring(9);
             result = true;
           }
+        else if (o.startsWith("-CInclude="))
+          {
+            _cInclude_ = o.substring(10);
+            result = true;
+          }
+        else if (o.startsWith("-CLink="))
+          {
+            _cLink_ = o.substring(7);
+            result = true;
+          }
         else if (o.startsWith("-XkeepGeneratedCode="))
           {
             _keepGeneratedCode_ = parseOnOffArg(o);
@@ -157,7 +169,7 @@ public class Fuzion extends Tool
       }
       void process(FuzionOptions options, FUIR fuir)
       {
-        new C(new COptions(options, _binaryName_, _useBoehmGC_, _cCompiler_, _cFlags_, _cTarget_, _keepGeneratedCode_), fuir).compile();
+        new C(new COptions(options, _binaryName_, _useBoehmGC_, _cCompiler_, _cFlags_, _cTarget_, _cInclude_, _cLink_, _keepGeneratedCode_), fuir).compile();
       }
     },
 


### PR DESCRIPTION
adds ability to include and link custom libraries, example:

`C_INCLUDE_PATH=/usr/lib/llvm-16/include/ LIBRARY_PATH=/usr/lib/llvm-16/lib fz -c -CInclude="clang-c/Index.h" -CLink=clang test.fz`
