### PR TITLE
docs: don't show 'Private Constructor' annotation for arguments

### DIFF
--- a/src/dev/flang/tools/docs/Html.java
+++ b/src/dev/flang/tools/docs/Html.java
@@ -303,7 +303,7 @@ public class Html extends ANY
    */
   private String annotatePrivateConstructor(AbstractFeature af)
   {
-    return af.visibility().eraseTypeVisibility() != Visi.PUB && !af.isArgument() // annotation does not make sense for argument fields
+    return af.visibility().eraseTypeVisibility() != Visi.PUB && af.isConstructor()
              ? "&nbsp;<div class='fd-parent' title='This feature can not be called to construct a new instance of itself, " +
                "only the type it defines is visible.'>[Private constructor]</div>" // NYI: replace title attribute with proper tooltip
              : "";

--- a/src/dev/flang/tools/docs/Html.java
+++ b/src/dev/flang/tools/docs/Html.java
@@ -303,7 +303,7 @@ public class Html extends ANY
    */
   private String annotatePrivateConstructor(AbstractFeature af)
   {
-    return af.visibility().eraseTypeVisibility() != Visi.PUB
+    return af.visibility().eraseTypeVisibility() != Visi.PUB && !af.isArgument() // annotation does not make sense for argument fields
              ? "&nbsp;<div class='fd-parent' title='This feature can not be called to construct a new instance of itself, " +
                "only the type it defines is visible.'>[Private constructor]</div>" // NYI: replace title attribute with proper tooltip
              : "";


### PR DESCRIPTION
for some reason the third argument in [Binary](https://fuzion-lang.dev/docs/base/Binary+%283+arguments%29/) had the `[Private constructor]` annotation
