### PR TITLE
ast: change `resultType` to never return`t_UNDEFINED`

### DIFF
--- a/src/dev/flang/ast/AbstractFeature.java
+++ b/src/dev/flang/ast/AbstractFeature.java
@@ -268,9 +268,8 @@ public abstract class AbstractFeature extends Expr implements Comparable<Abstrac
   /**
    * resultType returns the result type of this feature using.
    *
-   * @return the result type, t_ERROR in case of an error.  Never
-   * null. Types.t_UNDEFINED in case type inference for this type is cyclic and
-   * hence impossible.
+   * @return the result type, t_ERROR in case of an error.
+   * Never null. Never is or contains t_UNDEFINED.
    */
   public abstract AbstractType resultType();
 

--- a/src/dev/flang/ast/AbstractFeature.java
+++ b/src/dev/flang/ast/AbstractFeature.java
@@ -269,7 +269,7 @@ public abstract class AbstractFeature extends Expr implements Comparable<Abstrac
    * resultType returns the result type of this feature using.
    *
    * @return the result type, t_ERROR in case of an error.
-   * Never null. Never is or contains t_UNDEFINED.
+   * Never null.
    */
   public abstract AbstractType resultType();
 

--- a/src/dev/flang/ast/Feature.java
+++ b/src/dev/flang/ast/Feature.java
@@ -2392,9 +2392,8 @@ A ((Choice)) declaration must not contain a result type.
    * After type resolution, resultType returns the result type of this
    * feature using the formal generic argument.
    *
-   * @return the result type, t_ERROR in case of an error.  Never
-   * null. Types.t_UNDEFINED in case type inference for this type is cyclic and
-   * hence impossible.
+   * @return the result type, t_ERROR in case of an error.
+   * Never null. Never is or contains t_UNDEFINED.
    */
   @Override
   public AbstractType resultType()
@@ -2402,17 +2401,13 @@ A ((Choice)) declaration must not contain a result type.
     if (PRECONDITIONS) require
       (Errors.any() || _state.atLeast(State.RESOLVED_TYPES));
 
-    var result = _state.atLeast(State.RESOLVED_TYPES) ? resultTypeIfPresentUrgent(null, true) : null;
-    if (result == null)
-      {
-        if (CHECKS) check
-          (Errors.any());
-
-        result = Types.t_ERROR;
-      }
+    var result = _state.atLeast(State.RESOLVED_TYPES)
+      ? resultTypeIfPresentUrgent(null, true)
+      : Types.t_ERROR;
 
     if (POSTCONDITIONS) ensure
-      (result != null);
+      (Errors.any() || result != Types.t_ERROR,
+       !result.containsUndefined(false));
 
     return result;
   }

--- a/src/dev/flang/ast/Feature.java
+++ b/src/dev/flang/ast/Feature.java
@@ -2393,7 +2393,7 @@ A ((Choice)) declaration must not contain a result type.
    * feature using the formal generic argument.
    *
    * @return the result type, t_ERROR in case of an error.
-   * Never null. Never is or contains t_UNDEFINED.
+   * Never null.
    */
   @Override
   public AbstractType resultType()
@@ -2407,7 +2407,7 @@ A ((Choice)) declaration must not contain a result type.
 
     if (POSTCONDITIONS) ensure
       (Errors.any() || result != Types.t_ERROR,
-       !result.containsUndefined(false));
+       Errors.any() || !result.containsUndefined(false));
 
     return result;
   }


### PR DESCRIPTION
We have `resultTypeIfPresent` for that.
