### PR TITLE
jvm: better error handling for unreachable code

### DIFF
--- a/src/dev/flang/be/jvm/Choices.java
+++ b/src/dev/flang/be/jvm/Choices.java
@@ -468,9 +468,7 @@ public class Choices extends ANY implements ClassFileConstants
         }
       case boollike:
         {
-          var pos = jvm.reportErrorInCode("As per data flow analysis this code should be unreachable.");
-          var neg = jvm.reportErrorInCode("As per data flow analysis this code should be unreachable.");
-
+          Expr pos = null, neg = null;
           for (var mc = 0; mc < _fuir.matchCaseCount(s); mc++)
             {
               var tags = _fuir.matchCaseTags(s, mc);
@@ -486,6 +484,8 @@ public class Choices extends ANY implements ClassFileConstants
                   }
                 }
             }
+          pos = pos != null ? pos : jvm.reportUnreachable(s, "bool pos");
+          neg = neg != null ? neg : jvm.reportUnreachable(s, "bool neg");
           code = sub
             .andThen(Expr.branch(O_ifeq, neg, pos));
           break;
@@ -522,9 +522,7 @@ public class Choices extends ANY implements ClassFileConstants
         }
       case nullable:
         {
-          var pos = Expr.POP.andThen(jvm.reportErrorInCode("As per data flow analysis this code should be unreachable."));
-          var neg = Expr.POP.andThen(jvm.reportErrorInCode("As per data flow analysis this code should be unreachable."));
-
+          Expr pos = null, neg = null;
           for (var mc = 0; mc < _fuir.matchCaseCount(s); mc++)
             {
               var field = _fuir.matchCaseField(s, mc);
@@ -556,6 +554,8 @@ public class Choices extends ANY implements ClassFileConstants
                     }
                 }
             }
+          pos = pos != null ? pos : jvm.reportUnreachable(s, "nullable pos");
+          neg = neg != null ? neg : jvm.reportUnreachable(s, "nullable neg");
           code = sub                                                            // stack is sub
             .andThen(Expr.DUP)                                                  //          sub, sub
             .andThen(Expr.branch(O_ifnull,                                      //          sub

--- a/src/dev/flang/be/jvm/JVM.java
+++ b/src/dev/flang/be/jvm/JVM.java
@@ -1293,6 +1293,21 @@ should be avoided as much as possible.
 
 
   /**
+   * Create code that is supposed to be unreachable.
+   *
+   * @param site a site index where this unreachable code occured
+   *
+   * @param msg some text explaining what kind of statement we are trying to execute.
+   *
+   * @return an Expr to reprot the error and exit(1).
+   */
+  Expr reportUnreachable(int site, String msg)
+  {
+    return reportErrorInCode("As per data flow analysis this code should be unreachable. " + msg + " " + _fuir.siteAsString(site));
+  }
+
+
+  /**
    * Get the number of local var slots for the given routine
    *
    * @param cl id of clazz to generate code for


### PR DESCRIPTION
This is in case of a DFA or backend bug, now should be more efficient in case no code is unreachable and produce a more detailed error in case this code is executed.
