### PR TITLE
parser: prefix operator precedence over postfix

### DIFF
--- a/modules/base/src/numeric.fz
+++ b/modules/base/src/numeric.fz
@@ -142,14 +142,11 @@ public numeric : property.hashable, property.orderable is
   #
   # Nesting, however, does not work, e.g, `| - |a| |`, this requires parentheses `|(- |a|)|`.
   #
-  # NYI: CLEANUP: Due to #3081, we need `postfix |` as the first operation, should be
-  # `prefix |` first
-  #
-  public postfix | is
+  public prefix | is
 
     # only useful operation is the corresponding `prefix |`
     #
-    public prefix | => numeric.this.abs
+    public postfix | => numeric.this.abs
 
     # redefine as_string to try to explain what is wrong if only one `|` is used
     #

--- a/src/dev/flang/parser/OpExpr.java
+++ b/src/dev/flang/parser/OpExpr.java
@@ -38,40 +38,73 @@ import dev.flang.util.ANY;
 import dev.flang.util.FuzionConstants;
 
 /**
- * OpExpr
+ * Helper class to collect parsed operators and expressions
+ * then determine order of evaluation based on precedences.
  *
  * @author Fridtjof Siebert (siebert@tokiwa.software)
  */
-public class OpExpr extends ANY
+class OpExpr extends ANY
 {
 
-  /*----------------------------  variables  ----------------------------*/
+  /**
+   * Operator kind, prefix, infix or postfix
+   */
+  private enum Kind { prefix, infix, postfix };
+
+
+  /*----------------------------  constants  ----------------------------*/
 
 
   /**
+   * Initial characters of operators that bind to the right.
+   */
+  private static final String RIGHT_TO_LEFT_CHARS = "^";
+
+
+  /**
+   * List of freshly parsed operators and expressions.
+   */
+  private final ArrayList<Object> _els = new ArrayList<>();
+
+
+  /**
+   * table of precedences
+   */
+  private final Precedence[] precedences = {
+    new Precedence(16,        "@"  ),
+    new Precedence(15,        "^"  ),
+    new Precedence(14, 5, 14, "!"  ),
+    new Precedence(13,        "~"  ),
+    new Precedence(12,        "⁄"  ),
+    new Precedence(11,        "*/%⊛⊗⊘⦸⊝⊚⊙⦾⦿⨸⨁⨂⨷"),
+    new Precedence(10,        "+-⊕⊖" ),
+    new Precedence( 9,        "."  ),
+    new Precedence( 8,        "#"  ),
+    new Precedence(14, 7, 14, "$"  ),
+    new Precedence( 6,        ""   ),
+    new Precedence( 5,        "<>=⧁⧀⊜⩹⩺⩻⩼⩽⩾⩿⪀⪁⪂⪃⪄⪅⪆⪇⪈⪉⪊⪋⪌⪍⪎⪏⪐⪑⪒⪓⪔⪕⪖⪗⪘⪙⪚⪛⪜⪝⪞⪟⪠⪡⪢⪤⪥⪦⪧⪨⪩⪪⪫⪬⪭⪮⪯⪰⪱⪲⪴⪵⪶⪷⪸⪹⪺⪻⪼⫷⫸⫹⫺≟≤≥"),
+    new Precedence( 4,        "&"  ),
+    new Precedence( 3,        "|⦶⦷"),
+    new Precedence( 2,        "∀"  ),
+    new Precedence( 1,        "∃"  ),
+    // all other operators: 0
+    new Precedence( -1,       ":" ),
+  };
+
+
+  /**
+   * Offset added to the precedence if operator and expression
+   * have no white space in between.
    *
+   * NOTE: this must be higher than any other precendence
    */
-  final private ArrayList<Object> _els = new ArrayList<>();
-
-
-  /*--------------------------  constructors  ---------------------------*/
-
-
-  /**
-   * Constructor
-   */
-  OpExpr()
-  {
-  }
-
+  static final int NO_WHITESPACE_PRECENDENCE_OFFSET = 1000;
 
   /*-----------------------------  methods  -----------------------------*/
 
 
   /**
-   * add
-   *
-   * @param o
+   * add an element to list
    */
   void add(Object o)
   {
@@ -79,17 +112,6 @@ public class OpExpr extends ANY
       (o instanceof Expr || o instanceof Operator);
 
     _els.add(o);
-  }
-
-
-  /**
-   * toExpr
-   *
-   * @return
-   */
-  Expr toExpr()
-  {
-    return toExprUsePrecedence();
   }
 
 
@@ -103,7 +125,7 @@ public class OpExpr extends ANY
    * @return Expr an expression instance corresponding to this
    * operator expression.
    */
-  Expr toExprUsePrecedence()
+  Expr toExpr()
   {
     while (_els.size() > 1 && _els.get(0) != Call.ERROR)
       {
@@ -133,15 +155,16 @@ public class OpExpr extends ANY
                     if (// 'a + + b' => '(a+) + b' and
                         // 'a + +b' => 'a + (+b)'
                         // 'a+ +b'  => 'a + (+b)' due to white space
-                        isOp(i-1) && !op._whiteSpaceAfter && op._whiteSpaceBefore && op(i-1)._whiteSpaceBefore)
+                        isOp(i-1) && !op._whiteSpaceAfter && op._whiteSpaceBefore && op(i-1)._whiteSpaceBefore &&
+                        precedence(i, Kind.prefix) + NO_WHITESPACE_PRECENDENCE_OFFSET > pmax)
                       {
                         max = i;
-                        pmax = Integer.MAX_VALUE;
+                        pmax = precedence(i, Kind.prefix) + NO_WHITESPACE_PRECENDENCE_OFFSET;
                       }
                     else if (// 'a + * b' => 'a + (* b)' and
                              // 'a + + b' => 'a + (+ b)' and
                              // 'a * + b' => '(a *) + b' due to precedence
-                             precedence(i, Kind.prefix)  >= pmax)
+                             precedence(i, Kind.prefix)  > pmax)
                       { // a prefix operator
                         max = i;
                         pmax = precedence(i, Kind.prefix);
@@ -153,16 +176,17 @@ public class OpExpr extends ANY
                         // 'a + +b'  => 'a + (+b)' and
                         // 'a+ +b'   => 'a + (+b)' and
                         // 'a+ + b+' => '(a+) + (b+)' due to white space
-                        (isOp(i+1) && op(i+1)._whiteSpaceAfter || isOp(i-2) && op(i-2)._whiteSpaceAfter) && !op._whiteSpaceBefore && op._whiteSpaceAfter )
+                        (isOp(i+1) && op(i+1)._whiteSpaceAfter || isOp(i-2) && op(i-2)._whiteSpaceAfter) && !op._whiteSpaceBefore && op._whiteSpaceAfter &&
+                        precedence(i, Kind.postfix) + NO_WHITESPACE_PRECENDENCE_OFFSET > pmax)
                       {
                         // in case white space suggests higher precedence for
                         // postfix op, then treat it as a postfix op.
                         max = i;
-                        pmax = Integer.MAX_VALUE;
+                        pmax = precedence(i, Kind.postfix) + NO_WHITESPACE_PRECENDENCE_OFFSET;
                       }
                     else if (// 'a + * b' => 'a + (* b)' and
                              // 'a * + b' => '(a *) + b' due to precedence
-                             precedence(i, Kind.postfix) >= pmax)
+                             precedence(i, Kind.postfix) > pmax)
                       {
                         max = i;
                         pmax = precedence(i, Kind.postfix);
@@ -251,7 +275,7 @@ public class OpExpr extends ANY
    * @return true iff i is a valid index in els and els.get(i)
    * contains an operator.
    */
-  boolean isOp(int i)
+  private boolean isOp(int i)
   {
     return (i>=0) && (i<_els.size()) && (_els.get(i) instanceof Operator);
   }
@@ -279,7 +303,7 @@ public class OpExpr extends ANY
    *
    * @return -1 iff !isOp(i), else the precedence of the operator at index i.
    */
-  int precedence(int i, Kind kind)
+  private int precedence(int i, Kind kind)
   {
     return
       isOp(i)
@@ -295,7 +319,7 @@ public class OpExpr extends ANY
    *
    * @return true iff isOp(i) and the operator at index i is handled left-to-right
    */
-  boolean isLeftToRight(int i)
+  private boolean isLeftToRight(int i)
   {
     return isOp(i) && isLeftToRight(op(i));
   }
@@ -308,7 +332,7 @@ public class OpExpr extends ANY
    *
    * @return true iff isOp(i) and the operator at index i is handled right-to-left
    */
-  boolean isRightToLeft(int i)
+  private boolean isRightToLeft(int i)
   {
     return isOp(i) && isRightToLeft(op(i));
   }
@@ -334,7 +358,7 @@ public class OpExpr extends ANY
   /**
    * determine the precedence of operator op.
    */
-  int precedence(Operator op, Kind kind)
+  private int precedence(Operator op, Kind kind)
   {
     char c = op._text.charAt(0);
     int i=0;
@@ -350,36 +374,11 @@ public class OpExpr extends ANY
             : 0);
   }
 
-  enum Kind { prefix, infix, postfix };
-
-  /**
-   *
-   */
-  public final Precedence[] precedences = { new Precedence(16,        "@"  ),
-                                            new Precedence(15,        "^"  ),
-                                            new Precedence(14, 5, 14, "!"  ),
-                                            new Precedence(13,        "~"  ),
-                                            new Precedence(12,        "⁄"  ),
-                                            new Precedence(11,        "*/%⊛⊗⊘⦸⊝⊚⊙⦾⦿⨸⨁⨂⨷"),
-                                            new Precedence(10,        "+-⊕⊖" ),
-                                            new Precedence( 9,        "."  ),
-                                            new Precedence( 8,        "#"  ),
-                                            new Precedence(14, 7, 14, "$"  ),
-                                            new Precedence( 6,        ""   ),
-                                            new Precedence( 5,        "<>=⧁⧀⊜⩹⩺⩻⩼⩽⩾⩿⪀⪁⪂⪃⪄⪅⪆⪇⪈⪉⪊⪋⪌⪍⪎⪏⪐⪑⪒⪓⪔⪕⪖⪗⪘⪙⪚⪛⪜⪝⪞⪟⪠⪡⪢⪤⪥⪦⪧⪨⪩⪪⪫⪬⪭⪮⪯⪰⪱⪲⪴⪵⪶⪷⪸⪹⪺⪻⪼⫷⫸⫹⫺≟≤≥"),
-                                            new Precedence( 4,        "&"  ),
-                                            new Precedence( 3,        "|⦶⦷"),
-                                            new Precedence( 2,        "∀"  ),
-                                            new Precedence( 1,        "∃"  ),
-                                            // all other operators: 0
-                                            new Precedence( -1,       ":" ),
-  };
-
 
   /**
    * Precedence represents the precedence of an operator
    */
-  class Precedence
+  private class Precedence
   {
 
     /**
@@ -432,7 +431,7 @@ public class OpExpr extends ANY
   /**
    * Does the given operator bind to the left?
    */
-  boolean isLeftToRight(Operator op)
+  private boolean isLeftToRight(Operator op)
   {
     return !isRightToLeft(op);
   }
@@ -440,16 +439,11 @@ public class OpExpr extends ANY
   /**
    * Does the given operator bind to the right?
    */
-  boolean isRightToLeft(Operator op)
+  private boolean isRightToLeft(Operator op)
   {
     char c = op._text.charAt(0);
     return RIGHT_TO_LEFT_CHARS.indexOf(c) >= 0;
   }
-
-  /**
-   * Initial characters of operators that bind to the right.
-   */
-  public final String RIGHT_TO_LEFT_CHARS = "^";
 
 }
 

--- a/tests/reg_issue3081/Makefile
+++ b/tests/reg_issue3081/Makefile
@@ -1,0 +1,25 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test Makefile
+#
+# -----------------------------------------------------------------------
+
+override NAME = reg_issue3081
+include ../simple.mk

--- a/tests/reg_issue3081/reg_issue3081.fz
+++ b/tests/reg_issue3081/reg_issue3081.fz
@@ -1,0 +1,56 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test reg_issue3081
+#
+# -----------------------------------------------------------------------
+
+reg_issue3081 =>
+
+  x is
+    prefix  ~ => { say "prefix  ~"; x.this }
+    prefix  * => { say "prefix  *"; x.this }
+    prefix  + => { say "prefix  +"; x.this }
+    postfix ~ => { say "postfix ~"; x.this }
+    postfix * => { say "postfix *"; x.this }
+    postfix + => { say "postfix +"; x.this }
+
+  say "expecting prefix first:"
+  _ := *x+
+  say ""
+  say "expecting postfix first:"
+  _ := +x*
+  say ""
+  say "expecting prefix first:"
+  _ := ~x~
+  say ""
+  say "expecting prefix *, postfix +, postfix *, prefix +:"
+  _ := + *x+ *
+  say ""
+  say "expecting postfix *, prefix +, prefix *, postfix +:"
+  _ := * +x* +
+  say ""
+  # note that spaces reduce precedence:
+  say "expecting postfix +, prefix *, postfix *, prefix +:"
+  _ := + * x+ *
+  say ""
+  say "expecting prefix +, prefix *, postfix *, postfix +:"
+  _ := * +x * +
+
+

--- a/tests/reg_issue3081/reg_issue3081.fz.expected_out
+++ b/tests/reg_issue3081/reg_issue3081.fz.expected_out
@@ -1,0 +1,35 @@
+expecting prefix first:
+prefix  *
+postfix +
+
+expecting postfix first:
+postfix *
+prefix  +
+
+expecting prefix first:
+prefix  ~
+postfix ~
+
+expecting prefix *, postfix +, postfix *, prefix +:
+prefix  *
+postfix +
+postfix *
+prefix  +
+
+expecting postfix *, prefix +, prefix *, postfix +:
+postfix *
+prefix  +
+prefix  *
+postfix +
+
+expecting postfix +, prefix *, postfix *, prefix +:
+postfix +
+prefix  *
+postfix *
+prefix  +
+
+expecting prefix +, prefix *, postfix *, postfix +:
+prefix  +
+prefix  *
+postfix *
+postfix +


### PR DESCRIPTION
fixes #3081

principles:
- "no whitespace" always beats any precendence.
- left to right, unless infix operator `^` which is right to left

