### PR TITLE
dfa: Do not call `result()`in `Call.toString()`.

### DIFF
--- a/src/dev/flang/fuir/analysis/dfa/Call.java
+++ b/src/dev/flang/fuir/analysis/dfa/Call.java
@@ -403,9 +403,8 @@ public class Call extends ANY implements Comparable<Call>, Context
               .append("=")
               .append(a);
           }
-        var r = result();
         sb.append(" => ")
-          .append(r == null ? "*** VOID ***" : r)
+          .append(_returns ? "returns" : "*** VOID ***")
           .append(" ENV: ")
           .append(Errors.effe(Env.envAsString(env())));
         _toStringRecursion_.remove(this);


### PR DESCRIPTION
`result()` has all sorts of side effects since it tries to determine the result by code analysis.  Since `toString()` is used for debugging, this will change the state of the DFA in a way that makes this debugging harder.

So, I prefer printing no details on the results and not changing the state in `toString()` to not mess up with what I am debugging.