### PR TITLE
ast: relax precondition for `AbstractFeature.cotype`

### DIFF
--- a/src/dev/flang/ast/AbstractFeature.java
+++ b/src/dev/flang/ast/AbstractFeature.java
@@ -894,7 +894,7 @@ public abstract class AbstractFeature extends Expr implements Comparable<Abstrac
     if (PRECONDITIONS) require
       (res != null,
        Errors.any() || !isUniverse(),
-       res.state(this).atLeast(State.FINDING_DECLARATIONS),
+       Errors.any() || res.state(this).atLeast(State.FINDING_DECLARATIONS),
        !isCotype());
 
     if (_cotype == null)


### PR DESCRIPTION
Ran into this failing while working on #4492, but did not bother creating a test case...

