### PR TITLE
Fix partial application when calling infix operator, fix #4687

### DIFF
--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -873,8 +873,6 @@ public class Call extends AbstractCall
 
     FeatureAndOuter result = null;
     var n = expectedType.arity() + (_wasImplicitImmediateCall ? _originalArgCount : _actuals.size());
-    var newName = newNameForPartial(expectedType);
-    var name = newName != null ? newName : _name;
 
     // if loadCalledFeatureUnlessTargetVoid has found a suitable called
     // feature in an outer feature, it will have replaced a null _target, so
@@ -883,8 +881,8 @@ public class Call extends AbstractCall
     var targetFeature = traverseOuter ? context.outerFeature() : targetFeature(res, context);
     if (targetFeature != null)
       {
-        var fos = res._module.lookup(targetFeature, name, this, traverseOuter, false);
-        var calledName = FeatureName.get(name, n);
+        var fos = res._module.lookup(targetFeature, _name, this, traverseOuter, false);
+        var calledName = FeatureName.get(_name, n);
         result = FeatureAndOuter.filter(fos, pos(), FuzionConstants.OPERATION_CALL, calledName, ff -> ff.valueArguments().size() == n);
       }
     return result;
@@ -901,33 +899,6 @@ public class Call extends AbstractCall
   boolean isOperatorCall(boolean parenthesesAllowed)
   {
     return false;
-  }
-
-
-  /**
-   * Check if partial application would change the name of the called feature
-   * for this call.
-   *
-   * @param expectedType the expected function type
-   *
-   * @return the new name or null in case the name stays unchanged.
-   */
-  String newNameForPartial(AbstractType expectedType)
-  {
-    String result = null;
-    if (expectedType.arity() == 1 && isOperatorCall(true))
-      {
-        var name = _name;
-        if (name.startsWith(FuzionConstants.PREFIX_OPERATOR_PREFIX))
-          { // -v ==> x->x-v
-            result = FuzionConstants.INFIX_OPERATOR_PREFIX + name.substring(FuzionConstants.PREFIX_OPERATOR_PREFIX.length());
-          }
-        else if (name.startsWith(FuzionConstants.POSTFIX_OPERATOR_PREFIX))
-          { // -v ==> x->x-v
-            result = FuzionConstants.INFIX_OPERATOR_PREFIX + name.substring(FuzionConstants.POSTFIX_OPERATOR_PREFIX.length());
-          }
-      }
-    return result;
   }
 
 

--- a/src/dev/flang/ast/ParsedCall.java
+++ b/src/dev/flang/ast/ParsedCall.java
@@ -455,10 +455,16 @@ public class ParsedCall extends Call
         _calledFeature != Types.f_ERROR /* resulution did not cause an error */    )
       {
         checkPartialAmbiguity(res, context, expectedType);
-        if (isPartialInfix(expectedType) /* `1-` -> `x->1-x` */ ||
+        if (// try to solve error through partial application, e.g., for `[["a"]].map String.from_codepoints`
+            _pendingError != null                       ||
+
+            // convert pre/postfix to infix, e.g., `1-` -> `x->1-x` */
+            isPartialInfix(expectedType)                ||
+
+            // otherwise, try to solve inconsistent type
             paa != null                              &&
             (typeForInferencing() == null ||
-             !typeForInferencing().isFunctionType())    )
+             !typeForInferencing().isFunctionType())       )
           {
             l = applyPartially(res, context, expectedType);
           }

--- a/tests/partial_application/partial_application.fz
+++ b/tests/partial_application/partial_application.fz
@@ -370,3 +370,11 @@ partial_application is
     test "fun arg 4 4" (fun_arg_with_4_args f_4_args 4 2 0 69) "4,2,0,69"
 
   with_tp
+
+  # example code from #4687, partial application of infix operator
+  #
+  test_4687 =>
+
+    [(u8 0, u8 1)].map (||> x,y->unit) |> say
+
+  test_4687

--- a/tests/partial_application/partial_application.fz.expected_out
+++ b/tests/partial_application/partial_application.fz.expected_out
@@ -181,3 +181,4 @@ PASSED: fun arg 2 4: got '4,2,0,69'
 PASSED: fun arg 3 3: got '32,16,8'
 PASSED: fun arg 3 4: got '4,2,0,69'
 PASSED: fun arg 4 4: got '4,2,0,69'
+[unit]

--- a/tests/partial_application_negative/partial_application_negative.fz.expected_err
+++ b/tests/partial_application_negative/partial_application_negative.fz.expected_err
@@ -54,20 +54,12 @@ To solve this, rename one of the ambiguous features.
 --CURDIR--/partial_application_negative.fz:42:47: error 6: Could not find called feature
   test "data.map 3.prefix*   " (data.map    3.prefix*) "[3,6,9,12,15,18,21,24,27,30]"    // 1. should flag an error, do not change named prefix call to infix call
 ----------------------------------------------^^^^^^^
-Feature not found: 'prefix *' (one argument)
+Feature not found: 'prefix *' (no arguments)
 Target feature: 'i32'
 In call: '3.prefix*'
 
 
---CURDIR--/partial_application_negative.fz:42:38: error 7: Failed to infer actual type parameters
-  test "data.map 3.prefix*   " (data.map    3.prefix*) "[3,6,9,12,15,18,21,24,27,30]"    // 1. should flag an error, do not change named prefix call to infix call
--------------------------------------^^^
-In call to 'Sequence.map', no actual type parameters are given and inference of the type parameters failed.
-Expected type parameters: 'B'
-Type inference failed for one type parameter 'B'
-
-
---CURDIR--/partial_application_negative.fz:43:38: error 8: Failed to infer actual type parameters
+--CURDIR--/partial_application_negative.fz:43:38: error 7: Failed to infer actual type parameters
   test "data.map 3.prefix-   " (data.map    3.prefix-) "[3,6,9,12,15,18,21,24,27,30]"    // 2. should flag an error, do not change named prefix call to infix call
 -------------------------------------^^^
 In call to 'Sequence.map', no actual type parameters are given and inference of the type parameters failed.
@@ -75,34 +67,26 @@ Expected type parameters: 'B'
 Type inference failed for one type parameter 'B'
 
 
---CURDIR--/partial_application_negative.fz:44:47: error 9: Could not find called feature
+--CURDIR--/partial_application_negative.fz:44:47: error 8: Could not find called feature
   test "data.map 3.postfix*  " (data.map    3.postfix*) "[3,6,9,12,15,18,21,24,27,30]"  // 3. should flag an error, do not change named prefix call to infix call
 ----------------------------------------------^^^^^^^^
-Feature not found: 'postfix *' (one argument)
+Feature not found: 'postfix *' (no arguments)
 Target feature: 'i32'
 In call: '3.postfix*'
 
 
---CURDIR--/partial_application_negative.fz:44:38: error 10: Failed to infer actual type parameters
-  test "data.map 3.postfix*  " (data.map    3.postfix*) "[3,6,9,12,15,18,21,24,27,30]"  // 3. should flag an error, do not change named prefix call to infix call
--------------------------------------^^^
-In call to 'Sequence.map', no actual type parameters are given and inference of the type parameters failed.
-Expected type parameters: 'B'
-Type inference failed for one type parameter 'B'
-
-
---CURDIR--/partial_application_negative.fz:77:38: error 11: Different count of arguments needed when calling feature
+--CURDIR--/partial_application_negative.fz:77:38: error 9: Different count of arguments needed when calling feature
   test "data.map  .as_string " (data.map  .as_string ) "[1,2,3,4,5,6,7,8,9,10]"  // 11. should flag an error: dot-call partials require parentheses
 -------------------------------------^^^
 Feature not found: 'map' (no arguments)
 Target feature: 'interval'
 In call: 'map'
-To solve this, you might change the actual number of arguments to match the feature 'map' (2 arguments) at {base.fum}/Sequence.fz:344:10:
+To solve this, you might change the actual number of arguments to match the feature 'map' (2 arguments) at {base.fum}/Sequence.fz:347:10:
   public map(B type, f Unary B T) Sequence B =>
 ---------^^^
 
 
---CURDIR--/partial_application_negative.fz:72:20: error 12: Ambiguity between direct and partially applied call target
+--CURDIR--/partial_application_negative.fz:72:20: error 10: Ambiguity between direct and partially applied call target
   _ i32->String := ambig2 4711     // 9. should flag an error: ambiguous call to implicit ambig2.call (1 argument) or partially applied ambig2 (2 arguments)
 -------------------^^^^^^
 This call can be resolved in two ways, either as a direct call to 'partial_application_negative.ambig2' declared at --CURDIR--/partial_application_negative.fz:66:3:
@@ -114,7 +98,7 @@ or by partially applying arguments to a call to 'partial_application_negative.am
 To solve this, rename one of the ambiguous features.
 
 
---CURDIR--/partial_application_negative.fz:74:26: error 13: Ambiguity between direct and partially applied call target
+--CURDIR--/partial_application_negative.fz:74:26: error 11: Ambiguity between direct and partially applied call target
   _ := test2            (ambig2 4711)    // 10. should flag an error: ambiguous call to implicit `ambig2.call (1 argument)` or partially applied `ambig2 (2 arguments)`
 -------------------------^^^^^^
 This call can be resolved in two ways, either as a direct call to 'partial_application_negative.ambig2' declared at --CURDIR--/partial_application_negative.fz:66:3:
@@ -125,4 +109,4 @@ or by partially applying arguments to a call to 'partial_application_negative.am
 --^^^^^^.
 To solve this, rename one of the ambiguous features.
 
-13 errors.
+11 errors.

--- a/tests/partial_application_negative/partial_application_negative.fz.expected_err
+++ b/tests/partial_application_negative/partial_application_negative.fz.expected_err
@@ -54,12 +54,20 @@ To solve this, rename one of the ambiguous features.
 --CURDIR--/partial_application_negative.fz:42:47: error 6: Could not find called feature
   test "data.map 3.prefix*   " (data.map    3.prefix*) "[3,6,9,12,15,18,21,24,27,30]"    // 1. should flag an error, do not change named prefix call to infix call
 ----------------------------------------------^^^^^^^
-Feature not found: 'prefix *' (no arguments)
+Feature not found: 'prefix *' (one argument)
 Target feature: 'i32'
 In call: '3.prefix*'
 
 
---CURDIR--/partial_application_negative.fz:43:38: error 7: Failed to infer actual type parameters
+--CURDIR--/partial_application_negative.fz:42:38: error 7: Failed to infer actual type parameters
+  test "data.map 3.prefix*   " (data.map    3.prefix*) "[3,6,9,12,15,18,21,24,27,30]"    // 1. should flag an error, do not change named prefix call to infix call
+-------------------------------------^^^
+In call to 'Sequence.map', no actual type parameters are given and inference of the type parameters failed.
+Expected type parameters: 'B'
+Type inference failed for one type parameter 'B'
+
+
+--CURDIR--/partial_application_negative.fz:43:38: error 8: Failed to infer actual type parameters
   test "data.map 3.prefix-   " (data.map    3.prefix-) "[3,6,9,12,15,18,21,24,27,30]"    // 2. should flag an error, do not change named prefix call to infix call
 -------------------------------------^^^
 In call to 'Sequence.map', no actual type parameters are given and inference of the type parameters failed.
@@ -67,15 +75,23 @@ Expected type parameters: 'B'
 Type inference failed for one type parameter 'B'
 
 
---CURDIR--/partial_application_negative.fz:44:47: error 8: Could not find called feature
+--CURDIR--/partial_application_negative.fz:44:47: error 9: Could not find called feature
   test "data.map 3.postfix*  " (data.map    3.postfix*) "[3,6,9,12,15,18,21,24,27,30]"  // 3. should flag an error, do not change named prefix call to infix call
 ----------------------------------------------^^^^^^^^
-Feature not found: 'postfix *' (no arguments)
+Feature not found: 'postfix *' (one argument)
 Target feature: 'i32'
 In call: '3.postfix*'
 
 
---CURDIR--/partial_application_negative.fz:77:38: error 9: Different count of arguments needed when calling feature
+--CURDIR--/partial_application_negative.fz:44:38: error 10: Failed to infer actual type parameters
+  test "data.map 3.postfix*  " (data.map    3.postfix*) "[3,6,9,12,15,18,21,24,27,30]"  // 3. should flag an error, do not change named prefix call to infix call
+-------------------------------------^^^
+In call to 'Sequence.map', no actual type parameters are given and inference of the type parameters failed.
+Expected type parameters: 'B'
+Type inference failed for one type parameter 'B'
+
+
+--CURDIR--/partial_application_negative.fz:77:38: error 11: Different count of arguments needed when calling feature
   test "data.map  .as_string " (data.map  .as_string ) "[1,2,3,4,5,6,7,8,9,10]"  // 11. should flag an error: dot-call partials require parentheses
 -------------------------------------^^^
 Feature not found: 'map' (no arguments)
@@ -86,7 +102,7 @@ To solve this, you might change the actual number of arguments to match the feat
 ---------^^^
 
 
---CURDIR--/partial_application_negative.fz:72:20: error 10: Ambiguity between direct and partially applied call target
+--CURDIR--/partial_application_negative.fz:72:20: error 12: Ambiguity between direct and partially applied call target
   _ i32->String := ambig2 4711     // 9. should flag an error: ambiguous call to implicit ambig2.call (1 argument) or partially applied ambig2 (2 arguments)
 -------------------^^^^^^
 This call can be resolved in two ways, either as a direct call to 'partial_application_negative.ambig2' declared at --CURDIR--/partial_application_negative.fz:66:3:
@@ -98,7 +114,7 @@ or by partially applying arguments to a call to 'partial_application_negative.am
 To solve this, rename one of the ambiguous features.
 
 
---CURDIR--/partial_application_negative.fz:74:26: error 11: Ambiguity between direct and partially applied call target
+--CURDIR--/partial_application_negative.fz:74:26: error 13: Ambiguity between direct and partially applied call target
   _ := test2            (ambig2 4711)    // 10. should flag an error: ambiguous call to implicit `ambig2.call (1 argument)` or partially applied `ambig2 (2 arguments)`
 -------------------------^^^^^^
 This call can be resolved in two ways, either as a direct call to 'partial_application_negative.ambig2' declared at --CURDIR--/partial_application_negative.fz:66:3:
@@ -109,4 +125,4 @@ or by partially applying arguments to a call to 'partial_application_negative.am
 --^^^^^^.
 To solve this, rename one of the ambiguous features.
 
-11 errors.
+13 errors.

--- a/tests/reg_issue4549/reg_issue4549.fz.expected_err
+++ b/tests/reg_issue4549/reg_issue4549.fz.expected_err
@@ -11,15 +11,23 @@ s(a, b) => s := [1].map (s 1)
 To solve this, rename one of the ambiguous features.
 
 
---CURDIR--/reg_issue4549.fz:24:3: error 2: Type inference from actual arguments failed since no actual call was found
+--CURDIR--/reg_issue4549.fz:24:21: error 2: Failed to infer actual type parameters
+s(a, b) => s := [1].map (s 1)
+--------------------^^^
+In call to 'Sequence.map', no actual type parameters are given and inference of the type parameters failed.
+Expected type parameters: 'B'
+Type inference failed for one type parameter 'B'
+
+
+--CURDIR--/reg_issue4549.fz:24:3: error 3: Type inference from actual arguments failed since no actual call was found
 s(a, b) => s := [1].map (s 1)
 --^
 For the formal argument 's.a' the type can only be derived if there is a call to 's'.
 
 
---CURDIR--/reg_issue4549.fz:24:6: error 3: Type inference from actual arguments failed since no actual call was found
+--CURDIR--/reg_issue4549.fz:24:6: error 4: Type inference from actual arguments failed since no actual call was found
 s(a, b) => s := [1].map (s 1)
 -----^
 For the formal argument 's.b' the type can only be derived if there is a call to 's'.
 
-3 errors.
+4 errors.


### PR DESCRIPTION
Partial application was not done for infix operator if call resultion did not produce a pending error.  Added check for `isPartialInfix` in `ParsedCall.propagateExpectedTypeForPartial` to perform partial application in this case.
    
Also did some cleanup: Call ot `newNameForPartial` in `Call.partiallyApplicableAlternative` was not needed, so I removed this method altogether.
    
Added `isPartialInfix` as an alternative to `newNameForPartial` and added the code to actual create the new name as inline code to the only remaining place that needs the name.

Also addes test case for #4687 and updated expected error output since two subsequent errors are no longer produced.