### PR TITLE
ast: fix initialValueFromCall in case of errors

### DIFF
--- a/src/dev/flang/ast/Impl.java
+++ b/src/dev/flang/ast/Impl.java
@@ -493,7 +493,7 @@ public class Impl extends ANY
    */
   private Expr initialValueFromCall(int i, Resolution res)
   {
-    Expr result = null;
+    Expr result = Call.ERROR;
     var ic = _initialCalls.get(i);
     var aargs = ic._actuals.listIterator();
     for (var frml : ic.calledFeature().valueArguments())
@@ -511,7 +511,7 @@ public class Impl extends ANY
                     _infiniteRecursionInResolveTypes = false;
                   }
                 if (CHECKS) check
-                  (result == null);
+                  (result == Call.ERROR);
                 result = actl;
               }
           }

--- a/tests/reg_issue4549/Makefile
+++ b/tests/reg_issue4549/Makefile
@@ -1,0 +1,25 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test Makefile
+#
+# -----------------------------------------------------------------------
+
+override NAME = reg_issue4549
+include ../simple.mk

--- a/tests/reg_issue4549/reg_issue4549.fz
+++ b/tests/reg_issue4549/reg_issue4549.fz
@@ -1,0 +1,25 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test reg_issue4549
+#
+# -----------------------------------------------------------------------
+
+s(a, b) => s := [1].map (s 1)
+s(a) =>

--- a/tests/reg_issue4549/reg_issue4549.fz.expected_err
+++ b/tests/reg_issue4549/reg_issue4549.fz.expected_err
@@ -1,0 +1,33 @@
+
+--CURDIR--/reg_issue4549.fz:24:26: error 1: Ambiguity between direct and partially applied call target
+s(a, b) => s := [1].map (s 1)
+-------------------------^
+This call can be resolved in two ways, either as a direct call to 's' declared at --CURDIR--/reg_issue4549.fz:25:1:
+s(a) =>
+^
+or by partially applying arguments to a call to 's' declared at --CURDIR--/reg_issue4549.fz:24:1:
+s(a, b) => s := [1].map (s 1)
+^.
+To solve this, rename one of the ambiguous features.
+
+
+--CURDIR--/reg_issue4549.fz:24:21: error 2: Failed to infer actual type parameters
+s(a, b) => s := [1].map (s 1)
+--------------------^^^
+In call to 'Sequence.map', no actual type parameters are given and inference of the type parameters failed.
+Expected type parameters: 'B'
+Type inference failed for one type parameter 'B'
+
+
+--CURDIR--/reg_issue4549.fz:24:3: error 3: Type inference from actual arguments failed since no actual call was found
+s(a, b) => s := [1].map (s 1)
+--^
+For the formal argument 's.a' the type can only be derived if there is a call to 's'.
+
+
+--CURDIR--/reg_issue4549.fz:24:6: error 4: Type inference from actual arguments failed since no actual call was found
+s(a, b) => s := [1].map (s 1)
+-----^
+For the formal argument 's.b' the type can only be derived if there is a call to 's'.
+
+4 errors.


### PR DESCRIPTION
The called feature may be Error, in this case post condition was not satisfied

fixes #4549
