### PR TITLE
lib: avoid `as_list` in `Sequence.as_array` if array backed

### DIFF
--- a/modules/base/src/Sequence.fz
+++ b/modules/base/src/Sequence.fz
@@ -117,7 +117,10 @@ public Sequence(public T type) ref : property.equatable is
   # collect the contents of this Sequence into an array
   #
   public as_array array T =>
-    as_list.as_array
+    if is_array_backed
+      array count (i -> Sequence.this[i])
+    else
+      as_list.as_array
 
 
   # create an array backed version of this sequence in case this is not array


### PR DESCRIPTION
IMHO feels better like this and should improve performance, but I did not measure thatn. 