### PR TITLE
lib: buffered.writer, use LM of `buffered`

### DIFF
--- a/modules/base/src/io/buffered/writer.fz
+++ b/modules/base/src/io/buffered/writer.fz
@@ -27,13 +27,13 @@
 #
 # note: anything in the buffer when effect is uninstalled will be discarded.
 #
-public writer(wh Write_Handler, buf_size i32) : mutate
+public writer(wh Write_Handler, buf_size i32) : effect
 pre debug: buf_size > 0
 is
 
   # circular buffer backing this writer
   #
-  buffer := instate_self (() -> (mutate.circular_buffer u8).new writer.this buf_size.as_i64 0)
+  buffer := instate_self (() -> (mutate.circular_buffer u8).new LM buf_size.as_i64 0)
 
 
   # flush the buffer, that is, write out everything that is still
@@ -68,7 +68,7 @@ is
       for n_written := 0, n_written + r
           e outcome unit := unit, e0
       while n_written < n
-        y := new (outcome unit unit)
+        y := LM.env.new (outcome unit unit)
         f =>
           if buffer.buffered = 0 && (n - n_written) > buf_size
             # can write directly


### PR DESCRIPTION
Same as buffered.reader, writer should not inherit from mutate but use `LM` of `io.buffered`.