### PR TITLE
fuir: change logic in lookup_

### DIFF
--- a/src/dev/flang/fuir/GeneratingFUIR.java
+++ b/src/dev/flang/fuir/GeneratingFUIR.java
@@ -1479,8 +1479,10 @@ public class GeneratingFUIR extends FUIR
       (cl >= CLAZZ_BASE,
        cl < CLAZZ_BASE + _clazzes.size());
 
-    return _lookupDone && !id2clazz(cl).feature().inheritsFrom(Types.resolved.f_fuzion_Java_Object_Ref.outer())
+    return !id2clazz(cl).feature().inheritsFrom(Types.resolved.f_fuzion_Java_Object_Ref.outer())
       ? NO_CLAZZ
+      : _lookupDone
+      ? id2clazz(cl).lookup(Types.resolved.f_fuzion_Java_Object_Ref)._id
       : id2clazz(cl).lookupNeeded(Types.resolved.f_fuzion_Java_Object_Ref)._id;
   }
 
@@ -1501,7 +1503,7 @@ public class GeneratingFUIR extends FUIR
       (cl >= CLAZZ_BASE,
        cl < CLAZZ_BASE + _clazzes.size());
 
-    return _lookupDone && !id2clazz(cl).feature().inheritsFrom(Types.resolved.f_Function)
+    return !id2clazz(cl).feature().inheritsFrom(Types.resolved.f_Function)
       ? NO_CLAZZ
       : lookupCall(cl, !_lookupDone);
   }
@@ -1547,8 +1549,10 @@ public class GeneratingFUIR extends FUIR
       (cl >= CLAZZ_BASE,
        cl < CLAZZ_BASE + _clazzes.size());
 
-    return _lookupDone && !id2clazz(cl).feature().inheritsFrom(Types.resolved.f_effect_static_finally.outer())
+    return !id2clazz(cl).feature().inheritsFrom(Types.resolved.f_effect_static_finally.outer())
       ? NO_CLAZZ
+      : _lookupDone
+      ? id2clazz(cl).lookup(Types.resolved.f_effect_static_finally)._id
       : id2clazz(cl).lookupNeeded(Types.resolved.f_effect_static_finally)._id;
   }
 


### PR DESCRIPTION
The logic was flawed previously. When lookupDone, lookupNeeded should never be called. Likewise if inherits(...) is false it does not make sense to do a lookup.