### PR TITLE
build: show reason if test was cancelled because of timeout or stack limit

### DIFF
--- a/tests/check_simple_example_c.sh
+++ b/tests/check_simple_example_c.sh
@@ -61,13 +61,20 @@ else
     rm -f testbin
 
     # limit cpu time and stack size for executing test
-    ulimit -S -t 120  || echo "failed setting limit via ulimit"
-    ulimit -S -s 1024 || echo "failed setting limit via ulimit"
+    cpu_time_limit=120
+    stack_size_limit=1024
+    ulimit -S -t $cpu_time_limit  || echo "failed setting limit via ulimit"
 
-    EXIT_CODE=$( ( (FUZION_DISABLE_ANSI_ESCAPES=true FUZION_JAVA_OPTIONS="${FUZION_JAVA_OPTIONS="-Xss${FUZION_JAVA_STACK_SIZE=5m}"} ${OPT:-}" $1 -XmaxErrors=-1 -c ${FUZION_C_BACKEND_OPTIONS:+$FUZION_C_BACKEND_OPTIONS} "$2" -o=testbin                && ./testbin) 2>tmp_err.txt | head -n 10000) > tmp_out.txt; echo $?)
+    EXIT_CODE=$( ( (FUZION_DISABLE_ANSI_ESCAPES=true FUZION_JAVA_OPTIONS="${FUZION_JAVA_OPTIONS="-Xss${FUZION_JAVA_STACK_SIZE=5m}"} ${OPT:-}" $1 -XmaxErrors=-1 -c ${FUZION_C_BACKEND_OPTIONS:+$FUZION_C_BACKEND_OPTIONS} "$2" -o=testbin                && ulimit -S -s $stack_size_limit || echo "failed setting limit via ulimit" && ./testbin) 2>tmp_err.txt | head -n 10000) > tmp_out.txt; echo $?)
 
     # pipe to head may result in exit code 141 -- broken pipe.
-    if [ "$EXIT_CODE" -ne 0   ] &&
+    if [ "$EXIT_CODE" -eq 152 ]; then
+        echo  -e "\033[31;1m*** CANCELLED:\033[0m test $2 exceeded cpu time limit of $cpu_time_limit s"
+        exit 1
+    elif [ "$EXIT_CODE" -eq 139 ]; then
+        echo  -e "\033[31;1m*** CANCELLED:\033[0m test $2 exceeded stack size limit of $stack_size_limit KB"
+        exit 1
+    elif [ "$EXIT_CODE" -ne 0   ] &&
        [ "$EXIT_CODE" -ne 1   ] &&
        [ "$EXIT_CODE" -ne 141 ]; then
         echo "unexpected exit code $EXIT_CODE"

--- a/tests/check_simple_example_c.sh
+++ b/tests/check_simple_example_c.sh
@@ -65,7 +65,7 @@ else
     stack_size_limit=1024
     ulimit -S -t $cpu_time_limit  || echo "failed setting limit via ulimit"
 
-    EXIT_CODE=$( ( (FUZION_DISABLE_ANSI_ESCAPES=true FUZION_JAVA_OPTIONS="${FUZION_JAVA_OPTIONS="-Xss${FUZION_JAVA_STACK_SIZE=5m}"} ${OPT:-}" $1 -XmaxErrors=-1 -c ${FUZION_C_BACKEND_OPTIONS:+$FUZION_C_BACKEND_OPTIONS} "$2" -o=testbin                && ulimit -S -s $stack_size_limit || echo "failed setting limit via ulimit" && ./testbin) 2>tmp_err.txt | head -n 10000) > tmp_out.txt; echo $?)
+    EXIT_CODE=$( ( (FUZION_DISABLE_ANSI_ESCAPES=true FUZION_JAVA_OPTIONS="${FUZION_JAVA_OPTIONS="-Xss${FUZION_JAVA_STACK_SIZE=5m}"} ${OPT:-}" $1 -XmaxErrors=-1 -c ${FUZION_C_BACKEND_OPTIONS:+$FUZION_C_BACKEND_OPTIONS} "$2" -o=testbin                && (ulimit -S -s $stack_size_limit || echo "failed setting limit via ulimit") && ./testbin) 2>tmp_err.txt | head -n 10000) > tmp_out.txt; echo $?)
 
     # pipe to head may result in exit code 141 -- broken pipe.
     if [ "$EXIT_CODE" -eq 152 ]; then

--- a/tests/check_simple_example_c.sh
+++ b/tests/check_simple_example_c.sh
@@ -67,13 +67,15 @@ else
 
     EXIT_CODE=$( ( (FUZION_DISABLE_ANSI_ESCAPES=true FUZION_JAVA_OPTIONS="${FUZION_JAVA_OPTIONS="-Xss${FUZION_JAVA_STACK_SIZE=5m}"} ${OPT:-}" $1 -XmaxErrors=-1 -c ${FUZION_C_BACKEND_OPTIONS:+$FUZION_C_BACKEND_OPTIONS} "$2" -o=testbin                && (ulimit -S -s $stack_size_limit || echo "failed setting limit via ulimit") && ./testbin) 2>tmp_err.txt | head -n 10000) > tmp_out.txt; echo $?)
 
-    # pipe to head may result in exit code 141 -- broken pipe.
+    # 152 - 128 = 24 -> signal SIGXCPU
     if [ "$EXIT_CODE" -eq 152 ]; then
         echo  -e "\033[31;1m*** CANCELLED:\033[0m test $2 exceeded cpu time limit of $cpu_time_limit s"
         exit 1
+    # 139 - 128 = 11 -> signal SIGSEGV
     elif [ "$EXIT_CODE" -eq 139 ]; then
         echo  -e "\033[31;1m*** CANCELLED:\033[0m test $2 exceeded stack size limit of $stack_size_limit KB"
         exit 1
+    # pipe to head may result in exit code 141 -- broken pipe.
     elif [ "$EXIT_CODE" -ne 0   ] &&
        [ "$EXIT_CODE" -ne 1   ] &&
        [ "$EXIT_CODE" -ne 141 ]; then

--- a/tests/check_simple_example_int.sh
+++ b/tests/check_simple_example_int.sh
@@ -64,6 +64,7 @@ else
 
     EXIT_CODE=$(FUZION_DISABLE_ANSI_ESCAPES=true FUZION_JAVA_OPTIONS="${FUZION_JAVA_OPTIONS="-Xss${FUZION_JAVA_STACK_SIZE=5m}"} ${OPT:-}" $1 -XmaxErrors=-1 -interpreter "$2" >tmp_out.txt 2>tmp_err.txt; echo $?)
 
+    # 152 - 128 = 24 -> signal SIGXCPU
     if [ "$EXIT_CODE" -eq 152 ]; then
         echo  -e "\033[31;1m*** CANCELLED:\033[0m test $2 exceeded cpu time limit of $cpu_time_limit s"
         exit 1

--- a/tests/check_simple_example_int.sh
+++ b/tests/check_simple_example_int.sh
@@ -59,12 +59,16 @@ else
     head -n 1 "$2" | grep -q -E "# fuzion.debugLevel=0( .*)$" && export OPT=-Dfuzion.debugLevel=0
 
     # limit cpu time for executing test
-    ulimit -S -t 600 || echo "failed setting limit via ulimit"
+    cpu_time_limit=600
+    ulimit -S -t $cpu_time_limit || echo "failed setting limit via ulimit"
 
     EXIT_CODE=$(FUZION_DISABLE_ANSI_ESCAPES=true FUZION_JAVA_OPTIONS="${FUZION_JAVA_OPTIONS="-Xss${FUZION_JAVA_STACK_SIZE=5m}"} ${OPT:-}" $1 -XmaxErrors=-1 -interpreter "$2" >tmp_out.txt 2>tmp_err.txt; echo $?)
 
-    if [ "$EXIT_CODE" -ne 0 ] && [ "$EXIT_CODE" -ne 1 ]; then
-        echo "unexpected exit code"
+    if [ "$EXIT_CODE" -eq 152 ]; then
+        echo  -e "\033[31;1m*** CANCELLED:\033[0m test $2 exceeded cpu time limit of $cpu_time_limit s"
+        exit 1
+    elif [ "$EXIT_CODE" -ne 0 ] && [ "$EXIT_CODE" -ne 1 ]; then
+        echo "unexpected exit code $EXIT_CODE"
         exit "$EXIT_CODE"
     fi
 

--- a/tests/check_simple_example_jvm.sh
+++ b/tests/check_simple_example_jvm.sh
@@ -63,6 +63,7 @@ else
 
     EXIT_CODE=$(FUZION_DISABLE_ANSI_ESCAPES=true FUZION_JAVA_OPTIONS="${FUZION_JAVA_OPTIONS="-Xss${FUZION_JAVA_STACK_SIZE=5m}"} ${OPT:-}" $1 -XmaxErrors=-1 -jvm ${FUZION_JVM_BACKEND_OPTIONS:+ $FUZION_JVM_BACKEND_OPTIONS} "$2" >tmp_out.txt 2>tmp_err.txt; echo $?)
 
+    # 152 - 128 = 24 -> signal SIGXCPU
     if [ "$EXIT_CODE" -eq 152 ]; then
         echo  -e "\033[31;1m*** CANCELLED:\033[0m test $2 exceeded cpu time limit of $cpu_time_limit s"
         exit 1

--- a/tests/check_simple_example_jvm.sh
+++ b/tests/check_simple_example_jvm.sh
@@ -58,12 +58,16 @@ else
     head -n 1 "$2" | grep -q -E "# fuzion.debugLevel=0( .*)$" && export OPT=-Dfuzion.debugLevel=0
 
     # limit cpu time for executing test
-    ulimit -S -t 120 || echo "failed setting limit via ulimit"
+    cpu_time_limit=120
+    ulimit -S -t $cpu_time_limit || echo "failed setting limit via ulimit"
 
     EXIT_CODE=$(FUZION_DISABLE_ANSI_ESCAPES=true FUZION_JAVA_OPTIONS="${FUZION_JAVA_OPTIONS="-Xss${FUZION_JAVA_STACK_SIZE=5m}"} ${OPT:-}" $1 -XmaxErrors=-1 -jvm ${FUZION_JVM_BACKEND_OPTIONS:+ $FUZION_JVM_BACKEND_OPTIONS} "$2" >tmp_out.txt 2>tmp_err.txt; echo $?)
 
-    if [ "$EXIT_CODE" -ne 0 ] && [ "$EXIT_CODE" -ne 1 ]; then
-        echo "unexpected exit code"
+    if [ "$EXIT_CODE" -eq 152 ]; then
+        echo  -e "\033[31;1m*** CANCELLED:\033[0m test $2 exceeded cpu time limit of $cpu_time_limit s"
+        exit 1
+    elif [ "$EXIT_CODE" -ne 0 ] && [ "$EXIT_CODE" -ne 1 ]; then
+        echo "unexpected exit code $EXIT_CODE"
         exit "$EXIT_CODE"
     fi
 


### PR DESCRIPTION
fix #4946

~~This applies to local execution only, timeout in GitHub CI currently looks like [this](https://github.com/tokiwa-software/fuzion/actions/runs/13920912248/job/38953748147).~~

examples
```
❯ make -C ./build/tests/base64url                
make: Entering directory '/home/simon/fuzion/build/tests/base64url'
FUZION_HOME=/home/simon/fuzion/build                             ../check_simple_example_jvm.sh "../../bin/fz " base64url_test.fz || exit 1
RUN base64url_test.fz *** CANCELLED: test base64url_test.fz exceeded cpu time limit of 10 s
make: *** [../simple.mk:68: jvm] Error 1
make: Leaving directory '/home/simon/fuzion/build/tests/base64url'
```

```
❯ make -C ./build/tests/base64url                
make: Entering directory '/home/simon/fuzion/build/tests/base64url'
FUZION_HOME=/home/simon/fuzion/build                             ../check_simple_example_jvm.sh "../../bin/fz " base64url_test.fz || exit 1
RUN base64url_test.fz PASSED.
FUZION_HOME=/home/simon/fuzion/build                             ../check_simple_example_c.sh "../../bin/fz " base64url_test.fz || exit 1
RUN base64url_test.fz ../check_simple_example_c.sh: line 69: 931668 Segmentation fault      (core dumped) ( FUZION_DISABLE_ANSI_ESCAPES=true FUZION_JAVA_OPTIONS="${FUZION_JAVA_OPTIONS="-Xss${FUZION_JAVA_STACK_SIZE=5m}"} ${OPT:-}" $1 -XmaxErrors=-1 -c ${FUZION_C_BACKEND_OPTIONS:+$FUZION_C_BACKEND_OPTIONS} "$2" -o=testbin && ./testbin ) 2> tmp_err.txt
     931669 Done                    | head -n 10000
*** CANCELLED: test base64url_test.fz exceeded stack size limit of 50 KB
make: *** [../simple.mk:71: c] Error 1
make: Leaving directory '/home/simon/fuzion/build/tests/base64url'
```