### PR TITLE
parser: create helpful error for lowercase exponent indicator in integers

### DIFF
--- a/src/dev/flang/parser/Lexer.java
+++ b/src/dev/flang/parser/Lexer.java
@@ -1836,8 +1836,16 @@ PLUSMINUS   : "+"
     var p = curCodePoint();
     return switch (p)
       {
-      case 'P', 'E' ->
+      case 'P', 'E', 'p', 'e' ->
       {
+        if (p == 'p' || p == 'e')
+          {
+            Errors.error(sourcePos(),
+              "Broken numeric literal, exponent indicator must be in upper case.",
+              "To fix this change '" + (char) p + "' to '" + (p == 'e' ? 'E' : 'P') + "'.");
+            p = p == 'e' ? 'E' : 'P';
+          }
+
         nextCodePoint();
         var neg = switch (curCodePoint())
           {

--- a/tests/reg_issue2685/Makefile
+++ b/tests/reg_issue2685/Makefile
@@ -1,0 +1,25 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test Makefile
+#
+# -----------------------------------------------------------------------
+
+override NAME = reg_issue2685
+include ../simple_and_negative.mk

--- a/tests/reg_issue2685/reg_issue2685.fz
+++ b/tests/reg_issue2685/reg_issue2685.fz
@@ -1,0 +1,32 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test reg_issue2685
+#
+# -----------------------------------------------------------------------
+
+reg_issue2685 =>
+
+  say 1E3
+
+  say 1P10
+
+  say 1e3   # 1. should flag an error: exponent indicator must be in upper case
+
+  say 1p10  # 2. should flag an error: exponent indicator must be in upper case

--- a/tests/reg_issue2685/reg_issue2685.fz.expected_err
+++ b/tests/reg_issue2685/reg_issue2685.fz.expected_err
@@ -1,0 +1,13 @@
+
+--CURDIR--/reg_issue2685.fz:30:8: error 1: Broken numeric literal, exponent indicator must be in upper case.
+  say 1e3   # 1. should flag an error: exponent indicator must be in upper case
+-------^
+To fix this change 'e' to 'E'.
+
+
+--CURDIR--/reg_issue2685.fz:32:8: error 2: Broken numeric literal, exponent indicator must be in upper case.
+  say 1p10  # 2. should flag an error: exponent indicator must be in upper case
+-------^
+To fix this change 'p' to 'P'.
+
+2 errors.


### PR DESCRIPTION
fix #2685


example:
```
❯ FUZION_DISABLE_ANSI_ESCAPES=true fz -e 'x := 1e3; say x'

command line:1:7: error 1: Broken numeric literal, exponent indicator must be in upper case.
x := 1e3; say x
------^
To fix this change 'e' to 'E'.

one error.

```