### PR TITLE
be/int: Layout, do not use specialclazz pointer

### DIFF
--- a/src/dev/flang/be/interpreter/Interpreter.java
+++ b/src/dev/flang/be/interpreter/Interpreter.java
@@ -153,7 +153,8 @@ public class Interpreter extends FUIRContext
 
   /**
    * Get the result clazz of thiz
-   * or if thiz is an outer ref c_address.
+   * or if thiz is an address to a value
+   * c_address.
    */
   private static int clazzForField(int thiz)
   {

--- a/src/dev/flang/be/interpreter/Layout.java
+++ b/src/dev/flang/be/interpreter/Layout.java
@@ -134,10 +134,8 @@ class Layout extends FUIRContext
         for (int i = 0; i < fuir().clazzNumFields(cl); i++)
           {
             var f = fuir().clazzField(cl, i);
-            // NYI: Ugly special handling, clean up:
-            int fc = fuir().clazzFieldIsAdrOfValue(f)  ? fuir().clazz(SpecialClazzes.c_sys_ptr)
-                                                       : fuir().clazzResultClazz(f);
-            var fsz = fuir().clazzIsRef(fc)
+            int fc = fuir().clazzResultClazz(f);
+            var fsz = fuir().clazzFieldIsAdrOfValue(f) || fuir().clazzIsRef(fc)
               ? 1
               : switch (fuir().getSpecialClazz(fc))
                 {


### PR DESCRIPTION
DFA may not have created this specialclazz, so it may not be available und would lead to creating this clazz at runtime.
