### PR TITLE
ast: Call, mark `_type` private

### DIFF
--- a/src/dev/flang/ast/AbstractFeature.java
+++ b/src/dev/flang/ast/AbstractFeature.java
@@ -806,8 +806,7 @@ public abstract class AbstractFeature extends Expr implements Comparable<Abstrac
                     oc,
                     typeParameters,
                     Expr.NO_EXPRS,
-                    tf,
-                    null);
+                    tf);
   }
 
 

--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -149,7 +149,7 @@ public class Call extends AbstractCall
   /**
    * Static type of this call. Set during resolveTypes().
    */
-  AbstractType _type;
+  private AbstractType _type;
 
 
   /**
@@ -249,7 +249,7 @@ public class Call extends AbstractCall
    */
   Call(SourcePosition pos, Expr t, String n, List<Expr> la)
   {
-    this(pos, t, n, -1, NO_GENERICS, la, null, null);
+    this(pos, t, n, -1, NO_GENERICS, la, null);
 
     if (PRECONDITIONS) require
       (la != null);
@@ -302,17 +302,14 @@ public class Call extends AbstractCall
    * @param actuals
    *
    * @param calledFeature
-   *
-   * @param type
    */
   Call(SourcePosition pos,
        Expr target,
        List<AbstractType> generics,
        List<Expr> actuals,
-       AbstractFeature calledFeature,
-       AbstractType type)
+       AbstractFeature calledFeature)
   {
-    this(pos, target, calledFeature.featureName().baseName(), -1, generics, actuals, calledFeature, type);
+    this(pos, target, calledFeature.featureName().baseName(), -1, generics, actuals, calledFeature);
     if (PRECONDITIONS) check
       (calledFeature.generics().sizeMatches(generics) || generics.contains(Types.t_ERROR));
   }
@@ -345,8 +342,7 @@ public class Call extends AbstractCall
        int select,
        List<AbstractType> generics,
        List<Expr> actuals,
-       AbstractFeature calledFeature,
-       AbstractType type)
+       AbstractFeature calledFeature)
   {
     if (PRECONDITIONS) require
       (Errors.any() || generics.stream().allMatch(g -> !g.containsError()),
@@ -365,7 +361,6 @@ public class Call extends AbstractCall
       }
     this._originalTarget = _target;
     this._calledFeature = calledFeature;
-    this._type = type;
   }
 
 
@@ -2426,8 +2421,7 @@ public class Call extends AbstractCall
                           new Universe(),
                           new List<>(Types.resolved.t_void),
                           new List<>(_target),
-                          Types.resolved.f_id,
-                          Types.resolved.t_void);
+                          Types.resolved.f_id);
         result.resolveTypes(res, context);
       }
 
@@ -2880,9 +2874,10 @@ public class Call extends AbstractCall
     ERROR = new Call(SourcePosition.builtIn, Errors.ERROR_STRING)
     {
       {
-        _type = Types.t_ERROR;
         _calledFeature = Types.f_ERROR;
       }
+      @Override AbstractType typeForInferencing() { return Types.t_ERROR; }
+      @Override public AbstractType type() { return Types.t_ERROR; }
       @Override
       Expr box(AbstractType frmlT, Context context)
       {

--- a/src/dev/flang/ast/Contract.java
+++ b/src/dev/flang/ast/Contract.java
@@ -383,8 +383,7 @@ public class Contract extends ANY
                     t,
                     outer.generics().asActuals(),
                     args,
-                    f.preFeature(),
-                    Types.resolved.t_unit)
+                    f.preFeature())
       .resolveTypes(res, context);
   }
 
@@ -425,8 +424,7 @@ public class Contract extends ANY
                     t,
                     outer.generics().asActuals(),
                     args,
-                    f.preBoolFeature(),
-                    Types.resolved.t_bool)
+                    f.preBoolFeature())
       .resolveTypes(res, context);
   }
 
@@ -460,8 +458,7 @@ public class Contract extends ANY
                     t,
                     preAndCallOuter.generics().asActuals(),
                     args,
-                    f,
-                    null)
+                    f)
       {
         @Override
         boolean preChecked() { return true; }
@@ -542,8 +539,7 @@ public class Contract extends ANY
                                      t,
                                      origouter.isConstructor() ? new List<>() : in.generics().asActuals(),
                                      args,
-                                     origouter.postFeature(),
-                                     Types.resolved.t_unit);
+                                     origouter.postFeature());
     callPostCondition = callPostCondition.resolveTypes(res, in.context());
     return callPostCondition;
   }

--- a/src/dev/flang/ast/DotType.java
+++ b/src/dev/flang/ast/DotType.java
@@ -130,7 +130,6 @@ public class DotType extends ExprWithPos
                 -1,
                 new List<>(_lhs),
                 new List<>(),
-                null,
                 null).resolveTypes(res, context);
   }
 

--- a/src/dev/flang/ast/Expr.java
+++ b/src/dev/flang/ast/Expr.java
@@ -824,12 +824,9 @@ public abstract class Expr extends ANY implements HasSourcePosition
   {
     NO_VALUE = new Call(SourcePosition.builtIn, FuzionConstants.NO_VALUE_STRING)
     {
-      { _type = Types.t_ERROR; }
-      @Override
-      Expr box(AbstractType frmlT, Context context)
-      {
-        return this;
-      }
+      @Override Expr box(AbstractType frmlT, Context context) { return this; }
+      @Override AbstractType typeForInferencing() { return Types.t_ERROR; }
+      @Override public AbstractType type() { return Types.t_ERROR; }
     };
   }
 

--- a/src/dev/flang/ast/InlineArray.java
+++ b/src/dev/flang/ast/InlineArray.java
@@ -416,7 +416,7 @@ public class InlineArray extends ExprWithPos
     var fuzion       = new Call(SourcePosition.builtIn, null, "fuzion"              ).resolveTypes(res, context);
     var sys          = new Call(SourcePosition.builtIn, fuzion, "sys"               ).resolveTypes(res, context);
     var sysArrayCall = new Call(SourcePosition.builtIn, sys , "internal_array_init",
-                                -1, argsT, argsE, null, null                        ).resolveTypes(res, context);
+                                -1, argsT, argsE, null                              ).resolveTypes(res, context);
     var fuzionT      = new ParsedType(SourcePosition.builtIn, "fuzion", UnresolvedType.NONE, null);
     var sysT         = new ParsedType(SourcePosition.builtIn, "sys"   , UnresolvedType.NONE, fuzionT);
     var sysArrayT    = new ParsedType(SourcePosition.builtIn, "internal_array", eT, sysT);
@@ -450,7 +450,7 @@ public class InlineArray extends ExprWithPos
                                          unit3);
     var arrayCall       = new Call(SourcePosition.builtIn, null, FuzionConstants.ARRAY_NAME, -1,
                                    sysArrArgsT,
-                                   sysArrArgsE, null, null                          ).resolveTypes(res, context);
+                                   sysArrArgsE, null).resolveTypes(res, context);
     exprs.add(arrayCall);
 
     // we do not "replace" this inline array by instantiation code

--- a/src/dev/flang/ast/ParsedCall.java
+++ b/src/dev/flang/ast/ParsedCall.java
@@ -636,7 +636,7 @@ public class ParsedCall extends Call
    */
   Call pushCall(Resolution res, Context context, String name)
   {
-    var wasLazy = _type != null && _type.isLazyType();
+    var wasLazy = typeForInferencing() != null && typeForInferencing().isLazyType();
 
     if (CHECKS) check
       (select() == -1);
@@ -691,12 +691,12 @@ public class ParsedCall extends Call
   private boolean isImmediateFunctionCall()
   {
     return
-      _type.isFunctionTypeExcludingLazy()                      &&
+      type().isFunctionTypeExcludingLazy()                      &&
       _calledFeature != Types.resolved.f_Function && // exclude inherits call in function type
       _calledFeature.arguments().size() == 0      &&
       _actuals != NO_PARENTHESES
       ||
-      _type.isLazyType()                          &&   // we are `Lazy T`
+      type().isLazyType()                          &&   // we are `Lazy T`
       _calledFeature != Types.resolved.f_Lazy     &&   // but not an explicit call to `Lazy` (e.g., in inherits clause)
       _calledFeature.arguments().size() == 0      &&   // no arguments (NYI: maybe allow args for `Lazy (Function R V)`, then `l a` could become `l.call.call a`
       _actuals.isEmpty();                              // dto.

--- a/src/dev/flang/ast/Select.java
+++ b/src/dev/flang/ast/Select.java
@@ -45,7 +45,7 @@ public class Select extends Call {
 
   public Select(SourcePosition pos, Expr target, String name, int select)
   {
-    super(pos, target, name, select, NO_GENERICS, Expr.NO_EXPRS, null, null);
+    super(pos, target, name, select, NO_GENERICS, Expr.NO_EXPRS, null);
 
     if (PRECONDITIONS) require
       (select >= 0,
@@ -135,7 +135,7 @@ public class Select extends Call {
           {
             _currentlyResolving = _calledFeature.resultTypeIfPresentUrgent(res, true).isOpenGeneric()
               // explicit
-              ? new Call(pos(), _target, _name, _select, Call.NO_GENERICS, NO_EXPRS, null, null)
+              ? new Call(pos(), _target, _name, _select, Call.NO_GENERICS, NO_EXPRS, null)
               // implict
               : resolveImplicit(res, context, getActualResultType(res, context, true));
           }
@@ -172,12 +172,12 @@ public class Select extends Call {
       {
         if (_name == null)
           {
-            result = new Call(pos(), _target, f.featureName().baseName(), _select, Call.NO_GENERICS, NO_EXPRS, null, null);
+            result = new Call(pos(), _target, f.featureName().baseName(), _select, Call.NO_GENERICS, NO_EXPRS, null);
           }
         else
           {
-            var selectTarget = new Call(pos(), _target, _name, -1, Call.NO_GENERICS, NO_EXPRS, null, null);
-            result = new Call(pos(), selectTarget, f.featureName().baseName(), _select, Call.NO_GENERICS, NO_EXPRS, null, null);
+            var selectTarget = new Call(pos(), _target, _name, -1, Call.NO_GENERICS, NO_EXPRS, null);
+            result = new Call(pos(), selectTarget, f.featureName().baseName(), _select, Call.NO_GENERICS, NO_EXPRS, null);
           }
       }
     else

--- a/src/dev/flang/ast/This.java
+++ b/src/dev/flang/ast/This.java
@@ -259,7 +259,7 @@ public class This extends ExprWithPos
                     @Override
                     AbstractType typeForInferencing()
                     {
-                      return isAdr ? t : _type;
+                      return isAdr ? t : super.typeForInferencing();
                     }
                   }.resolveTypes(res, context);
 


### PR DESCRIPTION
The goal is to eventually get rid of `_type` in Call completely and always replace a `Call` by either Call.ERROR or a ResolvedCall (to be created).

