### PR TITLE
lib: add features like `codepoint.is_ascii_digit` for existing sets

### DIFF
--- a/modules/base/src/codepoint.fz
+++ b/modules/base/src/codepoint.fz
@@ -53,6 +53,46 @@ is
   #
   public redef is_ascii => codepoint.ascii.contains val
 
+  # is this an ASCII digit i.e. 0-9
+  #
+  public is_ascii_digit => codepoint.ascii_digit.contains val
+
+  # is this an ASCII letter i.e. A-Z or a-z
+  #
+  public is_ascii_letter => codepoint.latin_alphabet.contains val
+
+  # is this an uppercase ASCII letter i.e. A-Z
+  #
+  public is_uppercase_ascii_letter => codepoint.A_to_Z.contains val
+
+  # is this a lowercase ASCII letter i.e. a-z
+  #
+  public is_lowercase_ascii_letter => codepoint.a_to_z.contains val
+
+  # is this codepoint encoded in one byte
+  #
+  public is_one_byte => codepoint.utf8_encoded_in_one_byte.contains val
+
+  # is this codepoint encoded in two bytes
+  #
+  public is_two_byte => codepoint.type.utf8_encoded_in_two_bytes.contains val
+
+  # is this codepoint encoded in three bytes
+  #
+  public is_three_byte => codepoint.utf8_encoded_in_three_bytes.contains val
+
+  # is this codepoint encoded in four bytes
+  #
+  public is_four_byte => codepoint.utf8_encoded_in_four_bytes.contains val
+
+  # is this a codepoint reserved for utf16 surrogate pairs
+  #
+  public is_utf16_surrogate => codepoint.utf16_surrogate.contains val
+
+  # is this codepoint guaranteed to never be a legal unicode character
+  #
+  public is_not_a_character => codepoint.not_a_character.contains val
+
 
   # range of permitted value for a codepoint
   #

--- a/modules/base/src/codepoint.fz
+++ b/modules/base/src/codepoint.fz
@@ -69,22 +69,6 @@ is
   #
   public is_lowercase_ascii_letter => codepoint.a_to_z.contains val
 
-  # is this codepoint encoded in one byte
-  #
-  public is_one_byte => codepoint.utf8_encoded_in_one_byte.contains val
-
-  # is this codepoint encoded in two bytes
-  #
-  public is_two_byte => codepoint.type.utf8_encoded_in_two_bytes.contains val
-
-  # is this codepoint encoded in three bytes
-  #
-  public is_three_byte => codepoint.utf8_encoded_in_three_bytes.contains val
-
-  # is this codepoint encoded in four bytes
-  #
-  public is_four_byte => codepoint.utf8_encoded_in_four_bytes.contains val
-
   # is this a codepoint reserved for utf16 surrogate pairs
   #
   public is_utf16_surrogate => codepoint.utf16_surrogate.contains val


### PR DESCRIPTION
fix #4547
