### PR TITLE
build: Enable building `fuzion.ebnf` in a dir different than the source dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -479,7 +479,7 @@ $(BUILD_DIR)/%.md: $(FZ_SRC)/%.md
 
 $(FUZION_EBNF): $(FUZION_BASE) $(FZ_SRC)/bin/ebnf.fz
 	mkdir -p $(@D)
-	$(FZ) $(FZ_SRC)/bin/ebnf.fz > $@
+	$(FZ) $(FZ_SRC)/bin/ebnf.fz $(JAVA_FILES_PARSER) > $@
 
 $(JAVA_FILE_UTIL_VERSION): $(FZ_SRC)/version.txt $(JAVA_FILE_UTIL_VERSION_IN)
 	mkdir -p $(@D)

--- a/bin/ebnf.fz
+++ b/bin/ebnf.fz
@@ -74,6 +74,9 @@ main =>
 
   new_line := "\n"
 
+  if envir.args.count < 2
+    panic "expecting at least one file name argument"
+
   # first, strip out asciidoc code that is enclosed as blocks of the form
   #
   #   // tag::bla_bla
@@ -81,8 +84,6 @@ main =>
   #   // end::bla_bla
   #
   asciidoc_matcher        := ["pcregrep", "-v", "-M", "// tag::(\\n|.)*?// end::"]
-  lexer_without_asciidoc  := !(asciidoc_matcher ++ ["./src/dev/flang/parser/Lexer.java"])
-  parser_without_asciidoc := !(asciidoc_matcher ++ ["./src/dev/flang/parser/Parser.java"])
 
   # then, extract EBNF rules of the form
   #
@@ -98,16 +99,20 @@ main =>
   #         ;
   #
   rule_matcher := ["pcregrep", "-M",  "^(fragment\\n)*[a-zA-Z0-9_]+[ ]*:(\\n|.)*?( ;)"]
-  ebnf_lexer   := lexer_without_asciidoc  | rule_matcher
-  ebnf_parser  := parser_without_asciidoc | rule_matcher
-
 
   # header
   ebnf_header := "grammar Fuzion;$new_line$new_line"
-  # combine parser and lexer
-  ebnf := "$ebnf_header$ebnf_parser$new_line$ebnf_lexer"
-  # replace " by '
-    .replace "\"" "'"
+
+  ebnf := envir.args.drop 1
+    .map src->
+      if !io.file.exists src
+        panic "file not found '$src'."
+
+      src_without_asciidoc  := !(asciidoc_matcher ++ [src])
+      (src_without_asciidoc | rule_matcher)
+        .replace "\"" "'"     # replace " by '
+
+    .reduce ebnf_header (+)
 
   say ebnf
 


### PR DESCRIPTION
It should be possible to build `fuzion` from any dir using `make -f <fuzion-dir>/Makefile`. This did not work for `fuzion.ebnf` and, what is worse, the error was silently ignored with an empty `fuzion.ebnf` file.

Now, `ebnf.fz` expects the source files that contain ebnf data as arguments. Furthermore, it produces errors in case these arguments are missing or in case the files do not exist.
