### PR TITLE
Revert "devcontainer: preinstall clang"

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,8 +7,7 @@
       "installMaven": "false",
       "installGradle": "false"
     },
-    "ghcr.io/devcontainers/features/nix:1": {},
-    "ghcr.io/devcontainers/features/clang:1": {}
+    "ghcr.io/devcontainers/features/nix:1": {}
   },
 
   // Use 'forwardPorts' to make a list of ports inside the container available locally.


### PR DESCRIPTION
Reverts tokiwa-software/fuzion#4882
```
ERR: Feature 'ghcr.io/devcontainers/features/clang:1' could not be processed.  You may not have permission to access this Feature, or may not be logged in.  If the issue persists, report this to the Feature author.
```