### PR TITLE
time/date_time: use month and day arguments instead of day in year

### DIFF
--- a/include/shared.c
+++ b/include/shared.c
@@ -931,11 +931,12 @@ uint64_t fzE_unique_id()
  * result is a 32-bit array
  *
  * result[0] = year
- * result[1] = day_in_year
- * result[2] = hour
- * result[3] = min
- * result[4] = sec
- * result[5] = nanosec;
+ * result[1] = month
+ * result[2] = day_in_month
+ * result[3] = hour
+ * result[4] = min
+ * result[5] = sec
+ * result[6] = nanosec;
  */
 void fzE_date_time(void * result)
 {
@@ -943,11 +944,12 @@ void fzE_date_time(void * result)
   time(&rawtime);
   struct tm * ptm = gmtime(&rawtime);
   ((int32_t *)result)[0] = ptm->tm_year+1900;
-  ((int32_t *)result)[1] = ptm->tm_yday+1;
-  ((int32_t *)result)[2] = ptm->tm_hour;
-  ((int32_t *)result)[3] = ptm->tm_min;
-  ((int32_t *)result)[4] = ptm->tm_sec;
-  ((int32_t *)result)[5] = 0;
+  ((int32_t *)result)[1] = ptm->tm_mon+1;
+  ((int32_t *)result)[2] = ptm->tm_mday;
+  ((int32_t *)result)[3] = ptm->tm_hour;
+  ((int32_t *)result)[4] = ptm->tm_min;
+  ((int32_t *)result)[5] = ptm->tm_sec;
+  ((int32_t *)result)[6] = 0;
 }
 
 

--- a/modules/base/src/time/date_time.fz
+++ b/modules/base/src/time/date_time.fz
@@ -26,54 +26,15 @@
 # Represents a date and a time in the Gregorian calendar, without any specification of
 # a time zone or reference point.
 #
-public date_time(public year, day_in_year, hour, minute, second, nano_second i32) : property.orderable
+public date_time(public year, month, day, hour, minute, second, nano_second i32) : property.orderable
 pre
-  debug: (day_in_year ≥ 1  & day_in_year  ≤ days_in_year year)   # leap years have 366 days
-  debug: (hour        ≥ 0  & hour         ≤ 23               )
-  debug: (minute      ≥ 0  & minute       ≤ 59               )
-  debug: (second      ≥ 0  & second       ≤ 60               )   # 60 because of possible leap seconds
-  debug: (nano_second ≥ 0  & nano_second  ≤ 1E9              )
+  debug: 1 ≤ month ≤ 12
+  debug: 1 ≤ day ≤ days_in_month year month
+  debug: 0 ≤ hour ≤ 23
+  debug: 0 ≤ minute ≤ 59
+  debug: 0 ≤ second ≤ 60 # possible leap seconds
+  debug: 0 ≤ nano_second ≤ 1E9
 is
-
-  # how many days does february have in the given year?
-  #
-  days_in_february =>
-    if is_leap_year year then 29 else 28
-
-
-  # the days in the months of the year
-  # starting at january, february, ..., december
-  #
-  days_in_months =>
-    [31, days_in_february, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
-
-
-  # the month of the year
-  #
-  public month
-  post
-    debug: result ≥ 1 & result ≤ 12
-  =>
-    # Increase the month and add the days in month to
-    # the accumulated days. We found our month once
-    # the sum of accumulated days and the days in the
-    # processed month match or exceed the day_in_year.
-    days_in_months
-      .reduce (1,0) (r, md ->
-        (m, acc_days) := r
-        if acc_days+md ≥ day_in_year then abort (m,0) else (m+1,acc_days+md))
-      .values.0
-
-
-  # the day of the month
-  #
-  public day_of_month
-  post
-    debug: result ≥ 1 & result ≤ 31
-  =>
-    days_in_months
-      .reduce day_in_year (d, md -> if d-md ≤ 0 then abort d else d-md)
-
 
   # the millisecond of this datetime
   #
@@ -88,7 +49,7 @@ is
   # example: 2018-09-14T23:59:59.079
   #
   public redef as_string String =>
-    "{year.as_string 2 10}-{month.as_string 2 10}-{day_of_month.as_string 2 10}" +
+    "{year.as_string 2 10}-{month.as_string 2 10}-{day.as_string 2 10}" +
       "T{hour.as_string 2 10}:{minute.as_string 2 10}:{second.as_string 2 10}.{milli_second.as_string 3 10}"
 
 
@@ -107,7 +68,7 @@ is
   #
   # internal helper feature
   #
-  args_in_order => [year, day_in_year, hour, minute, second, nano_second]
+  args_in_order => [year, month, day, hour, minute, second, nano_second]
 
 
   # 0 = Sunday, 1 = Monday, etc.
@@ -118,7 +79,7 @@ is
   public day_of_week i32 =>
     t := [0, 3, 2, 5, 0, 3, 5, 1, 4, 6, 2, 4]
     y := year - (if month < 3 then 1 else 0)
-    (y + y/4 - y/100 + y/400 + t[month-1] + day_of_month) % 7
+    (y + y/4 - y/100 + y/400 + t[month-1] + day) % 7
 
 
   # defines an equality relation for date time
@@ -126,7 +87,8 @@ is
   public redef type.equality(a, b date_time.this) bool =>
     a.nano_second = b.nano_second &
      a.year = b.year &
-     a.day_in_year = b.day_in_year &
+     a.month = b.month &
+     a.day = b.day &
      a.hour = b.hour &
      a.minute = b.minute &
      a.second = b.second
@@ -155,44 +117,30 @@ public days_in_year(year i32) =>
   if is_leap_year year then 366 else 365
 
 
+# how many days does february have in the given year?
+#
+days_in_february(year i32) =>
+  if is_leap_year year then 29 else 28
+
+
+# the days in the months of the year
+# starting at january, february, ..., december
+#
+days_in_months(year i32) =>
+  [31, days_in_february year, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+
+
+# how many days does a given month of a given year have
+#
+public days_in_month(year, month i32)
+pre
+  debug: 1 ≤ month ≤ 12
+=>
+  (days_in_months year)[month - 1]
+
 
 # is the given year a leap year?
 #
 is_leap_year(year i32) =>
   (year % 4 = 0 & year % 100 != 0) |
     ((year % 100 = 0) & (year % 400 = 0))
-
-
-# short-hand to init date_time
-# where missing fields are initialized with zero
-#
-public date_time(year, day_in_year, hour, minute, second i32) =>
-  date_time year day_in_year hour minute second 0
-
-
-# short-hand to init date_time
-# where missing fields are initialized with zero
-#
-public date_time(year, day_in_year, hour, minute i32) =>
-  date_time year day_in_year hour minute 0
-
-
-# short-hand to init date_time
-# where missing fields are initialized with zero
-#
-public date_time(year, day_in_year, hour i32) =>
-  date_time year day_in_year hour 0
-
-
-# short-hand to init date_time
-# where missing fields are initialized with zero
-#
-public date_time(year, day_in_year i32) =>
-  date_time year day_in_year 0
-
-
-# short-hand to init date_time
-# where missing fields are initialized with zero
-#
-public date_time(year i32) =>
-  date_time year 0

--- a/modules/base/src/time/now.fz
+++ b/modules/base/src/time/now.fz
@@ -46,9 +46,9 @@ public now (p () -> time.date_time) : effect is
   #
   type.default_now ()->time.date_time => () ->
 
-    a := fuzion.sys.internal_array_init i32 6
+    a := fuzion.sys.internal_array_init i32 7
     fzE_date_time a.data
-    time.date_time a[0] a[1] a[2] a[3] a[4] a[5]
+    time.date_time a[0] a[1] a[2] a[3] a[4] a[5] a[6]
 
 
   type.install_default =>

--- a/tests/lib_time_date_time/lib_time_date_time.fz
+++ b/tests/lib_time_date_time/lib_time_date_time.fz
@@ -23,9 +23,9 @@
 
 lib_time_date_time =>
 
-  a := time.date_time 2024 30 10 30 12 1E8
-  b := time.date_time 2024 30 10 30 12 1E7
-  c := time.date_time 2023 30 10 30 12 1E8
+  a := time.date_time 2024 1 30 10 30 12 1E8
+  b := time.date_time 2024 1 30 10 30 12 1E7
+  c := time.date_time 2023 1 30 10 30 12 1E8
 
   say "a = $a"
   say "b = $b"


### PR DESCRIPTION
Also remove some untested short-hands that for example initialized the month to 0, which is invalid.