### PR TITLE
fix #4531

### DIFF
--- a/bin/add_simple_test.fz
+++ b/bin/add_simple_test.fz
@@ -25,8 +25,7 @@
 #
 add_simple_test =>
 
-  # NYI: BUG: #4531, can not end input via return currently
-  say "Name of the new test: (press Ctrl+D to end input)"
+  say "Name of the new test:"
 
   lm : mutate is
   lm ! ()->

--- a/include/posix.c
+++ b/include/posix.c
@@ -498,6 +498,8 @@ static pthread_mutex_t fzE_global_mutex;
  */
 void fzE_init()
 {
+  fcntl(STDIN_FILENO, F_SETFL, O_NONBLOCK);
+
 #ifdef FUZION_ENABLE_THREADS
   pthread_mutexattr_t attr;
   fzE_memset(&fzE_global_mutex, 0, sizeof(fzE_global_mutex));
@@ -830,11 +832,8 @@ void fzE_cnd_destroy(void *cnd) {
 
 int32_t fzE_file_read(void * file, void * buf, int32_t size)
 {
-  int fno = fileno(file);
-  fcntl(fno, F_SETFL, O_NONBLOCK);
-
   struct pollfd fds;
-  fds.fd = fno;
+  fds.fd = fileno(file);
   fds.events = POLLIN;
 
   int ten_seconds = 10000;
@@ -846,6 +845,6 @@ int32_t fzE_file_read(void * file, void * buf, int32_t size)
   return result > 0
     ? result
     : result == 0
-    ? -1
-    : -2;
+    ? -1  // EOF
+    : -2; // ERROR
 }

--- a/include/posix.c
+++ b/include/posix.c
@@ -836,9 +836,7 @@ int32_t fzE_file_read(void * file, void * buf, int32_t size)
   fds.fd = fileno(file);
   fds.events = POLLIN;
 
-  int ten_seconds = 10000;
-
-  while(poll(&fds, 1, ten_seconds) == 0);
+  while(poll(&fds, 1, -1) == 0);
 
   size_t result = fread(buf, 1, size, (FILE*)file);
 

--- a/include/posix.c
+++ b/include/posix.c
@@ -826,3 +826,26 @@ void fzE_cnd_destroy(void *cnd) {
 #else
 #endif
 }
+
+
+int64_t fzE_file_read(void * file, void * buf, int32_t size)
+{
+  int fno = fileno(file);
+  fcntl(fno, F_SETFL, O_NONBLOCK);
+
+  struct pollfd fds;
+  fds.fd = fno;
+  fds.events = POLLIN;
+
+  int ten_seconds = 10000;
+
+  while(poll(&fds, 1, ten_seconds) == 0);
+
+  size_t result = fread(buf, 1, size, (FILE*)file);
+
+  return result > 0
+    ? result
+    : result == 0
+    ? -1
+    : -2;
+}

--- a/include/shared.c
+++ b/include/shared.c
@@ -953,16 +953,6 @@ void fzE_date_time(void * result)
 }
 
 
-int64_t fzE_file_read(void * file, void * buf, int32_t size)
-{
-  size_t result = fread(buf, 1, size, (FILE*)file);
-  return ferror((FILE*)file)!=0
-    ? -2
-    : result==0 && feof((FILE*)file)!=0
-    ? -1
-    : (int64_t)result;
-}
-
 int64_t fzE_file_write(void * file, void * buf, int32_t size)
 {
   size_t result = fwrite(buf, 1, size, (FILE*)file);

--- a/include/win.c
+++ b/include/win.c
@@ -45,6 +45,7 @@ Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
 #include <time.h>
 
 // NYI remove POSIX imports
+#include <poll.h>
 #include <fcntl.h>      // fcntl
 
 #include <winsock2.h>

--- a/include/win.c
+++ b/include/win.c
@@ -937,10 +937,8 @@ int32_t fzE_file_read(void * file, void * buf, int32_t size)
   fds.fd = fileno(file);
   fds.events = POLLIN;
 
-  int ten_seconds = 10000;
-
   // NYI: poll is Posix only
-  while(poll(&fds, 1, ten_seconds) == 0);
+  while(poll(&fds, 1, -1) == 0);
 
   size_t result = fread(buf, 1, size, (FILE*)file);
 

--- a/include/win.c
+++ b/include/win.c
@@ -580,6 +580,8 @@ void fzE_init()
   _setmode( _fileno( stdout ), _O_BINARY ); // reopen stdout in binary mode
   _setmode( _fileno( stderr ), _O_BINARY ); // reopen stderr in binary mode
 
+  fcntl( _fileno( stdin ), F_SETFL, O_NONBLOCK);
+
 #ifdef FUZION_ENABLE_THREADS
   pthread_mutexattr_t attr;
   fzE_memset(&fzE_global_mutex, 0, sizeof(fzE_global_mutex));
@@ -930,11 +932,8 @@ void fzE_cnd_destroy(void *cnd) {
 
 int32_t fzE_file_read(void * file, void * buf, int32_t size)
 {
-  int fno = fileno(file);
-  fcntl(fno, F_SETFL, O_NONBLOCK);
-
   struct pollfd fds;
-  fds.fd = fno;
+  fds.fd = fileno(file);
   fds.events = POLLIN;
 
   int ten_seconds = 10000;
@@ -947,6 +946,6 @@ int32_t fzE_file_read(void * file, void * buf, int32_t size)
   return result > 0
     ? result
     : result == 0
-    ? -1
-    : -2;
+    ? -1  // EOF
+    : -2; // ERROR
 }

--- a/include/win.c
+++ b/include/win.c
@@ -926,3 +926,27 @@ void fzE_cnd_destroy(void *cnd) {
 #else
 #endif
 }
+
+
+int64_t fzE_file_read(void * file, void * buf, int32_t size)
+{
+  int fno = fileno(file);
+  fcntl(fno, F_SETFL, O_NONBLOCK);
+
+  struct pollfd fds;
+  fds.fd = fno;
+  fds.events = POLLIN;
+
+  int ten_seconds = 10000;
+
+  // NYI: poll is Posix only
+  while(poll(&fds, 1, ten_seconds) == 0);
+
+  size_t result = fread(buf, 1, size, (FILE*)file);
+
+  return result > 0
+    ? result
+    : result == 0
+    ? -1
+    : -2;
+}

--- a/modules/base/src/fuzion_runtime_init.fz
+++ b/modules/base/src/fuzion_runtime_init.fz
@@ -1,0 +1,28 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion standard library feature fuzion_runtime_init
+#
+# -----------------------------------------------------------------------
+
+# platform specific initialisation
+# of the fuzion runtime system
+#
+fuzion_runtime_init =>
+  fzE_init

--- a/modules/base/src/native.fz
+++ b/modules/base/src/native.fz
@@ -21,6 +21,13 @@
 #
 # -----------------------------------------------------------------------
 
+
+# platform specific initialisation
+# of the fuzion runtime system
+#
+module fzE_init unit => native
+
+
 # returns the latest error number of
 # the current thread
 #

--- a/src/dev/flang/ast/Impl.java
+++ b/src/dev/flang/ast/Impl.java
@@ -696,6 +696,20 @@ public class Impl extends ANY
     return result;
   }
 
+
+  /**
+   * Add initial call to the expression of
+   * this implementation.
+   */
+  public void addInitialCall(AbstractCall ac)
+  {
+    if (PRECONDITIONS) require
+      (ac.type().compareTo(Types.resolved.t_unit) == 0,
+       ac.calledFeature().resultType().compareTo(Types.resolved.t_unit) == 0);
+
+    _expr = new Block(new List<>(ac, _expr));
+  }
+
 }
 
 /* end of file */

--- a/src/dev/flang/be/c/C.java
+++ b/src/dev/flang/be/c/C.java
@@ -1118,8 +1118,6 @@ public class C extends ANY
 
     cf.println("int main(int argc, char **argv) { ");
 
-    cf.println("fzE_init();");
-
     cf.print(initializeEffectsEnvironment());
 
     var cl = _fuir.mainClazz();

--- a/src/dev/flang/fe/SourceModule.java
+++ b/src/dev/flang/fe/SourceModule.java
@@ -284,8 +284,12 @@ public class SourceModule extends Module implements SrcModule
     var d = _main == null
       ? _universe
       : lookupFeature(_universe, FeatureName.get(_main, 0), null);
-    ((Feature) d).impl()
-      .addInitialCall(fuzionRuntimeInitCall);
+    if (d != null)
+      {
+        ((Feature) d)
+          .impl()
+          .addInitialCall(fuzionRuntimeInitCall);
+      }
   }
 
 

--- a/src/dev/flang/fe/SourceModule.java
+++ b/src/dev/flang/fe/SourceModule.java
@@ -61,6 +61,7 @@ import dev.flang.ast.Resolution;
 import dev.flang.ast.SrcModule;
 import dev.flang.ast.State;
 import dev.flang.ast.Types;
+import dev.flang.ast.Universe;
 import dev.flang.ast.Visi;
 
 import dev.flang.parser.Parser;
@@ -258,6 +259,33 @@ public class SourceModule extends Module implements SrcModule
     findDeclarations(_universe, null);
     _universe.scheduleForResolution(_res);
     _res.resolve();
+    addRuntimeInitCall();
+  }
+
+
+  /**
+   * Add call at beginnig of application
+   * to initialize the fuzion runtime system
+   */
+  private void addRuntimeInitCall()
+  {
+    var fuzionRuntimeInitCall = new AbstractCall() {
+      @Override public SourcePosition pos() { return SourcePosition.notAvailable; }
+      @Override public List<AbstractType> actualTypeParameters() { return NO_GENERICS; }
+      @Override public AbstractFeature calledFeature() { return lookupFeature(_universe, FeatureName.get("fuzion_runtime_init", 0), null); }
+      @Override public Expr target() { return new Universe(); }
+      @Override public AbstractType type() { return Types.resolved.t_unit; }
+      @Override public List<Expr> actuals() { return NO_EXPRS; }
+      @Override public int select() { return -1; }
+      @Override public boolean isInheritanceCall() { return false; }
+      @Override public Expr visit(FeatureVisitor v, AbstractFeature outer) { v.action(this); return this; }
+    };
+
+    var d = _main == null
+      ? _universe
+      : lookupFeature(_universe, FeatureName.get(_main, 0), null);
+    ((Feature) d).impl()
+      .addInitialCall(fuzionRuntimeInitCall);
   }
 
 


### PR DESCRIPTION
This gist of this fix is that we set `stdin` to none blocking then use `poll` when reading to wait until input is available.
This way we can read line by line from stdin since stdin is usually line buffered. No Ctrl-D necessary anymore.
This will probably not work on Windows.

fixes #4531 