### PR TITLE
tests: fix typo and improve output of baseXX encoding tests

### DIFF
--- a/tests/base16/base16_test.fz
+++ b/tests/base16/base16_test.fz
@@ -58,7 +58,7 @@ base16_test is
   # ENCODING
 
   say """
-      Testing base16 encoding..."""
+      Testing base16 encoding:"""
 
   enc_test(test_vectors array (tuple my_c String), name String) =>
     for results := (Sequence (outcome String)).empty, results.concat (out:nil)
@@ -95,7 +95,7 @@ base16_test is
 
   say """
       \n
-      Testing base16 decoding..."""
+      Testing base16 decoding:"""
   dec_test(test_vectors array (tuple my_c String), name String) =>
     for results := (Sequence (outcome String)).empty, results.concat (out:nil)
         tup in test_vectors
@@ -135,7 +135,7 @@ base16_test is
 
   say """
       \n
-      Test error messages when decoding broken base16...
+      Test error messages when decoding broken base16:
       """
 
   broken_enc := ["66\r6F6F",   # carriage return

--- a/tests/base16/base16_test.fz.expected_out
+++ b/tests/base16/base16_test.fz.expected_out
@@ -1,14 +1,14 @@
-Testing base16 encoding...
+Testing base16 encoding:
 RFC 4648 test vectors are encoded correctly
 Additional test vectors are encoded correctly
 
 
-Testing base16 decoding...
+Testing base16 decoding:
 RFC 4648 test vectors are decoded correctly
 Additional test vectors are decoded correctly
 
 
-Test error messages when decoding broken base16...
+Test error messages when decoding broken base16:
 
 666F6F: error: line breaks are not allowed within encoded data, as required by RFC464, found CR at position 2
 6

--- a/tests/base32/base32_test.fz
+++ b/tests/base32/base32_test.fz
@@ -60,7 +60,7 @@ base32_test is
   # ENCODING
 
   say """
-      Testing base32 encoding..."""
+      Testing base32 encoding:"""
 
   enc_test(test_vectors array (tuple my_c String), name String) =>
     for results := (Sequence (outcome String)).empty, results.concat (out:nil)
@@ -97,7 +97,7 @@ base32_test is
 
   say """
       \n
-      Testing base32 decoding..."""
+      Testing base32 decoding:"""
   dec_test(test_vectors array (tuple my_c String), name String) =>
     for results := (Sequence (outcome String)).empty, results.concat (out:nil)
         tup in test_vectors
@@ -137,7 +137,7 @@ base32_test is
 
   say """
       \n
-      Test error messages when decoding broken base32...
+      Test error messages when decoding broken base32:
       """
 
   broken_enc := ["""

--- a/tests/base32/base32_test.fz.expected_out
+++ b/tests/base32/base32_test.fz.expected_out
@@ -1,14 +1,14 @@
-Testing base32 encoding...
+Testing base32 encoding:
 RFC 4648 test vectors are encoded correctly
 Additional test vectors are encoded correctly
 
 
-Testing base32 decoding...
+Testing base32 decoding:
 RFC 4648 test vectors are decoded correctly
 Additional test vectors are decoded correctly
 
 
-Test error messages when decoding broken base32...
+Test error messages when decoding broken base32:
 
 MZXW
 6===: error: line breaks are not allowed within encoded data, as required by RFC464, found LF at position 4

--- a/tests/base32hex/base32hex_test.fz
+++ b/tests/base32hex/base32hex_test.fz
@@ -60,7 +60,7 @@ base32hex_test is
   # ENCODING
 
   say """
-      Testing base32hex encoding..."""
+      Testing base32hex encoding:"""
 
   enc_test(test_vectors array (tuple my_c String), name String) =>
     for results := (Sequence (outcome String)).empty, results.concat (out:nil)
@@ -97,7 +97,7 @@ base32hex_test is
 
   say """
       \n
-      Testing base32hex decoding..."""
+      Testing base32hex decoding:"""
   dec_test(test_vectors array (tuple my_c String), name String) =>
     for results := (Sequence (outcome String)).empty, results.concat (out:nil)
         tup in test_vectors
@@ -137,7 +137,7 @@ base32hex_test is
 
   say """
       \n
-      Test error messages when decoding broken base32hex...
+      Test error messages when decoding broken base32hex:
       """
 
   broken_enc := ["""

--- a/tests/base32hex/base32hex_test.fz.expected_out
+++ b/tests/base32hex/base32hex_test.fz.expected_out
@@ -1,14 +1,14 @@
-Testing base32hex encoding...
+Testing base32hex encoding:
 RFC 4648 test vectors are encoded correctly
 Additional test vectors are encoded correctly
 
 
-Testing base32hex decoding...
+Testing base32hex decoding:
 RFC 4648 test vectors are decoded correctly
 Additional test vectors are decoded correctly
 
 
-Test error messages when decoding broken base32hex...
+Test error messages when decoding broken base32hex:
 
 CPN
 MU===: error: line breaks are not allowed within encoded data, as required by RFC464, found LF at position 3

--- a/tests/base64/base64_test.fz
+++ b/tests/base64/base64_test.fz
@@ -63,7 +63,7 @@ base64_test is
   # ENCODING
 
   say """
-      Testing base64 encoding..."""
+      Testing base64 encoding:"""
 
 
   enc_test(test_vectors array (tuple my_c String), name String) =>
@@ -101,7 +101,7 @@ base64_test is
 
   say """
       \n
-      Testing base64 decoding..."""
+      Testing base64 decoding:"""
   dec_test(test_vectors array (tuple my_c String), name String) =>
     for results := (Sequence (outcome String)).empty, results.concat (out:nil)
         tup in test_vectors
@@ -140,7 +140,7 @@ base64_test is
 
   say """
       \n
-      Test error messages when decoding broken base32...
+      Test error messages when decoding broken base64:
       """
 
   broken_enc := ["""

--- a/tests/base64/base64_test.fz.expected_out
+++ b/tests/base64/base64_test.fz.expected_out
@@ -1,14 +1,14 @@
-Testing base64 encoding...
+Testing base64 encoding:
 RFC 4648 test vectors are encoded correctly
 Additional test vectors are encoded correctly
 
 
-Testing base64 decoding...
+Testing base64 decoding:
 RFC 4648 test vectors are decoded correctly
 Additional test vectors are decoded correctly
 
 
-Test error messages when decoding broken base32...
+Test error messages when decoding broken base64:
 
 Zm9v
 Yg==: error: line breaks are not allowed within encoded data, as required by RFC464, found LF at position 4

--- a/tests/base64url/base64url_test.fz
+++ b/tests/base64url/base64url_test.fz
@@ -63,7 +63,7 @@ base64url_test is
   # ENCODING
 
   say """
-      Testing base64url encoding..."""
+      Testing base64url encoding:"""
 
 
   enc_test(test_vectors array (tuple my_c String), name String) =>
@@ -101,7 +101,7 @@ base64url_test is
 
   say """
       \n
-      Testing base64url decoding..."""
+      Testing base64url decoding:"""
   dec_test(test_vectors array (tuple my_c String), name String) =>
     for results := (Sequence (outcome String)).empty, results.concat (out:nil)
         tup in test_vectors
@@ -140,7 +140,7 @@ base64url_test is
 
   say """
       \n
-      Test error messages when decoding broken base32...
+      Test error messages when decoding broken base64url:
       """
 
   broken_enc := ["""

--- a/tests/base64url/base64url_test.fz.expected_out
+++ b/tests/base64url/base64url_test.fz.expected_out
@@ -1,14 +1,14 @@
-Testing base64url encoding...
+Testing base64url encoding:
 RFC 4648 test vectors are encoded correctly
 Additional test vectors are encoded correctly
 
 
-Testing base64url decoding...
+Testing base64url decoding:
 RFC 4648 test vectors are decoded correctly
 Additional test vectors are decoded correctly
 
 
-Test error messages when decoding broken base32...
+Test error messages when decoding broken base64url:
 
 Zm9v
 Yg==: error: line breaks are not allowed within encoded data, as required by RFC464, found LF at position 4


### PR DESCRIPTION
found this old branch that I apparently forgot to merge