### PR TITLE
tests: add missing Makefile for mutable_hash_map_test

### DIFF
--- a/tests/mutable_hash_map/Makefile
+++ b/tests/mutable_hash_map/Makefile
@@ -1,0 +1,25 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test Makefile
+#
+# -----------------------------------------------------------------------
+
+override NAME = mutable_hash_map_test
+include ../simple.mk

--- a/tests/mutable_hash_map/skip_int
+++ b/tests/mutable_hash_map/skip_int
@@ -1,0 +1,1 @@
+test takes to long when run by interpreter


### PR DESCRIPTION
seems I forgot to check in the Makefile for that test 🙈
