### PR TITLE
ai: Remove stack cleanup for in `AbstractInterpeter` for expression with `alwaysResultsInVoid`, fix #4662     

### DIFF
--- a/src/dev/flang/be/c/C.java
+++ b/src/dev/flang/be/c/C.java
@@ -1406,7 +1406,6 @@ public class C extends ANY
           }
         ol.add(acc);
         res = _fuir.alwaysResultsInVoid(s)
-              // _fuir.clazzIsVoidType(rt)
           ? null
           : callsResultEscapes || isCall && _fuir.hasData(rt) && _fuir.clazzFieldIsAdrOfValue(cc0)  // NYI: deref an outer ref to value type. Would be nice to have a separate expression for this
             ? res.deref()

--- a/src/dev/flang/be/c/C.java
+++ b/src/dev/flang/be/c/C.java
@@ -414,7 +414,7 @@ public class C extends ANY
      * Perform a match on value subv.
      */
     @Override
-    public Pair<CExpr, CStmnt> match(int s, AbstractInterpreter<CExpr, CStmnt> ai, CExpr sub)
+    public CStmnt match(int s, AbstractInterpreter<CExpr, CStmnt> ai, CExpr sub)
     {
       var subjClazz = _fuir.matchStaticSubject(s);
       var uniyon    = sub.field(CNames.CHOICE_UNION_NAME);
@@ -479,7 +479,7 @@ public class C extends ANY
           var notFound = reportErrorInCode0("unexpected reference type %d found in match", id);
           tdefault = CStmnt.suitch(id, rcases, notFound);
         }
-      return new Pair<>(CExpr.UNIT, CStmnt.seq(getRef, CStmnt.suitch(tag, tcases, tdefault)));
+      return CStmnt.seq(getRef, CStmnt.suitch(tag, tcases, tdefault));
     }
 
 

--- a/src/dev/flang/be/c/C.java
+++ b/src/dev/flang/be/c/C.java
@@ -1405,7 +1405,8 @@ public class C extends ANY
                                                    CExpr.string(_fuir.siteAsString(s))));
           }
         ol.add(acc);
-        res = _fuir.clazzIsVoidType(rt)
+        res = _fuir.alwaysResultsInVoid(s)
+              // _fuir.clazzIsVoidType(rt)
           ? null
           : callsResultEscapes || isCall && _fuir.hasData(rt) && _fuir.clazzFieldIsAdrOfValue(cc0)  // NYI: deref an outer ref to value type. Would be nice to have a separate expression for this
             ? res.deref()

--- a/src/dev/flang/be/jvm/CodeGen.java
+++ b/src/dev/flang/be/jvm/CodeGen.java
@@ -1014,10 +1014,9 @@ class CodeGen
    * @return the code for the match, produces unit type result.
    */
   @Override
-  public Pair<Expr, Expr> match(int s, AbstractInterpreter<Expr, Expr> ai, Expr sub)
+  public Expr match(int s, AbstractInterpreter<Expr, Expr> ai, Expr sub)
   {
-    var code = _choices.match(_jvm, ai, s, sub);
-    return new Pair<>(Expr.UNIT, code);
+    return _choices.match(_jvm, ai, s, sub);
   }
 
 

--- a/src/dev/flang/be/jvm/CodeGen.java
+++ b/src/dev/flang/be/jvm/CodeGen.java
@@ -377,7 +377,7 @@ class CodeGen
       {
         if (res != null)
           {
-            s = s.andThen(res);
+            s = s.andThen(res.drop());
           }
         res = null;
       }

--- a/src/dev/flang/be/jvm/CodeGen.java
+++ b/src/dev/flang/be/jvm/CodeGen.java
@@ -372,7 +372,6 @@ class CodeGen
         s = s.andThen(calpair.v1());
         res = calpair.v0();
       }
-    // if (_fuir.clazzIsVoidType(_fuir.clazzResultClazz(cc0)))
     if (_fuir.alwaysResultsInVoid(si))
       {
         if (res != null)

--- a/src/dev/flang/be/jvm/CodeGen.java
+++ b/src/dev/flang/be/jvm/CodeGen.java
@@ -372,7 +372,8 @@ class CodeGen
         s = s.andThen(calpair.v1());
         res = calpair.v0();
       }
-    if (_fuir.clazzIsVoidType(_fuir.clazzResultClazz(cc0)))
+    // if (_fuir.clazzIsVoidType(_fuir.clazzResultClazz(cc0)))
+    if (_fuir.alwaysResultsInVoid(si))
       {
         if (res != null)
           {

--- a/src/dev/flang/fuir/analysis/AbstractInterpreter.java
+++ b/src/dev/flang/fuir/analysis/AbstractInterpreter.java
@@ -545,7 +545,7 @@ public class AbstractInterpreter<VALUE, RESULT> extends ANY
               }
             break;
           case Match:
-            throw new Error("stack not empty after match with  _fuir.alwaysResultsInVoid at " + _fuir.siteAsString(last_s));
+            throw new Error("stack not empty after match with _fuir.alwaysResultsInVoid at " + _fuir.siteAsString(last_s));
           default:
             throw new Error("stack not empty after basic block ending in "+_fuir.codeAtAsString(last_s));
           }

--- a/src/dev/flang/fuir/analysis/AbstractInterpreter.java
+++ b/src/dev/flang/fuir/analysis/AbstractInterpreter.java
@@ -527,30 +527,9 @@ public class AbstractInterpreter<VALUE, RESULT> extends ANY
                                            _fuir.siteAsString(last_s)));
       }
 
-    // FUIR has the (so far undocumented) invariant that the stack must be
-    // empty at the end of a basic block.
+    // FUIR has the invariant that the stack must be empty at the end of a basic block.
     if (CHECKS) check
-      (containsVoid(stack) || stack.isEmpty() || _fuir.alwaysResultsInVoid(last_s));
-
-    if (!containsVoid(stack) && !stack.isEmpty() && _fuir.alwaysResultsInVoid(last_s))
-      {
-        switch (_fuir.codeAt(last_s))
-          {
-          case Call:
-            if (true) throw new Error("stack not empty after call with _fuir.alwaysResultsInVoid at " + _fuir.siteAsString(last_s));
-            var cc0 = _fuir.accessedClazz(last_s);
-            var rt = _fuir.clazzResultClazz(cc0);
-            if (!clazzHasUnitValue(rt))
-              {
-                l.add(_processor.drop(stack.pop(), rt));
-              }
-            break;
-          case Match:
-            throw new Error("stack not empty after match with _fuir.alwaysResultsInVoid at " + _fuir.siteAsString(last_s));
-          default:
-            throw new Error("stack not empty after basic block ending in "+_fuir.codeAtAsString(last_s));
-          }
-      }
+      (containsVoid(stack) || stack.isEmpty());
 
     return new Pair<>(v, _processor.sequence(l));
   }

--- a/src/dev/flang/fuir/analysis/AbstractInterpreter.java
+++ b/src/dev/flang/fuir/analysis/AbstractInterpreter.java
@@ -537,6 +537,7 @@ public class AbstractInterpreter<VALUE, RESULT> extends ANY
         switch (_fuir.codeAt(last_s))
           {
           case Call:
+            if (true) throw new Error("stack not empty after call with _fuir.alwaysResultsInVoid at " + _fuir.siteAsString(last_s));
             var cc0 = _fuir.accessedClazz(last_s);
             var rt = _fuir.clazzResultClazz(cc0);
             if (!clazzHasUnitValue(rt))

--- a/src/dev/flang/fuir/analysis/AbstractInterpreter2.java.patch
+++ b/src/dev/flang/fuir/analysis/AbstractInterpreter2.java.patch
@@ -178,63 +178,61 @@
 ---
 >         _processor.reportErrorInCode("Severe compiler bug! This code should be unreachable:\n" +
 >                                      _fuir.siteAsString(last_s));
-544c535
-<                 l.add(_processor.drop(stack.pop(), rt));
----
->                 _processor.drop(stack.pop(), rt);
-554c545
+529a521
+> 
+534c526
 <     return new Pair<>(v, _processor.sequence(l));
 ---
 >     return v;
-564,566d554
+544,546d535
 <    *
 <    * @return the result of the abstract interpretation, e.g., the generated
 <    * code.
-568c556
+548c537
 <   public RESULT process(int s, Stack<VALUE> stack)
 ---
 >   public void process(int s, Stack<VALUE> stack)
-580d567
+560d548
 <     RESULT res;
-593c580
+573c561
 <               res = _processor.assign(s, tvalue, avalue);
 ---
 >               _processor.assign(s, tvalue, avalue);
-597,598c584,585
+577,578c565,566
 <               res = _processor.sequence(new List<>(_processor.drop(tvalue, tc),
 <                                                     _processor.drop(avalue, ft)));
 ---
 >               _processor.drop(tvalue, tc);
 >               _processor.drop(avalue, ft);
-609c596
+589c577
 <               res = _processor.comment("Box is a NOP, clazz is already a ref");
 ---
 >               _processor.comment("Box is a NOP, clazz is already a ref");
-615,616c602
+595,596c583
 <               push(stack, rc, r.v0());
 <               res = r.v1();
 ---
 >               push(stack, rc, r);
-627c613
+607c594
 <           if (r.v0() == null)  // this may happen even if rt is not void (e.g., in case of tail recursion or error)
 ---
 >           if (r == null)  // this may happen even if rt is not void (e.g., in case of tail recursion or error)
-634c620
+614c601
 <               push(stack, rt, r.v0());
 ---
 >               push(stack, rt, r);
-636d621
+616d602
 <           res = r.v1();
-641c626
+621c607
 <           res = _processor.comment(_fuir.comment(s));
 ---
 >           _processor.comment(_fuir.comment(s));
-648,649c633
+628,629c614
 <           push(stack, cl, r.v0());
 <           res = r.v1();
 ---
 >           push(stack, cl, r);
-658,663c642
+638,643c623
 <           if (CHECKS) check
 <             // check that constant creation has no side effects.
 <             (r.v1() == _processor.nop());
@@ -243,29 +241,29 @@
 <           res = r.v1();
 ---
 >           push(stack, constCl, r);
-670,671c649,650
+650,651c630,631
 <           res = _processor.match(s, this, subv);
 <           if (_fuir.alwaysResultsInVoid(s))
 ---
 >           var r = _processor.match(s, this, subv);
 >           if (r == null)
-674a654,655
+654a635,636
 >           if (CHECKS) check
 >             (r == null || r == _processor.unitValue());
-686,687c667
+666,667c648
 <           push(stack, newcl, r.v0());
 <           res = r.v1();
 ---
 >           push(stack, newcl, r);
-701c681
+681c662
 <           res = _processor.drop(v, rt);
 ---
 >           _processor.drop(v, rt);
-707d686
+687d667
 <           res = null;
-716c695
+696c676
 <         say("process done: "+_fuir.siteAsString(s) + ":\t"+_fuir.codeAtAsString(s)+" stack is "+stack+" RES "+res);
 ---
 >         say("process done: "+_fuir.siteAsString(s) + ":\t"+_fuir.codeAtAsString(s)+" stack is "+stack);
-718d696
+698d677
 <     return res;

--- a/src/dev/flang/fuir/analysis/AbstractInterpreter2.java.patch
+++ b/src/dev/flang/fuir/analysis/AbstractInterpreter2.java.patch
@@ -104,7 +104,7 @@
 ---
 >     public abstract VALUE constData(int s, int constCl, byte[] d);
 225c224
-<     public abstract Pair<VALUE, RESULT> match(int s, AbstractInterpreter<VALUE, RESULT> ai, VALUE subv);
+<     public abstract RESULT match(int s, AbstractInterpreter<VALUE, RESULT> ai, VALUE subv);
 ---
 >     public abstract VALUE match(int s, AbstractInterpreter2<VALUE> ai, VALUE subv);
 239c238
@@ -182,59 +182,59 @@
 <                 l.add(_processor.drop(stack.pop(), rt));
 ---
 >                 _processor.drop(stack.pop(), rt);
-555c546
+554c545
 <     return new Pair<>(v, _processor.sequence(l));
 ---
 >     return v;
-565,567d555
+564,566d554
 <    *
 <    * @return the result of the abstract interpretation, e.g., the generated
 <    * code.
-569c557
+568c556
 <   public RESULT process(int s, Stack<VALUE> stack)
 ---
 >   public void process(int s, Stack<VALUE> stack)
-577d564
+580d567
 <     RESULT res;
-590c577
+593c580
 <               res = _processor.assign(s, tvalue, avalue);
 ---
 >               _processor.assign(s, tvalue, avalue);
-594,595c581,582
+597,598c584,585
 <               res = _processor.sequence(new List<>(_processor.drop(tvalue, tc),
 <                                                     _processor.drop(avalue, ft)));
 ---
 >               _processor.drop(tvalue, tc);
 >               _processor.drop(avalue, ft);
-606c593
+609c596
 <               res = _processor.comment("Box is a NOP, clazz is already a ref");
 ---
 >               _processor.comment("Box is a NOP, clazz is already a ref");
-612,613c599
+615,616c602
 <               push(stack, rc, r.v0());
 <               res = r.v1();
 ---
 >               push(stack, rc, r);
-624c610
+627c613
 <           if (r.v0() == null)  // this may happen even if rt is not void (e.g., in case of tail recursion or error)
 ---
 >           if (r == null)  // this may happen even if rt is not void (e.g., in case of tail recursion or error)
-631c617
+634c620
 <               push(stack, rt, r.v0());
 ---
 >               push(stack, rt, r);
-633d618
+636d621
 <           res = r.v1();
-638c623
+641c626
 <           res = _processor.comment(_fuir.comment(s));
 ---
 >           _processor.comment(_fuir.comment(s));
-645,646c630
+648,649c633
 <           push(stack, cl, r.v0());
 <           res = r.v1();
 ---
 >           push(stack, cl, r);
-655,660c639
+658,663c642
 <           if (CHECKS) check
 <             // check that constant creation has no side effects.
 <             (r.v1() == _processor.nop());
@@ -243,29 +243,29 @@
 <           res = r.v1();
 ---
 >           push(stack, constCl, r);
-668c647
-<           if (r.v0() == null)
+670,671c649,650
+<           res = _processor.match(s, this, subv);
+<           if (_fuir.alwaysResultsInVoid(s))
 ---
+>           var r = _processor.match(s, this, subv);
 >           if (r == null)
-673,674c652
-<             (r.v0() == null || r.v0() == _processor.unitValue());
-<           res = r.v1();
----
+674a654,655
+>           if (CHECKS) check
 >             (r == null || r == _processor.unitValue());
-686,687c664
+686,687c667
 <           push(stack, newcl, r.v0());
 <           res = r.v1();
 ---
 >           push(stack, newcl, r);
-701c678
+701c681
 <           res = _processor.drop(v, rt);
 ---
 >           _processor.drop(v, rt);
-707d683
+707d686
 <           res = null;
-716c692
+716c695
 <         say("process done: "+_fuir.siteAsString(s) + ":\t"+_fuir.codeAtAsString(s)+" stack is "+stack+" RES "+res);
 ---
 >         say("process done: "+_fuir.siteAsString(s) + ":\t"+_fuir.codeAtAsString(s)+" stack is "+stack);
-718d693
+718d696
 <     return res;


### PR DESCRIPTION
Instead, if the DFA had found that a `match` would never return, the `AbstractInterpreter` now stop interpreting after that `match`. Since the result of a match by the backend could only be a unit type anyway, this takes the burdern of return `null` in case of an effective `void` result form the backends.

Only uses of the `AbstractInterpreter` that directly return a value for `match`, i.e., the DFA and the interpreter backend, still use `null` to signal no return (DFA), or just never actually return (interpreter).

For `call`, the handling of `alwaysResutlsInVoid` has been moved to the jvm and C backends generalizing the handling of a `void` result type. 

As a bonus, extended the AbstractInterperter debug output for a specific feature to work not only if a regex matches, but also if there is a full match. This helps when there are `(`/`)` in the clazz name that do not need to be escaped. 
