### PR TITLE
cleanup: replace nested `match`es in `nom` with `.bind`

### DIFF
--- a/modules/nom/src/nom.fz
+++ b/modules/nom/src/nom.fz
@@ -45,12 +45,10 @@ public nom is
     #
     public map(OM type, mapper O -> outcome OM) Parser I R OM =>
       parser I R OM i->
-        match Parser.this.call i
-          s success =>
-            match mapper s.out
-              o OM => success s.rest o
-              e2 error => e2
-          e1 error => e1
+        Parser.this.call i .bind2 s->
+          id (parse_result R OM) (match mapper s.out
+                                    o OM => success s.rest o
+                                    e2 error => e2)
 
 
     # map input to parser p
@@ -87,3 +85,6 @@ public nom is
   # the result of Parser.call()
   #
   public parse_result(I, O type) : outcome (success I O) is
+    public bind2(f (success I O) -> parse_result I2 O2) parse_result I2 O2 =>
+      parse_result.this ? v (success I O) => f v
+                        | e error => e

--- a/modules/nom/src/nom/multi.fz
+++ b/modules/nom/src/nom/multi.fz
@@ -35,9 +35,8 @@ module multi is
   #
   public many1 (I, O type, p Parser I I O) =>
     parser I I (Sequence O) input->
-      match p.call input
-        _ success I O => (many0 p).call input
-        e error => e
+      p.call input .bind2 _->
+        (many0 p).call input
 
 
   # apply parser between m and n times, return results as sequence
@@ -79,10 +78,8 @@ module multi is
   #
   public separated_list1(I, O, D type, p_sep Parser I I D, p_value () -> (Parser I I O)) =>
     parse(input I) parse_result I (Sequence O) =>
-      match p_value().call input
-        s1 success =>
-          match (many0 (sequence.preceded p_sep p_value())).call s1.rest
-            s2 success => success s2.rest [s1.out]++s2.out
-            error => panic "invalid state, many0 always succeeds"
-        e error => e
+      p_value().call input .bind2 s1->
+        match (many0 (sequence.preceded p_sep p_value())).call s1.rest
+          s2 success => id (parse_result I (Sequence O)) (success s2.rest [s1.out]++s2.out)
+          error => panic "invalid state, many0 always succeeds"
     parser I _ _ (input -> parse input)

--- a/modules/nom/src/nom/sequence.fz
+++ b/modules/nom/src/nom/sequence.fz
@@ -21,13 +21,9 @@ module sequence is
   #
   public tuple2(I, O1, O2 type, p1 Parser I I O1, p2 Parser I I O2) =>
     parse(input I) parse_result I (tuple O1 O2) =>
-      match p1.call input
-        s1 success I O1 =>
-          match p2.call s1.rest
-            s2 success I O2 =>
-              success s2.rest (s1.out, s2.out)
-            e2 error => e2
-        e1 error => e1
+      p1.call input .bind2 s1->
+        p2.call s1.rest .bind2 s2->
+          id (parse_result I (tuple O1 O2)) (success s2.rest (s1.out, s2.out))
     parser I _ _ (input -> parse input)
 
 
@@ -35,15 +31,11 @@ module sequence is
   #
   public tuple3(I, O1, O2, O3 type, p1 Parser I I O1, p2 Parser I I O2, p3 Parser I I O3) =>
     parse(input I) parse_result I (tuple O1 O2 O3) =>
-      match p1.call input
-        s1 success I O1 =>
-          match p2.call s1.rest
-            s2 success I O2 =>
-              match p3.call s2.rest
-                s3 success I O3 => success s3.rest (s1.out, s2.out, s3.out)
-                e3 error => e3
-            e2 error => e2
-        e1 error => e1
+      p1.call input .bind2 s1->
+        p2.call s1.rest .bind2 s2->
+          p3.call s2.rest .bind2 s3->
+            id (parse_result I (tuple O1 O2 O3)) (success s3.rest (s1.out, s2.out, s3.out))
+
     parser I _ _ (input -> parse input)
 
 
@@ -56,18 +48,11 @@ module sequence is
     p4 Parser I I O4
     ) =>
     parse(input I) parse_result I (tuple O1 O2 O3 O4) =>
-      match p1.call input
-        s1 success I O1 =>
-          match p2.call s1.rest
-            s2 success I O2 =>
-              match p3.call s2.rest
-                s3 success I O3 =>
-                  match p4.call s3.rest
-                    s4 success I O4 => success s4.rest (s1.out, s2.out, s3.out, s4.out)
-                    e4 error => e4
-                e3 error => e3
-            e2 error => e2
-        e1 error => e1
+      p1.call input .bind2 s1->
+        p2.call s1.rest .bind2 s2->
+          p3.call s2.rest .bind2 s3->
+            p4.call s3.rest .bind2 s4->
+              id (parse_result I (tuple O1 O2 O3 O4)) (success s4.rest (s1.out, s2.out, s3.out, s4.out))
     parser I _ _ (input -> parse input)
 
 
@@ -75,10 +60,8 @@ module sequence is
   #
   public preceded(I, O1, O2 type, p1 Parser I I O1, p2 Parser I I O2) =>
     parse(input I) parse_result I O2 =>
-      match p1.call input
-        s1 success I O1 =>
-          p2.call s1.rest
-        e1 error => e1
+      p1.call input .bind2 s1->
+        p2.call s1.rest
     parser I _ _ (input -> parse input)
 
 
@@ -86,15 +69,10 @@ module sequence is
   #
   public delimited(I, O1, O2, O3 type, p1 Parser I I O1, p2 Parser I I O2, p3 Parser I I O3) =>
     parse(input I) parse_result I O2 =>
-      match p1.call input
-        s1 success I O1 =>
-          match p2.call s1.rest
-            s2 success I O2 =>
-              match p3.call s2.rest
-                s3 success I O3 => success s3.rest s2.out
-                e3 error => e3
-            e2 error => e2
-        e1 error => e1
+      p1.call input .bind2 s1->
+        p2.call s1.rest .bind2 s2->
+          p3.call s2.rest .bind2 s3->
+            id (parse_result I O2) (success s3.rest s2.out)
     parser I _ _ (input -> parse input)
 
 
@@ -102,13 +80,7 @@ module sequence is
   #
   public separated_pair(I type, R1, R2, R3, O1, O2, O3 type, p1 Parser I R1 O1, p_sep Parser R1 R2 O2, p2 () -> (Parser R2 R3 O3)) =>
     parser I R3 (tuple O1 O3) input->
-      match p1.call input
-        s1 success =>
-          match p_sep.call s1.rest
-            s2 success =>
-              match p2().call s2.rest
-                s3 success => success s3.rest (s1.out, s3.out)
-                e3 error => e3
-            e2 error => e2
-        e1 error => e1
-
+      p1.call input .bind2 s1->
+         p_sep.call s1.rest .bind2 s2->
+           p2().call s2.rest .bind2 s3->
+             id (parse_result R3 (tuple O1 O3)) (success s3.rest (s1.out, s3.out))


### PR DESCRIPTION
fix #4821