### PR TITLE
fe: add `ast.Select`

### DIFF
--- a/src/dev/flang/ast/AstErrors.java
+++ b/src/dev/flang/ast/AstErrors.java
@@ -2359,6 +2359,13 @@ public class AstErrors extends ANY
           + "To solve this, remove " + skw("...") + " after the highlighted error.");
   }
 
+  public static void selectIsNoType(SourcePosition pos)
+  {
+    error(pos,
+          "Select clause is not a valid type",
+          "To solve, this specify a valid type.");
+  }
+
 }
 
 /* end of file */

--- a/src/dev/flang/ast/Contract.java
+++ b/src/dev/flang/ast/Contract.java
@@ -363,8 +363,7 @@ public class Contract extends ANY
       {
         var ca = new Call(p,
                           new Current(p, outer),
-                          a,
-                          -1);
+                          a);
         ca = ca.resolveTypes(res, context);
         args.add(ca);
       }
@@ -432,8 +431,7 @@ public class Contract extends ANY
       {
         var ca = new Call(p,
                           new Current(p, outer),
-                          a,
-                          -1);
+                          a);
         ca = ca.resolveTypes(res, context);
         args.add(ca);
       }
@@ -473,8 +471,7 @@ public class Contract extends ANY
       {
         var ca = new Call(p,
                           new Current(p, preAndCallOuter),
-                          a,
-                          -1);
+                          a);
         ca = ca.resolveTypes(res, preAndCallOuter.context());
         args.add(ca);
       }
@@ -515,8 +512,7 @@ public class Contract extends ANY
           {
             var ca = new Call(p,
                               new Current(p, outer),
-                              a,
-                              -1);
+                              a);
             ca = ca.resolveTypes(res, context);
             args.add(ca);
           }
@@ -525,8 +521,7 @@ public class Contract extends ANY
       {
         var c2 = new Call(p,
                           new Current(p, outer),
-                          outer.resultField(),
-                          -1);
+                          outer.resultField());
         c2 = c2.resolveTypes(res, context);
         args.add(c2);
       }
@@ -1113,8 +1108,7 @@ The conditions of a post-condition are checked at run-time in sequential source-
                   {
                     var ca = new Call(pos,
                                       new Current(pos, pF),
-                                      a,
-                                      -1);
+                                      a);
                     ca = ca.resolveTypes(res, pF.context());
                     args2.add(ca);
                   }

--- a/src/dev/flang/ast/Destructure.java
+++ b/src/dev/flang/ast/Destructure.java
@@ -211,8 +211,11 @@ public class Destructure extends ExprWithPos
   {
     var outer = context.outerFeature();
     Expr thiz     = This.thiz(res, pos(), context, outer);
-    Call thiz_tmp = new Call(pos(), thiz    , tmp, -1    ).resolveTypes(res, context);
-    Call call_f   = new Call(pos(), thiz_tmp, f  , select).resolveTypes(res, context);
+    Call thiz_tmp = new Call(pos(), thiz, tmp).resolveTypes(res, context);
+    Call call_f   = (select == -1
+        ? new Call(pos(), thiz_tmp, f)
+        : new Select(pos(), thiz_tmp, f.featureName().baseName(), select))
+      .resolveTypes(res, context);
     Assign assign = null;
     if (fields != null && fields.hasNext())
       {

--- a/src/dev/flang/ast/Select.java
+++ b/src/dev/flang/ast/Select.java
@@ -1,0 +1,194 @@
+/*
+
+This file is part of the Fuzion language implementation.
+
+The Fuzion language implementation is free software: you can redistribute it
+and/or modify it under the terms of the GNU General Public License as published
+by the Free Software Foundation, version 3 of the License.
+
+The Fuzion language implementation is distributed in the hope that it will be
+useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+License for more details.
+
+You should have received a copy of the GNU General Public License along with The
+Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+*/
+
+/*-----------------------------------------------------------------------
+ *
+ * Tokiwa Software GmbH, Germany
+ *
+ * Source of class Select
+ *
+ *---------------------------------------------------------------------*/
+
+package dev.flang.ast;
+
+import dev.flang.util.List;
+import dev.flang.util.SourcePosition;
+
+public class Select extends Call {
+
+
+  private Call _currentlyResolving;
+
+
+  public Select(SourcePosition pos, Expr target, String name, int select)
+  {
+    super(pos, target, name, select, NO_GENERICS, Expr.NO_EXPRS, null, null);
+
+    if (PRECONDITIONS) require
+      (name != null,
+       select >= 0);
+  }
+
+
+  /**
+   * visit all the expressions within this feature.
+   *
+   * @param v the visitor instance that defines an action to be performed on
+   * visited objects.
+   *
+   * @param outer the feature surrounding this expression.
+   *
+   * @return this or an alternative Expr if the action performed during the
+   * visit replaces this by the alternative.
+   */
+  @Override
+  public Expr visit(FeatureVisitor v, AbstractFeature outer)
+  {
+    if (_currentlyResolving != null)
+      {
+        _currentlyResolving.visit(v, outer);
+        return this;
+      }
+    else
+      {
+        if (_target != null)
+          {
+            _target = _target.visit(v, outer);
+          }
+        v.action((AbstractCall) this);
+        return v.action(this);
+      }
+  }
+
+
+  @Override
+  public String toString()
+  {
+    return _target.toString() + "." + _name + "." + _select;
+  }
+
+
+  /**
+   * typeForInferencing returns the type of this expression or null if the type is
+   * still unknown, i.e., before or during type resolution.  This is redefined
+   * by sub-classes of Expr to provide type information.
+   *
+   * @return this Expr's type or null if not known.
+   */
+  @Override
+  AbstractType typeForInferencing()
+  {
+    throw new UnsupportedOperationException();
+  }
+
+
+  /**
+   * determine the static type of all expressions and declared features in this feature
+   *
+   * @param res the resolution instance.
+   *
+   * @param context the source code context where this Call is used
+   */
+  public Call resolveTypes(Resolution res, Context context)
+  {
+    loadCalledFeature(res, context);
+    _currentlyResolving = _calledFeature.resultTypeIfPresentUrgent(res, true).isOpenGeneric()
+      // explicit
+      ? new Call(pos(), _target, _name, _select, Call.NO_GENERICS, NO_EXPRS, null, null)
+      // implict
+      : resolveImplicit(res, context, _calledFeature.resultType());
+
+    return _currentlyResolving.resolveTypes(res, context);
+  }
+
+
+  /**
+   * Helper to try and implicitly resolve this select
+   * in case explicit is not possible.
+   *
+   * @param res the resolution instance.
+   *
+   * @param context the source code context where this assignment is used
+   *
+   */
+  private Call resolveImplicit(Resolution res, Context context, AbstractType t)
+  {
+    var result = Call.ERROR;
+
+    var at = getActualResultType(res, context, t);
+
+    var typeParameter = at.isGenericArgument() ? at.genericArgument().constraint(context).feature() : at.feature();
+    var f = res._module.lookupOpenTypeParameterResult(typeParameter, this);
+
+    if (f != null)
+      {
+        var selectTarget = new Call(pos(), _target, _name, -1, Call.NO_GENERICS, NO_EXPRS, null, null);
+        result = new Call(pos(), selectTarget, f.featureName().baseName(), _select, Call.NO_GENERICS, NO_EXPRS, null, null);
+      }
+    else
+      {
+        AstErrors.useOfSelectorRequiresCallWithOpenGeneric(pos(), _calledFeature, _name, _select, at);
+      }
+    return result;
+  }
+
+
+  /**
+   * perform static type checking, i.e., make sure that in all assignments from
+   * actual to formal arguments, the types match.
+   *
+   * @param res the resolution instance.
+   *
+   * @param context the source code context where this Call is used
+   */
+  @Override
+  void checkTypes(Resolution res, Context context)
+  {
+    throw new UnsupportedOperationException("select should have been replaced in resolveTypes");
+  }
+
+
+  @Override
+  public UnresolvedType asParsedType()
+  {
+    return null;
+  }
+
+
+  @Override
+  public ParsedName asParsedName()
+  {
+    throw new UnsupportedOperationException("Select.asParsedName");
+  }
+
+
+  @Override
+  public AbstractType asType()
+  {
+    AstErrors.selectIsNoType(_target != null ? _target.pos().rangeTo(pos().byteEndPos()) : pos());
+    return Types.t_ERROR;
+  }
+
+
+  @Override
+  public List<ParsedName> asQualifier()
+  {
+    throw new UnsupportedOperationException("Select.asQualifier");
+  }
+
+}

--- a/src/dev/flang/ast/This.java
+++ b/src/dev/flang/ast/This.java
@@ -254,7 +254,7 @@ public class This extends ExprWithPos
               {
                 var t = cur.outer().thisType(cur.isFixed());
                 var isAdr = cur.isOuterRefAdrOfValue();
-                Expr c = new Call(pos(), getOuter, or, -1)
+                Expr c = new Call(pos(), getOuter, or)
                   {
                     @Override
                     AbstractType typeForInferencing()

--- a/src/dev/flang/parser/Parser.java
+++ b/src/dev/flang/parser/Parser.java
@@ -1441,7 +1441,6 @@ actuals     : actualArgs
    */
   Expr call(boolean pure, Expr target)
   {
-    SourcePosition pos = tokenSourcePos();
     var n = name();
     Call result;
     var skippedDot = false;
@@ -1449,6 +1448,7 @@ actuals     : actualArgs
       {
         if (current() == Token.t_numliteral)
           {
+            var pos = tokenSourceRange();
             var select = skipNumLiteral().plainInteger();
             int s = -1;
             try
@@ -1461,7 +1461,7 @@ actuals     : actualArgs
               {
                 AstErrors.illegalSelect(pos, select, e);
               }
-            result = new ParsedCall(target, n, s);
+            result = new Select(pos, target, n._name, s);
           }
         else
           {

--- a/tests/asParsedType_negative/test_asParsedType_negative.fz.expected_err
+++ b/tests/asParsedType_negative/test_asParsedType_negative.fz.expected_err
@@ -85,31 +85,15 @@ expected one generic argument for 'T'
 found none.
 
 
---CURDIR--/test_asParsedType_negative.fz:149:5: error 10: Type not found
+--CURDIR--/test_asParsedType_negative.fz:149:5: error 10: Select clause is not a valid type
   x t.values.0                  // 10. should flag an error: select is not a type
-----^
-Type 't' was not found, no corresponding feature nor formal type parameter exists
-Type that was not found: 't'
-in feature: 'test_asParsedType_negative'
-However, one feature has been found that matches the type name but that does not define a type:
-'test_asParsedType_negative.t' defined at --CURDIR--/test_asParsedType_negative.fz:148:3:
-  t := (3,4,5)
---^
-
-To solve this, check the spelling of the type you have used.
+----^^^^^^^^^^
+To solve, this specify a valid type.
 
 
---CURDIR--/test_asParsedType_negative.fz:150:5: error 11: Type not found
+--CURDIR--/test_asParsedType_negative.fz:150:5: error 11: Select clause is not a valid type
   x t.values.2                  // 11. should flag an error: select is not a type
-----^
-Type 't' was not found, no corresponding feature nor formal type parameter exists
-Type that was not found: 't'
-in feature: 'test_asParsedType_negative'
-However, one feature has been found that matches the type name but that does not define a type:
-'test_asParsedType_negative.t' defined at --CURDIR--/test_asParsedType_negative.fz:148:3:
-  t := (3,4,5)
---^
-
-To solve this, check the spelling of the type you have used.
+----^^^^^^^^^^
+To solve, this specify a valid type.
 
 11 errors.


### PR DESCRIPTION
Idea is that Select contains all the logic of resolving a select-clause, hence this logic was removed from Call.
