### PR TITLE
ast: add error for illegal use of select

### DIFF
--- a/src/dev/flang/ast/Select.java
+++ b/src/dev/flang/ast/Select.java
@@ -131,6 +131,10 @@ public class Select extends Call {
               // implict
               : resolveImplicit(res, context, getActualResultType(res, context, true));
           }
+        else
+          {
+            AstErrors.useOfSelectorRequiresCallWithOpenGeneric(pos(), _calledFeature, null, _select, _target.type());
+          }
       }
     if (_currentlyResolving != null)
       {


### PR DESCRIPTION
Solves a failed check condition. Discovered by a test case in `tuple_negative` (so no reg test required).

before
```
❯ FUZION_DISABLE_ANSI_ESCAPES=true fz -e 'one9 := (42); say "one9 is {one9.values.0}"'

error 1: java.lang.Error: require-condition3 failed: AbstractType.java:464 "(this  .isGenericArgument() || this  .feature() != null || Errors.any(), actual.isGenericArgument() || actual.feature() != null || Errors.any(), Errors.any() || this != Types.t_ERROR && actual != Types.t_ERROR);"
        at dev.flang.util.ANY.require(ANY.java:136)
        at dev.flang.ast.AbstractType.isAssignableFrom(AbstractType.java:464)
        at dev.flang.ast.AbstractType.isAssignableFrom(AbstractType.java:352)
        at dev.flang.ast.AbstractType.isAssignableFromWithoutTagging(AbstractType.java:381)
        at dev.flang.ast.Call.checkTypes(Call.java:2707)
        at dev.flang.ast.Feature$7.action(Feature.java:2020)
        at dev.flang.ast.Feature$7.action(Feature.java:2016)
        at dev.flang.ast.Call.visit(Call.java:1119)
        at dev.flang.ast.Call.visit(Call.java:1116)
        at dev.flang.ast.Call.visitActuals(Call.java:1144)
        at dev.flang.ast.Call.visit(Call.java:1122)
        at dev.flang.ast.Block.visit(Block.java:212)
        at dev.flang.ast.Block.visit(Block.java:42)
        at dev.flang.ast.Impl.visit(Impl.java:302)
        at dev.flang.ast.Feature.visit(Feature.java:1187)
        at dev.flang.ast.Feature.checkTypes(Feature.java:2016)
        at dev.flang.ast.Resolution.resolveOne(Resolution.java:472)
        at dev.flang.ast.Resolution.resolve(Resolution.java:392)
        at dev.flang.fe.SourceModule.createASTandResolve(SourceModule.java:260)
        at dev.flang.fe.FrontEnd.<init>(FrontEnd.java:182)
        at dev.flang.tools.Fuzion.lambda$parseArgsForBackend$4(Fuzion.java:1071)
        at dev.flang.tools.Tool.lambda$run$0(Tool.java:142)
        at dev.flang.util.Errors.runAndExit(Errors.java:903)
        at dev.flang.tools.Tool.run(Tool.java:142)
        at dev.flang.tools.Fuzion.main(Fuzion.java:627)

*** fatal errors encountered, stopping.
one error.
```

now
```
❯ FUZION_DISABLE_ANSI_ESCAPES=true fz -e 'one9 := (42); say "one9 is {one9.values.0}"'

command line:1:41: error 1: Use of selector requires call to feature whose type is an open type parameter
one9 := (42); say "one9 is {one9.values.0}"
----------------------------------------^
Selected variant: '0'
Type of called feature: 'i32'

one error.
```