### PR TITLE
time: add skeleton implementation for `calendar_duration`

### DIFF
--- a/modules/base/src/time/calendar_duration.fz
+++ b/modules/base/src/time/calendar_duration.fz
@@ -59,6 +59,8 @@ is
 
   # this duration and another one combined
   #
+  # NYI overflow handling
+  #
   public infix + (other calendar_duration) =>
     calendar_duration
       (years + other.years)
@@ -71,6 +73,8 @@ is
 
 
   # this duration multiplied by n
+  #
+  # NYI overflow handling
   #
   public infix * (n u64) =>
     calendar_duration


### PR DESCRIPTION
A calendar duration represents a duration in the ISO 8601 calendar.