### PR TITLE
fe: add special type t_FORWARD_CYCLIC to distinguish from t_ERROR/t_U…

### DIFF
--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -1393,7 +1393,7 @@ public class Call extends AbstractCall
         result = _calledFeature.resultTypeIfPresentUrgent(res, urgent);
         _recursiveResolveType = false;
 
-        if (urgent && result == Types.t_FORWARD_CYCLIC)
+        if (result == Types.t_FORWARD_CYCLIC)
           {
             // Handling of cyclic type inference. It might be
             // better if this was done in `Feature.resultType`, but

--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -1412,6 +1412,21 @@ public class Call extends AbstractCall
   }
 
 
+  /**
+   * Adjust the _raw_ result type of the
+   * called feature for the call.
+   *
+   * 1) resolve select
+   * 2) apply type parameters of the target of the call
+   * 3) apply type parameters of the called feature
+   * 4) adjust this-types for the target of the call
+   * 5) handle special cases: calling a type parameters, type_as_value, outer refs, constructors
+   * 6) replace type parameters of cotype origin: e.g. equatable_sequence.T -> equatable_sequence.type.T
+   *
+   * @param rt the raw result type
+   *
+   * @return The actual result type of the call
+   */
   private AbstractType adjustResultType(Resolution res, Context context, AbstractType rt)
   {
     var tt = targetIsTypeParameter() && rt.isThisTypeInCotype()
@@ -1570,7 +1585,7 @@ public class Call extends AbstractCall
    * kind of feature that is called.
    *
    * In particular, this contains special handling for calling type parameters,
-   * for Types.get, for outer refs and for constructors.
+   * for type_as_value, for outer refs and for constructors.
    *
    * @param res the resolution instance.
    *

--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -771,6 +771,16 @@ public class Call extends AbstractCall
     if (PRECONDITIONS) require
       (Errors.any());
 
+    setToErrorState0();
+  }
+
+
+  /**
+   * same as setToErrorState but without
+   * the requirement that there are any errors.
+   */
+  private void setToErrorState0()
+  {
     if (!Types._options.isLanguageServer())
       {
         _calledFeature = Types.f_ERROR;
@@ -1076,11 +1086,15 @@ public class Call extends AbstractCall
   {
     // type() will only be called when we really need the type, so we can report
     // an error in case there is one pending.
+    var hasPendingError = _pendingError != null;
     reportPendingError();
     var result = typeForInferencing();
     if (result == null)
       {
-        result = Types.t_UNDEFINED;
+        result = hasPendingError || _actuals.stream().anyMatch(a -> a.typeForInferencing() == Types.t_ERROR)
+          ? Types.t_ERROR
+          : Types.t_FORWARD_CYCLIC;
+        setToErrorState0();
       }
     return result;
   }
@@ -1379,7 +1393,7 @@ public class Call extends AbstractCall
         result = _calledFeature.resultTypeIfPresentUrgent(res, urgent);
         _recursiveResolveType = false;
 
-        if (urgent && (result == Types.t_UNDEFINED || result == null))
+        if (urgent && result == Types.t_FORWARD_CYCLIC)
           {
             // Handling of cyclic type inference. It might be
             // better if this was done in `Feature.resultType`, but
@@ -1387,27 +1401,39 @@ public class Call extends AbstractCall
             // we do it here.
             AstErrors.forwardTypeInference(pos(), _calledFeature, _calledFeature.pos());
             result = Types.t_ERROR;
+            setToErrorState();
           }
-        else if (result != null)
-          {
-            var tt = targetIsTypeParameter() && result.isThisTypeInCotype()
-              ? // a call B.f for a type parameter target B. resultType() is the
-              // constraint of B, so we create the corresponding type feature's
-              // selfType:
-              // NYI: CLEANUP: remove this special handling!
-              _target.type().feature().selfType()
-              : targetType(res, context);
 
-            var t0 = tt == Types.t_ERROR ? tt : resolveSelect(result, tt);
-            var t1 = t0 == Types.t_ERROR ? t0 : t0.applyTypePars(tt);
-            var t2 = t1 == Types.t_ERROR ? t1 : t1.applyTypePars(_calledFeature, _generics);
-            var t3 = t2 == Types.t_ERROR ? t2 : tt.isGenericArgument() ? t2 : t2.resolve(res, tt.feature().context());
-            var t4 = t3 == Types.t_ERROR ? t3 : adjustThisTypeForTarget(t3, false, calledFeature(), context);
-            var t5 = t4 == Types.t_ERROR ? t4 : resolveForCalledFeature(res, t4, tt, context);
-            result = t5 == Types.t_ERROR ? t5 : calledFeature().isCotype() ? t5 : t5.replace_type_parameters_of_cotype_origin(context.outerFeature());
-          }
+        result = result == null
+          ? result
+          : adjustResultType(res, context, result);
+        // NYI: UNDER DEVELOPMENT:
+        // result = result == Types.t_UNDEFINED
+        //   ? null
+        //   : result;
       }
     return result;
+  }
+
+
+  private AbstractType adjustResultType(Resolution res, Context context, AbstractType rt)
+  {
+    var tt = targetIsTypeParameter() && rt.isThisTypeInCotype()
+      ? // a call B.f for a type parameter target B. resultType() is the
+      // constraint of B, so we create the corresponding type feature's
+      // selfType:
+      // NYI: CLEANUP: remove this special handling!
+      _target.type().feature().selfType()
+      : targetType(res, context);
+
+    var t0 = tt == Types.t_ERROR ? tt : resolveSelect(rt, tt);
+    var t1 = t0 == Types.t_ERROR ? t0 : t0.applyTypePars(tt);
+    var t2 = t1 == Types.t_ERROR ? t1 : t1.applyTypePars(_calledFeature, _generics);
+    var t3 = t2 == Types.t_ERROR ? t2 : tt.isGenericArgument() ? t2 : t2.resolve(res, tt.feature().context());
+    var t4 = t3 == Types.t_ERROR ? t3 : adjustThisTypeForTarget(t3, false, calledFeature(), context);
+    var t5 = t4 == Types.t_ERROR ? t4 : resolveForCalledFeature(res, t4, tt, context);
+    return
+             t5 == Types.t_ERROR ? t5 : calledFeature().isCotype() ? t5 : t5.replace_type_parameters_of_cotype_origin(context.outerFeature());
   }
 
 
@@ -1670,8 +1696,7 @@ public class Call extends AbstractCall
    */
   private void inferGenericsFromArgs(Resolution res, Context context)
   {
-    var cf = _calledFeature;
-    int sz = cf.generics().list.size();
+    int sz = _calledFeature.generics().list.size();
     boolean[] conflict = new boolean[sz]; // The generics that had conflicting types
     var foundAt  = new List<List<Pair<SourcePosition, AbstractType>>>(); // generics that were found will get the type and pos found stored here, null while not found
     for (var i = 0; i<sz ; i++)
@@ -1680,7 +1705,7 @@ public class Call extends AbstractCall
       }
 
     _generics = actualTypeParameters();
-    var va = cf.valueArguments();
+    var va = _calledFeature.valueArguments();
     var checked = new boolean[va.size()];
     int last, next = 0;
     do
@@ -1696,6 +1721,81 @@ public class Call extends AbstractCall
     while (last < next);
 
 
+    List<Generic> missing = missingGenerics();
+
+    if (!missing.isEmpty())
+      {
+        triggerErrorsForActuals();
+      }
+
+    var rt = _calledFeature.resultTypeIfPresentUrgent(res, false);
+
+    // We may be able to infer generics later
+    // via result type propagation, do not emit errors yet.
+    if ((rt == null ||
+        !rt.isGenericArgument() ||
+         rt.genericArgument().feature().outer() != _calledFeature.outer()))
+      {
+        reportConflicts(conflict, foundAt);
+        reportMissingInferred(missing);
+      }
+  }
+
+
+  /**
+   * Trigger error reporting of actuals
+   * by calling {@code type} for each actual.
+   */
+  private void triggerErrorsForActuals()
+  {
+    // we failed inferring all type parameters, so report errors
+    for (var a : _actuals)
+      {
+        if (a instanceof Call)
+          {
+            var ignore = a.type();
+          }
+      }
+  }
+
+
+  /**
+   * report any conflicts of inference
+   *
+   * @param conflict
+   * @param foundAt
+   */
+  private void reportConflicts(boolean[] conflict, List<List<Pair<SourcePosition, AbstractType>>> foundAt)
+  {
+    // replace any missing type parameters or conflicting ones with t_ERROR,
+    // report errors for conflicts
+    for (Generic g : _calledFeature.generics().list)
+      {
+        int i = g.index();
+        if (!g.isOpen() && _generics.get(i) == Types.t_UNDEFINED || conflict[i])
+          {
+            if (CHECKS) check
+              (Errors.any() || i < _generics.size());
+            if (conflict[i])
+              {
+                AstErrors.incompatibleTypesDuringTypeInference(pos(), g, foundAt.get(i));
+                setToErrorState();
+              }
+            if (i < _generics.size())
+              {
+                _generics = _generics.setOrClone(i, Types.t_ERROR);
+              }
+          }
+      }
+  }
+
+
+  /**
+   * @return list of generic arguments
+   *         which could not be inferred
+   */
+  private List<Generic> missingGenerics()
+  {
     List<Generic> missing = new List<Generic>();
     for (Generic g : _calledFeature.generics().list)
       {
@@ -1705,54 +1805,27 @@ public class Call extends AbstractCall
             missing.add(g);
           }
       }
-
-    if (!missing.isEmpty())
-      { // we failed inferring all type parameters, so report errors
-        for (var a : _actuals)
-          {
-            if (a instanceof Call)
-              {
-                var ignore = a.type();
-              }
-          }
-      }
+    return missing;
+  }
 
 
-    var rt = cf.resultTypeIfPresentUrgent(res, false);
-    // We may be able to infer generics later
-    // via result type propagation, do not emit errors yet.
-    if ((rt == null ||
-        !rt.isGenericArgument() ||
-         rt.genericArgument().feature().outer() != cf.outer()))
+  /**
+   * report that generics in missing could not be inferred.
+   *
+   * @param missing the list of generics that could not be inferred
+   */
+  private void reportMissingInferred(List<Generic> missing)
+  {
+    // report missing inferred types only if there were no errors trying to find
+    // the types of the actuals:
+    if (!missing.isEmpty() &&
+        !_calledFeature.isCotype() &&
+        _calledFeature != Types.f_ERROR &&
+        (!Errors.any() ||
+         _actuals.stream().allMatch(x -> x.type() != Types.t_ERROR)))
       {
-        // report missing inferred types only if there were no errors trying to find
-        // the types of the actuals:
-        if (!missing.isEmpty() &&
-            (!Errors.any() ||
-            _actuals.stream().allMatch(x -> x.type() != Types.t_ERROR)))
-          {
-            AstErrors.failedToInferActualGeneric(pos(),cf, missing);
-          }
-
-        // replace any missing type parameters or conflicting ones with t_ERROR,
-        // report errors for conflicts
-        for (Generic g : _calledFeature.generics().list)
-          {
-            int i = g.index();
-            if (!g.isOpen() && _generics.get(i) == Types.t_UNDEFINED || conflict[i])
-              {
-                if (CHECKS) check
-                  (Errors.any() || i < _generics.size());
-                if (conflict[i])
-                  {
-                    AstErrors.incompatibleTypesDuringTypeInference(pos(), g, foundAt.get(i));
-                  }
-                if (i < _generics.size())
-                  {
-                    _generics = _generics.setOrClone(i, Types.t_ERROR);
-                  }
-              }
-          }
+        AstErrors.failedToInferActualGeneric(pos(), _calledFeature, missing);
+        setToErrorState();
       }
   }
 
@@ -2466,10 +2539,6 @@ public class Call extends AbstractCall
           {
             var ignore = _target.type();
           }
-
-        if (CHECKS) check
-          (Errors.any());
-
         result = Call.ERROR; // short circuit this call
       }
 
@@ -2482,7 +2551,7 @@ public class Call extends AbstractCall
       }
 
     if (POSTCONDITIONS) ensure
-      (targetTypeUndefined() || _pendingError != null || Errors.any() || result.typeForInferencing() != Types.t_ERROR);
+      (targetTypeUndefined() || _pendingError != null || Errors.any() || result.typeForInferencing() != Types.t_ERROR || result == Call.ERROR);
 
     return  result;
   }

--- a/src/dev/flang/ast/Expr.java
+++ b/src/dev/flang/ast/Expr.java
@@ -628,7 +628,7 @@ public abstract class Expr extends ANY implements HasSourcePosition
       }
 
     if (POSTCONDITIONS) ensure
-      (Errors.count() > 0
+      (Errors.any()
         || type().isVoid()
         || frmlT.isGenericArgument()
         || frmlT.isThisType()

--- a/src/dev/flang/ast/FunctionReturnType.java
+++ b/src/dev/flang/ast/FunctionReturnType.java
@@ -89,7 +89,9 @@ public class FunctionReturnType extends ReturnType
    */
   public AbstractType functionReturnType()
   {
-    return type;
+    return type == Types.t_UNDEFINED
+      ? null
+      : type;
   }
 
 

--- a/src/dev/flang/ast/Impl.java
+++ b/src/dev/flang/ast/Impl.java
@@ -231,15 +231,18 @@ public class Impl extends ANY
         //   f type := ?;
         //
         // requires a type
-        if (rt == NoType.INSTANCE)
+        if (!f.isResultField())
           {
-            AstErrors.missingResultTypeForField(f);
-            rt = new FunctionReturnType(Types.t_ERROR);
-          }
-        else if (!(rt instanceof FunctionReturnType))
-          {
-            AstErrors.illegalResultTypeNoInit(f, rt);
-            rt = new FunctionReturnType(Types.t_ERROR);
+            if (rt == NoType.INSTANCE)
+              {
+                AstErrors.missingResultTypeForField(f);
+                rt = new FunctionReturnType(Types.t_ERROR);
+              }
+            else if (!(rt instanceof FunctionReturnType))
+              {
+                AstErrors.illegalResultTypeNoInit(f, rt);
+                rt = new FunctionReturnType(Types.t_ERROR);
+              }
           }
         break;
 

--- a/src/dev/flang/ast/ParsedCall.java
+++ b/src/dev/flang/ast/ParsedCall.java
@@ -690,13 +690,14 @@ public class ParsedCall extends Call
    */
   private boolean isImmediateFunctionCall()
   {
-    return
-      type().isFunctionTypeExcludingLazy()                      &&
+    return typeForInferencing() != null &&
+      typeForInferencing().isFunctionTypeExcludingLazy() &&
       _calledFeature != Types.resolved.f_Function && // exclude inherits call in function type
       _calledFeature.arguments().size() == 0      &&
       _actuals != NO_PARENTHESES
       ||
-      type().isLazyType()                          &&   // we are `Lazy T`
+      typeForInferencing() != null &&
+      typeForInferencing().isLazyType()           &&   // we are `Lazy T`
       _calledFeature != Types.resolved.f_Lazy     &&   // but not an explicit call to `Lazy` (e.g., in inherits clause)
       _calledFeature.arguments().size() == 0      &&   // no arguments (NYI: maybe allow args for `Lazy (Function R V)`, then `l a` could become `l.call.call a`
       _actuals.isEmpty();                              // dto.

--- a/src/dev/flang/ast/Types.java
+++ b/src/dev/flang/ast/Types.java
@@ -121,6 +121,9 @@ public class Types extends ANY
   /* artificial type for Expr with unknown type due to compilation error */
   public static ResolvedType t_ERROR;
 
+  /* artificial type for Expr with unknown type due to compilation error */
+  public static final AbstractType t_FORWARD_CYCLIC = new ArtificialBuiltInType("FORWARD_CYCLIC");
+
   /* artificial feature used when feature is not known due to compilation error */
   public static final Feature f_ERROR = new Feature(true)
   {

--- a/src/dev/flang/ast/Types.java
+++ b/src/dev/flang/ast/Types.java
@@ -107,7 +107,7 @@ public class Types extends ANY
    * Dummy name used for type t_FORWARD_CYCLIC which is used to
    * indicate a forward or cylic type inference.
    */
-  public static final String FORWARD_CYCLIC = "FORWARD_CYCLIC";
+  public static final String FORWARD_CYCLIC_NAME = "FORWARD_CYCLIC";
 
 
   /**

--- a/src/dev/flang/ast/Types.java
+++ b/src/dev/flang/ast/Types.java
@@ -104,6 +104,13 @@ public class Types extends ANY
 
 
   /**
+   * Dummy name used for type t_FORWARD_CYCLIC which is used to
+   * indicate a forward or cylic type inference.
+   */
+  public static final String FORWARD_CYCLIC = "FORWARD_CYCLIC";
+
+
+  /**
    * Names of internal types that are not backed by physical feature definitions.
    */
   static Set<String> INTERNAL_NAMES = Collections.<String>unmodifiableSet
@@ -122,7 +129,7 @@ public class Types extends ANY
   public static ResolvedType t_ERROR;
 
   /* artificial type for Expr with unknown type due to compilation error */
-  public static final AbstractType t_FORWARD_CYCLIC = new ArtificialBuiltInType("FORWARD_CYCLIC");
+  public static final AbstractType t_FORWARD_CYCLIC = new ArtificialBuiltInType(FORWARD_CYCLIC_NAME);
 
   /* artificial feature used when feature is not known due to compilation error */
   public static final Feature f_ERROR = new Feature(true)

--- a/tests/free_types_negative/test_free_types_negative.fz.expected_err
+++ b/tests/free_types_negative/test_free_types_negative.fz.expected_err
@@ -9,15 +9,7 @@ The existing type was declared at --CURDIR--/test_free_types_negative.fz:120:3:
 To solve this, you may use a different name for free type 'EXISTING_TYPE'.
 
 
---CURDIR--/test_free_types_negative.fz:49:3: error 2: Failed to infer actual type parameters
-  c1 3.14 "e"        # 2. should flag an error, incompatible types inferred for `T`
---^^
-In call to 'test_free_type_negative.c1', no actual type parameters are given and inference of the type parameters failed.
-Expected type parameters: 'T'
-Type inference failed for one type parameter 'T'
-
-
---CURDIR--/test_free_types_negative.fz:49:3: error 3: Incompatible types found during type inference for type parameters
+--CURDIR--/test_free_types_negative.fz:49:3: error 2: Incompatible types found during type inference for type parameters
   c1 3.14 "e"        # 2. should flag an error, incompatible types inferred for `T`
 --^^
 Types inferred for first type parameter 'T':
@@ -29,15 +21,7 @@ Types inferred for first type parameter 'T':
 -----^^^^
 
 
---CURDIR--/test_free_types_negative.fz:52:3: error 4: Failed to infer actual type parameters
-  c2 3.14 "e"        # 3. should flag an error, incompatible types inferred for `T`
---^^
-In call to 'test_free_type_negative.c2', no actual type parameters are given and inference of the type parameters failed.
-Expected type parameters: 'T'
-Type inference failed for one type parameter 'T'
-
-
---CURDIR--/test_free_types_negative.fz:52:3: error 5: Incompatible types found during type inference for type parameters
+--CURDIR--/test_free_types_negative.fz:52:3: error 3: Incompatible types found during type inference for type parameters
   c2 3.14 "e"        # 3. should flag an error, incompatible types inferred for `T`
 --^^
 Types inferred for first type parameter 'T':
@@ -49,15 +33,7 @@ Types inferred for first type parameter 'T':
 -----^^^^
 
 
---CURDIR--/test_free_types_negative.fz:61:3: error 6: Failed to infer actual type parameters
-  d 3.14 "e"         # 4. should flag an error, incompatible types inferred for same anonymous type
---^
-In call to 'test_free_type_negative.d', no actual type parameters are given and inference of the type parameters failed.
-Expected type parameters: '_'
-Type inference failed for one type parameter '_'
-
-
---CURDIR--/test_free_types_negative.fz:61:3: error 7: Incompatible types found during type inference for type parameters
+--CURDIR--/test_free_types_negative.fz:61:3: error 4: Incompatible types found during type inference for type parameters
   d 3.14 "e"         # 4. should flag an error, incompatible types inferred for same anonymous type
 --^
 Types inferred for first type parameter '_':
@@ -69,7 +45,7 @@ Types inferred for first type parameter '_':
 ----^^^^
 
 
---CURDIR--/test_free_types_negative.fz:115:17: error 8: Could not find called feature
+--CURDIR--/test_free_types_negative.fz:115:17: error 5: Could not find called feature
   neg(x i33) => -x   # 8. should flag an error that is not too confusing
 ----------------^
 Feature not found: 'prefix -' (no arguments)
@@ -80,7 +56,7 @@ To solve this, you might replace the free type 'test_free_type_negative.neg.i33'
 --------^^^
 
 
---CURDIR--/test_free_types_negative.fz:142:28: error 9: No type information can be inferred from a lambda expression
+--CURDIR--/test_free_types_negative.fz:142:28: error 6: No type information can be inferred from a lambda expression
   say ((apply2             a,b->"$a $b").call true 3.14)   # 10. should flag an error, unable to infer actual type parameters
 ---------------------------^^^^^^^^^^^^
 A lambda expression can only be used if assigned to a field or argument of type 'Function'
@@ -89,7 +65,7 @@ assigned field must be given explicitly.
 To solve this, declare an explicit type for the target field, e.g., 'f (i32, i32) -> bool := x, y -> x > y'.
 
 
---CURDIR--/test_free_types_negative.fz:150:25: error 10: No type information can be inferred from a lambda expression
+--CURDIR--/test_free_types_negative.fz:150:25: error 7: No type information can be inferred from a lambda expression
   say ((apply3a         a,b->"$a $b").call true (u8 127))  # 11. should flag an error, unable to infer actual type parameters
 ------------------------^^^^^^^^^^^^
 A lambda expression can only be used if assigned to a field or argument of type 'Function'
@@ -98,14 +74,14 @@ assigned field must be given explicitly.
 To solve this, declare an explicit type for the target field, e.g., 'f (i32, i32) -> bool := x, y -> x > y'.
 
 
---CURDIR--/test_free_types_negative.fz:35:3: error 11: Incompatible type parameter
+--CURDIR--/test_free_types_negative.fz:35:3: error 8: Incompatible type parameter
   a2 "fourty two"    # 1. should flag an error: type constraint not respected
 --^^
 formal type parameter 'T' with constraint 'numeric'
 actual type parameter 'String'
 
 
---CURDIR--/test_free_types_negative.fz:76:5: error 12: Incompatible types when passing argument in a call
+--CURDIR--/test_free_types_negative.fz:76:5: error 9: Incompatible types when passing argument in a call
   f 3.14 "e"         # 5.b should flag an error since two calls with incompatible actual argument types
 ----^^^^
 Actual type for argument #1 'v' does not match expected type.
@@ -117,14 +93,14 @@ for value assigned  : '3.14'
 To solve this, you could change the type of the target 'v' to 'f64' or convert the type of the assigned value to 'String'.
 
 
---CURDIR--/test_free_types_negative.fz:91:3: error 13: Incompatible type parameter
+--CURDIR--/test_free_types_negative.fz:91:3: error 10: Incompatible type parameter
   g ga3              # 6. should flag an error since type arguments are in the wrong order such that constraint is not matched
 --^
 formal type parameter 'B' with constraint 'numeric'
 actual type parameter 'String'
 
 
---CURDIR--/test_free_types_negative.fz:74:5: error 14: Type inference from actual arguments failed due to incompatible types of actual arguments
+--CURDIR--/test_free_types_negative.fz:74:5: error 11: Type inference from actual arguments failed due to incompatible types of actual arguments
   f(v,w) => say "f: $v $w"
 ----^
 For the formal argument 'test_free_type_negative.f.v' the following incompatible actual arguments where found for type inference:
@@ -136,7 +112,7 @@ actual is value of type 'f64' at --CURDIR--/test_free_types_negative.fz:76:5:
 ----^^^^
 
 
---CURDIR--/test_free_types_negative.fz:105:35: error 15: Incompatible types when passing argument in a call
+--CURDIR--/test_free_types_negative.fz:105:35: error 12: Incompatible types when passing argument in a call
   x2(s Sequence T, v U) => [v] ++ s ++ [v]    # 7. should flag an error since types are incompatible due to different free types
 ----------------------------------^
 Actual type for argument #1 's' does not match expected type.
@@ -149,4 +125,4 @@ assignable to       : 'Any',
 for value assigned  : 's'
 To solve this, you could change the type of the target 's' to 'Sequence test_free_type_negative.x2.T' or convert the type of the assigned value to 'Sequence test_free_type_negative.x2.U'.
 
-15 errors.
+12 errors.

--- a/tests/reg_issue3036/reg_issue3036.fz.expected_err
+++ b/tests/reg_issue3036/reg_issue3036.fz.expected_err
@@ -1,13 +1,5 @@
 
---CURDIR--/reg_issue3036.fz:24:13: error 1: Failed to infer actual type parameters
-say (8 %% 5 = 3)
-------------^
-In call to 'infix =', no actual type parameters are given and inference of the type parameters failed.
-Expected type parameters: 'T'
-Type inference failed for one type parameter 'T'
-
-
---CURDIR--/reg_issue3036.fz:24:13: error 2: Incompatible types found during type inference for type parameters
+--CURDIR--/reg_issue3036.fz:24:13: error 1: Incompatible types found during type inference for type parameters
 say (8 %% 5 = 3)
 ------------^
 Types inferred for first type parameter 'T':
@@ -18,4 +10,4 @@ say (8 %% 5 = 3)
 say (8 %% 5 = 3)
 --------------^
 
-2 errors.
+one error.

--- a/tests/reg_issue4251/reg_issue4251.fz.expected_err
+++ b/tests/reg_issue4251/reg_issue4251.fz.expected_err
@@ -1,17 +1,9 @@
 
---CURDIR--/reg_issue4251.fz:26:2: error 1: Failed to infer actual type parameters
-(say <| (.map **2)) <| (2..10:2)
--^^^
-In call to 'Unary', no actual type parameters are given and inference of the type parameters failed.
-Expected type parameters: 'T, U'
-Type inference failed for 2 type parameters 'T', 'U'
-
-
---CURDIR--/reg_issue4251.fz:26:21: error 2: Failed to infer actual type parameters
+--CURDIR--/reg_issue4251.fz:26:21: error 1: Failed to infer actual type parameters
 (say <| (.map **2)) <| (2..10:2)
 --------------------^^
 In call to 'infix <|', no actual type parameters are given and inference of the type parameters failed.
 Expected type parameters: 'A, R'
 Type inference failed for one type parameter 'R'
 
-2 errors.
+one error.

--- a/tests/reg_issue4518/reg_issue4518.fz.expected_err
+++ b/tests/reg_issue4518/reg_issue4518.fz.expected_err
@@ -6,15 +6,9 @@ Found no visible argument fields ''
 while there are 2 destructuring variables: '_', 'x'.
 
 
---CURDIR--/reg_issue4518.fz:24:22: error 2: Failed to infer type of expression.
-a(p) => (_,x) := p; $x
----------------------^
-Expression with unknown type: 'x'
-
-
---CURDIR--/reg_issue4518.fz:24:3: error 3: Type inference from actual arguments failed since no actual call was found
+--CURDIR--/reg_issue4518.fz:24:3: error 2: Type inference from actual arguments failed since no actual call was found
 a(p) => (_,x) := p; $x
 --^
 For the formal argument 'a.p' the type can only be derived if there is a call to 'a'.
 
-3 errors.
+2 errors.

--- a/tests/reg_issue4694/reg_issue4694.fz.expected_err
+++ b/tests/reg_issue4694/reg_issue4694.fz.expected_err
@@ -16,12 +16,4 @@ Type: container.expanding
 expected one generic argument for 'T'
 found none.
 
-
---CURDIR--/reg_issue4694.fz:26:5: error 3: Failed to infer actual type parameters
-  0 |> x,y->container.expanding.env.put
-----^^
-In call to 'infix |>', no actual type parameters are given and inference of the type parameters failed.
-Expected type parameters: 'A, R'
-Type inference failed for one type parameter 'R'
-
-3 errors.
+2 errors.

--- a/tests/reg_issue4935/Makefile
+++ b/tests/reg_issue4935/Makefile
@@ -1,0 +1,25 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test Makefile
+#
+# -----------------------------------------------------------------------
+
+override NAME = reg_issue4935
+include ../simple.mk

--- a/tests/reg_issue4935/reg_issue4935.fz
+++ b/tests/reg_issue4935/reg_issue4935.fz
@@ -1,0 +1,27 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test reg_issue4935
+#
+# -----------------------------------------------------------------------
+
+ay(a T) => a
+af => ay xxx
+af
+unit

--- a/tests/reg_issue4935/reg_issue4935.fz.expected_err
+++ b/tests/reg_issue4935/reg_issue4935.fz.expected_err
@@ -1,0 +1,9 @@
+
+--CURDIR--/reg_issue4935.fz:25:10: error 1: Could not find called feature
+af => ay xxx
+---------^^^
+Feature not found: 'xxx' (no arguments)
+Target feature: 'af'
+In call: 'xxx'
+
+one error.


### PR DESCRIPTION
fixes #4935

The main goals of this PR is to change Expr.type() such that it never returns null or `t_UNDEFINED`.

For this I added t_FORWARD_CYCLIC to indicate cyclic type inference. Before t_UNDEFINED was used for that. This change should make clearer what is actually happening.

In some cases I added a `setToErrorState` in Call when an Error is shown. This suppresses a few subsequent errors as can be witnessed in the updated test recordings.


