### PR TITLE
time: introduce instant, an abstract moment in time

### DIFF
--- a/modules/base/src/bench.fz
+++ b/modules/base/src/bench.fz
@@ -30,17 +30,17 @@
 #
 # returns: iterations per second
 #
-public bench(f ()->unit, nano_seconds u64, warm_up_nano_seconds u64) f64 ! time.nano =>
+public bench(f ()->unit, d time.duration, warm_up time.duration) f64 ! time.nano =>
   start := time.nano.read
 
-  is_warmup => time.nano.read - start < warm_up_nano_seconds
+  is_warmup => time.nano.read - start < warm_up
 
   for iter := (u64 0), if (is_warmup) iter else iter + 1
-  while time.nano.read - start < warm_up_nano_seconds + nano_seconds
+  while time.nano.read - start < warm_up + d
   do
     f.call
   else
-    iter.as_f64 / (nano_seconds.as_f64 * 1E-9)
+    iter.as_f64 / (d.nanos.as_f64 * 1E-9)
 
 
 # benchmark f for milli_seconds (1s warm up)
@@ -51,4 +51,4 @@ public bench(f ()->unit, nano_seconds u64, warm_up_nano_seconds u64) f64 ! time.
 # returns: iterations per second
 #
 public bench(f ()->unit, milli_seconds i32) f64 =>
-  bench f (milli_seconds.as_u64 * 1E6) 1E9
+  bench f (time.duration.ms milli_seconds.as_u64) (time.duration.s 1)

--- a/modules/base/src/random.fz
+++ b/modules/base/src/random.fz
@@ -197,7 +197,7 @@ simple_random_handler(seed1 u64, seed2 u64) : Random_Handler is
   type.time_seeded Random_Handler =>
     # initialize with large numbers XORed with nano time
     #
-    simple_random_handler (u64 77777777777777 ^ time.nano.read) 98765432109876543
+    simple_random_handler (u64 77777777777777 ^ time.nano.read_for_random) 98765432109876543
 
   # create a time-seeded handler for pseudo random numbers that are not safe
   # for security and that do not meet typical requirements for a good

--- a/modules/base/src/time/duration.fz
+++ b/modules/base/src/time/duration.fz
@@ -32,7 +32,7 @@
 # calendars that may require time spans exceeding several centuries or millennia,
 # nor astrological time spans.
 #
-private:public duration (
+module:public duration (
 
   # the duration in nano seconds
   #
@@ -72,6 +72,11 @@ is
   # this duration in whole Julian years, omitting fractional part
   #
   public years => nanos / units.nanos_per_year
+
+
+  # this duration and another one combined
+  #
+  public infix + (other duration) => duration (nanos + other.nanos)
 
 
   # this duration multiplied by n

--- a/modules/base/src/time/instant.fz
+++ b/modules/base/src/time/instant.fz
@@ -17,33 +17,33 @@
 #
 #  Tokiwa Software GmbH, Germany
 #
-#  Source code of Fuzion test call_with_ambiguous_result_type
-#
-#  Author: Fridtjof Siebert (siebert@tokiwa.software)
+#  Source code of Fuzion standard library feature time.instant
 #
 # -----------------------------------------------------------------------
 
-# This tests a tricky call situation where the result type of a call is ambiguous
-# since the outer type is a ref this.type that could be a boxed value type.
+# time.instant -- abstract moment in time used for measuring durations
 #
-call_with_ambiguous_result_type is
+module:public instant (val u64) : property.orderable is
 
-  r ref is
-    e is
-
-    # result type of g is r.this.e
-    g => e
-
-  h1 : r is
-  h2 : r is
-
-  # v will be set to `boxed h1` or `boxed h2`
-  v r := if random.next_bool then
-           h1
-         else
-           h2
-
-  # the result type of `v.g` is ambiguous: `h.e` for any
-  # heir of `r`.  So this will cause an error:
+  # which instant will be after the time specified by the duration
+  # has passed after this instant?
   #
-  _ := v.g   # error! ambiguous result type
+  public infix + (d duration) =>
+    instant (val + d.nanos)
+
+
+  # how much time passed between two instants?
+  #
+  public infix - (other instant) time.duration =>
+    time.duration (val - other.val)
+
+
+  # do two given instants represent the same moment in time?
+  #
+  public fixed redef type.equality(a, b time.instant) bool => a.val = b.val
+
+
+  # check whether an instant happened before or at the same moment in time
+  # as another instant
+  #
+  public fixed redef type.lteq(a, b time.instant) bool => a.val ≤ b.val

--- a/modules/base/src/time/nano.fz
+++ b/modules/base/src/time/nano.fz
@@ -40,7 +40,15 @@ public nano (p Nano_Time_Handler) : effect is
   public read =>
     res := p.read
     replace
+    instant res
+
+
+  # workaround for making the time seeded random handler work for now
+  module read_for_random =>
+    res := p.read
+    replace
     res
+
 
   # no guarantee can be given for precision nor resolution
   public sleep(d time.duration) =>

--- a/modules/base/src/time/stopwatch.fz
+++ b/modules/base/src/time/stopwatch.fz
@@ -28,4 +28,4 @@ public stopwatch(f () -> unit) time.duration =>
   start := nano.read
   f()
   end := nano.read
-  duration.ns end-start
+  end - start

--- a/tests/atomic/test_atomic.fz
+++ b/tests/atomic/test_atomic.fz
@@ -163,7 +163,7 @@ test_atomic is
     s2 := concur.atomic i64 -1
 
     thrd1 := concur.threads.spawn (()->
-      end := time.nano.read + (time.duration.seconds 5).nanos
+      end := time.nano.read + (time.duration.seconds 5)
       for
         s := i64 0, o=v ? s+1 : s
         c := i64 0, c+1
@@ -177,7 +177,7 @@ test_atomic is
       )
 
     thrd2 := concur.threads.spawn (()->
-      end := time.nano.read + (time.duration.seconds 5).nanos
+      end := time.nano.read + (time.duration.seconds 5)
       for
         s := i64 0, o=v ? s+1 : s
         c := i64 0, c+1

--- a/tests/reg_issue1588/reg_issue1588.fz
+++ b/tests/reg_issue1588/reg_issue1588.fz
@@ -22,7 +22,7 @@
 # -----------------------------------------------------------------------
 
 reg_issue1588 is
-  end := time.nano.read + (time.duration.seconds 5).nanos
+  end := time.nano.read + (time.duration.seconds 5)
   for
     c in 0..
   while time.nano.read < end do


### PR DESCRIPTION
instant is purely abstract, meaning it can only be used to measure the duration between two moments in time, and instants do not specify any absolute point in time.