### PR TITLE
dockerfile: switch from termurin to ubuntu

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM eclipse-temurin:21-alpine@sha256:a3ef08aadbf2d925a6af28ab644f9974df9bd053d3728caa4b28329ae968e7ad AS builder
+FROM ubuntu:24.04@sha256:72297848456d5d37d1262630108ab308d3e9ec7ed1c3286a32fe09856619a782 AS builder
 WORKDIR /fuzion
 COPY . .
-RUN apk add --no-cache bash clang18 git make patch pcre-tools && ln -s /usr/bin/clang-18 /usr/bin/clang && FUZION_REPRODUCIBLE_BUILD="true" PRECONDITIONS="true" POSTCONDITIONS="true" make
+RUN apt-get update && apt-get -y --no-install-recommends install openjdk-21-jdk-headless git make patch libgc1 libgc-dev shellcheck asciidoc asciidoctor ruby-asciidoctor-pdf pcregrep antlr4 clang-18 && ln -s /usr/bin/clang-18 /usr/bin/clang && FUZION_REPRODUCIBLE_BUILD="true" PRECONDITIONS="true" POSTCONDITIONS="true" make
 
-FROM eclipse-temurin:21-alpine@sha256:a3ef08aadbf2d925a6af28ab644f9974df9bd053d3728caa4b28329ae968e7ad AS runner
+FROM ubuntu:24.04@sha256:72297848456d5d37d1262630108ab308d3e9ec7ed1c3286a32fe09856619a782 AS runner
 COPY --from=builder /fuzion/build /fuzion
-RUN apk add --no-cache bash clang18 gc-dev
+RUN apt-get update && apt-get -y --no-install-recommends install openjdk-21-jdk-headless git make patch libgc1 libgc-dev shellcheck asciidoc asciidoctor ruby-asciidoctor-pdf pcregrep antlr4 clang-18 && ln -s /usr/bin/clang-18 /usr/bin/clang
 ENV PATH="/fuzion/bin:${PATH}" PRECONDITIONS="true" POSTCONDITIONS="true" dev_flang_tools_serializeFUIR="true"


### PR DESCRIPTION
[ci skip]
Reason is that alpine does not have antlr package which is now required be `make all`
