### PR TITLE
fuir: fix instability in clazz._id

### DIFF
--- a/src/dev/flang/fuir/Clazz.java
+++ b/src/dev/flang/fuir/Clazz.java
@@ -228,7 +228,7 @@ class Clazz extends ANY implements Comparable<Clazz>
   /**
    * Integer id of this Clazz used in FUIR instance.
    */
-  final int _id;
+  int _id = -1;
 
 
   /**
@@ -282,14 +282,11 @@ class Clazz extends ANY implements Comparable<Clazz>
    *
    * @param select in case actualType refers to a field whose result type is an
    * open generic parameter, select specifies the actual generic to be used.
-   *
-   * @param id the inter id used by FUIR to identify this Clazz.
    */
   Clazz(GeneratingFUIR fuir,
         Clazz outer,
         AbstractType type,
-        int select,
-        int id)
+        int select)
   {
     if (PRECONDITIONS) require
       (!type.dependsOnGenerics() || true /* NYI: UNDER DEVELOPMENT: Why? */,
@@ -307,7 +304,6 @@ class Clazz extends ANY implements Comparable<Clazz>
 
     _outer = outer;
     _select = select;
-    _id = id;
     _needsCode = false;
     _code = IR.NO_SITE;
   }
@@ -318,8 +314,9 @@ class Clazz extends ANY implements Comparable<Clazz>
    * Additional initialization code that has to be run after this Clazz was
    * added to FUIRI._clazzes for recursive clazz lookup.
    */
-  void init()
+  void init(int id)
   {
+    _id = id;
     _choiceGenerics = determineChoiceGenerics();
     var vas = feature().valueArguments();
     if (vas.size() == 0 || isBoxed())

--- a/src/dev/flang/fuir/GeneratingFUIR.java
+++ b/src/dev/flang/fuir/GeneratingFUIR.java
@@ -332,7 +332,7 @@ public class GeneratingFUIR extends FUIR
     // normalize outer to be value in case t describes a field
     outerR = t.feature().isField() ? outerR.asValue() : outerR;
 
-    var cl = new Clazz(this, outerR, t, select, CLAZZ_BASE + _clazzes.size());
+    var cl = new Clazz(this, outerR, t, select);
     var existing = _clazzesTM.get(cl);
     if (existing != null)
       {
@@ -341,7 +341,12 @@ public class GeneratingFUIR extends FUIR
     else
       {
         result = cl;
+        var fuirId = CLAZZ_BASE + _clazzes.size();
         _clazzes.add(cl);
+
+        if (CHECKS) check
+          (_clazzes.get(clazzId2num(fuirId)) == cl);
+
         if (_lookupDone)
           {
             if (false) // NYI: BUG: #4273: This still happens for some tests and
@@ -407,11 +412,11 @@ public class GeneratingFUIR extends FUIR
           }
         cl._specialClazzId = s;
         if (SHOW_NEW_CLAZZES) System.out.println("NEW CLAZZ "+cl);
-        cl.init();
+        cl.init(fuirId);
 
         result.registerAsHeir();
 
-        // C backend requires the value variant for all ref clazzes, so we make
+        // backends require the value variant for all ref clazzes, so we make
         // sure we have the value clazz as well:
         var ignore = clazzAsValue(result._id);
       }


### PR DESCRIPTION
I discovered some cases where `_classes.get(cl._id) != cl` because the Clazz constructor led to newClazz being called.
These cases do not trigger any bugs currently but enabling `lookupDone` and serializing the FUIR would not work.