### PR TITLE
ast: suppress subsequent errors for error types

### DIFF
--- a/src/dev/flang/ast/AbstractType.java
+++ b/src/dev/flang/ast/AbstractType.java
@@ -2192,7 +2192,10 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
 
         if (a == Types.t_UNDEFINED)
           {
-            AstErrors.failedToInferActualGeneric(pos, called, new List<>(f));
+            if (!Errors.any())
+              {
+                AstErrors.failedToInferActualGeneric(pos, called, new List<>(f));
+              }
           }
         else
           {

--- a/src/dev/flang/ast/AbstractType.java
+++ b/src/dev/flang/ast/AbstractType.java
@@ -2192,10 +2192,7 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
 
         if (a == Types.t_UNDEFINED)
           {
-            if (!Errors.any())
-              {
-                AstErrors.failedToInferActualGeneric(pos, called, new List<>(f));
-              }
+            AstErrors.failedToInferActualGeneric(pos, called, new List<>(f));
           }
         else
           {

--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -316,7 +316,7 @@ public class Call extends AbstractCall
   {
     this(pos, target, calledFeature.featureName().baseName(), -1, generics, actuals, calledFeature, type);
     if (PRECONDITIONS) check
-      (calledFeature.generics().sizeMatches(generics));
+      (calledFeature.generics().sizeMatches(generics) || generics.contains(Types.t_ERROR));
   }
 
 

--- a/src/dev/flang/ast/FormalGenerics.java
+++ b/src/dev/flang/ast/FormalGenerics.java
@@ -140,7 +140,7 @@ public class FormalGenerics extends ANY
     if (PRECONDITIONS) require
       (Errors.any() || !actualGenerics.contains(Types.t_ERROR));
 
-    var result = sizeMatches(actualGenerics);
+    var result = sizeMatches(actualGenerics) || actualGenerics.contains(Types.t_ERROR);
     if (!result)
       {
         AstErrors.wrongNumberOfGenericArguments(this,

--- a/src/dev/flang/ast/ResolvedNormalType.java
+++ b/src/dev/flang/ast/ResolvedNormalType.java
@@ -631,7 +631,7 @@ public class ResolvedNormalType extends ResolvedType
    */
   AbstractType clone(AbstractFeature originalOuterFeature)
   {
-    return this == Types.t_UNDEFINED ? this :
+    return (this == Types.t_UNDEFINED || this == Types.t_ERROR) ? this :
       new ResolvedNormalType(this, originalOuterFeature)
       {
         AbstractFeature originalOuterFeature(AbstractFeature currentOuter)

--- a/src/dev/flang/fe/SourceModule.java
+++ b/src/dev/flang/fe/SourceModule.java
@@ -1653,7 +1653,7 @@ A feature that is a constructor, choice or a type parameter may not redefine an 
       {
         var cod = f.code();
         var rt = cod.type();
-        if (!Types.resolved.t_unit.isAssignableFrom(rt))
+        if (!Types.resolved.t_unit.isAssignableFrom(rt) && !(Errors.any() && (rt == Types.t_UNDEFINED || rt == Types.t_ERROR)))
           {
             AstErrors.constructorResultMustBeUnit(cod);
           }

--- a/tests/reg_issue4694/Makefile
+++ b/tests/reg_issue4694/Makefile
@@ -1,0 +1,25 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test Makefile
+#
+# -----------------------------------------------------------------------
+
+override NAME = reg_issue4694
+include ../simple.mk

--- a/tests/reg_issue4694/reg_issue4694.fz
+++ b/tests/reg_issue4694/reg_issue4694.fz
@@ -1,0 +1,26 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test reg_issue4694
+#
+# -----------------------------------------------------------------------
+
+reg_issue4694 =>
+
+  0 |> x,y->container.expanding.env.put

--- a/tests/reg_issue4694/reg_issue4694.fz.expected_err
+++ b/tests/reg_issue4694/reg_issue4694.fz.expected_err
@@ -1,0 +1,27 @@
+
+--CURDIR--/reg_issue4694.fz:26:8: error 1: Wrong number of arguments in lambda expression
+  0 |> x,y->container.expanding.env.put
+-------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Lambda expression has 2 arguments while the target type expects one argument.
+Arguments of lambda expression: 'x', 'y'
+Expected function type: Unary --UNDEFINED-- i32
+To solve this, remove one argument from the list 'x', 'y' before the '->' of the lambda expression.
+
+
+--CURDIR--/reg_issue4694.fz:26:23: error 2: Wrong number of type parameters
+  0 |> x,y->container.expanding.env.put
+----------------------^^^^^^^^^
+Wrong number of actual type parameters in type:
+Type: container.expanding
+expected one generic argument for 'T'
+found none.
+
+
+--CURDIR--/reg_issue4694.fz:26:5: error 3: Failed to infer actual type parameters
+  0 |> x,y->container.expanding.env.put
+----^^
+In call to 'infix |>', no actual type parameters are given and inference of the type parameters failed.
+Expected type parameters: 'A, R'
+Type inference failed for one type parameter 'R'
+
+3 errors.


### PR DESCRIPTION
fix #4694

I think the remaining subsequent error is justified and should not be suppressed, but correct me if I'm wrong
```
❯ FUZION_DISABLE_ANSI_ESCAPES=true fz -e '0 |> x,y->container.expanding.env.put'

command line:1:6: error 1: Wrong number of arguments in lambda expression
0 |> x,y->container.expanding.env.put
-----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Lambda expression has 2 arguments while the target type expects one argument.
Arguments of lambda expression: 'x', 'y'
Expected function type: Unary --UNDEFINED-- i32
To solve this, remove one argument from the list 'x', 'y' before the '->' of the lambda expression.


command line:1:21: error 2: Wrong number of type parameters
0 |> x,y->container.expanding.env.put
--------------------^^^^^^^^^
Wrong number of actual type parameters in type:
Type: container.expanding
expected one generic argument for 'T'
found none.

2 errors.
```

Also I'm not sure if it is a good idea to just hide the error in `AbstractType.java` if other errors were reported in order to suppress this subsequent error
```
[...]
command line:1:3: error 3: Failed to infer actual type parameters
0 |> x,y->container.expanding.env.put
--^^
In call to 'infix |>', no actual type parameters are given and inference of the type parameters failed.
Expected type parameters: 'A, R'
Type inference failed for one type parameter 'R'

3 errors.
```