### PR TITLE
tests: remove unsupported test cases from `tupletest`

### DIFF
--- a/tests/tuple/tupletest.fz
+++ b/tests/tuple/tupletest.fz
@@ -119,9 +119,6 @@ tupletest is
 # (two10a, two10b)     := tuple i32 i32  4 2 ; p "two10 is $two10a, $two10b" // two-tuple using destructure and explicit types
   (two11a, two11b)     := tuple          4 2 ; p "two11 is $two11a, $two11b" // two-tuple using destructure and inferring generic
   (two12a, two12b)     :=               (4,2); p "two12 is $two12a, $two12b" // two-tuple using destructure and tuple syntax sugar
-# (two13a, two13b i32) := tuple i32 i32  4 2 ; p "two13 is $two13a, $two13b" // two-tuple using destructure and explicit types
-# (two14a, two14b i32) := tuple          4 2 ; p "two14 is $two14a, $two14b" // two-tuple using destructure and inferring generic
-# (two15a, two15b i32) :=               (4,2); p "two15 is $two15a, $two15b" // two-tuple using destructure and tuple syntax sugar
   public two16a, two16b, two17a, two17b, two18a, two18b i32 := 42
 # chck (two1.values.0=4 && two1.values.1=2) "two1"
   chck (two2.values.0=4 && two2.values.1=2) "two2"
@@ -132,9 +129,6 @@ tupletest is
 # chck (two10a=4 && two10b=2) "two10"
   chck (two11a=4 && two11b=2) "two11"
   chck (two12a=4 && two12b=2) "two12"
-# chck (two13a=4 && two13b=2) "two13"
-# chck (two14a=4 && two14b=2) "two14"
-# chck (two15a=4 && two15b=2) "two15"
 # chck (two16a=4 && two16b=2) "two16"
   chck (two17a=42 && two17b=42) "two17"
   chck (two18a=42 && two18b=42) "two18"
@@ -197,8 +191,6 @@ tupletest is
   chck t12a3=42  "third must be 42"
 # (t12a1,t12a1,t12a1) = t11 4 // 18. should flag an error, repeated elements in destructuring
 
-# (t12b1,t12b1,t12b3 i32) = t11 4 // 19. should flag an error, repeated elements in destructuring
-# (t12c1,t12c2,t12c2 i32) = t11 4 // 20. should flag an error, repeated elements in destructuring
   (t12d1,t12d2,t12d3) := t11 6
   chck t12d1=6   "first must be 6"
   chck t12d2=36  "second must be 36"
@@ -217,47 +209,23 @@ tupletest is
   (_,t12i2,_) := t11 9; chck t12i2=81  "t12i2 must be 81"
   (t12i1,_,_) := t11 9; chck t12i1=9   "t12i1 must be 9"
 
-# (_,_,t12j3 i32) := t11 10; chck t12j3=1000 "t12j3 must be 1000"
-# (_,t12j2,_ i32) := t11 10; chck t12j2=100  "t12j2 must be 100"
-# (t12j1,_,_ i32) := t11 10; chck t12j1=10   "t12j1 must be 10"
-
-# (_,_ i32) := (12, 23)
-# (_,_ i32) := (true, 23) // 23. should flag an error, illegal type
   (_,_) := (12, 23)
   (_,_) := (true, 23)
 
   public t13a1, t13a3 i32 := 42
   public t13a2 bool := false
-# (t13b1, _, _ i32) := (01, 12, 23); chck t13b1=01 "t13b1 must be 01"
-# (_, t13b2, _ i32) := (01, 12, 23); chck t13b2=12 "t13b2 must be 12"
-# (_, _, t13b3 i32) := (01, 12, 23); chck t13b3=23 "t13b3 must be 23"
-# (t13c1 i32, _ bool, _ i32) := (01, 12, 23); // 25. should flag an error, illegal type
-# (_ i32, t13c2 bool, _ i32) := (01, 12, 23); // 26. should flag an error, illegal type
-# (_ i32, _ bool, t13c3 i32) := (01, 12, 23); // 27. should flag an error, illegal type
   (t13d1,_,_) := (01, 12, 23); chck t13d1=01 "t13d1 must be 01"
   (_,t13d2,_) := (01, 12, 23); chck t13d2=12 "t13d2 must be 12"
   (_,_,t13d3) := (01, 12, 23); chck t13d3=23 "t13d3 must be 23"
 
   public t14a1, t14a3 i32 := 42
   public t14a2 bool := false
-# (t14b1,_,_ i32) := (01, true, 23); // 28. should flag an error, illegal type
-# (_,t14b2,_ i32) := (01, true, 23); // 29. should flag an error, illegal type
-# (_,_,t14b3 i32) := (01, true, 23); // 30. should flag an error, illegal type
-# (t14c1 i32, _ bool, _ i32) := (01, true, 23); chck t14c1=01 "t14c1 must be 01"
-# (_ i32, t14c2 bool, _ i32) := (01, true, 23); chck t14c2    "t14c2 must be true"
-# (_ i32, _ bool, t14c3 i32) := (01, true, 23); chck t14c3=23 "t14c3 must be 23"
   (t14d1,_,_) := (01, true, 23); chck t14d1=01 "t14d1 must be 01"
   (_,t14d2,_) := (01, true, 23); chck t14d2    "t14d2 must be true"
   (_,_,t14d3) := (01, true, 23); chck t14d3=23 "t14d3 must be 23"
 
   public t15a1, t15a3 i32 := 42
   public t15a2 bool := false
-# (t15a1,_,_ i32) := (01, true, 23); // 28. should flag an error, duplicate declaration
-# (_,t15a2,_ i32) := (01, true, 23); // 28. should flag an error, duplicate declaration
-# (_,_,t15a3 i32) := (01, true, 23); // 28. should flag an error, duplicate declaration
-# (t15a1 i32, _ bool, _ i32) := (01, true, 23); // 28. should flag an error, duplicate declaration
-# (_ i32, t15a2 bool, _ i32) := (01, true, 23); // 28. should flag an error, duplicate declaration
-# (_ i32, _ bool, t15a3 i32) := (01, true, 23); // 28. should flag an error, duplicate declaration
 # (t15a1,_,_) := (01, true, 23); // 28. should flag an error, duplicate declaration
 # (_,t15a2,_) := (01, true, 23); // 28. should flag an error, duplicate declaration
 # (_,_,t15a3) := (01, true, 23); // 28. should flag an error, duplicate declaration


### PR DESCRIPTION
possibility to specify types in destructuring was removed in #4702

fix #4735