### PR TITLE
ast: forbid setting `private` visibility on arguments of function features

### DIFF
--- a/src/dev/flang/ast/Function.java
+++ b/src/dev/flang/ast/Function.java
@@ -282,7 +282,7 @@ public class Function extends AbstractLambda
         for (var n : _names)
           {
             var arg = new Feature(n._pos,
-                                  Visi.PRIV,
+                                  Visi.UNSPECIFIED,
                                   0,
                                   i < gs.size() ? gs.get(i) : Types.t_ERROR,
                                   n._name,

--- a/src/dev/flang/ast/UnresolvedType.java
+++ b/src/dev/flang/ast/UnresolvedType.java
@@ -1019,8 +1019,9 @@ public abstract class UnresolvedType extends AbstractType implements HasSourcePo
     if (CHECKS) check
       (outer.isValueArgument());
 
+    var outOut = context.outerFeature().outer();
     var tp = new Feature(pos(),
-                         outer.visibility(),
+                         (outOut.isRoutine() || outOut.isIntrinsic() || outOut.isNative()) ? Visi.UNSPECIFIED : outer.visibility(),
                          0,
                          freeTypeConstraint().resolve(res, context),
                          _name,

--- a/src/dev/flang/fe/SourceModule.java
+++ b/src/dev/flang/fe/SourceModule.java
@@ -1718,9 +1718,10 @@ A feature that is a constructor, choice or a type parameter may not redefine an 
   {
     if (
         f.isArgument()
+     && !f.outer().featureName().isInternal()
      && !f.outer().definesType()
      && !f.outer().isCotype()
-     && f.visibility() != Visi.PRIV
+     && f.isVisibilitySpecified()
     )
       {
         AstErrors.illegalVisibilityArgument(f);


### PR DESCRIPTION
`public` is already forbidden, arguments are private by default

fix #4886