### PR TITLE
ast: forbid setting argument visibility on non constructor features

### DIFF
--- a/src/dev/flang/ast/Feature.java
+++ b/src/dev/flang/ast/Feature.java
@@ -702,6 +702,18 @@ public class Feature extends AbstractFeature
   {
     this(qpname.getLast()._pos, v, m, r, qpname.map2(x -> x._name), a, i, c, p);
 
+    // arguments of function features must not have visibility modifier
+    if (!isConstructor())
+      {
+        for (var arg : a)
+          {
+            if (arg instanceof Feature f && f.isVisibilitySpecified())
+              {
+                AstErrors.illegalVisibilityArgument(f);
+              }
+          }
+      }
+
     _effects = effects;
 
     if (PRECONDITIONS) require

--- a/src/dev/flang/fe/SourceModule.java
+++ b/src/dev/flang/fe/SourceModule.java
@@ -1688,7 +1688,6 @@ A feature that is a constructor, choice or a type parameter may not redefine an 
     checkRedefVisibility(f);
     checkLegalTypeVisibility(f);
     checkResultTypeVisibility(f);
-    checkArgVisibility(f);
     checkArgTypesVisibility(f);
     checkPreconditionVisibility(f);
     checkAbstractVisibility(f);
@@ -1739,24 +1738,6 @@ A feature that is a constructor, choice or a type parameter may not redefine an 
   private boolean inTypeFeature(AbstractFeature f)
   {
     return f.isTypeFeature() || (f.outer() != null && inTypeFeature(f.outer()));
-  }
-
-
-  /*
-   * check that arguments of functions etc.
-   * do not have visibility modifier.
-   */
-  private void checkArgVisibility(Feature f)
-  {
-    if (
-        f.isArgument()
-     && !f.outer().definesType()
-     && !f.outer().isCotype()
-     && f.visibility() != Visi.PRIV
-    )
-      {
-        AstErrors.illegalVisibilityArgument(f);
-      }
   }
 
 

--- a/tests/function_argument_visibility/Makefile
+++ b/tests/function_argument_visibility/Makefile
@@ -1,0 +1,25 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test Makefile
+#
+# -----------------------------------------------------------------------
+
+override NAME = function_argument_visibility
+include ../simple.mk

--- a/tests/function_argument_visibility/Makefile
+++ b/tests/function_argument_visibility/Makefile
@@ -22,4 +22,4 @@
 # -----------------------------------------------------------------------
 
 override NAME = function_argument_visibility
-include ../simple.mk
+include ../simple_and_negative.mk

--- a/tests/function_argument_visibility/function_argument_visibility.fz
+++ b/tests/function_argument_visibility/function_argument_visibility.fz
@@ -36,16 +36,16 @@ function_argument_visibility =>
   # NEGATIVE TESTS
   # specifying a visibility for arguments of non constructor features should cause an error
 
-  f1(public a i32) =>
+  f1(public a i32) =>    # 1. should flag an error: Argument features of non-constructors must not have visibility modifier.
 
-  f2(module b String) =>
+  f2(module b String) => # 2. should flag an error: Argument features of non-constructors must not have visibility modifier.
 
-  f3(private c Any) =>
+  f3(private c Any) =>   # 3. should flag an error: Argument features of non-constructors must not have visibility modifier.
 
-  f4(x1 i32, public a i32, module b String, x2 i32, private c Any) =>
+  f4(x1 i32, public a i32, module b String, x2 i32, private c Any) => # 4. 5. 6. should flag an error: Argument features of non-constructors must not have visibility modifier.
 
-  f5(public a i32) Any => abstract
+  f5(public a i32) Any => abstract  # 7. should flag an error: Argument features of non-constructors must not have visibility modifier.
 
-  f6(public a i32) Any => intrinsic
+  f6(public a i32) Any => intrinsic # 8. should flag an error: Argument features of non-constructors must not have visibility modifier.
 
-  f7(public a i32) i32 => native
+  f7(public a i32) i32 => native    # 9. should flag an error: Argument features of non-constructors must not have visibility modifier.

--- a/tests/function_argument_visibility/function_argument_visibility.fz
+++ b/tests/function_argument_visibility/function_argument_visibility.fz
@@ -1,0 +1,51 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test function_argument_visibility
+#
+# -----------------------------------------------------------------------
+
+function_argument_visibility =>
+
+  # POSITIVE TEST
+
+  # constructor features can have visibility for arguments
+  constr(public a i32, module b String, private c Any, d i64) is
+
+  # no visibility specified
+  f0(x i32) =>
+
+
+
+  # NEGATIVE TESTS
+  # specifying a visibility for arguments of non constructor features should cause an error
+
+  f1(public a i32) =>
+
+  f2(module b String) =>
+
+  f3(private c Any) =>
+
+  f4(x1 i32, public a i32, module b String, x2 i32, private c Any) =>
+
+  f5(public a i32) Any => abstract
+
+  f6(public a i32) Any => intrinsic
+
+  f7(public a i32) i32 => native

--- a/tests/function_argument_visibility/function_argument_visibility.fz.expected_err
+++ b/tests/function_argument_visibility/function_argument_visibility.fz.expected_err
@@ -1,54 +1,54 @@
 
 --CURDIR--/function_argument_visibility.fz:39:13: error 1: Argument features of non-constructors must not have visibility modifier.
-  f1(public a i32) =>
+  f1(public a i32) =>    # 1. should flag an error: Argument features of non-constructors must not have visibility modifier.
 ------------^
 To solve this, remove the visibility modifier 'public' from feature 'a'.
 
 
 --CURDIR--/function_argument_visibility.fz:41:13: error 2: Argument features of non-constructors must not have visibility modifier.
-  f2(module b String) =>
+  f2(module b String) => # 2. should flag an error: Argument features of non-constructors must not have visibility modifier.
 ------------^
 To solve this, remove the visibility modifier 'module' from feature 'b'.
 
 
 --CURDIR--/function_argument_visibility.fz:43:14: error 3: Argument features of non-constructors must not have visibility modifier.
-  f3(private c Any) =>
+  f3(private c Any) =>   # 3. should flag an error: Argument features of non-constructors must not have visibility modifier.
 -------------^
 To solve this, remove the visibility modifier 'private' from feature 'c'.
 
 
 --CURDIR--/function_argument_visibility.fz:45:21: error 4: Argument features of non-constructors must not have visibility modifier.
-  f4(x1 i32, public a i32, module b String, x2 i32, private c Any) =>
+  f4(x1 i32, public a i32, module b String, x2 i32, private c Any) => # 4. 5. 6. should flag an error: Argument features of non-constructors must not have visibility modifier.
 --------------------^
 To solve this, remove the visibility modifier 'public' from feature 'a'.
 
 
 --CURDIR--/function_argument_visibility.fz:45:35: error 5: Argument features of non-constructors must not have visibility modifier.
-  f4(x1 i32, public a i32, module b String, x2 i32, private c Any) =>
+  f4(x1 i32, public a i32, module b String, x2 i32, private c Any) => # 4. 5. 6. should flag an error: Argument features of non-constructors must not have visibility modifier.
 ----------------------------------^
 To solve this, remove the visibility modifier 'module' from feature 'b'.
 
 
 --CURDIR--/function_argument_visibility.fz:45:61: error 6: Argument features of non-constructors must not have visibility modifier.
-  f4(x1 i32, public a i32, module b String, x2 i32, private c Any) =>
+  f4(x1 i32, public a i32, module b String, x2 i32, private c Any) => # 4. 5. 6. should flag an error: Argument features of non-constructors must not have visibility modifier.
 ------------------------------------------------------------^
 To solve this, remove the visibility modifier 'private' from feature 'c'.
 
 
 --CURDIR--/function_argument_visibility.fz:47:13: error 7: Argument features of non-constructors must not have visibility modifier.
-  f5(public a i32) Any => abstract
+  f5(public a i32) Any => abstract  # 7. should flag an error: Argument features of non-constructors must not have visibility modifier.
 ------------^
 To solve this, remove the visibility modifier 'public' from feature 'a'.
 
 
 --CURDIR--/function_argument_visibility.fz:49:13: error 8: Argument features of non-constructors must not have visibility modifier.
-  f6(public a i32) Any => intrinsic
+  f6(public a i32) Any => intrinsic # 8. should flag an error: Argument features of non-constructors must not have visibility modifier.
 ------------^
 To solve this, remove the visibility modifier 'public' from feature 'a'.
 
 
 --CURDIR--/function_argument_visibility.fz:51:13: error 9: Argument features of non-constructors must not have visibility modifier.
-  f7(public a i32) i32 => native
+  f7(public a i32) i32 => native    # 9. should flag an error: Argument features of non-constructors must not have visibility modifier.
 ------------^
 To solve this, remove the visibility modifier 'public' from feature 'a'.
 

--- a/tests/function_argument_visibility/function_argument_visibility.fz.expected_err
+++ b/tests/function_argument_visibility/function_argument_visibility.fz.expected_err
@@ -1,0 +1,55 @@
+
+--CURDIR--/function_argument_visibility.fz:39:13: error 1: Argument features of non-constructors must not have visibility modifier.
+  f1(public a i32) =>
+------------^
+To solve this, remove the visibility modifier 'public' from feature 'a'.
+
+
+--CURDIR--/function_argument_visibility.fz:41:13: error 2: Argument features of non-constructors must not have visibility modifier.
+  f2(module b String) =>
+------------^
+To solve this, remove the visibility modifier 'module' from feature 'b'.
+
+
+--CURDIR--/function_argument_visibility.fz:43:14: error 3: Argument features of non-constructors must not have visibility modifier.
+  f3(private c Any) =>
+-------------^
+To solve this, remove the visibility modifier 'private' from feature 'c'.
+
+
+--CURDIR--/function_argument_visibility.fz:45:21: error 4: Argument features of non-constructors must not have visibility modifier.
+  f4(x1 i32, public a i32, module b String, x2 i32, private c Any) =>
+--------------------^
+To solve this, remove the visibility modifier 'public' from feature 'a'.
+
+
+--CURDIR--/function_argument_visibility.fz:45:35: error 5: Argument features of non-constructors must not have visibility modifier.
+  f4(x1 i32, public a i32, module b String, x2 i32, private c Any) =>
+----------------------------------^
+To solve this, remove the visibility modifier 'module' from feature 'b'.
+
+
+--CURDIR--/function_argument_visibility.fz:45:61: error 6: Argument features of non-constructors must not have visibility modifier.
+  f4(x1 i32, public a i32, module b String, x2 i32, private c Any) =>
+------------------------------------------------------------^
+To solve this, remove the visibility modifier 'private' from feature 'c'.
+
+
+--CURDIR--/function_argument_visibility.fz:47:13: error 7: Argument features of non-constructors must not have visibility modifier.
+  f5(public a i32) Any => abstract
+------------^
+To solve this, remove the visibility modifier 'public' from feature 'a'.
+
+
+--CURDIR--/function_argument_visibility.fz:49:13: error 8: Argument features of non-constructors must not have visibility modifier.
+  f6(public a i32) Any => intrinsic
+------------^
+To solve this, remove the visibility modifier 'public' from feature 'a'.
+
+
+--CURDIR--/function_argument_visibility.fz:51:13: error 9: Argument features of non-constructors must not have visibility modifier.
+  f7(public a i32) i32 => native
+------------^
+To solve this, remove the visibility modifier 'public' from feature 'a'.
+
+9 errors.


### PR DESCRIPTION
except for `private` this is already forbidden
function arguments are private by default

fix #4886