### PR TITLE
docs: make api sources link configurable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1194,7 +1194,7 @@ $(REF_MANUAL_HTML): $(REF_MANUAL_SOURCES) $(BUILD_DIR)/generated/doc/fum_file.ad
 
 # NYI integrate into fz: fz -docs
 $(BUILD_DIR)/apidocs/index.html: $(FUZION_BASE) $(CLASS_FILES_TOOLS_DOCS) $(FUZION_FILES)
-	$(JAVA) -cp $(CLASSES_DIR) -Xss64m -Dfuzion.home=$(BUILD_DIR) dev.flang.tools.docs.Docs -bare $(@D)
+	$(JAVA) -cp $(CLASSES_DIR) -Xss64m -Dfuzion.home=$(BUILD_DIR) dev.flang.tools.docs.Docs -bare -api-src=/api $(@D)
 
 # NYI integrate into fz: fz -docs
 .phony: debug_api_docs

--- a/src/dev/flang/tools/docs/Docs.java
+++ b/src/dev/flang/tools/docs/Docs.java
@@ -189,14 +189,28 @@ public class Docs extends ANY
 
     if (Stream.of(args).anyMatch(arg -> arg.equals("-styles")))
       {
-        return new DocsOptions(null, false, true, false);
+        return new DocsOptions(null, null, false, true, false);
+      }
+
+    String apiSrcDir = null;
+    var apiSrcDirArg = Stream.of(args).filter(s->s.startsWith("-api-src=")).collect(Collectors.toList());
+    if (apiSrcDirArg.size() >= 1)
+      {
+        if (apiSrcDirArg.size() == 1)
+          {
+            apiSrcDir = apiSrcDirArg.getFirst().replace("-api-src=", "");
+          }
+        else
+          {
+            Errors.fatal("option '-api-src' specified multiple times");
+          }
       }
 
     var destination = parseDestination(args);
 
     var bare = Stream.of(args).anyMatch(arg -> arg.equals("-bare"));
     var ignoreVisibility = Stream.of(args).anyMatch(arg -> arg.equals("-ignoreVisibility"));
-    return new DocsOptions(destination, bare, false, ignoreVisibility);
+    return new DocsOptions(destination, apiSrcDir, bare, false, ignoreVisibility);
   }
 
 
@@ -239,7 +253,7 @@ public class Docs extends ANY
   private static String usage()
   {
     return """
-      Usage: fzdoc [-bare] <destination>
+      Usage: fzdoc [-bare] [-api-src=<path>] <destination>
       or     fzdoc -styles
       """;
   }

--- a/src/dev/flang/tools/docs/DocsOptions.java
+++ b/src/dev/flang/tools/docs/DocsOptions.java
@@ -30,11 +30,21 @@ import java.nio.file.Path;
 
 /**
  * api doc specific options
+ *
+ * @param destination
+ * @param apiSrcDir the location to which the src links in the docs should point to, null for default
+ * @param bare
+ * @param printCSSStyles
+ * @param ignoreVisibility
  */
-public record DocsOptions(Path destination, boolean bare, boolean printCSSStyles, boolean ignoreVisibility)
+public record DocsOptions(Path destination, String apiSrcDir, boolean bare, boolean printCSSStyles, boolean ignoreVisibility)
 {
 
-  static final String baseApiDir = "/api";
+  public String apiSrcDir()
+  {
+    return apiSrcDir == null ? "/api" : apiSrcDir;
+  }
+
 
   public boolean ignoreVisibility()
   {

--- a/src/dev/flang/tools/docs/Html.java
+++ b/src/dev/flang/tools/docs/Html.java
@@ -558,7 +558,7 @@ public class Html extends ANY
   /**
    * the link [src] to the source file
    */
-  private static String source(AbstractFeature feature)
+  private String source(AbstractFeature feature)
   {
     return "<div class='pl-5'><a href='$1'>[src]</a></div>"
       .replace("$1", featureURL(feature));
@@ -733,11 +733,11 @@ public class Html extends ANY
    * @param f
    * @return
    */
-  private static String featureURL(AbstractFeature f)
+  private String featureURL(AbstractFeature f)
   {
     return f.pos()._sourceFile._fileName
       .toString()
-      .replaceFirst("\\{(.*?)\\.fum\\}", DocsOptions.baseApiDir + "/$1")
+      .replaceFirst("\\{(.*?)\\.fum\\}", config.apiSrcDir() + "/$1")
       + "#l" + f.pos().line();
   }
 


### PR DESCRIPTION
fix #4705

I'm not sure how helpful this is other than for the web server, because for `-api-src=custDir` this would generate links like the following
`custDir/base/abort.fz`
but in the fuzion repo this file is in 
`modules/base/src/abort.fz`

So should the part `base/abort.fz` be also configurable so that `src` could be added? 