### PR TITLE
ast: Fix #197 by fixing order of `applyTypePars` for call resul type

### DIFF
--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -1460,7 +1460,7 @@ public class Call extends AbstractCall
    * unknown and urgent is false, Types.t_ERROR in case of an error (e.g. urgent
    * is true and the formal result type is still unknown).
    */
-  protected AbstractType setActualResultType(Resolution res, Context context, boolean urgent)
+  private AbstractType setActualResultType(Resolution res, Context context, boolean urgent)
   {
     AbstractType frmlT;
     if (isTailRecursive(context.outerFeature()) || _recursiveResolveType)

--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -1440,8 +1440,6 @@ public class Call extends AbstractCall
   }
 
 
-
-
   /**
    * Helper function for resolveTypes to determine the static result type of
    * this call.
@@ -1454,7 +1452,13 @@ public class Call extends AbstractCall
    *
    * @param context the source code context where this Call is used
    *
-   * @param urgent
+   * @param urgent true if we should produce an error in case the formal result
+   * type of the called feature is not available, false if this is still
+   * acceptable and the result type can be set later.
+   *
+   * @return the formal type of the called feature, or null if this is still
+   * unknown and urgent is false, Types.t_ERROR in case of an error (e.g. urgent
+   * is true and the formal result type is still unknown).
    */
   protected AbstractType setActualResultType(Resolution res, Context context, boolean urgent)
   {
@@ -1466,7 +1470,6 @@ public class Call extends AbstractCall
     else
       {
         _recursiveResolveType = true;
-
         frmlT = _calledFeature.resultTypeIfPresentUrgent(res, urgent);
         if (urgent && (frmlT == Types.t_UNDEFINED || frmlT == null))
           {
@@ -1477,66 +1480,28 @@ public class Call extends AbstractCall
             AstErrors.forwardTypeInference(pos(), _calledFeature, _calledFeature.pos());
             frmlT = Types.t_ERROR;
           }
-    _recursiveResolveType = false;
+        _recursiveResolveType = false;
       }
 
     if (frmlT != null)
       {
-        if (!true) {
-    var tt = targetIsTypeParameter() && frmlT.isThisTypeInCotype()
-      ? // a call B.f for a type parameter target B. resultType() is the
-        // constraint of B, so we create the corresponding type feature's
-        // selfType:
-        // NYI: CLEANUP: remove this special handling!
-        _target.type().feature().selfType()
-      : targetType(res, context);
+        var tt = targetIsTypeParameter() && frmlT.isThisTypeInCotype()
+          ? // a call B.f for a type parameter target B. resultType() is the
+          // constraint of B, so we create the corresponding type feature's
+          // selfType:
+          // NYI: CLEANUP: remove this special handling!
+          _target.type().feature().selfType()
+          : targetType(res, context);
 
-    var t1 = tt == Types.t_ERROR ? tt : resolveSelect(frmlT, tt);
-    var t2 = t1 == Types.t_ERROR ? t1 : t1.applyTypePars(tt);
-    var t3 = t2 == Types.t_ERROR ? t2 : tt.isGenericArgument() ? t2 : t2.resolve(res, tt.feature().context());
-    var t4 = t3 == Types.t_ERROR ? t3 : adjustThisTypeForTarget(t3, false, calledFeature(), context);
-    var t5 = t4 == Types.t_ERROR ? t4 : resolveForCalledFeature(res, t4, tt, context);
-    _type = t5;
-        } else {
-    var tt = targetIsTypeParameter() && frmlT.isThisTypeInCotype()
-      ? // a call B.f for a type parameter target B. resultType() is the
-        // constraint of B, so we create the corresponding type feature's
-        // selfType:
-        // NYI: CLEANUP: remove this special handling!
-        _target.type().feature().selfType()
-      : targetType(res, context);
-
-    var tm2 = tt == Types.t_ERROR ? tt : resolveSelect(frmlT, tt);
-    var tm1 = tm2 == Types.t_ERROR ? tm2 : tm2.applyTypePars(tt);
-    var t0 = tm1 == null ? null : tm1.applyTypePars(_calledFeature, _generics);
-    var t1 = t0; // t0 == Types.t_ERROR || !t0.isOpenGeneric() ? t0 : resolveSelect(t0, tt);
-    var t2 = t1; // t1 == Types.t_ERROR ? t1 : t1.applyTypePars(tt);
-    var t3 = t2 == Types.t_ERROR ? t2 : tt.isGenericArgument() ? t2 : t2.resolve(res, tt.feature().context());
-    var t4 = t3 == Types.t_ERROR ? t3 : adjustThisTypeForTarget(t3, false, calledFeature(), context);
-    var t5 = t4 == Types.t_ERROR ? t4 : resolveForCalledFeature(res, t4, tt, context);
-    _type = t5;
-        }
+        var t0 = tt == Types.t_ERROR ? tt : resolveSelect(frmlT, tt);
+        var t1 = t0 == Types.t_ERROR ? t0 : t0.applyTypePars(tt);
+        var t2 = t1 == Types.t_ERROR ? t1 : t1.applyTypePars(_calledFeature, _generics);
+        var t3 = t2 == Types.t_ERROR ? t2 : tt.isGenericArgument() ? t2 : t2.resolve(res, tt.feature().context());
+        var t4 = t3 == Types.t_ERROR ? t3 : adjustThisTypeForTarget(t3, false, calledFeature(), context);
+        var t5 = t4 == Types.t_ERROR ? t4 : resolveForCalledFeature(res, t4, tt, context);
+        _type = t5;
       }
     return frmlT;
-  }
-
-
-  protected void setActualResultType1(Resolution res, Context context, AbstractType frmlT)
-  {
-    var tt = targetIsTypeParameter() && frmlT.isThisTypeInCotype()
-      ? // a call B.f for a type parameter target B. resultType() is the
-        // constraint of B, so we create the corresponding type feature's
-        // selfType:
-        // NYI: CLEANUP: remove this special handling!
-        _target.type().feature().selfType()
-      : targetType(res, context);
-
-    var t1 = tt == Types.t_ERROR ? tt : resolveSelect(frmlT, tt);
-    var t2 = t1 == Types.t_ERROR ? t1 : t1.applyTypePars(tt);
-    var t3 = t2 == Types.t_ERROR ? t2 : tt.isGenericArgument() ? t2 : t2.resolve(res, tt.feature().context());
-    var t4 = t3 == Types.t_ERROR ? t3 : adjustThisTypeForTarget(t3, false, calledFeature(), context);
-    var t5 = t4 == Types.t_ERROR ? t4 : resolveForCalledFeature(res, t4, tt, context);
-    _type = t5;
   }
 
 

--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -1454,7 +1454,7 @@ public class Call extends AbstractCall
    *
    * @param context the source code context where this Call is used
    *
-   * @param frmlT the result type of the called feature, might be open generic.
+   * @param urgent
    */
   protected AbstractType setActualResultType(Resolution res, Context context, boolean urgent)
   {

--- a/src/dev/flang/ast/ParsedCall.java
+++ b/src/dev/flang/ast/ParsedCall.java
@@ -702,9 +702,8 @@ public class ParsedCall extends Call
         if (f != null)
           {
             // replace Function call `c.123` by `c.f.123`:
-            result = pushCall(res, context, f.featureName().baseName());
-            setActualResultType(res, context, false); // setActualResultType will be done again by resolveTypes, but we need it now.
-            result = result.resolveTypes(res, context);
+            result = pushCall(res, context, f.featureName().baseName())
+                       .resolveTypes(res, context);
           }
       }
     return result;

--- a/src/dev/flang/ast/ParsedCall.java
+++ b/src/dev/flang/ast/ParsedCall.java
@@ -703,7 +703,7 @@ public class ParsedCall extends Call
           {
             // replace Function call `c.123` by `c.f.123`:
             result = pushCall(res, context, f.featureName().baseName());
-            setActualResultType(res, context, t); // setActualResultType will be done again by resolveTypes, but we need it now.
+            setActualResultType1(res, context, t); // setActualResultType will be done again by resolveTypes, but we need it now.
             result = result.resolveTypes(res, context);
           }
       }

--- a/src/dev/flang/ast/ParsedCall.java
+++ b/src/dev/flang/ast/ParsedCall.java
@@ -703,7 +703,7 @@ public class ParsedCall extends Call
           {
             // replace Function call `c.123` by `c.f.123`:
             result = pushCall(res, context, f.featureName().baseName());
-            setActualResultType1(res, context, t); // setActualResultType will be done again by resolveTypes, but we need it now.
+            setActualResultType(res, context, false); // setActualResultType will be done again by resolveTypes, but we need it now.
             result = result.resolveTypes(res, context);
           }
       }

--- a/tests/reg_issue197/Makefile
+++ b/tests/reg_issue197/Makefile
@@ -1,0 +1,25 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test Makefile
+#
+# -----------------------------------------------------------------------
+
+override NAME = reg_issue197
+include ../simple.mk

--- a/tests/reg_issue197/reg_issue197.fz
+++ b/tests/reg_issue197/reg_issue197.fz
@@ -1,0 +1,76 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test reg_issue197
+#
+# -----------------------------------------------------------------------
+
+# This contains a few test cases that depend on the correct order
+# or application of type parameters
+#
+reg_issue197 =>
+
+  # the original example from the issue.
+  #
+  # The problem here was that the actual result type of the call
+  # to `my_map` uses `my_array.T` and type parameters where
+  # replaced in the wrong order:
+  #
+  #   1. for the call: B -> T
+  #   2. for outer feature: T -> Monoid T
+  #
+  # while the correct order is the other way around
+  #
+  #   1. for the outer feature: B -> B
+  #   2. for the call: B -> T
+  #
+  ex =>
+    my_array(T type) is
+      my_map(B type) my_array B =>
+        my_array B
+      f (ms my_array (Monoid T)) my_array T =>
+        ms.my_map T
+
+    r := my_array u64 .f (my_array (Monoid u64))
+    say "r's type is {type_of r} (expecting ex.my_array u64)"
+
+  ex
+
+  # smallest example that I found:
+  a(T type) is
+    b(U type) a U => do
+    v a T => (a u8).b T
+
+  say "a.v: {type_of_lazy (a f32 .v)} (expecting a f32)"
+
+  # smallest example that I found:
+  a0(T type) is
+    b(U type) U => do
+    v T => (a0 u8).b T
+
+  say "a0.v: {type_of_lazy (a0 i16 .v)} expecting (i16)"
+
+  a1(T type) is
+    b(U type) (T,U,option T,Sequence U) => do
+    _() (u8,T,option u8,Sequence T) := (a1 u8).b T
+
+  q : a1 unit is
+
+  x() (unit, i64, option unit, Sequence i64) => q.b i64
+  say "q.b: {type_of_lazy (q.b u128)} (expecting (unit, u128, option unit, Sequence u128)"

--- a/tests/reg_issue197/reg_issue197.fz
+++ b/tests/reg_issue197/reg_issue197.fz
@@ -74,3 +74,16 @@ reg_issue197 =>
 
   x() (unit, i64, option unit, Sequence i64) => q.b i64
   say "q.b: {type_of_lazy (q.b u128)} (expecting (unit, u128, option unit, Sequence u128)"
+
+
+  # same example as `a1`, but using the type `T` and `U` as an argument
+  # type.
+  #
+  a2(T type, v T) is
+    bb(U type, w (T,U,option T,Sequence U)) => say "type is {type_of w}"
+    if !(T : u8)
+      (a2 u8 123).bb codepoint (u8 255,"a",option (u8 128),["b"].cycle.take 3)
+
+  q2 : a2 bool true is
+  _ := q2.bb unit (false,unit,option true,id (Sequence unit) (unit : nil))
+  (a2 f32 3.14).bb i64 (f32 3.14,i64 1E12,option (f32 0.1),[i64 1E14].cycle.take 3)

--- a/tests/reg_issue197/reg_issue197.fz.expected_out
+++ b/tests/reg_issue197/reg_issue197.fz.expected_out
@@ -2,3 +2,7 @@ r's type is Type of 'reg_issue197.ex.my_array u64' (expecting ex.my_array u64)
 a.v: Type of 'reg_issue197.a f32' (expecting a f32)
 a0.v: Type of 'i16' expecting (i16)
 q.b: Type of 'tuple unit u128 (option unit) (Sequence u128)' (expecting (unit, u128, option unit, Sequence u128)
+type is Type of 'tuple u8 codepoint (option u8) (Sequence codepoint)'
+type is Type of 'tuple bool unit (option bool) (Sequence unit)'
+type is Type of 'tuple u8 codepoint (option u8) (Sequence codepoint)'
+type is Type of 'tuple f32 i64 (option f32) (Sequence i64)'

--- a/tests/reg_issue197/reg_issue197.fz.expected_out
+++ b/tests/reg_issue197/reg_issue197.fz.expected_out
@@ -1,0 +1,4 @@
+r's type is Type of 'reg_issue197.ex.my_array u64' (expecting ex.my_array u64)
+a.v: Type of 'reg_issue197.a f32' (expecting a f32)
+a0.v: Type of 'i16' expecting (i16)
+q.b: Type of 'tuple unit u128 (option unit) (Sequence u128)' (expecting (unit, u128, option unit, Sequence u128)


### PR DESCRIPTION
The problem is that a call `(a X).(b Y)` where `a` and `b` are generic needs to apply the actual generics to `b`'s forma result type, and these could come from  the outer type `a X` and from the call `b Y`.  This, unfortunately, was done in the wrong order: It has to be done first taking the formal result type of `b` and replacing type parameters in there by the outer  type `a X`, and then  applying the type parameters given in the call `b Y`.

When done the other way around, i.e., first applying the type parameters given to the call to `b Y` and then those in the outer type `a X`, the result is wrong if the calls is done within `a` and `Y` contains type parameters of `a`.

To be able to do this, the code to determine the call's formal result type, which contained `t.applyTypePars(cf, _generics)`, first had to be moved into `setActualResultType`. Then the call to `applyTypePars` was moved at the right position, i.e., `var t2 = ...`. 

Finally, some cleanup was done, the call to `setActualResultType` in `ParsedCall.resolveImplicitSelect` seems not necessary, so it was removed. 

NOTE: Best reviewed with `Hide whitespace` in the diff view since indentation of quite a lot of code changed.