### PR TITLE
fuir: add convenience method, fuir clazzNativeName

### DIFF
--- a/src/dev/flang/be/c/C.java
+++ b/src/dev/flang/be/c/C.java
@@ -1980,7 +1980,7 @@ public class C extends ANY
       }
 
     var rc = _fuir.clazzResultClazz(cl);
-    var call = CExpr.call(_fuir.clazzBaseName(cl), args);
+    var call = CExpr.call(_fuir.clazzNativeName(cl), args);
     return switch (_fuir.getSpecialClazz(rc))
       {
         case

--- a/src/dev/flang/be/interpreter/Executor.java
+++ b/src/dev/flang/be/interpreter/Executor.java
@@ -289,7 +289,7 @@ public class Executor extends ProcessExpression<Value, Object>
         var mh = Linker.nativeLinker()
           .downcallHandle(
             SymbolLookup.libraryLookup(System.mapLibraryName("fuzion" /* NYI */), Arena.ofAuto())
-              .find(_fuir.clazzBaseName(cc))
+              .find(_fuir.clazzNativeName(cc))
               .orElseThrow(() -> new UnsatisfiedLinkError("unresolved symbol: " + _fuir.clazzBaseName(cc))),
 
               _fuir.clazzIsUnitType(rt)

--- a/src/dev/flang/be/jvm/JVM.java
+++ b/src/dev/flang/be/jvm/JVM.java
@@ -1005,7 +1005,7 @@ should be avoided as much as possible.
     var rt = _fuir.clazzResultClazz(cl);
     cf.addToClInit(
       Expr
-        .stringconst(_fuir.clazzBaseName(cl))                                          // String
+        .stringconst(_fuir.clazzNativeName(cl))                                        // String
         .andThen(funDescArgs(cl))                                                      // String, (MemoryLayout), [MemoryLayout
         // invoking: FunctionDescriptor.of(...) / FunctionDescriptor.ofVoid(...)
         .andThen(Expr.invokeStatic(

--- a/src/dev/flang/fuir/FUIR.java
+++ b/src/dev/flang/fuir/FUIR.java
@@ -226,6 +226,18 @@ public abstract class FUIR extends IR
   }
 
 
+  /**
+   * for clazz cl return the name of the native
+   * function we are calling.
+   *
+   * @param cl a clazz id.
+   */
+  public String clazzNativeName(int cl)
+  {
+    return clazzBaseName(cl).split(" ", 2)[0];
+  }
+
+
   /*------------------------  accessing fields  ------------------------*/
 
 


### PR DESCRIPTION
clazzBaseName includes generics, hence we need to split at space and take only the first part.

We will need generics in native definitions for passing callbacks. Example: `sqlite3_exec(F type : Function i32 fuzion.sys.Pointer i32 fuzion.sys.Pointer fuzion.sys.Pointer, db fuzion.sys.Pointer, sql fuzion.sys.Pointer, callback F, arg fuzion.sys.Pointer, errmsg fuzion.sys.Pointer) i32 => native`


