### PR TITLE
lib: Add `Sequence.dedup` and `Sequence.unique`, fix #4552, workaround for #4628

### DIFF
--- a/modules/base/src/Sequence.fz
+++ b/modules/base/src/Sequence.fz
@@ -1077,6 +1077,50 @@ public Sequence(public T type) ref : property.equatable is
                     res : nil
 
 
+  # filter out consecutive duplicate elements.
+  #
+  # Keep the order of elements unchanged.
+  #
+  # ex.
+  #   [1,2,2,3,2,2,2,4].dedup = [1,2,3,2,4]
+  #
+  public dedup Sequence T
+    pre
+      T : property.equatable
+    =>
+      as_list.dedup_list
+
+
+  # filter out consecutive duplicate elements using the
+  # given relation.
+  #
+  # Keep the order of elements unchanged.
+  #
+  # ex.
+  #   [4,2,2,6,2,1,2,4].dedup (a,b -> a%2=b%2) = [4,1,2]
+  #   [4,2,2,6,2,1,2,4].dedup (<=) = [4,2,1]
+  #
+  public dedup(by (T,T) -> bool) Sequence T
+    pre
+      T : property.equatable
+    =>
+      as_list.dedup_list by
+
+
+  # filter out duplicate elements.
+  #
+  # Keep the order of elements unchanged.
+  #
+  # ex.
+  #   [4,1,2,2,3,2,2,2,4].unique = [4, 1, 2, 3]
+  #
+  public unique Sequence T
+    pre
+      T : property.orderable
+    =>
+      as_list.unique_list
+
+
   # the arithmetic mean of the sequence
   # https://en.wikipedia.org/wiki/Arithmetic_mean
   public average option T
@@ -1157,7 +1201,6 @@ public Sequence(public T type) ref : property.equatable is
       T : float
   =>
     ((map x->x**T.two).fold T.sum).sqrt
-
 
 
   # create an empty Sequence

--- a/modules/base/src/list.fz
+++ b/modules/base/src/list.fz
@@ -558,6 +558,71 @@ public list(public A type) : choice nil (Cons A (list A)), Sequence A is
     flat_map x->(b.map y->(f x y))
 
 
+  # filter out consecutive duplicate elements and return result as a list.
+  #
+  # Keep the order of elements unchanged.
+  #
+  # ex.
+  #   [1,2,2,3,2,2,2,4].dedup_list = [1,2,3,2,4]
+  #
+  public dedup_list list A
+    pre
+      A : property.equatable
+    =>
+      match list.this
+        nil    => nil
+        c Cons => c.head : c.tail.drop_while_list (=c.head) .dedup_list
+
+
+  # filter out consecutive duplicate elements using the
+  # given relation and return result as a list.
+  #
+  # Keep the order of elements unchanged.
+  #
+  # ex.
+  #   [4,2,2,6,2,1,2,4].dedup_list (a,b -> a%2=b%2) = [4,1,2]
+  #   [4,2,2,6,2,1,2,4].dedup_list (<=) = [4,2,1]
+  #
+  public dedup_list(by (A,A) -> bool) list A
+    pre
+      A : property.equatable
+    =>
+      match list.this
+        nil    => nil
+        c Cons => c.head : c.tail.drop_while_list (x -> by c.head x) .dedup_list by
+
+
+  # filter out duplicate elements and return result as a list.
+  #
+  # Keep the order of elements unchanged.
+  #
+  # ex.
+  #   [4,1,2,2,3,2,2,2,4].unique_list = [4, 1, 2, 3]
+  #
+  public unique_list list A
+    pre
+      A : property.orderable
+    =>
+      /* NYI: CLEANUP: #4628 the following code can be used once #4628 is fixed
+
+        unique_list2(l list A, existing container.Set A) list A =>
+          match list.this
+            nil    => nil
+            c Cons => if existing.contains c.head then          unique_list2 l  existing
+                      else                             c.head : unique_list2 l (existing.add c.head)
+        unique_list2 list.this (container.ps_set A).empty
+      */
+
+      # workaround for #4628 using new type parameter `X`:
+      unique_list(X type : property.orderable, l list X, existing container.Set X) list X =>
+        match l
+          nil    => nil
+          c Cons => if existing.contains c.head then          unique_list X c.tail  existing
+                    else                             c.head : unique_list X c.tail (existing.add c.head)
+
+      unique_list A list.this (container.ps_set A).empty
+
+
   # create an empty list
   #
   public fixed type.empty list A =>


### PR DESCRIPTION
Also adds variant of `dedup` with a relation function and, for `list`, variants of these that return a `list`.

Since type constraints in preconditions and `if` statements are not powerful enough yet, had to add a workaround for #4628.
