### PR TITLE
ast: call, resolveFormalArg, use resultType with urgent=true

### DIFF
--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -1184,7 +1184,7 @@ public class Call extends AbstractCall
   private void resolveFormalArg(Resolution res, int argnum, AbstractFeature frml, Context context)
   {
     int cnt = 1;
-    var frmlT = frml.resultTypeIfPresent(res);
+    var frmlT = frml.resultTypeIfPresentUrgent(res, true);
 
     var declF = _calledFeature.outer();
     var heir = _target.type();


### PR DESCRIPTION
I think, we really need the result type here and want to emit errors if it would not be present.

