### PR TITLE
fe: don't inherit visibility for redefinitions when no visibility is specified

### DIFF
--- a/modules/base/src/Cons.fz
+++ b/modules/base/src/Cons.fz
@@ -38,4 +38,4 @@ public Cons(public A, B type) ref is
 #
 # A cons is a cell that contains a head and a tail
 #
-public cons(A, B type, redef head A, redef tail B) : Cons A B is
+public cons(A, B type, public redef head A, public redef tail B) : Cons A B is

--- a/modules/base/src/Sequence.fz
+++ b/modules/base/src/Sequence.fz
@@ -1111,8 +1111,8 @@ public Sequence(public T type) ref : property.countable is
         nil     => (id (Sequence T) Sequence.this) : nil  # NYI: With better type propagation, this could be `Sequence.this : nil` or `[Sequence.this].as_list`
         idx i32 =>
           ref : Cons (Sequence T) (list (Sequence T))
-            redef head Sequence T := take (if split_after then idx + s.count else idx)
-            redef tail =>
+            public redef head Sequence T := take (if split_after then idx + s.count else idx)
+            public redef tail =>
               rest := drop (idx + s.count)
 
               match limit
@@ -1453,11 +1453,11 @@ public Sequence(public T type) ref : property.countable is
 
       # associative operation
       #
-      redef infix ∙ (a, b Sequence T) Sequence T => a.concat b
+      public redef infix ∙ (a, b Sequence T) Sequence T => a.concat b
 
       # identity element
       #
-      redef e Sequence T =>
+      public redef e Sequence T =>
         (list T).empty
 
 

--- a/modules/base/src/String.fz
+++ b/modules/base/src/String.fz
@@ -60,7 +60,7 @@ public String ref : property.equatable, property.hashable, property.orderable is
     n ≥ 0
     # NYI String.this.utf8.finite, Strings where utf8 is a list are currently always infinite.
   is
-    redef utf8 Sequence u8 =>
+    public redef utf8 Sequence u8 =>
       bytes := String.this.utf8
       bytes.cycle.take (bytes.count * n)
 
@@ -312,8 +312,8 @@ public String ref : property.equatable, property.hashable, property.orderable is
         # return list of c and rest
         ret(c outcome codepoint, rest list u8) list (outcome codepoint) =>
           ref : Cons (outcome codepoint) (list (outcome codepoint))
-            redef head => c
-            redef tail => codepoints_and_errors rest
+            public redef head => c
+            public redef tail => codepoints_and_errors rest
 
         p := codepoint.type
         e(msg String) => error "Bad UTF8 encoding found: cannot decode $msg"
@@ -516,8 +516,8 @@ public String ref : property.equatable, property.hashable, property.orderable is
       h :=  String.from_bytes (l.take_while (c -> !c.is_ascii_white_space)).as_array
       t := (String.from_bytes (l.drop_while (c -> !c.is_ascii_white_space))).split
       ref : Cons String (list String)
-        redef head => h
-        redef tail => t
+        public redef head => h
+        public redef tail => t
 
 
   # split string at s
@@ -781,8 +781,8 @@ public String ref : property.equatable, property.hashable, property.orderable is
   #
   public type.concat =>
     ref : Monoid String
-      redef infix ∙ (a, b String) => a + b
-      redef e => ""
+      public redef infix ∙ (a, b String) => a + b
+      public redef e => ""
 
 
   # monoid of strings with infix '+ sep +' operation, i.e., concatenate with
@@ -790,8 +790,8 @@ public String ref : property.equatable, property.hashable, property.orderable is
   #
   public type.concat(sep String) =>
     ref : Monoid String
-      redef infix ∙ (a, b String) String => if (a.is_empty || b.is_empty) a + b else a + sep + b
-      redef e => ""
+      public redef infix ∙ (a, b String) String => if (a.is_empty || b.is_empty) a + b else a + sep + b
+      public redef e => ""
 
 
   # concat strings a and b by
@@ -799,7 +799,7 @@ public String ref : property.equatable, property.hashable, property.orderable is
   #
   public type.concat(a, b String) String =>
     ref : String
-      redef utf8 Sequence u8 => a.utf8 ++ b.utf8
+      public redef utf8 Sequence u8 => a.utf8 ++ b.utf8
 
 
   # Takes a sequence of strings and concatenates its elements, while adding the separator
@@ -834,11 +834,11 @@ public String ref : property.equatable, property.hashable, property.orderable is
 
     ref : String
 
-      redef utf8 Sequence u8 =>
+      public redef utf8 Sequence u8 =>
         a.as_list.flat_map ai->ai.as_string.utf8
 
 
-      redef infix + (other Any) String =>
+      public redef infix + (other Any) String =>
         a.add other
         from_mutable_array a
 
@@ -847,14 +847,14 @@ public String ref : property.equatable, property.hashable, property.orderable is
   #
   public type.from_bytes(utf8_bytes Sequence u8) String =>
     ref : String
-      redef utf8 := utf8_bytes.as_array_backed
+      public redef utf8 := utf8_bytes.as_array_backed
 
 
   # create string from the given codepoints
   #
   public type.from_codepoints(codepoints Sequence codepoint) String =>
     ref : String
-      redef utf8 Sequence u8 =>
+      public redef utf8 Sequence u8 =>
         codepoints
           .flat_map x->x.utf8
           .as_array_backed

--- a/modules/base/src/array2.fz
+++ b/modules/base/src/array2.fz
@@ -33,7 +33,7 @@
 private:public array2(
        public T type,
        public length0, length1 i32,
-       redef internal_array fuzion.sys.internal_array T,
+       module redef internal_array fuzion.sys.internal_array T,
        _ unit,
        _ unit)
  : array internal_array unit unit unit
@@ -96,8 +96,8 @@ is
       debug: 0 ≤ i < length0
       debug: 0 ≤ j < length1
   is
-    redef head => (i, j, index[] i j)
-    redef tail list (tuple i32 i32 T) =>
+    public redef head => (i, j, index[] i j)
+    public redef tail list (tuple i32 i32 T) =>
       if      j < length1-1 then enumerate_cons i j+1
       else if i < length0-1 then enumerate_cons i+1 0
       else                       nil

--- a/modules/base/src/array3.fz
+++ b/modules/base/src/array3.fz
@@ -33,7 +33,7 @@
 private:public array3(
        public T type,
        public length0, length1, length2 i32,
-       redef internal_array fuzion.sys.internal_array T,
+       module redef internal_array fuzion.sys.internal_array T,
        _ unit,
        _ unit)
  : array internal_array unit unit unit
@@ -110,8 +110,8 @@ is
       debug: 0 ≤ j < length1
       debug: 0 ≤ k < length2
   is
-    redef head => (i, j, k, index[] i j k)
-    redef tail list (tuple i32 i32 i32 T) =>
+    public redef head => (i, j, k, index[] i j k)
+    public redef tail list (tuple i32 i32 i32 T) =>
       if      k < length2-1 then enumerate_cons i   j   k+1
       else if j < length1-1 then enumerate_cons i   j+1 0
       else if i < length0-1 then enumerate_cons i+1 0   0

--- a/modules/base/src/bitset.fz
+++ b/modules/base/src/bitset.fz
@@ -113,5 +113,5 @@ is
   #
   public type.union =>
     ref : Monoid bitset
-      redef infix ∙ (a, b bitset) => a ∪ b
-      redef e bitset => bitset.empty
+      public redef infix ∙ (a, b bitset) => a ∪ b
+      public redef e bitset => bitset.empty

--- a/modules/base/src/concur/thread_pool.fz
+++ b/modules/base/src/concur/thread_pool.fz
@@ -139,9 +139,9 @@ is
           compute_result.write cr
           check fut_cnd.broadcast
 
-      redef is_done => compute_result.read.exists
+      public redef is_done => compute_result.read.exists
 
-      redef get T =>
+      public redef get T =>
         if !is_done
           fut_cnd.synchronized ()->
             if !is_done
@@ -149,7 +149,7 @@ is
 
         compute_result.read.val
 
-      redef and_then(T2 type, new_task T->T2) =>
+      public redef and_then(T2 type, new_task T->T2) =>
         submit T2 ()->(new_task get)
 
     res := fut

--- a/modules/base/src/concur/threads.fz
+++ b/modules/base/src/concur/threads.fz
@@ -55,7 +55,7 @@ is
 
   # join all running threads
   #
-  redef finally =>
+  public redef finally =>
     running.for_each t->
       t.join
 

--- a/modules/base/src/container/Linked_List.fz
+++ b/modules/base/src/container/Linked_List.fz
@@ -53,8 +53,7 @@ public Linked_List(public T type) ref : Sequence T is
 
   # return this linked list as a list
   #
-  redef as_list =>
+  public redef as_list =>
     match next
       ll Linked_List T => (data : ()->ll.as_list)
       nil => (data : ()->nil)
-

--- a/modules/base/src/container/Mutable_Hash_Map.fz
+++ b/modules/base/src/container/Mutable_Hash_Map.fz
@@ -151,7 +151,7 @@ is
 
   # number of entries in this map
   #
-  redef size =>
+  public redef size =>
     load.get
 
 

--- a/modules/base/src/container/Mutable_Linked_List.fz
+++ b/modules/base/src/container/Mutable_Linked_List.fz
@@ -34,7 +34,7 @@ private:public Mutable_Linked_List(# mutate effect to be used to create mutable 
                     T type,
 
                     # the data stored in this element.
-                    redef data T) ref : Linked_List T is
+                    public redef data T) ref : Linked_List T is
 
 
   # mutable references to next. Initializes to refer to nil to form

--- a/modules/base/src/container/Set.fz
+++ b/modules/base/src/container/Set.fz
@@ -145,5 +145,5 @@ is
   #
   public type.union =>
     ref : Monoid (container.Set E)
-      redef infix ∙ (a, b container.Set E) => a ∪ b
-      redef e => (container.Set E).new []
+      public redef infix ∙ (a, b container.Set E) => a ∪ b
+      public redef e => (container.Set E).new []

--- a/modules/base/src/container/abstract_array.fz
+++ b/modules/base/src/container/abstract_array.fz
@@ -180,8 +180,8 @@ public abstract_array
     pre
       debug: 0 ≤ i < to ≤ length
   is
-    redef head => abstract_array.this[i]
-    redef tail => (slice i+1 to).as_list
+    public redef head => abstract_array.this[i]
+    public redef tail => (slice i+1 to).as_list
 
 
   # map the array to a new array applying function f to all elements
@@ -246,8 +246,8 @@ public abstract_array
       debug: 0 ≤ i
       debug: i < length
   is
-    redef head => (i, index[] i)
-    redef tail list (tuple i32 T) =>
+    public redef head => (i, index[] i)
+    public redef tail list (tuple i32 T) =>
       if i < length-1 then enumerate_cons i+1
       else                 nil
 

--- a/modules/base/src/container/hash_map.fz
+++ b/modules/base/src/container/hash_map.fz
@@ -38,7 +38,7 @@ is
 
   # number of entries in this map
   #
-  redef size => ks.length
+  public redef size => ks.length
 
 
   # size of allocated contents array, allows for some empty slots

--- a/modules/base/src/container/ps_set.fz
+++ b/modules/base/src/container/ps_set.fz
@@ -71,7 +71,7 @@ is
 
   # create a sorted array from the elements of this set
   #
-  redef as_array => psm.as_key_array
+  public redef as_array => psm.as_key_array
 
 
   # check if an element equal to given element k is part of this set

--- a/modules/base/src/effect.fz
+++ b/modules/base/src/effect.fz
@@ -413,12 +413,12 @@ instate_helper(# result type
 
   # wrapper to call `code` and store result in 'res`
   call_code : Function unit is
-    redef call =>
+    public redef call =>
       set res := code()
 
   # wrapper to call `def` on final effect value and store result in 'res`
   call_def : Function unit ET is
-    redef call(cur_e ET) =>
+    public redef call(cur_e ET) =>
       set res := def cur_e
 
 

--- a/modules/base/src/encodings/base32hex.fz
+++ b/modules/base/src/encodings/base32hex.fz
@@ -28,7 +28,7 @@ public base32hex : base32 "0123456789ABCDEFGHIJKLMNOPQRSTUV".utf8.as_array "base
 
   # decode a valid base32hex character to 5 bits
   #
-  redef quintet_bits(n u8) =>
+  module redef quintet_bits(n u8) =>
     if 65 <= n <= 86        # case A-V
       n.as_u64 - 55
     else                    # case 0-9
@@ -37,5 +37,5 @@ public base32hex : base32 "0123456789ABCDEFGHIJKLMNOPQRSTUV".utf8.as_array "base
 
   # checks if a character is valid in the encoding
   #
-  redef is_valid(c u8) =>
+  module redef is_valid(c u8) =>
     (65 <= c <= 86) || (48 <= c <= 57)

--- a/modules/base/src/envir/vars.fz
+++ b/modules/base/src/envir/vars.fz
@@ -68,9 +68,9 @@ public vars (p Vars_Handler) : effect is
   #
   type.default_vars_handler =>
     ref : envir.Vars_Handler
-      redef get(v String) => fuzion.sys.env_vars.get v
-      redef set1(n String, v String) => fuzion.sys.env_vars.set1 n v
-      redef unset(n String) => fuzion.sys.env_vars.unset n
+      public redef get(v String) => fuzion.sys.env_vars.get v
+      public redef set1(n String, v String) => fuzion.sys.env_vars.set1 n v
+      public redef unset(n String) => fuzion.sys.env_vars.unset n
 
 
 # short-hand for accessing envir.args effect in current environment

--- a/modules/base/src/exit.fz
+++ b/modules/base/src/exit.fz
@@ -71,19 +71,19 @@ is
 
       # exit with the given code
       #
-      redef exit(code u8) =>
+      public redef exit(code u8) =>
         fuzion.std.exit code.as_i32
 
 
       # exit with the stored code
       #
-      redef exit =>
+      public redef exit =>
         fuzion.std.exit exit_code.as_i32
 
 
       # set the stored exit code
       #
-      redef set_exit_code(code u8) outcome unit
+      public redef set_exit_code(code u8) outcome unit
         post then
           debug: exit_code = code
         =>

--- a/modules/base/src/f32.fz
+++ b/modules/base/src/f32.fz
@@ -56,7 +56,7 @@ public f32(public val f32) : float, java_primitive is
 
 
   # conversion
-  redef as_i64 => as_f64.as_i64
+  public redef as_i64 => as_f64.as_i64
 
 
   public as_f64 f64 => intrinsic

--- a/modules/base/src/fuzion/java.fz
+++ b/modules/base/src/fuzion/java.fz
@@ -103,7 +103,7 @@ public fuzion.java is
   # A Java array
   #
   public Array(public T type,
-               redef java_ref Java_Ref) ref : Sequence T, Java_Object java_ref
+               public redef java_ref Java_Ref) ref : Sequence T, Java_Object java_ref
   is
     public length                  => array_length T java_ref
     public redef finite trit       => trit.yes
@@ -127,8 +127,8 @@ public fuzion.java is
       pre
         debug: 0 ≤ i < length
     is
-      redef head => Array.this[i]
-      redef tail => as_list i+1
+      public redef head => Array.this[i]
+      public redef tail => as_list i+1
 
 
     # get the java signature for type T.
@@ -156,7 +156,7 @@ public fuzion.java is
 
   # Java's 'java.lang.String' type
   #
-  public Java_String(redef java_ref Java_Ref) ref : String, Java_Object java_ref
+  public Java_String(public redef java_ref Java_Ref) ref : String, Java_Object java_ref
   is
     public redef utf8 => (java_string_to_string java_ref).utf8
 

--- a/modules/base/src/fuzion/sys/thread.fz
+++ b/modules/base/src/fuzion/sys/thread.fz
@@ -32,7 +32,7 @@ module thread is
   #
   module spawn(code ()->unit) =>
     Do_Call ref : Function unit is
-      redef call =>
+      public redef call =>
         code()
 
     spawn0 Do_Call

--- a/modules/base/src/i128.fz
+++ b/modules/base/src/i128.fz
@@ -267,7 +267,7 @@ public i128(public hi i64, public lo u64) : num.wrap_around, has_interval is
 
 
   # returns the number in whose bit representation all bits are ones
-  fixed redef type.all_bits_set => i128 -1 u64.max
+  public fixed redef type.all_bits_set => i128 -1 u64.max
 
 
   # minimum

--- a/modules/base/src/i16.fz
+++ b/modules/base/src/i16.fz
@@ -30,7 +30,7 @@ public i16(public val i16) : num.wrap_around, has_interval, java_primitive is
   # overflow checking
 
   # would negation cause an overflow?
-  redef wrapped_on_neg => is_min
+  public redef wrapped_on_neg => is_min
 
   # would addition + other cause an overflow or underflow?
   public fixed redef overflow_on_add (other i16) => val > 0 && i16.max -° val < other
@@ -146,12 +146,12 @@ public i16(public val i16) : num.wrap_around, has_interval, java_primitive is
 
   # identity element for 'infix +'
   #
-  fixed redef type.zero i16 => 0
+  public fixed redef type.zero i16 => 0
 
 
   # identity element for 'infix *'
   #
-  fixed redef type.one  i16 => 1
+  public fixed redef type.one  i16 => 1
 
 
   # equality
@@ -165,7 +165,7 @@ public i16(public val i16) : num.wrap_around, has_interval, java_primitive is
 
 
   # returns the number in whose bit representation all bits are ones
-  fixed redef type.all_bits_set => i16 -1
+  public fixed redef type.all_bits_set => i16 -1
 
 
   # minimum

--- a/modules/base/src/i32.fz
+++ b/modules/base/src/i32.fz
@@ -30,7 +30,7 @@ public i32(public val i32) : num.wrap_around, has_interval, java_primitive is
   # overflow checking
 
   # would negation cause an overflow?
-  redef wrapped_on_neg => is_min
+  public redef wrapped_on_neg => is_min
 
   # would addition + other cause an overflow or underflow?
   public fixed redef overflow_on_add (other i32) => val > 0 && i32.max -° val < other
@@ -157,12 +157,12 @@ public i32(public val i32) : num.wrap_around, has_interval, java_primitive is
 
   # identity element for 'infix +'
   #
-  fixed redef type.zero i32 => 0
+  public fixed redef type.zero i32 => 0
 
 
   # identity element for 'infix *'
   #
-  fixed redef type.one  i32 => 1
+  public fixed redef type.one  i32 => 1
 
 
   # equality

--- a/modules/base/src/i64.fz
+++ b/modules/base/src/i64.fz
@@ -30,7 +30,7 @@ public i64(public val i64) : num.wrap_around, has_interval, java_primitive is
   # overflow checking
 
   # would negation cause an overflow?
-  redef wrapped_on_neg => is_min
+  public redef wrapped_on_neg => is_min
 
   # would addition + other cause an overflow or underflow?
   public fixed redef overflow_on_add (other i64) => val > 0 && i64.max -° val < other
@@ -215,12 +215,12 @@ public i64(public val i64) : num.wrap_around, has_interval, java_primitive is
 
   # identity element for 'infix +'
   #
-  fixed redef type.zero i64 => 0
+  public fixed redef type.zero i64 => 0
 
 
   # identity element for 'infix *'
   #
-  fixed redef type.one  i64 => 1
+  public fixed redef type.one  i64 => 1
 
 
   # equality
@@ -234,7 +234,7 @@ public i64(public val i64) : num.wrap_around, has_interval, java_primitive is
 
 
   # returns the number in whose bit representation all bits are ones
-  fixed redef type.all_bits_set => i64 -1
+  public fixed redef type.all_bits_set => i64 -1
 
 
   # minimum

--- a/modules/base/src/i8.fz
+++ b/modules/base/src/i8.fz
@@ -30,7 +30,7 @@ public i8(public val i8) : num.wrap_around, has_interval, java_primitive is
   # overflow checking
 
   # would negation cause an overflow?
-  redef wrapped_on_neg => is_min
+  public redef wrapped_on_neg => is_min
 
   # would addition + other cause an overflow or underflow?
   public fixed redef overflow_on_add (other i8) => val > 0 && i8.max -° val < other
@@ -141,12 +141,12 @@ public i8(public val i8) : num.wrap_around, has_interval, java_primitive is
 
   # identity element for 'infix +'
   #
-  fixed redef type.zero i8  => 0
+  public fixed redef type.zero i8  => 0
 
 
   # identity element for 'infix *'
   #
-  fixed redef type.one  i8  => 1
+  public fixed redef type.one  i8  => 1
 
 
   # equality
@@ -160,7 +160,7 @@ public i8(public val i8) : num.wrap_around, has_interval, java_primitive is
 
 
   # returns the number in whose bit representation all bits are ones
-  fixed redef type.all_bits_set => i8 -1
+  public fixed redef type.all_bits_set => i8 -1
 
 
   # minimum

--- a/modules/base/src/int.fz
+++ b/modules/base/src/int.fz
@@ -46,7 +46,7 @@ is
     int num.plus uint.one
 
 
-  fixed redef prefix - int =>
+  public fixed redef prefix - int =>
     match ns
       num.plus => int num.minus n
       num.minus => int num.plus n

--- a/modules/base/src/internationalization/ISO.fz
+++ b/modules/base/src/internationalization/ISO.fz
@@ -29,14 +29,12 @@ public ISO : provide is
     #
     # ex.`date 2024 4 12` results in `2024-04-12`.
     #
-    redef date(d i32, m i32, y i32)
+    public redef date(d i32, m i32, y i32)
     =>
         "{y}-{($m).pad_left("0", 2)}-{($d).pad_left("0", 2)}"
 
     # ex.`currency 300000` results in `300000?`.
     #
-    redef currency(c i32)
+    public redef currency(c i32)
     =>
         "{c}?"
-
-

--- a/modules/base/src/internationalization/american.fz
+++ b/modules/base/src/internationalization/american.fz
@@ -30,17 +30,12 @@ public american : provide is
     #
     # ex.`date 2024 4 12` results in `12/04/2024`.
     #
-    redef date(d i32, m i32,y i32)
+    public redef date(d i32, m i32,y i32)
     =>
         "{($m).pad_left "0" 2}/{($d).pad_left "0" 2}/{y}"
 
     # ex.`currency 300000` results in `300000$`.
     #
-    redef currency(c i32)
+    public redef currency(c i32)
     =>
         "\${c}"
-
-
-
-
-

--- a/modules/base/src/internationalization/german.fz
+++ b/modules/base/src/internationalization/german.fz
@@ -30,12 +30,12 @@ public german: provide is
     #
     # ex.`date 2024 4 12` results in `12.4.2024`.
     #
-    redef date(d i32, m i32, y i32)
+    public redef date(d i32, m i32, y i32)
     =>
         "{d}.{m}.{y}"
 
     # ex.`currency 300000` results in `300000€`.
     #
-    redef currency (c i32)
+    public redef currency (c i32)
     =>
         "{c}€"

--- a/modules/base/src/internationalization/japanese.fz
+++ b/modules/base/src/internationalization/japanese.fz
@@ -30,14 +30,12 @@ public japanese : provide is
     #
     # ex.`date 2024 4 12` results in `2024年 12月 4日`.
     #
-    redef date(d i32, m i32, y i32)
+    public redef date(d i32, m i32, y i32)
     =>
         "{y}年 {m}月 {d}日"
 
     # ex.`currency 300000` results in `300000¥`.
     #
-    redef currency(c i32)
+    public redef currency(c i32)
     =>
         "{c}¥"
-
-

--- a/modules/base/src/internationalization/korean.fz
+++ b/modules/base/src/internationalization/korean.fz
@@ -30,14 +30,12 @@ public korean : provide is
     #
     # ex.`date 2024 4 12` results in `2024년 12월 4일`.
     #
-    redef date(d i32, m i32, y i32)
+    public redef date(d i32, m i32, y i32)
     =>
         "{y}년 {m}월 {d}일"
 
     # example: `currency 300000` results in `300000₩`.
     #
-    redef currency(c i32)
+    public redef currency(c i32)
     =>
         "{c}₩"
-
-

--- a/modules/base/src/io/buffered/reader.fz
+++ b/modules/base/src/io/buffered/reader.fz
@@ -221,7 +221,7 @@ public read_delimiter (delim u8, strip_cr bool) switch String io.end_of_file ! r
               true
 
     ref : String
-      redef utf8 Sequence u8 := res.as_array
+      public redef utf8 Sequence u8 := res.as_array
 
 
 # use the currently installed byte reader effect

--- a/modules/base/src/io/dir/open.fz
+++ b/modules/base/src/io/dir/open.fz
@@ -40,7 +40,7 @@ module:public open(dd Directory_Descriptor,
 
   # close dir when de-instating effect
   #
-  redef finally =>
+  public redef finally =>
     _ := fzE_dir_close dd
 
 

--- a/modules/base/src/io/file/mapped_buffer.fz
+++ b/modules/base/src/io/file/mapped_buffer.fz
@@ -53,6 +53,6 @@ module:public mapped_buffer
 
   # cleanup
   #
-  redef finally =>
+  public redef finally =>
     # NYI: what to do on error?
     _ := fzE_munmap memory length

--- a/modules/base/src/io/file/open.fz
+++ b/modules/base/src/io/file/open.fz
@@ -34,10 +34,10 @@ module:public open(fd File_Descriptor,
 
     hndlr :=
       ref : Seek_Handler
-        redef seek(offset i64) =>
+        public redef seek(offset i64) =>
           fuzion.sys.fileio.seek fd offset
 
-        redef file_position =>
+        public redef file_position =>
           fuzion.sys.fileio.file_position fd
 
     file.this.seek hndlr ! code
@@ -68,7 +68,7 @@ module:public open(fd File_Descriptor,
 
   # close file when de-instating effect
   #
-  redef finally =>
+  public redef finally =>
     _ := fuzion.sys.fileio.close fd
 
 

--- a/modules/base/src/io/file/use.fz
+++ b/modules/base/src/io/file/use.fz
@@ -49,7 +49,7 @@ public use(R type, LM type : mutate, file_name String, m mode.val, code ()-> out
   # definition of read handler for file
   #
   read_handler(desc File_Descriptor) : io.Read_Handler is
-    redef read(count i32) choice (array u8) io.end_of_file error =>
+    public redef read(count i32) choice (array u8) io.end_of_file error =>
       match fuzion.sys.fileio.read desc count.as_u64
         a array u8 => if a.is_empty then io.end_of_file else a
         e error => e
@@ -57,7 +57,7 @@ public use(R type, LM type : mutate, file_name String, m mode.val, code ()-> out
   # definition of write handler for file
   #
   write_handler (desc File_Descriptor) : io.Write_Handler is
-    redef write (bytes Sequence u8) outcome unit =>
+    public redef write (bytes Sequence u8) outcome unit =>
       fuzion.sys.fileio.write desc bytes.as_array
 
 

--- a/modules/base/src/io/stdin.fz
+++ b/modules/base/src/io/stdin.fz
@@ -83,7 +83,7 @@ stdin_read_handler : Read_Handler is
 
   # implementation of read for reading from stdin
   #
-  redef read(count i32) choice (array u8) io.end_of_file error =>
+  public redef read(count i32) choice (array u8) io.end_of_file error =>
     arr := fuzion.sys.internal_array_init u8 count
     v := fzE_file_read fzE_file_stdin arr.data count
     if v < -1

--- a/modules/base/src/list.fz
+++ b/modules/base/src/list.fz
@@ -160,7 +160,7 @@ public list(public A type) : choice nil (Cons A (list A)), Sequence A is
   #
   public redef as_array =>
     lm : mutate is
-      redef mpanic(msg String) => fuzion.std.panic msg
+      module redef mpanic(msg String) => fuzion.std.panic msg
     lm ! ()->
       e := lm.env.new list.this
       array A count _->
@@ -179,8 +179,8 @@ public list(public A type) : choice nil (Cons A (list A)), Sequence A is
       nil    => nil
       c Cons =>
         ref : Cons B (list B)
-          redef head => f c.head
-          redef tail => c.tail.map_to_list f
+          public redef head => f c.head
+          public redef tail => c.tail.map_to_list f
 
 
   # map the list to a new list applying function f to all elements
@@ -197,8 +197,8 @@ public list(public A type) : choice nil (Cons A (list A)), Sequence A is
           nil     => c.tail.flat_map_to_list f
           c2 Cons =>
             ref : Cons B (list B)
-              redef head => c2.head
-              redef tail => (c2.tail ++ c.tail.flat_map_to_list f).as_list
+              public redef head => c2.head
+              public redef tail => (c2.tail ++ c.tail.flat_map_to_list f).as_list
 
 
   # fold the elements of this list using the given monoid.
@@ -334,8 +334,8 @@ public list(public A type) : choice nil (Cons A (list A)), Sequence A is
         nil    => nil
         c Cons =>
           ref : Cons A (list A)   # NYI: indentation syntax for anonymous not supported
-            redef head => c.head
-            redef tail => if n = 1 then nil else c.tail.take_list n-1
+            public redef head => c.head
+            public redef tail => if n = 1 then nil else c.tail.take_list n-1
 
 
   # reverse the order of the elements in this list
@@ -462,8 +462,8 @@ public list(public A type) : choice nil (Cons A (list A)), Sequence A is
       c Cons =>
         if p c.head
           ref : Cons A (list A)   # NYI: indentation syntax for anonymous not supported
-            redef head => c.head
-            redef tail => c.tail.take_while_list p
+            public redef head => c.head
+            public redef tail => c.tail.take_while_list p
         else
           nil
 
@@ -505,8 +505,8 @@ public list(public A type) : choice nil (Cons A (list A)), Sequence A is
     match drop_while_list (a -> !(p a))
       nil    => nil
       c Cons => ref : Cons A (list A)   # NYI: indentation syntax for anonymous not supported
-                  redef head => c.head
-                  redef tail => c.tail.filter_list p
+                  public redef head => c.head
+                  public redef tail => c.tail.filter_list p
 
 
   # create a list that repeats the current list indefinitely.  In case 'list.this'
@@ -524,8 +524,8 @@ public list(public A type) : choice nil (Cons A (list A)), Sequence A is
       nil    => nil
       c Cons =>
         cycle_cons (h Cons A (list A)) : Cons A (list A) is
-          redef head => h.head
-          redef tail list A =>
+          public redef head => h.head
+          public redef tail list A =>
             cycle_cons (h.tail ? nil    => c
                                | d Cons => d)
         cycle_cons c
@@ -536,8 +536,8 @@ public list(public A type) : choice nil (Cons A (list A)), Sequence A is
   #
   public redef tails list (list A) =>
     ref : Cons (list A) (list (list A))
-      redef head => list.this
-      redef tail =>
+      public redef head => list.this
+      public redef tail =>
         list.this ? nil    => nil
                   | c Cons => c.tail.tails
 
@@ -557,8 +557,8 @@ public list(public A type) : choice nil (Cons A (list A)), Sequence A is
       c1 Cons =>
         b.as_list ? c2 Cons =>
                       zip_cons : Cons V (list V) is
-                        redef head => f c1.head c2.head
-                        redef tail => c1.tail.zip_list c2.tail f
+                        public redef head => f c1.head c2.head
+                        public redef tail => c1.tail.zip_list c2.tail f
                       zip_cons
                   | nil    => nil
       nil => nil
@@ -692,11 +692,11 @@ public list(public A type) : choice nil (Cons A (list A)), Sequence A is
 
       # associative operation
       #
-      redef infix ∙ (a, b list A) list A => a.concat_list b
+      public redef infix ∙ (a, b list A) list A => a.concat_list b
 
       # identity element
       #
-      redef e list A =>
+      public redef e list A =>
         nil
 
 
@@ -705,8 +705,8 @@ public list(public A type) : choice nil (Cons A (list A)), Sequence A is
 #
 public list(T type, h T, t Lazy (list T)) list T =>
   ref : Cons T (list T)
-    redef head => h
-    redef tail => t
+    public redef head => h
+    public redef tail => t
 
 
 # infix operator to create a list from head h and lazy tail t.

--- a/modules/base/src/memoize.fz
+++ b/modules/base/src/memoize.fz
@@ -51,7 +51,7 @@ public memoize(MM type : container.Mutable_Map T R, T type : property.equatable,
 
     # implementation of abstract feature Unary.call
     #
-    redef call(a T) R =>
+    public redef call(a T) R =>
       # compute if not yet computed
       if store[a].is_nil
         store.put a (f a)

--- a/modules/base/src/net/channel.fz
+++ b/modules/base/src/net/channel.fz
@@ -54,7 +54,7 @@ is
 # for a given descriptor
 #
 module read_handler(desc i32) : io.Read_Handler is
-  redef read(count i32) choice (array u8) io.end_of_file error =>
+  public redef read(count i32) choice (array u8) io.end_of_file error =>
     match fuzion.sys.net.read desc count.as_i64
       a array => a
       e error => e
@@ -65,5 +65,5 @@ module read_handler(desc i32) : io.Read_Handler is
 # for a given descriptor
 #
 module write_handler(desc i32) : io.Write_Handler is
-  redef write(data Sequence u8) outcome unit =>
+  public redef write(data Sequence u8) outcome unit =>
     fuzion.sys.net.write desc data.as_array

--- a/modules/base/src/os/process.fz
+++ b/modules/base/src/os/process.fz
@@ -52,7 +52,7 @@ module:public process(module id, std_in, std_out, std_err i64) : property.ordera
   # read bytes from standard out
   #
   read_handler(desc i64) : io.Read_Handler is
-    redef read(count i32) choice (array u8) io.end_of_file error =>
+    public redef read(count i32) choice (array u8) io.end_of_file error =>
       arr := array u8 pipe_buffer_size i->0
       res := fzE_pipe_read desc arr.internal_array.data arr.count
       if res = -1
@@ -68,7 +68,7 @@ module:public process(module id, std_in, std_out, std_err i64) : property.ordera
   # write bytes to standard in
   #
   write_handler (desc i64) : io.Write_Handler is
-    redef write (bytes Sequence u8) outcome unit =>
+    public redef write (bytes Sequence u8) outcome unit =>
       if fzE_pipe_write desc bytes.as_array.internal_array.data bytes.count = -1
         error "error while writing"
       else

--- a/modules/base/src/os/processes.fz
+++ b/modules/base/src/os/processes.fz
@@ -38,7 +38,7 @@ public processes (ph os.Process_Handler, public running_processes container.Set 
 
   # cleanup effect
   #
-  redef finally =>
+  public redef finally =>
     running_processes.for_each p->
       _ := wait p
 
@@ -136,4 +136,3 @@ public processes =>
 public Process_Handler ref is
 
   public start(name String, args Sequence String, env_vars container.Map String String) outcome os.process => abstract
-

--- a/modules/base/src/random.fz
+++ b/modules/base/src/random.fz
@@ -161,7 +161,7 @@ simple_random_handler(seed1 u64, seed2 u64) : Random_Handler is
 
   # get next instance by shuffling bits in seeds around
   #
-  redef next Random_Handler =>
+  public redef next Random_Handler =>
     # NYI: This does not meet any requirements on a decent random number generator
     s1 := (seed1 *° 1717171717 +° 13113131313) ^ seed2
     s2 := (seed2 *° 9191919191 +° 37637373737) ^ seed1
@@ -172,7 +172,7 @@ simple_random_handler(seed1 u64, seed2 u64) : Random_Handler is
 
   # get current random number
   #
-  redef get u64 => seed1
+  public redef get u64 => seed1
 
 
   # name of env var to provide default random seed.

--- a/modules/base/src/u128.fz
+++ b/modules/base/src/u128.fz
@@ -30,7 +30,7 @@ public u128(public hi u64, public lo u64) : num.wrap_around, has_interval is
   # overflow checking
 
   # would negation cause an overflow?
-  redef wrapped_on_neg => !is_zero
+  public redef wrapped_on_neg => !is_zero
 
   # would addition + other cause an overflow or underflow?
   public fixed redef overflow_on_add (other u128) => u128.max -° u128.this < other
@@ -239,7 +239,7 @@ public u128(public hi u64, public lo u64) : num.wrap_around, has_interval is
 
 
   # returns the number in whose bit representation all bits are ones
-  fixed redef type.all_bits_set => u128 0x_ffff_ffff_ffff_ffff 0x_ffff_ffff_ffff_ffff
+  public fixed redef type.all_bits_set => u128 0x_ffff_ffff_ffff_ffff 0x_ffff_ffff_ffff_ffff
 
 
   # minimum
@@ -260,4 +260,3 @@ public u128(public hi u64, public lo u64) : num.wrap_around, has_interval is
   # identity element for 'infix *'
   #
   public fixed redef type.one => u128 0 1
-

--- a/modules/base/src/u16.fz
+++ b/modules/base/src/u16.fz
@@ -30,7 +30,7 @@ public u16(public val u16) : num.wrap_around, has_interval, java_primitive is
   # overflow checking
 
   # would negation cause an overflow?
-  redef wrapped_on_neg => !is_zero
+  public redef wrapped_on_neg => !is_zero
 
   # would addition + other cause an overflow or underflow?
   public fixed redef overflow_on_add (other u16) => u16.max -° val < other
@@ -140,12 +140,12 @@ public u16(public val u16) : num.wrap_around, has_interval, java_primitive is
 
   # identity element for 'infix +'
   #
-  fixed redef type.zero u16 => 0
+  public fixed redef type.zero u16 => 0
 
 
   # identity element for 'infix *'
   #
-  fixed redef type.one  u16 => 1
+  public fixed redef type.one  u16 => 1
 
 
   # equality
@@ -159,7 +159,7 @@ public u16(public val u16) : num.wrap_around, has_interval, java_primitive is
 
 
   # returns the number in whose bit representation all bits are ones
-  fixed redef type.all_bits_set => u16 0xffff
+  public fixed redef type.all_bits_set => u16 0xffff
 
 
   # minimum

--- a/modules/base/src/u32.fz
+++ b/modules/base/src/u32.fz
@@ -30,7 +30,7 @@ public u32(public val u32) : num.wrap_around, has_interval is
   # overflow checking
 
   # would negation cause an overflow?
-  redef wrapped_on_neg => !is_zero
+  public redef wrapped_on_neg => !is_zero
 
   # would addition + other cause an overflow or underflow?
   public fixed redef overflow_on_add (other u32) => u32.max -° val < other
@@ -210,12 +210,12 @@ public u32(public val u32) : num.wrap_around, has_interval is
 
   # identity element for 'infix +'
   #
-  fixed redef type.zero u32 => 0
+  public fixed redef type.zero u32 => 0
 
 
   # identity element for 'infix *'
   #
-  fixed redef type.one  u32 => 1
+  public fixed redef type.one  u32 => 1
 
 
   # equality

--- a/modules/base/src/u64.fz
+++ b/modules/base/src/u64.fz
@@ -30,7 +30,7 @@ public u64(public val u64) : num.wrap_around, has_interval is
   # overflow checking
 
   # would negation cause an overflow?
-  redef wrapped_on_neg => !is_zero
+  public redef wrapped_on_neg => !is_zero
 
   # would addition + other cause an overflow or underflow?
   public fixed redef overflow_on_add (other u64) => u64.max -° val < other
@@ -227,12 +227,12 @@ public u64(public val u64) : num.wrap_around, has_interval is
 
   # identity element for 'infix +'
   #
-  fixed redef type.zero u64 => 0
+  public fixed redef type.zero u64 => 0
 
 
   # identity element for 'infix *'
   #
-  fixed redef type.one  u64 => 1
+  public fixed redef type.one  u64 => 1
 
 
   # equality
@@ -246,7 +246,7 @@ public u64(public val u64) : num.wrap_around, has_interval is
 
 
   # returns the number in whose bit representation all bits are ones
-  fixed redef type.all_bits_set => u64 0x_ffff_ffff_ffff_ffff
+  public fixed redef type.all_bits_set => u64 0x_ffff_ffff_ffff_ffff
 
 
   # minimum

--- a/modules/base/src/u8.fz
+++ b/modules/base/src/u8.fz
@@ -30,7 +30,7 @@ public u8(public val u8) : num.wrap_around, has_interval is
   # overflow checking
 
   # would negation cause an overflow?
-  redef wrapped_on_neg => !is_zero
+  public redef wrapped_on_neg => !is_zero
 
   # would addition + other cause an overflow or underflow?
   public fixed redef overflow_on_add (other u8) => u8.max -° val < other
@@ -153,12 +153,12 @@ public u8(public val u8) : num.wrap_around, has_interval is
 
   # identity element for 'infix +'
   #
-  fixed redef type.zero u8  => 0
+  public fixed redef type.zero u8  => 0
 
 
   # identity element for 'infix *'
   #
-  fixed redef type.one  u8  => 1
+  public fixed redef type.one  u8  => 1
 
 
   # equality
@@ -172,7 +172,7 @@ public u8(public val u8) : num.wrap_around, has_interval is
 
 
   # returns the number in whose bit representation all bits are ones
-  fixed redef type.all_bits_set => u8 0xff
+  public fixed redef type.all_bits_set => u8 0xff
 
 
   # minimum

--- a/modules/base/src/unique_id.fz
+++ b/modules/base/src/unique_id.fz
@@ -36,7 +36,7 @@ is
   #
   type.default_handler =>
     ref : Unique_Id_Handler
-      redef get => fzE_unique_id
+      public redef get => fzE_unique_id
 
 
 public Unique_Id_Handler ref is

--- a/modules/lock_free/src/lock_free/Map.fz
+++ b/modules/lock_free/src/lock_free/Map.fz
@@ -57,7 +57,7 @@
 # a tomb node
 # "a T-node is the last value assigned to an I-node"
 tomb_node(CTK type : property.hashable, CTV type, sn singleton_node CTK CTV) is
-  redef as_string => "tomb_node($sn)"
+  public redef as_string => "tomb_node($sn)"
 
   as_list => sn.as_list
 
@@ -66,7 +66,7 @@ tomb_node(CTK type : property.hashable, CTV type, sn singleton_node CTK CTV) is
 # a singleton node
 # the node type containing actual data
 singleton_node(CTK type : property.hashable, CTV type, k CTK, v CTV) is
-  redef as_string => "singleton_node($k, $v)"
+  public redef as_string => "singleton_node($k, $v)"
 
   as_list => [(k,v)].as_list
 
@@ -75,7 +75,7 @@ singleton_node(CTK type : property.hashable, CTV type, k CTK, v CTV) is
 # an indirection or a singleton node
 # these are put into a container node
 branch(CTK type : property.hashable, CTV type) : choice (Indirection_Node CTK CTV) (singleton_node CTK CTV) is
-  redef as_string =>
+  public redef as_string =>
     match branch.this
       indirection_node Indirection_Node => "$indirection_node"
       singleton_node singleton_node => "$singleton_node"
@@ -113,7 +113,7 @@ is
   index [] (pos i32) branch CTK CTV =>
     array[pos]
 
-  redef as_string => "container_node[gen=$gen]({array.as_string ", "})"
+  public redef as_string => "container_node[gen=$gen]({array.as_string ", "})"
 
   as_list(f Indirection_Node CTK CTV -> Main_Node CTK CTV) =>
     array.flat_map (tuple CTK CTV) (b -> b.as_list f)
@@ -129,7 +129,7 @@ is
 #
 prev_node(CTK type : property.hashable, CTV type) : choice (failed_node CTK CTV) (Main_Node CTK CTV) nil is
 
-  redef as_string =>
+  public redef as_string =>
     match prev_node.this
       f lock_free.failed_node => f.as_string
       m lock_free.Main_Node => m.as_string
@@ -151,14 +151,14 @@ Main_Node(CTK type : property.hashable, CTV type, data choice (container_node CT
   # a previous node that gets set during a generational aware compare and set
   prev := concur.atomic (prev_node CTK CTV) p
 
-  fixed redef type.equality(a, b Main_Node.this) bool =>
+  public fixed redef type.equality(a, b Main_Node.this) bool =>
     a.id = b.id
 
   # compare and update `prev`
   cas_prev(o,n prev_node CTK CTV) =>
     prev.compare_and_set o n
 
-  redef as_string =>
+  public redef as_string =>
     s := match data
       container_node container_node => "$container_node"
       tomb_node tomb_node => "$tomb_node"
@@ -179,7 +179,7 @@ Main_Node(CTK type : property.hashable, CTV type, data choice (container_node CT
 # a failed node where the previous indirection node contains a main node
 failed_node(CTK type : property.hashable, CTV type, prev Main_Node CTK CTV) is
 
-  redef as_string =>
+  public redef as_string =>
     "failed_node($prev)"
 
 
@@ -193,14 +193,14 @@ Indirection_Node(CTK type : property.hashable, CTV type, data concur.atomic (Mai
 
   id := unique_id
 
-  fixed redef type.equality(a, b Indirection_Node.this) =>
+  public fixed redef type.equality(a, b Indirection_Node.this) =>
     a.id = b.id
 
   # compare and update
   cas(old_n, new_n Main_Node CTK CTV) =>
     data.compare_and_set old_n new_n
 
-  redef as_string => "Indirection_Node[gen=$gen]({data.read})"
+  public redef as_string => "Indirection_Node[gen=$gen]({data.read})"
 
   as_list(f Indirection_Node CTK CTV -> Main_Node CTK CTV) =>
     (f Indirection_Node.this).as_list f
@@ -211,16 +211,16 @@ Indirection_Node(CTK type : property.hashable, CTV type, data concur.atomic (Mai
 list_node(CTK type : property.hashable, CTV type, from Sequence (singleton_node CTK CTV)) : Sequence (tuple CTK CTV)
 pre from ∀ (sn -> (from.filter (snn -> (hash sn.k) = (hash snn.k))).count = 1)
 is
-  redef as_list => from
+  public redef as_list => from
     .map sn->(sn.k, sn.v)
     .as_list
 
   # is this sequence known to be finite?  For infinite sequences, features like
   # count diverge.
   #
-  redef finite => trit.yes
+  public redef finite => trit.yes
 
-  redef as_string => "list_node({from.as_string ", "})"
+  public redef as_string => "list_node({from.as_string ", "})"
 
   # find k in linked nodes
   find_key(k CTK) choice restart not_found CTV =>
@@ -250,7 +250,7 @@ is
   # but it probably does not hurt either.
   committed := concur.atomic false
 
-  redef as_string =>
+  public redef as_string =>
     "Rdcss_Descriptor($ov, $exp, $nv)"
 
 
@@ -258,7 +258,7 @@ is
 # in case the root node is currently replaced it is a Rdcss_Descriptor temporarily.
 root_node(CTK type : property.hashable, CTV type) : choice (Indirection_Node CTK CTV) (Rdcss_Descriptor CTK CTV) is
 
-  redef as_string =>
+  public redef as_string =>
     s => match root_node.this
       i lock_free.Indirection_Node => i.as_string
       r lock_free.Rdcss_Descriptor => r.as_string

--- a/modules/lock_free/src/lock_free/Sieve_Cache.fz
+++ b/modules/lock_free/src/lock_free/Sieve_Cache.fz
@@ -23,7 +23,7 @@
 
 
 Node(K type, V type, pair (K,V), visited concur.atomic bool, prev concur.atomic (option (lock_free.Node K V)), next concur.atomic (option (lock_free.Node K V))) ref is
-  redef as_string => "({pair.0},{pair.1})"
+  public redef as_string => "({pair.0},{pair.1})"
 
 
 # "SIEVE is a cache eviction algorithm that decides what to keep in the cache and what to discard.

--- a/modules/nom/src/nom.fz
+++ b/modules/nom/src/nom.fz
@@ -59,7 +59,7 @@ public nom is
     #
     public map_input(I2 type, map_fn I2 -> I) Parser I2 R O =>
       ref : Parser I2 R O
-        redef call(input I2) => Parser.this.call (map_fn input)
+        public redef call(input I2) => Parser.this.call (map_fn input)
 
 
 
@@ -68,7 +68,7 @@ public nom is
   #
   public parser(I, R, O type, f I -> parse_result R O) =>
     ref : Parser I R O
-      redef call(i I) => f i
+      public redef call(i I) => f i
 
 
 
@@ -78,7 +78,7 @@ public nom is
   # out  = the result of parsing, e.g. a concrete syntax tree
   #
   public success(R, O type, public rest R, public out O) is
-    redef as_string => $out
+    public redef as_string => $out
 
 
 

--- a/modules/nom/src/nom/parsers/json.fz
+++ b/modules/nom/src/nom/parsers/json.fz
@@ -27,7 +27,7 @@
 # json supports the following types: strings, numbers, booleans, null, arrays and objects
 #
 public json_value : choice String f64 bool nil (Sequence json_value) (container.Map String json_value) is
-  redef as_string =>
+  public redef as_string =>
     match json_value.this
       s String => "\"$s\""
       f f64 => $f

--- a/src/dev/flang/ast/AstErrors.java
+++ b/src/dev/flang/ast/AstErrors.java
@@ -2169,7 +2169,7 @@ public class AstErrors extends ANY
   public static void redefMoreRestrictiveVisibility(Feature f, AbstractFeature redefined)
   {
     error(f.pos(), "Redefinition must not have more restrictive visibility.",
-      "To solve this, increase the visibility of " + s(f) + " to at least " + s(redefined.visibility()));
+      "To solve this, increase the visibility of " + s(f) + " to " + (redefined.visibility() == Visi.PUB ? "" : "at least ") + s(redefined.visibility()));
   }
 
   public static void illegalVisibilityModifier(Feature f)
@@ -2220,7 +2220,8 @@ public class AstErrors extends ANY
   public static void abstractFeaturesVisibilityMoreRestrictiveThanOuter(Feature f)
   {
     error(f.pos(), "Abstract features visibility must not be more restrictive than outer features visibility.",
-      "To solve this, increase the visibility of " + s(f) + " to at least " + s(f.outer().visibility().eraseTypeVisibility()));
+      "To solve this, increase the visibility of " + s(f) + " to "
+      + ((f.outer().visibility().eraseTypeVisibility()) == Visi.PUB ? "" : "at least ") + s(f.outer().visibility().eraseTypeVisibility()));
   }
 
   public static void ambiguousCall(Call c, AbstractFeature f, AbstractFeature tf)

--- a/src/dev/flang/fe/SourceModule.java
+++ b/src/dev/flang/fe/SourceModule.java
@@ -1583,11 +1583,6 @@ A post-condition of a feature that does not redefine an inherited feature must s
    */
   public void checkTypes(Feature f)
   {
-    if (!f.isVisibilitySpecified() && !f.redefines().isEmpty())
-      {
-        f.setVisibility(f.redefines().stream().map(r -> r.visibility()).sorted().findAny().get());
-      }
-
     f.impl().checkTypes(f);
     var args = f.arguments();
     var fixed = (f.modifiers() & FuzionConstants.MODIFIER_FIXED) != 0;

--- a/tests/argumentcount_negative/argumentcount_negative.fz
+++ b/tests/argumentcount_negative/argumentcount_negative.fz
@@ -26,7 +26,7 @@
 argumentcount_negative is
 
   opengenerics11 ref : Function i32 is
-    redef call() i32 => 42
+    public redef call() i32 => 42
   opengenerics12 ref : Function i32 is
     redef call(x i32) i32 => 42                // 1. should flag an error, wrong number of arguments
   opengenerics13 ref : Function i32 is
@@ -35,12 +35,12 @@ argumentcount_negative is
   opengenerics14 ref : Function i32 bool is
     redef call() i32 => 42                     // 3. should flag an error, wrong number of arguments
   opengenerics15 ref : Function i32 bool is
-    redef call(x bool) i32 => 42
+    public redef call(x bool) i32 => 42
   opengenerics16 ref : Function i32 bool is
     redef call(x bool, y bool) i32 => 42       // 4. should flag an error, wrong number of arguments
 
   opengenerics17 ref : Function unit is
-    redef call() => unit
+    public redef call() => unit
   opengenerics18 ref : Function unit is
     redef call(x i32) is                       // 5. should flag an error, wrong number of arguments
   opengenerics19 ref : Function unit is
@@ -49,7 +49,7 @@ argumentcount_negative is
   opengenerics20 ref : Function unit bool is
     redef call() is                            // 7. should flag an error, wrong number of arguments
   opengenerics21 ref : Function unit bool is
-    redef call(x bool) => unit
+    public redef call(x bool) => unit
   opengenerics22 ref : Function unit i32 is
     redef call(x, y bool) is                   // 8. should flag an error, wrong number of arguments
 

--- a/tests/assignments/assignments.fz
+++ b/tests/assignments/assignments.fz
@@ -36,7 +36,7 @@ value_assignments =>
     y := mut 3.14
     z := mut "hi!"
 
-    redef as_string => "value: $x $y $z"
+    public redef as_string => "value: $x $y $z"
 
     set_x(x0) => x <- x0
     set_y(y0) => y <- y0
@@ -145,7 +145,7 @@ ref_assignments =>
     y := mut 3.14
     z := mut "hi!"
 
-    redef as_string => "ref: $x $y $z"
+    public redef as_string => "ref: $x $y $z"
 
     set_x(x0) => x <- x0
     set_y(y0) => y <- y0

--- a/tests/atomic/test_atomic.fz
+++ b/tests/atomic/test_atomic.fz
@@ -57,8 +57,8 @@ test_atomic is
     test0 a b c d (v1,v2)->v1=v2
 
   p(x, y i64) : property.equatable is
-    fixed redef type.equality(a, b test_atomic.p) => a.x = b.x && a.y = b.y
-    redef as_string => "$x,$y"
+    public fixed redef type.equality(a, b test_atomic.p) => a.x = b.x && a.y = b.y
+    public redef as_string => "$x,$y"
 
   test 1 2 3 4
   test 0.1 0.2 0.3 0.4
@@ -73,7 +73,7 @@ test_atomic is
   unit_like : choice unit is
     ord => match unit_like.this
       unit => 0
-    redef as_string => match unit_like.this
+    public redef as_string => match unit_like.this
       unit => "unit"
   test0 unit_like unit unit unit unit ((a,b)-> a.ord=b.ord)
 
@@ -82,7 +82,7 @@ test_atomic is
     ord => match unit_like2.this
       unit => 0
       void => 1   # cannot happen!
-    redef as_string => match unit_like2.this
+    public redef as_string => match unit_like2.this
       unit => "unit"
       void => "*** cannot happen ***"
   test0 unit_like2 unit unit unit unit ((a,b)-> a.ord=b.ord)
@@ -93,7 +93,7 @@ test_atomic is
     ord => match my_switch.this
       on => 0
       off => 1
-    redef as_string => match my_switch.this
+    public redef as_string => match my_switch.this
       on => "on"
       off => "off"
     type.equality(a, b my_switch.this) => a.ord = b.ord
@@ -106,7 +106,7 @@ test_atomic is
       red => 0
       yellow => 1
       green => 2
-    redef as_string => match lights.this
+    public redef as_string => match lights.this
       red => "red"
       yellow => "yellow"
       green => "green"
@@ -115,9 +115,9 @@ test_atomic is
   # test refs-and-units choice
   Sign ref is
   yield : Sign is
-    redef as_string => "yield sign"
+    public redef as_string => "yield sign"
   prio : Sign is
-    redef as_string => "priority sign"
+    public redef as_string => "priority sign"
   lights2 : choice red yellow green String Sign is
     ord => match lights2.this
       red => 0
@@ -125,7 +125,7 @@ test_atomic is
       green => 2
       String => 3
       Sign => 4
-    redef as_string => match lights2.this
+    public redef as_string => match lights2.this
       red => "red"
       yellow => "yellow"
       green => "green"
@@ -141,7 +141,7 @@ test_atomic is
       green => 2
       String => 3
       error => 4
-    redef as_string => match lights3.this
+    public redef as_string => match lights3.this
       red => "red"
       yellow => "yellow"
       green => "green"

--- a/tests/covariance/test_covariance.fz
+++ b/tests/covariance/test_covariance.fz
@@ -65,7 +65,7 @@ test_covariance is
     # create string representation consisting of type, to_u32
     # and valueString
     #
-    redef as_string => "num0.this {to_u32} {to_u32_loop} '$valueString'"
+    public redef as_string => "num0.this {to_u32} {to_u32_loop} '$valueString'"
 
     # string representation of this value, to be implemented by
     # children.
@@ -159,15 +159,15 @@ test_this_type =>
 
   a is
     type.s => "a"
-    redef as_string => "{a.this.s}"
+    public redef as_string => "{a.this.s}"
     b is
       type.s => "b"
-      redef as_string => "{a.this.s}{b.this.s}"
+      public redef as_string => "{a.this.s}{b.this.s}"
       c is
         type.s => "c"
         d is
           type.s => "d"
-          redef as_string => "{a.this.s}{b.this.s}{c.this.s}{d.this.s}"
+          public redef as_string => "{a.this.s}{b.this.s}{c.this.s}{d.this.s}"
 
   k : a is
     redef type.s => "k"
@@ -251,9 +251,9 @@ test_this_type_in_cotype =>
           type.choose4L(a, b     def.this) abc.def.this => a
           type.choose4R(a, b     def.this) abc.def.this => b
 
-          redef as_string => "abc.def.ghi.jkl $val $msg"
+          public redef as_string => "abc.def.ghi.jkl $val $msg"
 
-      redef as_string => s
+      public redef as_string => s
 
   v1 := (abc.def "ignore").ghi.jkl 1 "PASS"
   v2 := (abc.def "ignore").ghi.jkl 2 "*** FAIL ***"

--- a/tests/effect_installed/test_effect.fz
+++ b/tests/effect_installed/test_effect.fz
@@ -39,9 +39,9 @@ test_effect is
   use_b_err2 => _ := b.env       # 2. should flag an error: effect not installed
   use_c_err3 => _ := c.env       # 3. should flag an error: effect not installed
   use_d_err4 => _ := d.env       # 4. should flag an error: effect not installed
-  FA : Function unit is redef call => use_a
-  FB : Function unit is redef call => use_b
-  FC : Function unit is redef call => use_c
+  FA : Function unit is public redef call => use_a
+  FB : Function unit is public redef call => use_b
+  FC : Function unit is public redef call => use_c
   fa Function unit := FA
   fb Function unit := FB
   fc Function unit := FC

--- a/tests/effect_installed_negative/test_effect_neg.fz
+++ b/tests/effect_installed_negative/test_effect_neg.fz
@@ -41,9 +41,9 @@ test_effect_neg is
   use_b_err2 => _ := b.env       # 2. should flag an error: effect not installed
   use_c_err3 => _ := c.env       # 3. should flag an error: effect not installed
   use_d_err4 => _ := d.env       # 4. should flag an error: effect not installed
-  FA : Function unit is redef call => use_a
-  FB : Function unit is redef call => use_b
-  FC : Function unit is redef call => use_c
+  FA : Function unit is public redef call => use_a
+  FB : Function unit is public redef call => use_b
+  FC : Function unit is public redef call => use_c
   fa Function unit := FA
   fb Function unit := FB
   fc Function unit := FC

--- a/tests/equals/test_equals.fz
+++ b/tests/equals/test_equals.fz
@@ -117,7 +117,7 @@ test_equals_types is
 
     # equality relation comparing the value produced by 'col'
     #
-    fixed redef type.equality(a, b test_equals_types.Has_color) =>
+    public fixed redef type.equality(a, b test_equals_types.Has_color) =>
 
       # NYI: There is currently no easy way to compare choice types, so we do exhaustive
       # matches:
@@ -142,12 +142,12 @@ test_equals_types is
     redef col color,
 
     # the string
-    redef utf8 Sequence u8)
+    public redef utf8 Sequence u8)
 
    : Has_color, String, property.equatable is
 
     # equality relation comparing color and strings
     #
-    fixed redef type.equality(a, b test_equals_types.colored_text) =>
+    public fixed redef type.equality(a, b test_equals_types.colored_text) =>
       (test_equals_types.eq_color a b &&
        String.equality       a b   )

--- a/tests/functions/functions.fz
+++ b/tests/functions/functions.fz
@@ -70,13 +70,13 @@ functions is
 
     say "here 1c---------------"
     x (ref : Binary i32 Any i32 {
-        redef call(o Any, i i32) i32 =>
+        public redef call(o Any, i i32) i32 =>
           say "in anonymous function: $o"
           o.hash_code + i
        })
 
     F ref : Binary i32 Any i32 is
-        redef call(o Any, i i32) i32 =>
+        public redef call(o Any, i i32) i32 =>
           say "here F.call---------------"
           res := o.hash_code + i
           say "here F.call done---------------"

--- a/tests/generics_negative/generics_negative.fz
+++ b/tests/generics_negative/generics_negative.fz
@@ -63,13 +63,13 @@ generics_negative is
     x3 : choice A C B is  // 8. should flag an error: choice cannot use open generic
 
   opengenerics11 ref : Function i32 is
-    redef call() i32 => 42
+    public redef call() i32 => 42
   opengenerics15 ref : Function i32 bool is
-    redef call(x bool) i32 => 42
+    public redef call(x bool) i32 => 42
   opengenerics17 ref : Function unit is
-    redef call() unit =>
+    public redef call() unit =>
   opengenerics21 ref : Function unit i32 is
-    redef call(x i32) unit =>
+    public redef call(x i32) unit =>
 
   f1 Function i32 := opengenerics11
   _ := f1.call()

--- a/tests/i18n_default_test/i18n_default_test.fz
+++ b/tests/i18n_default_test/i18n_default_test.fz
@@ -24,7 +24,7 @@
 i18n_default_test is
 
     h : envir.Vars_Handler is
-      redef get(v String) option String => "de_DE.UTF-8"
+      public redef get(v String) option String => "de_DE.UTF-8"
 
     (envir.vars h) ! ()->
 
@@ -34,4 +34,3 @@ i18n_default_test is
             say "{internationalization.provide.current.currency 300000}"
 
         main
-

--- a/tests/infer_via_contraints_type_parameter/infer_via_contraints_type_parameter.fz
+++ b/tests/infer_via_contraints_type_parameter/infer_via_contraints_type_parameter.fz
@@ -2,7 +2,7 @@ ex =>
 
   a(T type, S type : array T, s S) is
 
-    redef as_string =>
+    public redef as_string =>
       s.as_string
 
   say (a [32])# This file is part of the Fuzion language implementation.
@@ -32,7 +32,7 @@ infer_via_contraints_type_parameter =>
 
   a(T type, S type : array T, s S) is
 
-    redef as_string =>
+    public redef as_string =>
       s.as_string
 
   say (a [32])

--- a/tests/inherit_postcondition/inherit_postcondition.fz
+++ b/tests/inherit_postcondition/inherit_postcondition.fz
@@ -217,7 +217,7 @@ test_postcondition is
     =>
       4711
 
-    redef g
+    public redef g
       post then
         ok "redef g $result"
         { io.Out.env.println "ho"; true }
@@ -233,7 +233,7 @@ test_postcondition is
     =>
       4716
 
-    redef g
+    public redef g
       post then
         ok "redef g $result"
         { io.Out.env.println "he"; true }
@@ -273,7 +273,7 @@ test_postcondition is
   _ := mod.post_accessing_result_child4.f
 
   inh_module1 : mod.post_accessing_result is
-    redef f
+    public redef f
       post then
         ok "redef $result"
     =>
@@ -283,9 +283,9 @@ test_postcondition is
     # redefining non-argument field is not allowed
     # redef n := 64
     # redefining a routine as a field is allowed
-    redef m := 64
-    redef r => 128
-    redef f
+    public redef m := 64
+    public redef r => 128
+    public redef f
       post then
         ok "redef $result"
     =>

--- a/tests/inherit_postcondition/module_src/mod.fz
+++ b/tests/inherit_postcondition/module_src/mod.fz
@@ -58,7 +58,7 @@ public mod is
     =>
       4711
 
-    redef g
+    public redef g
       post then
         ok "redef g $result"
         { io.Out.env.println "ho"; true }
@@ -74,7 +74,7 @@ public mod is
     =>
       4716
 
-    redef g
+    public redef g
       post then
         ok "redef g $result"
         { io.Out.env.println "he"; true }
@@ -82,12 +82,12 @@ public mod is
     => 42069
 
   public post_accessing_result_child3 : post_accessing_result is
-    redef f
+    public redef f
       post then
     =>
       32168
 
   public post_accessing_result_child4 : post_accessing_result is
-    redef f
+    public redef f
     =>
       112

--- a/tests/lazy/ex_lazy.fz
+++ b/tests/lazy/ex_lazy.fz
@@ -43,8 +43,8 @@ ex_lazy is
 
   lst(T type, h T, t Lazy (list T)) list T =>
     ref : Cons T (list T)
-      redef head => h
-      redef tail => t
+      public redef head => h
+      public redef tail => t
 
   stars => {say "eval stars!"; lst "*" stars}
 

--- a/tests/listFold/listFoldTest.fz
+++ b/tests/listFold/listFoldTest.fz
@@ -97,8 +97,8 @@ listFoldTest is
 
   // product mod 11
   m : Monoid i32 is
-    redef infix ∙ (a, b i32) => a * b % 11
-    redef e => 1
+    public redef infix ∙ (a, b i32) => a * b % 11
+    public redef e => 1
 
   say "product mod 11 is {l1.fold m}"; chck ((l1.fold m) = 1) "l1.fold produc mod 11"
   say "product mod 11 is {l2.fold m}"; chck ((l2.fold m) = 9) "l2.fold produc mod 11"

--- a/tests/local_mutate/test_local_mutate.fz
+++ b/tests/local_mutate/test_local_mutate.fz
@@ -244,7 +244,7 @@ test_local_mutate is
       next, prev Ring T => abstract
       data T => abstract
 
-      redef as_string =>
+      public redef as_string =>
         for
           s := "[ ", s + "{e.data} <-> "
           # e2 := r, e2.next    # NYI causes crash!

--- a/tests/nested_choice/nested_choice.fz
+++ b/tests/nested_choice/nested_choice.fz
@@ -27,13 +27,13 @@ nested_choice =>
 
     simple =>
       the_choice : choice i32 f64 is
-        redef as_string =>
+        public redef as_string =>
           match the_choice.this
             n i32 => $n
             f f64 => $f
 
       map_res : choice the_choice String is
-        redef as_string =>
+        public redef as_string =>
           match map_res.this
             t the_choice => $t
             s String => s
@@ -49,7 +49,7 @@ nested_choice =>
       bool_or_u64 : choice u64 bool is
 
       tripel_nested_choice : choice i32 bool_or_u64 is
-        redef as_string =>
+        public redef as_string =>
           match tripel_nested_choice.this
             i i32 => $i
             b1 bool_or_u64 =>
@@ -76,19 +76,19 @@ nested_choice =>
 
     only_references =>
       My_Ref1 ref is
-        redef as_string => "ref1"
+        public redef as_string => "ref1"
       My_Ref2 ref is
-        redef as_string => "ref2"
+        public redef as_string => "ref2"
       My_Ref3 ref is
-        redef as_string => "ref3"
+        public redef as_string => "ref3"
 
       only_ref : choice My_Ref1 My_Ref2 is
-        redef as_string =>
+        public redef as_string =>
           match only_ref.this
             mr1 My_Ref1 => $mr1
             mr2 My_Ref2 => $mr2
       only_ref_nested : choice My_Ref3 only_ref is
-        redef as_string =>
+        public redef as_string =>
           match only_ref_nested.this
             mr3 My_Ref3 => $mr3
             or only_ref => $or
@@ -111,7 +111,7 @@ nested_choice =>
 
     mix_ref_and_non_ref =>
       choice_mixed : choice i32 (choice String u64) is
-        redef as_string =>
+        public redef as_string =>
           match choice_mixed.this
             n i32 => $n
             c1 choice String u64 =>
@@ -164,7 +164,7 @@ nested_choice =>
 
   issue562 =>
     my_choice : choice (choice nil String) nil is
-      redef as_string =>
+      public redef as_string =>
         match my_choice.this
           choice choice nil String =>
             match choice
@@ -179,7 +179,7 @@ nested_choice =>
     say b
 
     my_choice2 : choice (choice nil String) (choice nil unit) is
-      redef as_string =>
+      public redef as_string =>
         match my_choice2.this
           choice choice nil String =>
             match choice

--- a/tests/nested_choice_negative/nested_choice_negative.fz
+++ b/tests/nested_choice_negative/nested_choice_negative.fz
@@ -24,7 +24,7 @@
 # -----------------------------------------------------------------------
 nested_choice_negative =>
   my_choice : choice (choice nil String) (choice nil unit) is
-    redef as_string =>
+    public redef as_string =>
       match my_choice.this
         choice choice nil String =>
           match choice

--- a/tests/nom/nom_test.fz
+++ b/tests/nom/nom_test.fz
@@ -38,7 +38,7 @@ nom_test =>
     p   := nom.parsers
 
     hex_color(r,g,b u8) is
-      redef as_string String =>
+      public redef as_string String =>
         "r: $r, g: $g, b: $b"
 
     is_valid(c codepoint) bool =>
@@ -80,4 +80,3 @@ nom_test =>
   simple_parser_test
   hex_parser_test
   json_parser_test
-

--- a/tests/outerNormalization/outerNormalization.fz
+++ b/tests/outerNormalization/outerNormalization.fz
@@ -96,7 +96,7 @@ outerNormalization is
     rj ref : n j is
     j : rj is
       redef a => j
-      redef as_string => "a 'j'"
+      public redef as_string => "a 'j'"
 
     t(r rj) =>
       say "testNormalize: {r.b}"
@@ -117,7 +117,7 @@ outerNormalization is
     rj ref : n is
     j : rj is
       redef a => 3
-      redef as_string => "a 'j'"
+      public redef as_string => "a 'j'"
 
     t(r rj) =>
       say "testNormalize2: {r.b}"

--- a/tests/process/test_process.fz
+++ b/tests/process/test_process.fz
@@ -30,7 +30,7 @@ test_process =>
   # create string of given byte size
   get_str(byte_size i32) =>
     ref : String
-      redef utf8 Sequence u8 =>
+      public redef utf8 Sequence u8 =>
         (1..byte_size)
           .map u8 (x -> codepoint.type.zero_char)
 

--- a/tests/process_utf8/process_utf8.fz
+++ b/tests/process_utf8/process_utf8.fz
@@ -30,7 +30,7 @@ process_utf8 =>
   # create string of given byte size
   get_str(byte_size i32) =>
     ref : String
-      redef utf8 Sequence u8 =>
+      public redef utf8 Sequence u8 =>
         (1..byte_size)
           .map u8 (x -> codepoint.type.zero_char)
 

--- a/tests/reg_issue1236/issue1236.fz
+++ b/tests/reg_issue1236/issue1236.fz
@@ -42,13 +42,13 @@ test1 is
 test2 is
   a ref is
     dt => a.this.type
-    redef as_string => $"a"
+    public redef as_string => $"a"
     b : c is
-      redef as_string => $"b"
+      public redef as_string => $"b"
       say a.this.type
 
   c : a is
-    redef as_string => $"c"
+    public redef as_string => $"c"
 
   ex_1236b =>
     _ := a.b

--- a/tests/reg_issue1247/src/a.fz
+++ b/tests/reg_issue1247/src/a.fz
@@ -8,4 +8,4 @@ module a : property.equatable is
 
   module type.identity a.this => abstract
 
-  redef type.equality(a, b a.this) bool => true
+  public redef type.equality(a, b a.this) bool => true

--- a/tests/reg_issue1247/src/b.fz
+++ b/tests/reg_issue1247/src/b.fz
@@ -1,9 +1,9 @@
 
 module b : a is
-  redef as_string String =>
+  public redef as_string String =>
     if b.this.sign ≤ 0
       "negative"
     else
       "positive"
 
-  fixed redef type.identity b => b
+  public fixed redef type.identity b => b

--- a/tests/reg_issue1294/issue1294.fz
+++ b/tests/reg_issue1294/issue1294.fz
@@ -323,7 +323,7 @@ scenario8 is
     # create string representation consisting of type, to_u32
     # and valueString
     #
-    redef as_string => "num0.this {to_u32} {to_u32_loop} '$valueString'"
+    public redef as_string => "num0.this {to_u32} {to_u32_loop} '$valueString'"
 
     # string representation of this value, to be implemented by
     # children.
@@ -332,8 +332,8 @@ scenario8 is
 
     type.sum =>
       ref : Monoid num0.this
-        redef infix ∙ (a, b num0.this) => a.plus b
-        redef e => zero
+        public redef infix ∙ (a, b num0.this) => a.plus b
+        public redef e => zero
 
 
   # integer mod 2 implementation of num0

--- a/tests/reg_issue1507/reg_issue1507.fz
+++ b/tests/reg_issue1507/reg_issue1507.fz
@@ -26,11 +26,11 @@ reg_issue1507 =>
   a is
     me a.this => abstract
     me2 => a
-    redef as_string => $"a"
+    public redef as_string => $"a"
 
   b(s String) : a is
     fixed redef me => (b "new")
-    redef as_string => "b$s"
+    public redef as_string => "b$s"
 
   say a.me2
   say (b "orig").me

--- a/tests/reg_issue1559_post_condition/test_issue1559.fz
+++ b/tests/reg_issue1559_post_condition/test_issue1559.fz
@@ -24,4 +24,4 @@
 a option String =>
   mutate ! ()->
     ref : String
-      redef utf8 => (list u8).empty
+      public redef utf8 => (list u8).empty

--- a/tests/reg_issue1559_post_condition/test_issue1559.fz.expected_err
+++ b/tests/reg_issue1559_post_condition/test_issue1559.fz.expected_err
@@ -1,7 +1,7 @@
 
---CURDIR--/test_issue1559.fz:27:13: error 1: Wrong result type in redefined feature
-      redef utf8 => (list u8).empty
-------------^^^^
+--CURDIR--/test_issue1559.fz:27:20: error 1: Wrong result type in redefined feature
+      public redef utf8 => (list u8).empty
+-------------------^^^^
 In 'a.λ.call.anonymous.utf8' that redefines 'String.utf8'
 result type is       : 'list u8'
 result type should be: 'Sequence u8'

--- a/tests/reg_issue1561_incompatible_types/test_issue1561.fz
+++ b/tests/reg_issue1561_incompatible_types/test_issue1561.fz
@@ -26,6 +26,6 @@ ex =>
 
     (try unit String ()->
       ref : String
-        redef utf8 Sequence u8 =>
+        public redef utf8 Sequence u8 =>
           (list u8).empty
     ).as_option

--- a/tests/reg_issue1943_type_parameter_as_outer_type/issue1943.fz
+++ b/tests/reg_issue1943_type_parameter_as_outer_type/issue1943.fz
@@ -30,7 +30,7 @@ test_outer_as_type_parameter is
   # here the test from #1943
   x is
     y is
-      redef as_string => "y in {x.this}"
+      public redef as_string => "y in {x.this}"
 
   z : x is
 

--- a/tests/reg_issue2214/issue_2214.fz
+++ b/tests/reg_issue2214/issue_2214.fz
@@ -34,7 +34,7 @@
 scenario1 =>
 
   u : Unary unit i32 is
-    redef call(i i32) =>
+    public redef call(i i32) =>
   _ := (a i32).m u
 
   a(T type) is

--- a/tests/reg_issue2249/issue2249.fz
+++ b/tests/reg_issue2249/issue2249.fz
@@ -26,14 +26,14 @@ issue2249 =>
   refs =>
     a =>
       ref : String
-        redef utf8 Sequence u8 => []
+        public redef utf8 Sequence u8 => []
 
     say (type_of a)
     say a.dynamic_type
 
     b :=
       ref : String
-        redef utf8 Sequence u8 => []
+        public redef utf8 Sequence u8 => []
 
     say (type_of b)
     say b.dynamic_type

--- a/tests/reg_issue2273/reg_issue2273.fz
+++ b/tests/reg_issue2273/reg_issue2273.fz
@@ -26,7 +26,7 @@ door : choice open closed is
   toggle door => match door.this
     open   => closed
     closed => open
-  redef as_string =>  match door.this
+  public redef as_string =>  match door.this
     open   => "open"
     closed => "closed"
 

--- a/tests/reg_issue2564/reg_issue2564.fz
+++ b/tests/reg_issue2564/reg_issue2564.fz
@@ -26,13 +26,13 @@ reg_issue2564 =>
   o := (mutate.array Any).type.new mutate
 
   do_it1(n i32) =>
-    redef as_string => "do_it1 $n"
+    public redef as_string => "do_it1 $n"
     o.add do_it1.this
     if n < 3
       do_it1 n+1
 
   do_it2(n i32) is
-    redef as_string => "do_it2 $n"
+    public redef as_string => "do_it2 $n"
     o.add do_it2.this
     if n < 3
       _ := do_it2 n+1

--- a/tests/reg_issue25_unbox_outerref/unboxOuterRef.fz
+++ b/tests/reg_issue25_unbox_outerref/unboxOuterRef.fz
@@ -36,7 +36,7 @@ unboxOuterRef is
     f unit => abstract
 
   y (i i32) : ry is
-    redef as_string => "y $i"
+    public redef as_string => "y $i"
     g (v y) =>
       vs := v.as_string
       say "in g: $vs $i"

--- a/tests/reg_issue263_anoynmous_inner_feature_as_arg/issue263.fz
+++ b/tests/reg_issue263_anoynmous_inner_feature_as_arg/issue263.fz
@@ -27,6 +27,6 @@ issue263 is
 
   say ([1,2,3].fold (
     ref : Monoid i32
-      redef infix ∙ (a, b i32) => a*b
-      redef e => 1
+      public redef infix ∙ (a, b i32) => a*b
+      public redef e => 1
     ))

--- a/tests/reg_issue2647/reg_issue2647.fz
+++ b/tests/reg_issue2647/reg_issue2647.fz
@@ -24,6 +24,6 @@
 reg_issue2647 =>
 
   a(ELEMENT_TYPE type...) is
-      redef as_string => ELEMENT_TYPE.as_string
+      public redef as_string => ELEMENT_TYPE.as_string
 
   say (a 3)

--- a/tests/reg_issue2647/reg_issue2647.fz.expected_err
+++ b/tests/reg_issue2647/reg_issue2647.fz.expected_err
@@ -1,6 +1,6 @@
 
---CURDIR--/reg_issue2647.fz:27:26: error 1: Open type parameters must not be called.
-      redef as_string => ELEMENT_TYPE.as_string
--------------------------^^^^^^^^^^^^
+--CURDIR--/reg_issue2647.fz:27:33: error 1: Open type parameters must not be called.
+      public redef as_string => ELEMENT_TYPE.as_string
+--------------------------------^^^^^^^^^^^^
 
 one error.

--- a/tests/reg_issue2719/reg_issue2719.fz
+++ b/tests/reg_issue2719/reg_issue2719.fz
@@ -21,6 +21,6 @@
 #
 # -----------------------------------------------------------------------
 
-f : Function i32 is redef call => 123
+f : Function i32 is public redef call => 123
 x(g Function i32) => say g()
 x f

--- a/tests/reg_issue292_inherited_open_generics/ex292.fz
+++ b/tests/reg_issue292_inherited_open_generics/ex292.fz
@@ -35,6 +35,6 @@ ex292 is
 
   a fn(i32, i32) =>
     ref : fn i32 i32
-      redef call(r, v i32) => 42
+      public redef call(r, v i32) => 42
 
   say (a.call 1 2)

--- a/tests/reg_issue293_confusion_of_type_and_value_params/issue293.fz
+++ b/tests/reg_issue293_confusion_of_type_and_value_params/issue293.fz
@@ -32,7 +32,7 @@ issue293 is
 
   into(TACC, T type, seq Sequence T, xf (Transducer (Sequence TACC) TACC T)) Sequence TACC =>
     rf := ref : reducing_fn((Sequence TACC),TACC)
-      redef call(res Sequence TACC, val TACC) Sequence(TACC) =>
+      public redef call(res Sequence TACC, val TACC) Sequence(TACC) =>
         res ++ [val]
     red := xf.call rf
     for
@@ -44,9 +44,9 @@ issue293 is
   # a Transducer mappping values from T to U
   map(TACC, T, U type, mapper T -> U) Transducer TACC U T =>
     ref : Transducer TACC U T
-      redef call(red reducing_fn TACC U) =>
+      public redef call(red reducing_fn TACC U) =>
         ref : reducing_fn TACC T
-          redef call(res TACC, val T) =>
+          public redef call(res TACC, val T) =>
             red.call res (mapper val)
 
 

--- a/tests/reg_issue3308/reg_issue3308.fz
+++ b/tests/reg_issue3308/reg_issue3308.fz
@@ -49,7 +49,7 @@ reg_issue3308 is
       _ := f (t unit)
 
       # fifth: access outer ref in partial application and call `as_string`
-      redef as_string => "--a--"
+      public redef as_string => "--a--"
       u(x Any) => say x
       say (g (u a.this))
 
@@ -74,7 +74,7 @@ reg_issue3308 is
       _ := f (t unit)
 
       # fifth: access outer ref in partial application and call `as_string`
-      redef as_string => "--b--"
+      public redef as_string => "--b--"
       u(x Any) => say x
       say (g (u b.this))
 

--- a/tests/reg_issue3369/child.fz
+++ b/tests/reg_issue3369/child.fz
@@ -1,6 +1,6 @@
 public child : parent is
 
-  redef get_name => "CHILD"
+  module redef get_name => "CHILD"
 
   # This caused a java exception
   _ := get_name

--- a/tests/reg_issue4486/reg_issue4486.fz
+++ b/tests/reg_issue4486/reg_issue4486.fz
@@ -37,7 +37,7 @@ reg_issue4486 =>
   #
   read_handler(arg String) : io.Read_Handler is
     already_returned := mut false
-    redef read(count i32) choice (array u8) io.end_of_file error =>
+    public redef read(count i32) choice (array u8) io.end_of_file error =>
       if !already_returned.get
         already_returned <- true
         # return eof for empty string to simulate: `printf "" | fz read_lines_test.fz`

--- a/tests/reg_issue4609/reg_issue4609.fz
+++ b/tests/reg_issue4609/reg_issue4609.fz
@@ -30,7 +30,7 @@ reg_issue4609 =>
   say "It is important that the stack trace contains no generated lambdas:"
 
   s : Function unit is
-    redef call => check false
+    public redef call => check false
   q s
   q(f ()->unit) => r f
   r(f ()->unit) => f.call

--- a/tests/reg_issue4609/reg_issue4609.fz.expected_err_int
+++ b/tests/reg_issue4609/reg_issue4609.fz.expected_err_int
@@ -17,8 +17,8 @@ fuzion.runtime.checkcondition_fault#1: {base.fum}/fuzion/runtime/check_fault.fz:
 public checkcondition_fault(msg String) => check_fault.cause msg
 -------------------------------------------^^^^^^^^^^^^^^^^^^^^^
 reg_issue4609.s.call: --CURDIR--/reg_issue4609.fz:33:25:
-    redef call => check false
-------------------------^^^^^
+    public redef call => check false
+-------------------------------^^^^^
 reg_issue4609.r#1: --CURDIR--/reg_issue4609.fz:36:20:
   r(f ()->unit) => f.call
 -------------------^^^^^^

--- a/tests/reg_issue624/reg_issue624.fz
+++ b/tests/reg_issue624/reg_issue624.fz
@@ -28,4 +28,4 @@ _ := test_equals
 
 t is
   X : property.equatable is
-      redef type.equality(a,b X.this) => true
+      public redef type.equality(a,b X.this) => true

--- a/tests/reg_issue776/reg_issue776.fz
+++ b/tests/reg_issue776/reg_issue776.fz
@@ -26,7 +26,7 @@ String.mysubstring(from, to i32) String
     debug: 0 <= from <= to <= String.this.byte_length
   =>
     ref : String
-      redef utf8 Sequence u8 =>
+      public redef utf8 Sequence u8 =>
         String.this.utf8.slice(from, to)
 
 

--- a/tests/reg_issue874ff/issue874.fz
+++ b/tests/reg_issue874ff/issue874.fz
@@ -81,7 +81,7 @@ test_this3 is
         u := u32 0, u+1
       while num0.this.zero.lessThan x
 
-    redef as_string => "num0.this {to_u32_loop} 'as_string'"
+    public redef as_string => "num0.this {to_u32_loop} 'as_string'"
 
   intM5(v u8) : num0 is
     fixed redef type.zero => test_this3.intM5 0
@@ -112,7 +112,7 @@ test_this4 is
       else
         u
 
-    redef as_string => "num0.this {to_u32_loop} 'as_string'"
+    public redef as_string => "num0.this {to_u32_loop} 'as_string'"
 
 
   intM5(v u8) : num0 is
@@ -139,7 +139,7 @@ test_cov is
       x := n.this
       _ := x.p n.this
 
-    redef as_string => "{f}"
+    public redef as_string => "{f}"
 
   i(is_zero bool) : n is
     fixed redef p(other i) => other
@@ -180,7 +180,7 @@ test_cov2 is
       x := n.this
       _ := x.p n.this
 
-    redef as_string => "{f}"
+    public redef as_string => "{f}"
 
   i(is_zero bool) : n is
     fixed redef p(other i) => other
@@ -277,10 +277,10 @@ test_return_this =>
   a is
     x a.this =>
       a.this
-    redef as_string => $"a"
+    public redef as_string => $"a"
 
   b : a is
-    redef as_string => $"b"
+    public redef as_string => $"b"
 
   say a.x
   say b.x
@@ -293,10 +293,10 @@ test_return_this
 aaa is
   x aaa.this =>
     aaa.this
-  redef as_string => $"a"
+  public redef as_string => $"a"
 
 bbb : aaa is
-  redef as_string => $"b"
+  public redef as_string => $"b"
 
 say aaa.x
 say bbb.x
@@ -306,16 +306,16 @@ say bbb.x
 #
 q is
   b : aaa is
-    redef as_string => "q.b"
+    public redef as_string => "q.b"
 
 r is
   a is
     x a.this =>
       a.this
-    redef as_string => "r.a"
+    public redef as_string => "r.a"
 
 c : r.a is
-  redef as_string => $"c"
+  public redef as_string => $"c"
 
 say q.b.x
 say r.a.x
@@ -327,13 +327,13 @@ say c.x
 d is
   y => 3
   x d.this =>
-    redef as_string => $"d"
+    public redef as_string => $"d"
     d.this
 
 t is
   e : d is
     redef y := 4
-    redef as_string => "s.e"
+    public redef as_string => "s.e"
 
 _ := t.e.x.y
 
@@ -343,25 +343,25 @@ _ := t.e.x.y
 ua is
   x ua.this =>
     ua.this
-  redef as_string => $"a"
+  public redef as_string => $"a"
 
 ub : ua is
-  redef as_string => $"b"
+  public redef as_string => $"b"
 
 uq is
   v := "v"
   say v
   b : ua is
-    redef as_string => "q.b"
+    public redef as_string => "q.b"
 
 ur is
   a is
     x a.this =>
       a.this
-    redef as_string => "r.a"
+    public redef as_string => "r.a"
 
 uc : ur.a is
-  redef as_string => $"c"
+  public redef as_string => $"c"
 
 say ua.x
 say ub.x
@@ -382,10 +382,10 @@ test_generic_this_type is
     call_f =>
       f g.this
 
-    redef as_string => "g $T"
+    public redef as_string => "g $T"
 
   h : g bool is
-    redef as_string => $"h"
+    public redef as_string => $"h"
 
   a := g i32
   b := g i32

--- a/tests/resource_cleanunp/resource_cleanunp.fz
+++ b/tests/resource_cleanunp/resource_cleanunp.fz
@@ -42,7 +42,7 @@ resource_cleanunp =>
       say "open: $s"
       (e ([s] ++ opened) state).replace
 
-    redef finally =>
+    public redef finally =>
       for s in opened do
         say "closing $s"
 

--- a/tests/this_type/test_this_type.fz
+++ b/tests/this_type/test_this_type.fz
@@ -107,7 +107,7 @@ test_redef_using_fixed =>
   #
   a is
 
-    redef as_string => "instance of 'a'"
+    public redef as_string => "instance of 'a'"
 
     # abstract feature that will be redefined as abstract
     #
@@ -127,7 +127,7 @@ test_redef_using_fixed =>
 
   b(val String) : a is
 
-    redef as_string => "instance of {b.type.as_string} with $val"
+    public redef as_string => "instance of {b.type.as_string} with $val"
 
     redef me2 b.this => b.this
 
@@ -147,7 +147,7 @@ test_redef_using_fixed =>
 
   c : b "from c" is
 
-    redef as_string => "instance of {c.type.as_string}"
+    public redef as_string => "instance of {c.type.as_string}"
 
     # redefine abstract feature with co-variant argument and result
     #

--- a/tests/type_feature/test_type_feature.fz
+++ b/tests/type_feature/test_type_feature.fz
@@ -28,11 +28,11 @@ hasTypeArg is
 
 ex(T, U type) : hasTypeArg, property.equatable is
   redef type.showTypeArgs => "T:$T U:$U"
-  fixed redef type.equality(a, b ex T U) bool => false
+  public fixed redef type.equality(a, b ex T U) bool => false
 
 ex2(T, U type: property.equatable, a0, b0 T, c0 U) : hasTypeArg, property.equatable is
   redef type.showTypeArgs => "T:$T U:$U"
-  fixed redef type.equality(a1, b1 ex2 T U) bool =>
+  public fixed redef type.equality(a1, b1 ex2 T U) bool =>
     (a1.a0 = b1.a0 &&
      a1.b0 = b1.b0 &&
      a1.c0 = b1.c0   )

--- a/tests/unary/ex_unary.fz
+++ b/tests/unary/ex_unary.fz
@@ -24,11 +24,11 @@
 ex_unary is
 
   g ref : Unary i32 i32 is
-    redef call (xg i32) i32 => 2*xg
+    public redef call (xg i32) i32 => 2*xg
 
 
   f ref : Unary i32 i32 is
-    redef call (yf i32) i32 => yf+2
+    public redef call (yf i32) i32 => yf+2
 
   x := (f ∘ g).call 3
   say x

--- a/tests/valWithLongLife/valWithLongLife.fz
+++ b/tests/valWithLongLife/valWithLongLife.fz
@@ -40,8 +40,8 @@ valWithLongLife is
 
   v (f String, id i32) is
     e (eid u8) is
-      redef as_string => "{v.this.as_string}-$eid"
-    redef as_string => f+id
+      public redef as_string => "{v.this.as_string}-$eid"
+    public redef as_string => f+id
 
   g(f String, id i32, eid u8) => (v f id).e eid
 

--- a/tests/visibility_modules/mod/b.fz
+++ b/tests/visibility_modules/mod/b.fz
@@ -40,7 +40,7 @@ public b : a is
     say "hello_a from b"
 
   priv is
-    redef as_string => "priv"
+    public redef as_string => "priv"
 
   public get_any Any =>
     priv

--- a/tests/visibility_modules_negative/main.fz.expected_err
+++ b/tests/visibility_modules_negative/main.fz.expected_err
@@ -94,18 +94,18 @@ To solve this, increase the visibility of 'm.my_false' or do not use this featur
 --CURDIR--/main.fz:80:18: error 15: Redefinition must not have more restrictive visibility.
     module redef b unit => // should flag an error Redefinition must not have more restrictive visibility.
 -----------------^
-To solve this, increase the visibility of 'm.redef_test_0.b' to at least 'public'
+To solve this, increase the visibility of 'm.redef_test_0.b' to 'public'
 
 
 --CURDIR--/main.fz:82:18: error 16: Redefinition must not have more restrictive visibility.
     module redef e unit => // should flag an error Redefinition must not have more restrictive visibility.
 -----------------^
-To solve this, increase the visibility of 'm.redef_test_0.e' to at least 'public'
+To solve this, increase the visibility of 'm.redef_test_0.e' to 'public'
 
 
 --CURDIR--/main.fz:89:5: error 17: Abstract features visibility must not be more restrictive than outer features visibility.
     inner_abstract i32 => abstract // should flag an error Abstract features visibility must not be more restrictive than outer features visibility.
 ----^^^^^^^^^^^^^^
-To solve this, increase the visibility of 'm.outer.inner_abstract' to at least 'public'
+To solve this, increase the visibility of 'm.outer.inner_abstract' to 'public'
 
 17 errors.

--- a/tests/visibility_scoping/visibility_scoping.fz
+++ b/tests/visibility_scoping/visibility_scoping.fz
@@ -55,7 +55,7 @@ visibility_scoping is
          while false
 
     ref : Function unit
-      redef call =>
+      public redef call =>
         say ar  # should flag an error: feature not found
 
 


### PR DESCRIPTION
fix #3989
