### PR TITLE
Makefile: Add missing dependency and fix building docs for work != fuzion dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1187,10 +1187,10 @@ $(REF_MANUAL_HTML): $(REF_MANUAL_SOURCES) $(BUILD_DIR)/generated/doc/fum_file.ad
 
 
 # NYI integrate into fz: fz -docs
-$(BUILD_DIR)/apidocs/index.html: $(FUZION_BASE) $(CLASS_FILES_TOOLS_DOCS) $(FUZION_FILES)
+$(BUILD_DIR)/apidocs/index.html: $(FUZION_BASE) $(CLASS_FILES_TOOLS_DOCS) $(FUZION_FILES) $(MOD_FZ_CMD)
 	$(JAVA) -cp $(CLASSES_DIR) -Xss64m -Dfuzion.home=$(BUILD_DIR) dev.flang.tools.docs.Docs -bare $(@D)
 	printf "\n<!-- docs created on:  $(shell date) -->\n" >> $(BUILD_DIR)/apidocs/index.html
-	git show --quiet --format="<!-- generated from: %H %an %ad %s -->" >> $(BUILD_DIR)/apidocs/index.html
+	(cd $(FZ_SRC); git show --quiet --format="<!-- generated from: %H %an %ad %s -->" >> $(BUILD_DIR)/apidocs/index.html)
 
 # NYI integrate into fz: fz -docs
 .phony: debug_api_docs


### PR DESCRIPTION
The fz_cmd module seems to be required and a `cd $(FZ_SRC)` is needed to call git show...`.
