### PR TITLE
ast: suppress subsequent error "Illegal forward or cyclic type inference"

### DIFF
--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -1388,7 +1388,10 @@ public class Call extends AbstractCall
             // better if this was done in `Feature.resultType`, but
             // there we do not have access to Call.this.pos(), so
             // we do it here.
-            AstErrors.forwardTypeInference(pos(), _calledFeature, _calledFeature.pos());
+            if (result != Types.t_UNDEFINED || !Errors.any())
+              {
+                AstErrors.forwardTypeInference(pos(), _calledFeature, _calledFeature.pos());
+              }
             result = Types.t_ERROR;
           }
         else if (result != null)

--- a/tests/reg_issue4429/Makefile
+++ b/tests/reg_issue4429/Makefile
@@ -1,0 +1,25 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test Makefile
+#
+# -----------------------------------------------------------------------
+
+override NAME = reg_issue4429
+include ../simple.mk

--- a/tests/reg_issue4429/reg_issue4429.fz
+++ b/tests/reg_issue4429/reg_issue4429.fz
@@ -1,0 +1,26 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test reg_issue4429
+#
+# -----------------------------------------------------------------------
+
+reg_issue4429 =>
+
+  for x in true ? [0] : 1..2 do

--- a/tests/reg_issue4429/reg_issue4429.fz.expected_err
+++ b/tests/reg_issue4429/reg_issue4429.fz.expected_err
@@ -1,0 +1,15 @@
+
+--CURDIR--/reg_issue4429.fz:26:17: error 1: Failed to infer type of expression.
+  for x in true ? [0] : 1..2 do
+----------------^
+Expression with unknown type: ''
+
+
+--CURDIR--/reg_issue4429.fz:26:17: error 2: Failed to infer actual type parameters
+  for x in true ? [0] : 1..2 do
+----------------^
+In call to 'bool.ternary ? :', no actual type parameters are given and inference of the type parameters failed.
+Expected type parameters: 'T'
+Type inference failed for one type parameter 'T'
+
+2 errors.


### PR DESCRIPTION
fix #4429

before
```
❯ FUZION_DISABLE_ANSI_ESCAPES=true fz -e 'for x in true ? [0] : 1..2 do'

command line:1:15: error 1: Failed to infer type of expression.
for x in true ? [0] : 1..2 do
--------------^
Expression with unknown type: ''


<source position not available>: error 2: Illegal forward or cyclic type inference
The definition of a field using ':=', or of a feature or function
using '=>' must not create cyclic type dependencies.
Referenced feature: 'loop' at <source position not available>:


command line:1:15: error 3: Failed to infer actual type parameters
for x in true ? [0] : 1..2 do
--------------^
In call to 'bool.ternary ? :', no actual type parameters are given and inference of the type parameters failed.
Expected type parameters: 'T'
Type inference failed for one type parameter 'T'

3 errors.
```


now
```
FUZION_DISABLE_ANSI_ESCAPES=true fz -e 'for x in true ? [0] : 1..2 do'

command line:1:15: error 1: Failed to infer type of expression.
for x in true ? [0] : 1..2 do
--------------^
Expression with unknown type: ''


command line:1:15: error 2: Failed to infer actual type parameters
for x in true ? [0] : 1..2 do
--------------^
In call to 'bool.ternary ? :', no actual type parameters are given and inference of the type parameters failed.
Expected type parameters: 'T'
Type inference failed for one type parameter 'T'

2 errors.
```


Should the last error also be suppressed?