### PR TITLE
ast: remove possibility to specify types in tuple destructuring

### DIFF
--- a/src/dev/flang/ast/Destructure.java
+++ b/src/dev/flang/ast/Destructure.java
@@ -218,13 +218,6 @@ public class Destructure extends ExprWithPos
       {
         var newF = (Feature) fields.next();
 
-        var a = newF._returnType.functionReturnType().resolve(res, context);
-
-        if (a != Types.t_UNDEFINED && !(!newF._returnType.isConstructorType() && a.isAssignableFrom(t)) )
-          {
-            AstErrors.incompatibleType(newF._returnType.posOrNull(), "in tuple destructuring", "", "", newF._returnType.functionReturnType(), assign, t, context);
-          }
-
         newF._returnType = new FunctionReturnType(t);
         assign = new Assign(res, pos(), newF, call_f, context);
       }

--- a/src/dev/flang/ast/Destructure.java
+++ b/src/dev/flang/ast/Destructure.java
@@ -217,6 +217,14 @@ public class Destructure extends ExprWithPos
     if (fields != null && fields.hasNext())
       {
         var newF = (Feature) fields.next();
+
+        var a = newF._returnType.functionReturnType().resolve(res, context);
+
+        if (a != Types.t_UNDEFINED && !(!newF._returnType.isConstructorType() && a.isAssignableFrom(t)) )
+          {
+            AstErrors.incompatibleType(newF._returnType.posOrNull(), "in tuple destructuring", "", "", newF._returnType.functionReturnType(), assign, t, context);
+          }
+
         newF._returnType = new FunctionReturnType(t);
         assign = new Assign(res, pos(), newF, call_f, context);
       }

--- a/src/dev/flang/parser/Parser.java
+++ b/src/dev/flang/parser/Parser.java
@@ -3106,11 +3106,8 @@ assign      : "set" name ":=" exprInLine
    * Parse destructure
    *
 destructure : destructr
-            | destructrDcl
             ;
 destructr   : "(" argNames ")"       ":=" exprInLine
-            ;
-destructrDcl: formArgs               ":=" exprInLine
             ;
    */
   Expr destructure()
@@ -3142,21 +3139,8 @@ destructrDcl: formArgs               ":=" exprInLine
    */
   boolean isDestructurePrefix()
   {
-    return (current() == Token.t_lparen) && (fork().skipDestructrDclPrefix() ||
-                                             fork().skipDestructrPrefix()        ) ||
+    return (current() == Token.t_lparen) && fork().skipDestructrPrefix() ||
       (current() == Token.t_set) && (fork().skipDestructrPrefix());
-  }
-
-
-  /**
-   * Check if the current position starts a destructure using formArgs and skip an
-   * unspecified part of it.
-   *
-   * @return true iff the next token(s) start a destructureDecl
-   */
-  boolean skipDestructrDclPrefix()
-  {
-    return skipFormArgs() && isOperator(":=");
   }
 
 

--- a/tests/tuple/tupletest.fz
+++ b/tests/tuple/tupletest.fz
@@ -63,9 +63,9 @@ tupletest is
   nothing7       := tuple  ; p "nothing7 is $nothing7" // empty tuple inferring type and explicit type
   nothing8       := tuple  ; p "nothing8 is $nothing8" // empty tuple inferring type and inferring generic
   nothing9       :=      (); p "nothing9 is $nothing9" // empty tuple inferring type and tuple syntax sugar
-  ()             := tuple  ; p "nothing10 is ()"
-  ()             := tuple  ; p "nothing11 is ()"
-  ()             :=      (); p "nothing12 is ()"
+# ()             := tuple  ; p "nothing10 is ()"
+# ()             := tuple  ; p "nothing11 is ()"
+# ()             :=      (); p "nothing12 is ()"
 # ()             := tuple  ; p "nothing10 is ()"                   // should cause syntax error
 # ()             := tuple  ; p "nothing11 is ()"                   // should cause syntax error
 # ()             :=      (); p "nothing12 is ()"                   // should cause syntax error
@@ -120,8 +120,8 @@ tupletest is
   (two11a, two11b)     := tuple          4 2 ; p "two11 is $two11a, $two11b" // two-tuple using destructure and inferring generic
   (two12a, two12b)     :=               (4,2); p "two12 is $two12a, $two12b" // two-tuple using destructure and tuple syntax sugar
 # (two13a, two13b i32) := tuple i32 i32  4 2 ; p "two13 is $two13a, $two13b" // two-tuple using destructure and explicit types
-  (two14a, two14b i32) := tuple          4 2 ; p "two14 is $two14a, $two14b" // two-tuple using destructure and inferring generic
-  (two15a, two15b i32) :=               (4,2); p "two15 is $two15a, $two15b" // two-tuple using destructure and tuple syntax sugar
+# (two14a, two14b i32) := tuple          4 2 ; p "two14 is $two14a, $two14b" // two-tuple using destructure and inferring generic
+# (two15a, two15b i32) :=               (4,2); p "two15 is $two15a, $two15b" // two-tuple using destructure and tuple syntax sugar
   public two16a, two16b, two17a, two17b, two18a, two18b i32 := 42
 # chck (two1.values.0=4 && two1.values.1=2) "two1"
   chck (two2.values.0=4 && two2.values.1=2) "two2"
@@ -133,8 +133,8 @@ tupletest is
   chck (two11a=4 && two11b=2) "two11"
   chck (two12a=4 && two12b=2) "two12"
 # chck (two13a=4 && two13b=2) "two13"
-  chck (two14a=4 && two14b=2) "two14"
-  chck (two15a=4 && two15b=2) "two15"
+# chck (two14a=4 && two14b=2) "two14"
+# chck (two15a=4 && two15b=2) "two15"
 # chck (two16a=4 && two16b=2) "two16"
   chck (two17a=42 && two17b=42) "two17"
   chck (two18a=42 && two18b=42) "two18"
@@ -179,7 +179,7 @@ tupletest is
 # (t10b1, t10b2, t10b2) = t10   // should cause error: too many destructuring variables
 # (t10b1) = t10                 // should cause error: too few destructuring variables
 
-  (t10c1 i32, t10c2 bool) := t10
+  (t10c1, t10c2) := t10
   p "tuple t10c1/2 is {t10c1}, {t10c2}"
   chck t10c1=3 "t10c1"
   chck !t10c2  "t10c2"
@@ -199,7 +199,7 @@ tupletest is
 
 # (t12b1,t12b1,t12b3 i32) = t11 4 // 19. should flag an error, repeated elements in destructuring
 # (t12c1,t12c2,t12c2 i32) = t11 4 // 20. should flag an error, repeated elements in destructuring
-  (t12d1,t12d2,t12d3 i32) := t11 6
+  (t12d1,t12d2,t12d3) := t11 6
   chck t12d1=6   "first must be 6"
   chck t12d2=36  "second must be 36"
   chck t12d3=216 "third must be 216"
@@ -217,20 +217,20 @@ tupletest is
   (_,t12i2,_) := t11 9; chck t12i2=81  "t12i2 must be 81"
   (t12i1,_,_) := t11 9; chck t12i1=9   "t12i1 must be 9"
 
-  (_,_,t12j3 i32) := t11 10; chck t12j3=1000 "t12j3 must be 1000"
-  (_,t12j2,_ i32) := t11 10; chck t12j2=100  "t12j2 must be 100"
-  (t12j1,_,_ i32) := t11 10; chck t12j1=10   "t12j1 must be 10"
+# (_,_,t12j3 i32) := t11 10; chck t12j3=1000 "t12j3 must be 1000"
+# (_,t12j2,_ i32) := t11 10; chck t12j2=100  "t12j2 must be 100"
+# (t12j1,_,_ i32) := t11 10; chck t12j1=10   "t12j1 must be 10"
 
-  (_,_ i32) := (12, 23)
+# (_,_ i32) := (12, 23)
 # (_,_ i32) := (true, 23) // 23. should flag an error, illegal type
   (_,_) := (12, 23)
   (_,_) := (true, 23)
 
   public t13a1, t13a3 i32 := 42
   public t13a2 bool := false
-  (t13b1, _, _ i32) := (01, 12, 23); chck t13b1=01 "t13b1 must be 01"
-  (_, t13b2, _ i32) := (01, 12, 23); chck t13b2=12 "t13b2 must be 12"
-  (_, _, t13b3 i32) := (01, 12, 23); chck t13b3=23 "t13b3 must be 23"
+# (t13b1, _, _ i32) := (01, 12, 23); chck t13b1=01 "t13b1 must be 01"
+# (_, t13b2, _ i32) := (01, 12, 23); chck t13b2=12 "t13b2 must be 12"
+# (_, _, t13b3 i32) := (01, 12, 23); chck t13b3=23 "t13b3 must be 23"
 # (t13c1 i32, _ bool, _ i32) := (01, 12, 23); // 25. should flag an error, illegal type
 # (_ i32, t13c2 bool, _ i32) := (01, 12, 23); // 26. should flag an error, illegal type
 # (_ i32, _ bool, t13c3 i32) := (01, 12, 23); // 27. should flag an error, illegal type
@@ -243,9 +243,9 @@ tupletest is
 # (t14b1,_,_ i32) := (01, true, 23); // 28. should flag an error, illegal type
 # (_,t14b2,_ i32) := (01, true, 23); // 29. should flag an error, illegal type
 # (_,_,t14b3 i32) := (01, true, 23); // 30. should flag an error, illegal type
-  (t14c1 i32, _ bool, _ i32) := (01, true, 23); chck t14c1=01 "t14c1 must be 01"
-  (_ i32, t14c2 bool, _ i32) := (01, true, 23); chck t14c2    "t14c2 must be true"
-  (_ i32, _ bool, t14c3 i32) := (01, true, 23); chck t14c3=23 "t14c3 must be 23"
+# (t14c1 i32, _ bool, _ i32) := (01, true, 23); chck t14c1=01 "t14c1 must be 01"
+# (_ i32, t14c2 bool, _ i32) := (01, true, 23); chck t14c2    "t14c2 must be true"
+# (_ i32, _ bool, t14c3 i32) := (01, true, 23); chck t14c3=23 "t14c3 must be 23"
   (t14d1,_,_) := (01, true, 23); chck t14d1=01 "t14d1 must be 01"
   (_,t14d2,_) := (01, true, 23); chck t14d2    "t14d2 must be true"
   (_,_,t14d3) := (01, true, 23); chck t14d3=23 "t14d3 must be 23"

--- a/tests/tuple/tupletest.fz.expected_out
+++ b/tests/tuple/tupletest.fz.expected_out
@@ -13,9 +13,6 @@ nothing6 is instance[tuple]
 nothing7 is instance[tuple]
 nothing8 is instance[tuple]
 nothing9 is instance[tuple]
-nothing10 is ()
-nothing11 is ()
-nothing12 is ()
 one2 is 42
 one10 is 42
 one12 is 42
@@ -26,15 +23,11 @@ two3 is 4, 2
 two9 is 4, 2
 two11 is 4, 2
 two12 is 4, 2
-two14 is 4, 2
-two15 is 4, 2
 PASSED: two2
 PASSED: two3
 PASSED: two9
 PASSED: two11
 PASSED: two12
-PASSED: two14
-PASSED: two15
 PASSED: two17
 PASSED: two18
 tuple t10 is 3, false
@@ -77,18 +70,9 @@ PASSED: third must be 343
 PASSED: t12i3 must be 729
 PASSED: t12i2 must be 81
 PASSED: t12i1 must be 9
-PASSED: t12j3 must be 1000
-PASSED: t12j2 must be 100
-PASSED: t12j1 must be 10
-PASSED: t13b1 must be 01
-PASSED: t13b2 must be 12
-PASSED: t13b3 must be 23
 PASSED: t13d1 must be 01
 PASSED: t13d2 must be 12
 PASSED: t13d3 must be 23
-PASSED: t14c1 must be 01
-PASSED: t14c2 must be true
-PASSED: t14c3 must be 23
 PASSED: t14d1 must be 01
 PASSED: t14d2 must be true
 PASSED: t14d3 must be 23


### PR DESCRIPTION
forbids this
```
❯ FUZION_DISABLE_ANSI_ESCAPES=true fz -e '(a i32, b i32) := (1, 2); _:=a; _:=b'

command line:1:1: error 1: Failed to infer open type parameter type from actual argument.
(a i32, b i32) := (1, 2); _:=a; _:=b
^
Type of second actual argument could not be inferred at command line:1:2:
(a i32, b i32) := (1, 2); _:=a; _:=b
-^


command line:1:30: error 2: Could not find called feature
(a i32, b i32) := (1, 2); _:=a; _:=b
-----------------------------^
Feature not found: 'a' (no arguments)
Target feature: 'universe'
In call: 'a'


command line:1:36: error 3: Could not find called feature
(a i32, b i32) := (1, 2); _:=a; _:=b
-----------------------------------^
Feature not found: 'b' (no arguments)
Target feature: 'universe'
In call: 'b'

3 errors.
```