### PR TITLE
fuir: remove inlineArrayElementClazz from GeneratingFUIR

### DIFF
--- a/src/dev/flang/fuir/FUIR.java
+++ b/src/dev/flang/fuir/FUIR.java
@@ -1518,7 +1518,10 @@ public abstract class FUIR extends IR
    *
    * @return e.g. {@code tuple i32 codepoint}
    */
-  public abstract int inlineArrayElementClazz(int constCl);
+  public int inlineArrayElementClazz(int constCl)
+  {
+    return this.clazzActualGeneric(constCl, 0);
+  }
 
 
   /**

--- a/src/dev/flang/fuir/GeneratingFUIR.java
+++ b/src/dev/flang/fuir/GeneratingFUIR.java
@@ -2805,28 +2805,6 @@ public class GeneratingFUIR extends FUIR
 
 
   /**
-   * the clazz of the elements of the array
-   *
-   * @param constCl, e.g. {@code array (tuple i32 codepoint)}
-   *
-   * @return e.g. {@code tuple i32 codepoint}
-   */
-  @Override
-  public int inlineArrayElementClazz(int constCl)
-  {
-    if (PRECONDITIONS) require
-      (clazzIsArray(constCl));
-
-    var result = type2clazz(id2clazz(constCl)._type.generics().get(0))._id;
-
-    if (POSTCONDITIONS) ensure
-      (result >= 0);
-
-    return result;
-  }
-
-
-  /**
    * Is {@code cl} an array?
    */
   @Override


### PR DESCRIPTION
can be implemented via clazzActualGeneric
