### PR TITLE
time/instant: add precondition to `infix -`

### DIFF
--- a/modules/base/src/time/instant.fz
+++ b/modules/base/src/time/instant.fz
@@ -36,7 +36,7 @@ module:public instant (val u64) : property.orderable is
   #
   public fixed infix - (other instant) time.duration
   pre
-    debug: other < instant.this
+    debug: other <= instant.this
   =>
     time.duration (val - other.val)
 

--- a/modules/base/src/time/instant.fz
+++ b/modules/base/src/time/instant.fz
@@ -28,13 +28,16 @@ module:public instant (val u64) : property.orderable is
   # which instant will be after the time specified by the duration
   # has passed after this instant?
   #
-  public infix + (d duration) =>
+  public fixed infix + (d duration) =>
     instant (val + d.nanos)
 
 
   # how much time passed between two instants?
   #
-  public infix - (other instant) time.duration =>
+  public fixed infix - (other instant) time.duration
+  pre
+    debug: other < instant.this
+  =>
     time.duration (val - other.val)
 
 


### PR DESCRIPTION
Mark `infix -` as a fixed feature as this is required for types to be compatible. Do the same for `infix +` for consistency.