### PR TITLE
docs: fix navigation on the left side escaping the frame of the site

### DIFF
--- a/assets/docs/style.css
+++ b/assets/docs/style.css
@@ -151,7 +151,6 @@ Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
 }
 
 .fd .sidenav{
-  max-height: 100vh;
   padding-right: 15px;
 }
 


### PR DESCRIPTION
fixes this
![image](https://github.com/user-attachments/assets/43f304f5-73bf-4a32-a565-ac310a1726de)
