### PR TITLE
lib: add `array.type.empty`

### DIFF
--- a/modules/base/src/array.fz
+++ b/modules/base/src/array.fz
@@ -86,6 +86,12 @@ module:public array(
     array.this
 
 
+  # create an empty array of type T
+  #
+  public fixed type.empty array T =>
+    array (fuzion.sys.internal_array_init T 0) unit unit unit
+
+
   # array -- create initialized one-dimensional immutable array
   #
   public type.new(length i32, init i32 -> T) array T


### PR DESCRIPTION
This is sometimes useful, since just `[]` does not specify the type while `(array String).empty` gives us an array of String.