### PR TITLE
remove uses of ast.Context anywhere but `ast`

### DIFF
--- a/src/dev/flang/ast/AbstractAssign.java
+++ b/src/dev/flang/ast/AbstractAssign.java
@@ -149,7 +149,7 @@ public abstract class AbstractAssign extends Expr
    *
    * @param context the source code context where this assignment is used
    */
-  public void resolveTypes(Resolution res, Context context)
+  void resolveTypes(Resolution res, Context context)
   {
     resolveTypes(res, context, null);
   }
@@ -165,7 +165,7 @@ public abstract class AbstractAssign extends Expr
    * @param destructure if this is called for an assignment that is created to
    * replace a Destructure, this refers to the Destructure expression.
    */
-  public void resolveTypes(Resolution res, Context context, Destructure destructure)
+  void resolveTypes(Resolution res, Context context, Destructure destructure)
   {
   }
 
@@ -181,7 +181,7 @@ public abstract class AbstractAssign extends Expr
    *
    * @param context the source code context where this Expr is used
    */
-  public void propagateExpectedType(Resolution res, Context context)
+  void propagateExpectedType(Resolution res, Context context)
   {
     if (CHECKS) check
       (_assignedField != Types.f_ERROR || Errors.any());
@@ -202,7 +202,7 @@ public abstract class AbstractAssign extends Expr
    *
    * @param context the source code context where this assignment is used
    */
-  public void wrapValueInLazy(Resolution res, Context context)
+  void wrapValueInLazy(Resolution res, Context context)
   {
     if (CHECKS) check
       (_assignedField != Types.f_ERROR || Errors.any());
@@ -222,7 +222,7 @@ public abstract class AbstractAssign extends Expr
    *
    * @param context the source code context where this assignment is used
    */
-  public void unwrapValue(Resolution res, Context context)
+  void unwrapValue(Resolution res, Context context)
   {
     if (CHECKS) check
       (_assignedField != Types.f_ERROR || Errors.any());
@@ -250,7 +250,7 @@ public abstract class AbstractAssign extends Expr
    *
    * @param context the source code context where this assignment is used
    */
-  public void boxVal(Context context)
+  void boxVal(Context context)
   {
     if (CHECKS) check
       (_assignedField != Types.f_ERROR || Errors.any());
@@ -269,7 +269,7 @@ public abstract class AbstractAssign extends Expr
    *
    * @param context the source code context where this assignment is used
    */
-  public void checkTypes(Resolution res, Context context)
+  void checkTypes(Resolution res, Context context)
   {
     if (CHECKS) check
       (_assignedField != Types.f_ERROR || Errors.any());

--- a/src/dev/flang/ast/AbstractCurrent.java
+++ b/src/dev/flang/ast/AbstractCurrent.java
@@ -110,7 +110,7 @@ public abstract class AbstractCurrent extends Expr
    * Expr {@code Current.outer_ref. .. .outer_ref} to access the same current instance
    * from within a new, nested outer feature.
    */
-  public Expr resolveTypes(Resolution res, Context context)
+  Expr resolveTypes(Resolution res, Context context)
   {
     var of = _type.feature();
     return of == Types.f_ERROR || of == context.outerFeature()

--- a/src/dev/flang/ast/AbstractLambda.java
+++ b/src/dev/flang/ast/AbstractLambda.java
@@ -70,7 +70,7 @@ public abstract class AbstractLambda extends ExprWithPos
    * @return the result type inferred from this lambda or Types.t_UNDEFINED if
    * not result type available.
    */
-  public AbstractType inferLambdaResultType(Resolution res, Context context, AbstractType t)
+  AbstractType inferLambdaResultType(Resolution res, Context context, AbstractType t)
   {
     return propagateTypeAndInferResult(res, context, t, true);
   }
@@ -94,10 +94,10 @@ public abstract class AbstractLambda extends ExprWithPos
    * Types.t_UNDEFINED if not result type available.  if !inferResultType, t. In
    * case of error, return Types.t_ERROR.
    */
-  protected abstract AbstractType propagateTypeAndInferResult(Resolution res,
-                                                              Context context,
-                                                              AbstractType t,
-                                                              boolean inferResultType);
+  abstract AbstractType propagateTypeAndInferResult(Resolution res,
+                                                    Context context,
+                                                    AbstractType t,
+                                                    boolean inferResultType);
 
 }
 

--- a/src/dev/flang/ast/Assign.java
+++ b/src/dev/flang/ast/Assign.java
@@ -113,7 +113,7 @@ public class Assign extends AbstractAssign
    *
    * @param context the source code context where this assignment is used
    */
-  public Assign(Resolution res, SourcePosition pos, AbstractFeature f, Expr v, Context context)
+  Assign(Resolution res, SourcePosition pos, AbstractFeature f, Expr v, Context context)
   {
     super(f, This.thiz(res, pos, context, f.outer()), v);
 
@@ -159,7 +159,7 @@ public class Assign extends AbstractAssign
    * replace a Destructure, this refers to the Destructure expression.
    */
   @Override
-  public void resolveTypes(Resolution res, Context context, Destructure destructure)
+  void resolveTypes(Resolution res, Context context, Destructure destructure)
   {
     var f = _assignedField;
     if (f == null)

--- a/src/dev/flang/ast/Block.java
+++ b/src/dev/flang/ast/Block.java
@@ -357,7 +357,7 @@ public class Block extends AbstractBlock
    * result. In particular, if the result is assigned to a temporary field, this
    * will be replaced by the expression that reads the field.
    */
-  public Expr propagateExpectedType(Resolution res, Context context, AbstractType type)
+  Expr propagateExpectedType(Resolution res, Context context, AbstractType type)
   {
     if (type.compareTo(Types.resolved.t_unit) == 0 && hasImplicitResult())
       { // return unit if this is expected even if we would implicitly return

--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -2425,7 +2425,7 @@ public class Call extends AbstractCall
    *
    * @param context the source code context where this Call is used
    */
-  public void tryResolveTypeCall(Resolution res, Context context)
+  void tryResolveTypeCall(Resolution res, Context context)
   {
     var outer = context.outerFeature();
     if (_calledFeature == null && _target != null && outer.state().atLeast(State.RESOLVED_INHERITANCE))
@@ -2485,7 +2485,7 @@ public class Call extends AbstractCall
    *
    * @param context the source code context where this Call is used
    */
-  public Call resolveTypes(Resolution res, Context context)
+  Call resolveTypes(Resolution res, Context context)
   {
     Call result = this;
     if (_resolvedFor == context)
@@ -2645,7 +2645,7 @@ public class Call extends AbstractCall
    *
    * @param context the source code context where this Expr is used
    */
-  public void propagateExpectedType(Resolution res, Context context)
+  void propagateExpectedType(Resolution res, Context context)
   {
     applyToActualsAndFormalTypes((actual, formalType) -> actual.propagateExpectedType(res, context, formalType));
 
@@ -2687,7 +2687,7 @@ public class Call extends AbstractCall
    * result. In particular, if the result is assigned to a temporary field, this
    * will be replaced by the expression that reads the field.
    */
-  public Expr propagateExpectedType(Resolution res, Context context, AbstractType t)
+  Expr propagateExpectedType(Resolution res, Context context, AbstractType t)
   {
     Expr r = this;
     if (t.isFunctionTypeExcludingLazy()         &&
@@ -2716,7 +2716,7 @@ public class Call extends AbstractCall
    *
    * @param context the source code context where this Call is used
    */
-  public void wrapActualsInLazy(Resolution res, Context context)
+  void wrapActualsInLazy(Resolution res, Context context)
   {
     applyToActualsAndFormalTypes((actual, formalType) -> actual.wrapInLazy(res, context, formalType));
   }
@@ -2730,7 +2730,7 @@ public class Call extends AbstractCall
    *
    * @param context the source code context where this Call is used
    */
-  public void unwrapActuals(Resolution res, Context context)
+  void unwrapActuals(Resolution res, Context context)
   {
     applyToActualsAndFormalTypes((actual, formalType) -> actual.unwrap(res, context, formalType));
   }
@@ -2773,7 +2773,7 @@ public class Call extends AbstractCall
    *
    * @param context the source code context where this Call is used
    */
-  public void boxArgs(Context context)
+  void boxArgs(Context context)
   {
     if (_type != Types.t_ERROR && _resolvedFormalArgumentTypes != null)
       {
@@ -2808,7 +2808,7 @@ public class Call extends AbstractCall
    *
    * @param context the source code context where this Call is used
    */
-  public void checkTypes(Resolution res, Context context)
+  void checkTypes(Resolution res, Context context)
   {
     reportPendingError();
 
@@ -2979,7 +2979,7 @@ public class Call extends AbstractCall
    *
    * @param context the source code context where this Call is used
    */
-  public Call updateTarget(Resolution res, Context context)
+  Call updateTarget(Resolution res, Context context)
   {
     if (_targetFrom != null)
       {

--- a/src/dev/flang/ast/Cond.java
+++ b/src/dev/flang/ast/Cond.java
@@ -129,7 +129,7 @@ public class Cond
    *
    * @param context the source code context where this Cond is used
    */
-  public void propagateExpectedType(Resolution res, Context context)
+  void propagateExpectedType(Resolution res, Context context)
   {
     cond = cond.propagateExpectedType(res, context, Types.resolved.t_bool);
   }

--- a/src/dev/flang/ast/Context.java
+++ b/src/dev/flang/ast/Context.java
@@ -43,7 +43,7 @@ import dev.flang.util.ANY;
  *
  * @author Fridtjof Siebert (siebert@tokiwa.software)
  */
-public abstract class Context extends ANY
+abstract class Context extends ANY
 {
 
   /*----------------------------  constants  ----------------------------*/
@@ -52,7 +52,7 @@ public abstract class Context extends ANY
   /**
    * Pre-allocated instance for no context.
    */
-  public static final Context NONE = new Context()
+  static final Context NONE = new Context()
     {
       @Override AbstractFeature outerFeature()
       {
@@ -113,7 +113,7 @@ public abstract class Context extends ANY
         }
 
         @Override
-        public AbstractType constraintFor(AbstractFeature typeParameter)
+        AbstractType constraintFor(AbstractFeature typeParameter)
         {
           if (f instanceof Feature ff)
             {
@@ -165,7 +165,7 @@ public abstract class Context extends ANY
    *
    * @param typeParameter a type parameter feature.
    */
-  public AbstractType constraintFor(AbstractFeature typeParameter)
+  AbstractType constraintFor(AbstractFeature typeParameter)
   {
     var e = exterior();
     return e != null ? e.constraintFor(typeParameter)
@@ -177,7 +177,7 @@ public abstract class Context extends ANY
    * Create a new context that adds the constraint imposed by a call {@code T : x} to
    * this context.
    */
-  public Context addTypeConstraint(AbstractCall infix_colon_call)
+  Context addTypeConstraint(AbstractCall infix_colon_call)
   {
     if (PRECONDITIONS) require
       (infix_colon_call.calledFeature() == Types.resolved.f_Type_infix_colon);

--- a/src/dev/flang/ast/Destructure.java
+++ b/src/dev/flang/ast/Destructure.java
@@ -244,7 +244,7 @@ public class Destructure extends ExprWithPos
    *
    * @param context the source code context where this Call is used
    */
-  public Expr resolveTypes(Resolution res, Context context)
+  Expr resolveTypes(Resolution res, Context context)
   {
     List<Expr> exprs = new List<>();
     // NYI: This might fail in conjunction with type inference.  We should maybe

--- a/src/dev/flang/ast/DotType.java
+++ b/src/dev/flang/ast/DotType.java
@@ -120,7 +120,7 @@ public class DotType extends ExprWithPos
    *
    * @param context the source code context where this Call is used
    */
-  public Expr resolveTypes(Resolution res, Context context)
+  Expr resolveTypes(Resolution res, Context context)
   {
     return _lhs.isGenericArgument() && !_lhs.genericArgument().isThisTypeInCotype()
       ? _lhsExpr

--- a/src/dev/flang/ast/Expr.java
+++ b/src/dev/flang/ast/Expr.java
@@ -187,7 +187,7 @@ public abstract class Expr extends HasGlobalIndex implements HasSourcePosition
    * @return the union of exprs result type, defaulting to Types.resolved.t_void if
    * no expression can be inferred yet.
    */
-  public static AbstractType union(List<Expr> exprs, Context context)
+  static AbstractType union(List<Expr> exprs, Context context)
   {
     AbstractType t = Types.resolved.t_void;
 
@@ -421,7 +421,7 @@ public abstract class Expr extends HasGlobalIndex implements HasSourcePosition
    *
    * @param t the type this expression is assigned to.
    */
-  public Expr wrapInLazy(Resolution res, Context context, AbstractType t)
+  Expr wrapInLazy(Resolution res, Context context, AbstractType t)
   {
     var result = this;
 
@@ -465,7 +465,7 @@ public abstract class Expr extends HasGlobalIndex implements HasSourcePosition
    * result. In particular, if the result is assigned to a temporary field, this
    * will be replaced by the expression that reads the field.
    */
-  public Expr propagateExpectedType(Resolution res, Context context, AbstractType t)
+  Expr propagateExpectedType(Resolution res, Context context, AbstractType t)
   {
     return this;
   }
@@ -764,7 +764,7 @@ public abstract class Expr extends HasGlobalIndex implements HasSourcePosition
    *
    * @return the unwrapped expression
    */
-  public Expr unwrap(Resolution res, Context context, AbstractType expectedType)
+  Expr unwrap(Resolution res, Context context, AbstractType expectedType)
   {
     var t = type();
     return this != Call.ERROR && t != Types.t_ERROR

--- a/src/dev/flang/ast/Feature.java
+++ b/src/dev/flang/ast/Feature.java
@@ -1982,26 +1982,6 @@ A ((Choice)) declaration must not contain a result type.
 
 
   /**
-   * Perform type checking, in particular, verify that all redefinitions of this
-   * have the argument types.  Create compile time errors if this is not the
-   * case.
-   */
-  private void checkTypes(Resolution res, Context context)
-  {
-    if (PRECONDITIONS) require
-      (_state.atLeast(State.CHECKING_TYPES));
-
-      res._module.checkTypes(this, context);
-
-      // warn about unused, non public, non ignored fields
-      if (isUsageCheckRequired() && !isUsed())
-        {
-          AstErrors.unusedField(this);
-        }
-  }
-
-
-  /**
    * Perform static type checking, i.e., make sure, that for all assignments from
    * actual to formal arguments or from values to fields, the types match.
    *
@@ -2019,6 +1999,7 @@ A ((Choice)) declaration must not contain a result type.
 
     _selfType   = selfType() .checkChoice(_pos,             context());
     _resultType = _resultType.checkChoice(_posOfReturnType == SourcePosition.builtIn ? _pos : _posOfReturnType, context());
+
     visit(new ContextVisitor(context()) {
         /* if an error is reported in a call it might no longer make sense to check the actuals: */
         @Override public boolean visitActualsLate() { return true; }
@@ -2031,7 +2012,15 @@ A ((Choice)) declaration must not contain a result type.
         @Override public void         action(Cond           c) {        c.checkTypes();                         }
         @Override public void         actionBefore(Block    b) {        b.checkTypes();                         }
       });
-    checkTypes(res, context());
+
+    res._module.checkTypes(this);
+
+    // warn about unused, non public, non ignored fields
+    if (isUsageCheckRequired() && !isUsed())
+      {
+        AstErrors.unusedField(this);
+      }
+
     visit(new ContextVisitor(context()) {
       @Override public Expr action(Feature f, AbstractFeature outer) { return new Nop(_pos);}
     });
@@ -2130,7 +2119,7 @@ A ((Choice)) declaration must not contain a result type.
    *
    * @param rss1 the visitor to resolve syntax sugar 1, used to visit recursively.
    */
-  public Expr resolveSyntacticSugar1(Resolution res, Context context, ContextVisitor rss1)
+  Expr resolveSyntacticSugar1(Resolution res, Context context, ContextVisitor rss1)
   {
     var outer = context.outerFeature();
 

--- a/src/dev/flang/ast/Function.java
+++ b/src/dev/flang/ast/Function.java
@@ -183,7 +183,7 @@ public class Function extends AbstractLambda
    * result. In particular, if the result is assigned to a temporary field, this
    * will be replaced by the expression that reads the field.
    */
-  public Expr propagateExpectedType(Resolution res, Context context, AbstractType t)
+  Expr propagateExpectedType(Resolution res, Context context, AbstractType t)
   {
     _type = propagateTypeAndInferResult(res, context, t.functionTypeFromChoice(context), false);
     return this;
@@ -243,7 +243,7 @@ public class Function extends AbstractLambda
    * case of error, return Types.t_ERROR.
    */
   @Override
-  public AbstractType propagateTypeAndInferResult(Resolution res, Context context, AbstractType t, boolean inferResultType)
+  AbstractType propagateTypeAndInferResult(Resolution res, Context context, AbstractType t, boolean inferResultType)
   {
     AbstractType result = inferResultType ? Types.t_UNDEFINED : t;
     if (_call == null)
@@ -374,7 +374,7 @@ public class Function extends AbstractLambda
    *
    * @param context the source code context where this Call is used
    */
-  public void resolveTypes(Resolution res, Context context)
+  void resolveTypes(Resolution res, Context context)
   {
     if (CHECKS) check
       (this._call == null || this._feature != null);

--- a/src/dev/flang/ast/Generic.java
+++ b/src/dev/flang/ast/Generic.java
@@ -117,7 +117,7 @@ public class Generic extends ANY implements Comparable<Generic>
    *
    * @return the constraint.
    */
-  public AbstractType constraint(Context context)
+  AbstractType constraint(Context context)
   {
     if (PRECONDITIONS) require
       (_typeParameter.state().atLeast(State.RESOLVED_TYPES));
@@ -145,7 +145,7 @@ public class Generic extends ANY implements Comparable<Generic>
    *
    * @return the resolved constraint(context).
    */
-  public AbstractType constraint(Resolution res, Context context)
+  AbstractType constraint(Resolution res, Context context)
   {
     if (PRECONDITIONS) require
       (res.state(feature()).atLeast(State.RESOLVING_DECLARATIONS));

--- a/src/dev/flang/ast/If.java
+++ b/src/dev/flang/ast/If.java
@@ -277,7 +277,7 @@ public class If extends ExprWithPos
    *
    * @param context the source code context where this Expr is used
    */
-  public void propagateExpectedType(Resolution res, Context context)
+  void propagateExpectedType(Resolution res, Context context)
   {
     if (cond != null)
       {
@@ -304,7 +304,7 @@ public class If extends ExprWithPos
    * will be replaced by the expression that reads the field.
    */
   @Override
-  public Expr propagateExpectedType(Resolution res, Context context, AbstractType t)
+  Expr propagateExpectedType(Resolution res, Context context, AbstractType t)
   {
     // NYI: CLEANUP: there should be another mechanism, for
     // adding missing result fields instead of misusing

--- a/src/dev/flang/ast/Impl.java
+++ b/src/dev/flang/ast/Impl.java
@@ -371,7 +371,7 @@ public class Impl extends ANY
    *
    * @param context the source code context where this Expr is used
    */
-  public void propagateExpectedType(Resolution res, Context context)
+  void propagateExpectedType(Resolution res, Context context)
   {
     if (needsImplicitAssignmentToResult(context.outerFeature()))
       {
@@ -390,7 +390,7 @@ public class Impl extends ANY
    *
    * @param t the expected type.
    */
-  public void propagateExpectedType(Resolution res, Context context, AbstractType t)
+  void propagateExpectedType(Resolution res, Context context, AbstractType t)
   {
     _expr = _expr.propagateExpectedType(res, context, t);
   }
@@ -416,7 +416,7 @@ public class Impl extends ANY
    *
    * @param context the source code context where this assignment is used
    */
-  public void resolveSyntacticSugar2(Resolution res, Context context)
+  void resolveSyntacticSugar2(Resolution res, Context context)
   {
     var outer = context.outerFeature();
     if (outer.isConstructor() && outer.preFeature() != null)

--- a/src/dev/flang/ast/InlineArray.java
+++ b/src/dev/flang/ast/InlineArray.java
@@ -166,7 +166,7 @@ public class InlineArray extends ExprWithPos
    * will be replaced by the expression that reads the field.
    */
   @Override
-  public Expr propagateExpectedType(Resolution res, Context context, AbstractType t)
+  Expr propagateExpectedType(Resolution res, Context context, AbstractType t)
   {
     if (_type == null)
       {
@@ -275,7 +275,7 @@ public class InlineArray extends ExprWithPos
    *
    * @param context the source code context where this Expr is used
    */
-  public void boxElements(Context context)
+  void boxElements(Context context)
   {
     var li = _elements.listIterator();
     while (li.hasNext())
@@ -293,7 +293,7 @@ public class InlineArray extends ExprWithPos
    *
    * @param context the source code context where this InlineArray is used
    */
-  public void checkTypes(Context context)
+  void checkTypes(Context context)
   {
     if (PRECONDITIONS) require
       (Errors.any() || _type != null || _elements.isEmpty() /* no inferred type for empty array, see #3552 */ );
@@ -397,7 +397,7 @@ public class InlineArray extends ExprWithPos
    *
    * @param context the source code context where this Expr is used
    */
-  public Expr resolveSyntacticSugar2(Resolution res, Context context)
+  Expr resolveSyntacticSugar2(Resolution res, Context context)
   {
     // elements may be boxed later
     // therefore wrap all elements in block

--- a/src/dev/flang/ast/Match.java
+++ b/src/dev/flang/ast/Match.java
@@ -142,7 +142,7 @@ public class Match extends AbstractMatch
    *
    * @param context the source code context where this Call is used
    */
-  public void resolveTypes(Resolution res, Context context)
+  void resolveTypes(Resolution res, Context context)
   {
     var st = _subject.type();
     if (CHECKS) check
@@ -234,7 +234,7 @@ public class Match extends AbstractMatch
    * will be replaced by the expression that reads the field.
    */
   @Override
-  public Expr propagateExpectedType(Resolution res, Context context, AbstractType t)
+  Expr propagateExpectedType(Resolution res, Context context, AbstractType t)
   {
     // NYI: CLEANUP: there should be another mechanism, for
     // adding missing result fields instead of misusing

--- a/src/dev/flang/ast/NumLiteral.java
+++ b/src/dev/flang/ast/NumLiteral.java
@@ -840,7 +840,7 @@ public class NumLiteral extends Constant
    * result. In particular, if the result is assigned to a temporary field, this
    * will be replaced by the expression that reads the field.
    */
-  public Expr propagateExpectedType(Resolution res, Context context, AbstractType t)
+  Expr propagateExpectedType(Resolution res, Context context, AbstractType t)
   {
     var result = propagateExpectedTypeForPartial(res, context, t);
     if (result != this)
@@ -875,7 +875,7 @@ public class NumLiteral extends Constant
    * @param t the type this expression is assigned to.
    */
   @Override
-  public Expr wrapInLazy(Resolution res, Context context, AbstractType t)
+  Expr wrapInLazy(Resolution res, Context context, AbstractType t)
   {
     if (t.isLazyType())
       {

--- a/src/dev/flang/ast/ParsedCall.java
+++ b/src/dev/flang/ast/ParsedCall.java
@@ -537,7 +537,7 @@ public class ParsedCall extends Call
                               this)
           {
             @Override
-            public AbstractType propagateTypeAndInferResult(Resolution res, Context context, AbstractType t, boolean inferResultType)
+            AbstractType propagateTypeAndInferResult(Resolution res, Context context, AbstractType t, boolean inferResultType)
             {
               var rs = super.propagateTypeAndInferResult(res, context, t, inferResultType);
               updateTarget(res);
@@ -640,7 +640,7 @@ public class ParsedCall extends Call
           return wasLazy ? ParsedCall.this : super.originalLazyValue();
         }
         @Override
-        public Expr propagateExpectedType(Resolution res, Context context, AbstractType expectedType)
+        Expr propagateExpectedType(Resolution res, Context context, AbstractType expectedType)
         {
           if (expectedType.isFunctionTypeExcludingLazy())
             { // produce an error if the original call is ambiguous with partial application

--- a/src/dev/flang/ast/Partial.java
+++ b/src/dev/flang/ast/Partial.java
@@ -163,7 +163,7 @@ public class Partial extends AbstractLambda
    * will be replaced by the expression that reads the field.
    */
   @Override
-  public Expr propagateExpectedType(Resolution res, Context context, AbstractType t)
+  Expr propagateExpectedType(Resolution res, Context context, AbstractType t)
   {
     Expr result = this;
     t = t.functionTypeFromChoice(context);
@@ -195,7 +195,7 @@ public class Partial extends AbstractLambda
    * case of error, return Types.t_ERROR.
    */
   @Override
-  public AbstractType propagateTypeAndInferResult(Resolution res, Context context, AbstractType t, boolean inferResultType)
+  AbstractType propagateTypeAndInferResult(Resolution res, Context context, AbstractType t, boolean inferResultType)
   {
     AbstractType result = inferResultType ? Types.t_UNDEFINED : t;
     if (_function == null && t.isFunctionType() && (t.arity() == 1 || t.arity() == 2))

--- a/src/dev/flang/ast/SrcModule.java
+++ b/src/dev/flang/ast/SrcModule.java
@@ -63,7 +63,7 @@ public interface SrcModule extends AbstractModule
   void findDeclaredOrInheritedFeatures(Feature outer);
   List<FeatureAndOuter> lookup(AbstractFeature thiz, String name, Expr use, boolean traverseOuter, boolean hidden);
   AbstractFeature lookupOpenTypeParameterResult(AbstractFeature outer, Expr use);
-  void checkTypes(Feature f, Context context);
+  void checkTypes(Feature f);
   FeatureAndOuter lookupType(SourcePosition pos,
                              AbstractFeature outer,
                              String name,

--- a/src/dev/flang/ast/Tag.java
+++ b/src/dev/flang/ast/Tag.java
@@ -68,11 +68,11 @@ public class Tag extends ExprWithPos
   /**
    * Constructor
    *
-   * @param context the source code context where this Tag is to be used
-   *
    * @param value the value instance
+   *
+   * @param context the source code context where this Tag is to be used
    */
-  public Tag(Expr value, AbstractType taggedType, Context context)
+  Tag(Expr value, AbstractType taggedType, Context context)
   {
     super(value.pos());
 
@@ -99,6 +99,17 @@ public class Tag extends ExprWithPos
       .stream()
       .takeWhile(cg -> !cg.isAssignableFromWithoutTagging(value.type(), context))
       .count();
+  }
+
+
+  /**
+   * Constructor
+   *
+   * @param value the value instance
+   */
+  public Tag(Expr value, AbstractType taggedType)
+  {
+    this(value, taggedType, Context.NONE);
   }
 
 

--- a/src/dev/flang/ast/This.java
+++ b/src/dev/flang/ast/This.java
@@ -139,7 +139,7 @@ public class This extends ExprWithPos
    *
    * @return the type resolved expression to access f.this.
    */
-  public static Expr thiz(Resolution res, SourcePosition pos, Context context, AbstractFeature f)
+  static Expr thiz(Resolution res, SourcePosition pos, Context context, AbstractFeature f)
   {
     if (PRECONDITIONS) require
       (context != null,
@@ -202,7 +202,7 @@ public class This extends ExprWithPos
    * @return a call to the outer references to access the value represented by
    * this.
    */
-  public Expr resolveTypes(Resolution res, Context context)
+  Expr resolveTypes(Resolution res, Context context)
   {
     if (PRECONDITIONS) require
       (res != null || Errors.any(),

--- a/src/dev/flang/fe/LibraryFeature.java
+++ b/src/dev/flang/fe/LibraryFeature.java
@@ -45,7 +45,6 @@ import dev.flang.ast.AbstractMatch;
 import dev.flang.ast.AbstractType;
 import dev.flang.ast.Box;
 import dev.flang.ast.Constant;
-import dev.flang.ast.Context;
 import dev.flang.ast.Contract;
 import dev.flang.ast.Expr;
 import dev.flang.ast.Feature;
@@ -722,7 +721,7 @@ public class LibraryFeature extends AbstractFeature
             {
               var val = s.pop();
               var taggedType = _libModule.tagType(iat);
-              x = new Tag(val, taggedType, Context.NONE);
+              x = new Tag(val, taggedType);
               break;
             }
           case Unit:

--- a/src/dev/flang/fuir/Clazz.java
+++ b/src/dev/flang/fuir/Clazz.java
@@ -39,7 +39,6 @@ import dev.flang.ast.AbstractFeature;
 import dev.flang.ast.AbstractCall;
 import dev.flang.ast.AbstractType;
 import dev.flang.ast.AstErrors;
-import dev.flang.ast.Context;
 import dev.flang.ast.Expr;
 import dev.flang.ast.ResolvedNormalType;
 import dev.flang.ast.Types;
@@ -450,7 +449,7 @@ class Clazz extends ANY implements Comparable<Clazz>
       }
     else
       {
-        var t = this._type.actualType(f.selfType(), Context.NONE).asRef();
+        var t = this._type.actualType(f.selfType()).asRef();
         return normalize2(t);
       }
   }
@@ -525,7 +524,7 @@ class Clazz extends ANY implements Comparable<Clazz>
       {
         var pt = p.type();
         var t1 = isRef().yes() && !pt.isVoid() ? pt.asRef() : pt.asValue();
-        var t2 = _type.actualType(t1, Context.NONE);
+        var t2 = _type.actualType(t1);
         var pc = _fuir.newClazz(t2);
         if (CHECKS) check
           (Errors.any() || pc.isVoidType() || isRef() == pc.isRef());
@@ -633,7 +632,7 @@ class Clazz extends ANY implements Comparable<Clazz>
   {
     if (feature().isCotype())
       {
-        t = _type.generics().get(0).actualType(t, Context.NONE);
+        t = _type.generics().get(0).actualType(t);
         var g = t.cotypeActualGenerics();
         var o = t.outer();
         if (o != null)
@@ -1085,7 +1084,7 @@ class Clazz extends ANY implements Comparable<Clazz>
           }
         else
           {
-            t = _type.actualType(t, Context.NONE);  // e.g., {@code (Types.get (array f64)).T} -> {@code array f64}
+            t = _type.actualType(t);  // e.g., {@code (Types.get (array f64)).T} -> {@code array f64}
 
 /*
   We have the following possibilities when calling a feature {@code f} declared in do {@code on}
@@ -1935,8 +1934,7 @@ class Clazz extends ANY implements Comparable<Clazz>
                 // {@code t.replace_this_type(parentf, childf, foundRef)} a few lines
                 // above.
                 t = t.replace_this_type_by_actual_outer2(child._type,
-                                                         foundRef,
-                                                         Context.NONE);
+                                                         foundRef);
               }
             // NYI: UNDER DEVELOPMENT: Where is the different to just using _outer?
             child = childf.hasOuterRef() ? child.lookup(childf.outerRef()).resultClazz()

--- a/src/dev/flang/fuir/GeneratingFUIR.java
+++ b/src/dev/flang/fuir/GeneratingFUIR.java
@@ -41,7 +41,6 @@ import dev.flang.ast.AbstractMatch;
 import dev.flang.ast.AbstractType;
 import dev.flang.ast.Box;
 import dev.flang.ast.Constant;
-import dev.flang.ast.Context;
 import dev.flang.ast.Expr;
 import dev.flang.ast.InlineArray;
 import dev.flang.ast.NumLiteral;
@@ -2157,7 +2156,7 @@ public class GeneratingFUIR extends FUIR
         if (c.calledFeature() == Types.resolved.f_Type_infix_colon)
           {
             var T = innerClazz.actualTypeParameters()[0];
-            cf = T._type.constraintAssignableFrom(Context.NONE, tclazz._type.generics().get(0))
+            cf = T._type.constraintAssignableFrom(tclazz._type.generics().get(0))
               ? Types.resolved.f_Type_infix_colon_true
               : Types.resolved.f_Type_infix_colon_false;
             innerClazz = tclazz.lookup(new FeatureAndActuals(cf, typePars), -1, c.isInheritanceCall());
@@ -2640,12 +2639,12 @@ public class GeneratingFUIR extends FUIR
     int nt = f != null ? 1 : ts.size();
     var resultL = new List<Integer>();
     int tag = 0;
-    for (var cg : m.subject().type().choiceGenerics(Context.NONE /* NYI: CLEANUP: Context should no longer be needed during FUIR */))
+    for (var cg : m.subject().type().choiceGenerics())
       {
         for (int tix = 0; tix < nt; tix++)
           {
             var t = f != null ? f.resultType() : ts.get(tix);
-            if (t.isAssignableFromWithoutTagging(cg, Context.NONE /* NYI: CLEANUP: Context should no longer be needed during FUIR */))
+            if (t.isAssignableFromWithoutTagging(cg))
               {
                 resultL.add(tag);
               }
@@ -2701,7 +2700,7 @@ public class GeneratingFUIR extends FUIR
             var T = innerClazz.actualTypeParameters()[0];
             var pos = cf == Types.resolved.f_Type_infix_colon_true ||
               cf == Types.resolved.f_Type_infix_colon  &&
-              T._type.constraintAssignableFrom(Context.NONE /* NYI: CLEANUP: Context should no longer be needed during FUIR */, tclazz._type.generics().get(0));
+              T._type.constraintAssignableFrom(tclazz._type.generics().get(0));
             var tf = pos ? Types.resolved.f_TRUE : Types.resolved.f_FALSE;
             if (!c.types().stream().anyMatch(x->x.compareTo(tf.selfType())==0))
               {


### PR DESCRIPTION
fixes #3546

I also changed the visibilities to account for this change.