### PR TITLE
lib/be: add `Mutex ref`, `Condition ref`

### DIFF
--- a/modules/base/src/concur/sync.fz
+++ b/modules/base/src/concur/sync.fz
@@ -26,24 +26,24 @@
 #
 public sync is
 
-  mtx_init outcome fuzion.sys.Pointer => intrinsic
-  mtx_lock(mtx fuzion.sys.Pointer) bool => intrinsic
+  mtx_init outcome Mutex => intrinsic
+  mtx_lock(mtx Mutex) bool => intrinsic
   # NYI: mtx_timedlock
-  mtx_trylock(mtx fuzion.sys.Pointer) bool => intrinsic
-  mtx_unlock(mtx fuzion.sys.Pointer) bool => intrinsic
-  mtx_destroy(mtx fuzion.sys.Pointer) unit => intrinsic
+  mtx_trylock(mtx Mutex) bool => intrinsic
+  mtx_unlock(mtx Mutex) bool => intrinsic
+  mtx_destroy(mtx Mutex) unit => intrinsic
 
-  cnd_init(mtx fuzion.sys.Pointer) outcome fuzion.sys.Pointer => intrinsic
-  cnd_signal(cnd fuzion.sys.Pointer) bool => intrinsic
-  cnd_broadcast(cnd fuzion.sys.Pointer) bool => intrinsic
-  cnd_wait(cnd fuzion.sys.Pointer, mtx fuzion.sys.Pointer) bool => intrinsic
+  cnd_init(mtx Mutex) outcome Condition => intrinsic
+  cnd_signal(cnd Condition) bool => intrinsic
+  cnd_broadcast(cnd Condition) bool => intrinsic
+  cnd_wait(cnd Condition, mtx Mutex) bool => intrinsic
   # NYI: cnd_timedwait
-  cnd_destroy(cnd fuzion.sys.Pointer) unit => intrinsic
+  cnd_destroy(cnd Condition) unit => intrinsic
 
 
   # NYI: documentation missing, waiting for JVM backend impl
 
-  private:public mutex(module mtx fuzion.sys.Pointer) is
+  private:public mutex(module mtx Mutex) is
 
     public type.new outcome concur.sync.mutex =>
       concur.sync.mtx_init.bind concur.sync.mutex mtx->
@@ -56,7 +56,7 @@ public sync is
     # NYI destroy
 
 
-  private:public condition(mtx fuzion.sys.Pointer, cnd fuzion.sys.Pointer) is
+  private:public condition(mtx Mutex, cnd Condition) is
 
     public is_locked := concur.atomic false
 

--- a/modules/base/src/internal.fz
+++ b/modules/base/src/internal.fz
@@ -1,0 +1,31 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Internal features which are not meant
+#  to be used outside of this module.
+#
+# -----------------------------------------------------------------------
+
+# a type denoting a mutex, used in concur.sync
+#
+private:module Mutex ref is
+
+# a type denoting a condition, used in concur.sync
+#
+private:module Condition ref is

--- a/src/dev/flang/be/c/Intrinsics.java
+++ b/src/dev/flang/be/c/Intrinsics.java
@@ -1014,7 +1014,7 @@ public class Intrinsics extends ANY
           CStmnt.decl("void *", tmp, CExpr.call("fzE_mtx_init", new List<>())),
           CStmnt.iff(tmp.eq(CNames.NULL),
             c.returnOutcome(c._fuir.clazz_error(), c.error(c.boxedConstString("An error occurred initializing the mutex.")), rc, 1),
-            c.returnOutcome(c._fuir.clazz(SpecialClazzes.c_sys_ptr), tmp, rc , 0)
+            c.returnOutcome(c._fuir.clazz(SpecialClazzes.c_Mutex), tmp, rc , 0)
           )
         );
       }
@@ -1031,7 +1031,7 @@ public class Intrinsics extends ANY
           CStmnt.decl("void *", tmp, CExpr.call("fzE_cnd_init",      new List<>())),
           CStmnt.iff(tmp.eq(CNames.NULL),
             c.returnOutcome(c._fuir.clazz_error(), c.error(c.boxedConstString("An error occurred initializing the condition variable.")), rc, 1),
-            c.returnOutcome(c._fuir.clazz(SpecialClazzes.c_sys_ptr), tmp, rc , 0)
+            c.returnOutcome(c._fuir.clazz(SpecialClazzes.c_Condition), tmp, rc , 0)
           )
         );
       }

--- a/src/dev/flang/be/interpreter/JavaInterface.java
+++ b/src/dev/flang/be/interpreter/JavaInterface.java
@@ -229,6 +229,8 @@ public class JavaInterface extends FUIRContext
     else if (resultClazz == fuir().clazz(SpecialClazzes.c_unit) && o == null             ) { return new Instance(resultClazz); }
     // NYI: UNDER DEVELOPMENT: remove this, abusing javaObjectToPlainInstance in mtx_*, cnd_* intrinsics
     else if (resultClazz == fuir().clazz(SpecialClazzes.c_sys_ptr)) { return new JavaRef(o); }
+    else if (resultClazz == fuir().clazz(SpecialClazzes.c_Mutex)) { return new JavaRef(o); }
+    else if (resultClazz == fuir().clazz(SpecialClazzes.c_Condition)) { return new JavaRef(o); }
     else
       {
         var result = new Instance(resultClazz);

--- a/src/dev/flang/be/interpreter/Value.java
+++ b/src/dev/flang/be/interpreter/Value.java
@@ -319,7 +319,8 @@ public abstract class Value extends FUIRContext
    */
   protected Object toNative()
   {
-    Errors.fatal("NYI: toNative " + this.getClass().getName());
+    Thread.dumpStack();
+    Errors.fatal("NYI: toNative " + this.toString());
     return null;
   }
 

--- a/src/dev/flang/be/jvm/Intrinsix.java
+++ b/src/dev/flang/be/jvm/Intrinsix.java
@@ -545,6 +545,12 @@ public class Intrinsix extends ANY implements ClassFileConstants
       case c_sys_ptr -> {
         yield Expr.aload(slot, JAVA_LANG_OBJECT);
       }
+      case c_Mutex -> {
+        yield Expr.aload(slot, JAVA_LANG_OBJECT);
+      }
+      case c_Condition -> {
+        yield Expr.aload(slot, JAVA_LANG_OBJECT);
+      }
       default -> {
         var rt = jvm._types.javaType(rc0);
         var jref = jvm._fuir.lookupJavaRef(rc0);

--- a/src/dev/flang/be/jvm/Types.java
+++ b/src/dev/flang/be/jvm/Types.java
@@ -376,6 +376,8 @@ public class Types extends ANY implements ClassFileConstants
       case c_f32     -> PrimitiveType.type_float;
       case c_f64     -> PrimitiveType.type_double;
       case c_sys_ptr -> JAVA_LANG_OBJECT;
+      case c_Mutex   -> JAVA_LANG_OBJECT;
+      case c_Condition-> JAVA_LANG_OBJECT;
       default        ->
         {
           if (cl == _fuir.clazzUniverse()                        ||

--- a/src/dev/flang/fuir/GeneratingFUIR.java
+++ b/src/dev/flang/fuir/GeneratingFUIR.java
@@ -408,6 +408,8 @@ public class GeneratingFUIR extends FUIR
               case "fuzion"                    -> SpecialClazzes.c_fuzion      ;
               case "fuzion.sys"                -> SpecialClazzes.c_fuzion_sys  ;
               case "fuzion.sys.Pointer"        -> SpecialClazzes.c_sys_ptr     ;
+              case "Mutex"                     -> SpecialClazzes.c_Mutex       ;
+              case "Condition"                 -> SpecialClazzes.c_Condition   ;
               default                          -> SpecialClazzes.c_NOT_FOUND   ;
               };
             if (s != SpecialClazzes.c_NOT_FOUND)

--- a/src/dev/flang/fuir/SpecialClazzes.java
+++ b/src/dev/flang/fuir/SpecialClazzes.java
@@ -61,6 +61,8 @@ public enum SpecialClazzes
   c_java        ("java"                       , 0, c_fuzion    ),
   c_fuzion_sys  ("sys"                        , 0, c_fuzion    ),
   c_sys_ptr     ("Pointer"                    , 0, c_fuzion_sys),
+  c_Mutex       ("Mutex"                      , 0, c_universe  ),
+  c_Condition   ("Condition"                  , 0, c_universe  ),
   ;
 
   final String _name;

--- a/src/dev/flang/fuir/analysis/dfa/DFA.java
+++ b/src/dev/flang/fuir/analysis/dfa/DFA.java
@@ -2306,10 +2306,12 @@ public class DFA extends ANY
 
     put("concur.sync.mtx_init"              , cl ->
       {
+        var rc = fuir(cl).clazzResultClazz(cl._cc);
+        var ag = fuir(cl).clazzActualGeneric(rc, 0);
         return outcome(cl._dfa,
                        cl,
-                       fuir(cl).clazzResultClazz(cl._cc),
-                       cl._dfa.newInstance(fuir(cl).clazz(SpecialClazzes.c_sys_ptr), NO_SITE, cl._context));
+                       rc,
+                       cl._dfa.newInstance(ag, NO_SITE, cl._context));
       });
     put("concur.sync.mtx_lock"              , cl ->
       {
@@ -2334,10 +2336,12 @@ public class DFA extends ANY
     put("concur.sync.cnd_init"              , cl ->
       {
         cl._dfa.readField(fuir(cl).clazzArg(cl._cc, 0));
+        var rc = fuir(cl).clazzResultClazz(cl._cc);
+        var ag = fuir(cl).clazzActualGeneric(rc, 0);
         return outcome(cl._dfa,
                        cl,
-                       fuir(cl).clazzResultClazz(cl._cc),
-                       cl._dfa.newInstance(fuir(cl).clazz(SpecialClazzes.c_sys_ptr), NO_SITE, cl._context));
+                       rc,
+                       cl._dfa.newInstance(ag, NO_SITE, cl._context));
       });
     put("concur.sync.cnd_signal"            , cl ->
       {


### PR DESCRIPTION
We have taken `fuzion.sys.Pointer` a bit too far already.
Especially since the DFA creates `SysArray` for allocated memory.
This created problems in my sqlite PR, since then the DFA may try joining a generic `fuzion.sys.Pointer` and a `SysArray`.

This is a start in cleaning this up.
