### PR TITLE
fe: fix soundness issue in checkLegalQualThisType

### DIFF
--- a/modules/base/src/container/Set.fz
+++ b/modules/base/src/container/Set.fz
@@ -52,12 +52,12 @@ public Set(public E type : property.equatable) ref : Sequence E is
 
   # create a new Set from a sequence of elements
   #
-  public type.new (s Sequence E) Set.this => abstract
+  public type.new (s Sequence E) container.Set E => abstract
 
 
   # create a union of these two Sets
   #
-  public union(other container.Set E) Set E =>
+  public union(other container.Set E) container.Set E =>
     Set.this.new (Set.this ++ other)
 
 
@@ -69,7 +69,7 @@ public Set(public E type : property.equatable) ref : Sequence E is
 
   # create an intersection of these two Sets
   #
-  public intersection(other container.Set E) Set E =>
+  public intersection(other container.Set E) container.Set E =>
     Set.this.new (Set.this ++ other).filter(el -> Set.this.contains el && other.contains el)
 
 
@@ -81,7 +81,7 @@ public Set(public E type : property.equatable) ref : Sequence E is
 
   # this Set without all elements in other
   #
-  public difference(other container.Set E) Set E =>
+  public difference(other container.Set E) container.Set E =>
     Set.this.new filter(el -> !other.contains el)
 
 

--- a/modules/base/src/container/ps_set.fz
+++ b/modules/base/src/container/ps_set.fz
@@ -116,4 +116,4 @@ is
   #
   # This feature creates a pre-initialized instance of ps_set.
   #
-  public fixed redef type.new(vs Sequence K) => (container.ps_set K).empty.add_all vs
+  public fixed redef type.new(vs Sequence K) container.Set K => (container.ps_set K).empty.add_all vs

--- a/modules/base/src/interval.fz
+++ b/modules/base/src/interval.fz
@@ -119,7 +119,7 @@ is
   # "(Errors.any() || !thiz.dependsOnGenerics(),
   #   outerClazz != null || thiz.feature().outer() == null, Errors.any()
   #     || thiz == Types.t_ERROR || outerClazz == null || outerClazz.feature().inheritsFrom(thiz.feature().outer()));"
-  public fixed redef type.new (s Sequence T) interval.this => panic "not applicable"
+  public fixed redef type.new (s Sequence T) container.Set T => panic "not applicable"
 
 
   # is this sequence known to be finite?  For infinite sequences, features like

--- a/src/dev/flang/fe/SourceModule.java
+++ b/src/dev/flang/fe/SourceModule.java
@@ -1729,10 +1729,11 @@ A feature that is a constructor, choice or a type parameter may not redefine an 
    */
   private void checkLegalQualThisType(Feature f)
   {
-    if (f.resultType().containsThisType())
+    // NYI: UNDER DEVELOPMENT: do we need to check type parameters?
+    if (!f.isTypeParameter() && f.resultType().containsThisType())
       {
         var t = f.resultType();
-        while (t != null)
+        while (t != null && !t.isGenericArgument())
           {
             if (t.isThisType())
               {

--- a/src/dev/flang/fe/SourceModule.java
+++ b/src/dev/flang/fe/SourceModule.java
@@ -1729,25 +1729,33 @@ A feature that is a constructor, choice or a type parameter may not redefine an 
    */
   private void checkLegalQualThisType(Feature f)
   {
-    if (f.resultType().isThisType())
+    if (f.resultType().containsThisType())
       {
-        var subject = f.resultType().feature();
-        var found = false;
-        AbstractFeature o = f;
-        while(o != null)
+        var t = f.resultType();
+        while (t != null)
           {
-            if (subject == o)
+            if (t.isThisType())
               {
-                found = true;
-                break;
+                var subject = t.feature();
+                var found = false;
+                AbstractFeature o = f;
+                while(o != null)
+                  {
+                    if (subject == o)
+                      {
+                        found = true;
+                        break;
+                      }
+                    o = o.outer();
+                  }
+                if (!found &&
+                  // okay for post condition features result field
+                  !(f.isResultField() && f.outer().featureName().baseName().startsWith(FuzionConstants.POSTCONDITION_FEATURE_PREFIX)))
+                  {
+                    AstErrors.illegalResultTypeThisType(f);
+                  }
               }
-            o = o.outer();
-          }
-        if (!found &&
-          // okay for post condition features result field
-          !(f.isResultField() && f.outer().featureName().baseName().startsWith(FuzionConstants.POSTCONDITION_FEATURE_PREFIX)))
-          {
-            AstErrors.illegalResultTypeThisType(f);
+            t = t.outer();
           }
       }
   }


### PR DESCRIPTION
fixes #4512

Since the changes in checkLegalQualThisType would lead to an error building base.fum, I changed stdlib accordingly.
```
./build/modules/base/src/codepoint.fz:101:15: error 1: Illegal '.this' type: 'container.this.Set u32'
  public type.latin_alphabet => A_to_Z ∪ a_to_z

No suitable surrounding feature was found that matches the type.

one error.
```

