### PR TITLE
lib: small cleanup of NYI and unnecessary parens

### DIFF
--- a/modules/base/src/fuzion/runtime/check_fault.fz
+++ b/modules/base/src/fuzion/runtime/check_fault.fz
@@ -29,7 +29,7 @@
 public check_fault (
   # the handler this effect uses to fail
   p String -> void
-  ) : eff.fallible (String) /* NYI: BUG: this type parameter is required, type inference results in NullPointException */ p
+  ) : eff.fallible p
 is
 
 

--- a/modules/base/src/fuzion/runtime/post_fault.fz
+++ b/modules/base/src/fuzion/runtime/post_fault.fz
@@ -29,7 +29,7 @@
 public post_fault (
   # the handler this effect uses to fail
   p String -> void
-  ) : eff.fallible (String) /* NYI: BUG: this type parameter is required, type inference results in NullPointerException */ p
+  ) : eff.fallible String /* NYI: BUG: this type parameter is required, type inference results in NullPointerException */ p
 is
 
 

--- a/modules/base/src/fuzion/runtime/pre_fault.fz
+++ b/modules/base/src/fuzion/runtime/pre_fault.fz
@@ -29,7 +29,7 @@
 public pre_fault (
   # the handler this effect uses to fail
   p String -> void
-  ) : eff.fallible (String) /* NYI: BUG: this type parameter is required, type inference results in NullPointerException */ p
+  ) : eff.fallible p
 is
 
 


### PR DESCRIPTION
A bit weird that only for post_fault the type infer does not yet work...