### PR TITLE
lib: Add heuristics to avoid `Sequence.concat` to cause quadratic performance

### DIFF
--- a/modules/base/src/Sequence.fz
+++ b/modules/base/src/Sequence.fz
@@ -309,11 +309,7 @@ public Sequence(public T type) ref : property.equatable is
       for ea := container.expanding_array T .empty, ea.add e1
           e1 in Sequence.this
       else
-        for ea2 := ea, ea2.add e2
-            e2 in s
-        else
-          ea2
-
+        ea.concat s
 
   # infix operand synonym for concat
   #

--- a/modules/base/src/Sequence.fz
+++ b/modules/base/src/Sequence.fz
@@ -274,7 +274,45 @@ public Sequence(public T type) ref : property.equatable is
   # create a Sequence that consists of all the elements of this Sequence followed
   # by all the elements of s
   #
-  public concat (s Sequence T) Sequence T => as_list.concat_list s.as_list
+  # General case: This will perform `as_list.concat_list` in case one of
+  # `Sequence.this` or `s`is not known to be finite (`finite != trit.yet`) or
+  # `s.count` is larger than `count`.
+  #
+  # Otherwise, if `Sequence.this` or `s` is empty, the result will be `s` or
+  # `Sequence.this`, respectively.
+  #
+  # In all other cases, an instance of `container.expanding_array` will be
+  # created and the elements of `this` and `s` will be added.  Note that
+  # `concat` is redefined for `container.expanding_array` to achieve
+  # average `O(1)` performance for repeated concatenation with `s.count < c`
+  # for some constant `c`.
+  #
+  # Performance: O(count + s.count) worst case, O(s.count) average case
+  #
+  # NOTE: For repeated concatenation `a.concat b` that fall into the general
+  # case the resulting sequence will have iteration performance in `O(n²)`
+  # for `n` concatenation. Explicitly use `container.expanding_array` to
+  # avoid this. This implementation cannot do this automatically since
+  # repeated wrapping of `a` into an `expanding_array` would result
+  # in `O(n²)` performance for the concatenations.
+  #
+  public concat (s Sequence T) Sequence T =>
+    c1 :=   finite != trit.yes ? -1 :   count
+    c2 := s.finite != trit.yes ? -1 : s.count
+    if c1 < 0 || c2 < 0 || max 1 c1 < c2 then
+      as_list.concat_list s.as_list
+    else if c1 = 0
+      s
+    else if c2 = 0
+      Sequence.this
+    else
+      for ea := container.expanding_array T .empty, ea.add e1
+          e1 in Sequence.this
+      else
+        for ea2 := ea, ea2.add e2
+            e2 in s
+        else
+          ea2
 
 
   # infix operand synonym for concat

--- a/modules/base/src/container/expanding_array.fz
+++ b/modules/base/src/container/expanding_array.fz
@@ -170,14 +170,43 @@ is
   # create a Sequence that consists of all the elements of this Sequence followed
   # by all the elements of s
   #
-  public redef concat (s Sequence T) Sequence T =>
-    if s.finite != trit.yes || count < s.count then
+  public redef fixed concat (s Sequence T) Sequence T =>
+
+    if s.is_empty
+
+      # nothing to be added
+      #
+      expanding_array.this
+
+    else if s.finite != trit.yes || count < s.count
+
+      # use lazy version in case `s` might be infinite, since then code below would not
+      # terminate, if if `s` is larger than `this`, which would avoids quadratic performance
+      # in code like the following:
+      #
+      #  for i in 0..n
+      #      r := (expanding_array i32).empty, [i].concat r
+      #
       as_list.concat_list s.as_list
-    else
+
+    else if false  # NYI: OPTIMIZATION: This nicer (and faster?) version cannot be used due to DFA performance #4634?
+
+      # bulk expand by all elements of `s`
       expand s.count ()->
         for e in s.indexed do
           (i,v) := e
           container.expanding T .env.put length+i v
+
+    else
+
+      # indiviudally add each elements of `s`
+      for # `expanding_array.concat` is `fixed`, so type of expanding_array.this
+          # is `expanding_array`:
+          n := expanding_array.this,
+               n.add e
+          e in s
+      else
+        n
 
 
   # collect the contents of this expanding_array as an array.

--- a/modules/base/src/container/expanding_array.fz
+++ b/modules/base/src/container/expanding_array.fz
@@ -167,6 +167,19 @@ is
     expanding_array data0 new_length
 
 
+  # create a Sequence that consists of all the elements of this Sequence followed
+  # by all the elements of s
+  #
+  public redef concat (s Sequence T) Sequence T =>
+    if s.finite != trit.yes || count < s.count then
+      as_list.concat_list s.as_list
+    else
+      expand s.count ()->
+        for e in s.indexed do
+          (i,v) := e
+          container.expanding T .env.put length+i v
+
+
   # collect the contents of this expanding_array as an array.
   #
   public redef as_array array T =>

--- a/tests/atomic/test_atomic.fz.effect
+++ b/tests/atomic/test_atomic.fz.effect
@@ -10,3 +10,4 @@ time.nano
 envir.args
 state unit (cache#2 (num.ryū f64).step_3#7.pow5_split_cache_key).cache_item
 state unit (cache#2 (num.ryū f64).step_3#7.pow5_inv_split_cache_key).cache_item
+panic

--- a/tests/hello/HelloWorld.fz.effect
+++ b/tests/hello/HelloWorld.fz.effect
@@ -3,3 +3,4 @@ fuzion.runtime.pre_fault
 fuzion.runtime.fault
 io.Err
 fuzion.runtime.post_fault
+panic

--- a/tests/i18n_default_test/i18n_default_test.fz.effect
+++ b/tests/i18n_default_test/i18n_default_test.fz.effect
@@ -5,3 +5,4 @@ fuzion.runtime.fault
 io.Err
 fuzion.runtime.post_fault
 io.Out
+panic

--- a/tests/lib_concur_sync/lib_concur_sync.fz.effect
+++ b/tests/lib_concur_sync/lib_concur_sync.fz.effect
@@ -6,4 +6,5 @@ fuzion.runtime.pre_fault
 io.Err
 io.Out
 fuzion.runtime.post_fault
+panic
 time.nano

--- a/tests/mod_lock_free_Map_threads/ctrie_threads.fz.effect
+++ b/tests/mod_lock_free_Map_threads/ctrie_threads.fz.effect
@@ -5,6 +5,6 @@ fuzion.runtime.post_fault
 io.Out
 unique_id
 concur.atomic_access
+panic
 concur.threads
 envir.args
-panic


### PR DESCRIPTION
Concatenating finite sequences where the right sequence is shorter are now performed using `container.expanding_array`.

I see the performance of the test in #4465 improve signficantly:

    4194304:	 [1]++l: 5239ms 1249ns/it    0ns/it² | l++[1]: 1869ms  445ns/it    0ns/it² factor: 0

