### PR TITLE
fe: Expr.type never `t_UNDEFINED`

### DIFF
--- a/src/dev/flang/ast/AbstractBlock.java
+++ b/src/dev/flang/ast/AbstractBlock.java
@@ -124,8 +124,7 @@ public abstract class AbstractBlock extends Expr
    * still unknown, i.e., before or during type resolution.
    *
    * @return this Expr's type or t_ERROR in case it is not known yet.
-   * t_UNDEFINED in case Expr depends on the inferred result type of a feature
-   * that is not available yet (or never will due to circular inference).
+   * t_FORWARD_CYCLIC in case the type can not be inferred due to circular inference.
    */
   @Override
   public AbstractType type()

--- a/src/dev/flang/ast/AbstractMatch.java
+++ b/src/dev/flang/ast/AbstractMatch.java
@@ -152,10 +152,8 @@ public abstract class AbstractMatch extends Expr
    * type returns the type of this expression or Types.t_ERROR if the type is
    * still unknown, i.e., before or during type resolution.
    *
-   * @return this Expr's type or t_ERROR in case it is not known
-   * yet. t_UNDEFINED in case Expr depends on the inferred result type of a
-   * feature that is not available yet (or never will due to circular
-   * inference).
+   * @return this Expr's type or t_ERROR in case it is not known yet.
+   * t_FORWARD_CYCLIC in case the type can not be inferred due to circular inference.
    */
   @Override
   public AbstractType type()
@@ -179,6 +177,9 @@ public abstract class AbstractMatch extends Expr
               });
           }
       }
+    if (POSTCONDITIONS) ensure
+      (_type != null,
+       _type != Types.t_UNDEFINED);
     return _type;
   }
 

--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -1078,8 +1078,7 @@ public class Call extends AbstractCall
    * still unknown, i.e., before or during type resolution.
    *
    * @return this Expr's type or t_ERROR in case it is not known yet.
-   * t_UNDEFINED in case Expr depends on the inferred result type of a feature
-   * that is not available yet (or never will due to circular inference).
+   * t_FORWARD_CYCLIC in case the type can not be inferred due to circular inference.
    */
   @Override
   public AbstractType type()
@@ -2573,14 +2572,21 @@ public class Call extends AbstractCall
     var t = getActualResultType(res, context, false);
 
     if (CHECKS) check
-      (_type == null || t.compareTo(_type) == 0);
+      (_type == null || t.compareTo(_type) == 0,
+       Errors.any() || t != Types.t_ERROR);
 
     _type = t;
 
     if (_type == null || isTailRecursive(context.outerFeature()))
       {
-        _calledFeature.whenResolvedTypes
-          (() -> _type = getActualResultType(res, context, true));
+        _calledFeature.whenResolvedTypes(() ->
+          {
+            var t2 = getActualResultType(res, context, true);
+            if (CHECKS) check
+              (_type == null || t2.compareTo(_type) == 0,
+              Errors.any() || t2 != Types.t_ERROR);
+            _type = t2;
+          });
       }
   }
 

--- a/src/dev/flang/ast/Expr.java
+++ b/src/dev/flang/ast/Expr.java
@@ -141,14 +141,14 @@ public abstract class Expr extends ANY implements HasSourcePosition
    * type returns the type of this expression or Types.t_ERROR if the type is
    * still unknown, i.e., before or during type resolution.
    *
-   * @return this Expr's type or t_ERROR in case it is not known
-   * yet. t_UNDEFINED in case Expr depends on the inferred result type of a
-   * feature that is not available yet (or never will due to circular
-   * inference).
+   * @return this Expr's type or t_ERROR in case it is not known yet.
+   * t_FORWARD_CYCLIC in case the type can not be inferred due to circular inference.
    */
   public AbstractType type()
   {
     var result = typeForInferencing();
+    if (CHECKS) check
+      (result != Types.t_UNDEFINED);
     if (result == null)
       {
         result = Types.t_ERROR;
@@ -156,6 +156,9 @@ public abstract class Expr extends ANY implements HasSourcePosition
         // print the problem
         AstErrors.failedToInferType(this);
       }
+    if (POSTCONDITIONS) ensure
+      (result != null,
+       result != Types.t_UNDEFINED);
     return result;
   }
 

--- a/src/dev/flang/ast/Feature.java
+++ b/src/dev/flang/ast/Feature.java
@@ -2392,7 +2392,9 @@ A ((Choice)) declaration must not contain a result type.
       }
 
     if (POSTCONDITIONS) ensure
-      (!urgent || result != null);
+      (!urgent || result != null,
+       result != Types.t_UNDEFINED,
+       Errors.any() || result != Types.t_ERROR);
 
     return result;
   }

--- a/src/dev/flang/ast/Function.java
+++ b/src/dev/flang/ast/Function.java
@@ -473,6 +473,9 @@ public class Function extends AbstractLambda
    */
   public AbstractType type()
   {
+    if (CHECKS) check
+      (_type != Types.t_UNDEFINED);
+
     if (_type == null)
       {
         if (_expr.type() != Types.t_ERROR || !Errors.any())
@@ -481,6 +484,9 @@ public class Function extends AbstractLambda
           }
         _type = Types.t_ERROR;
       }
+    if (POSTCONDITIONS) ensure
+      (_type != null,
+       _type != Types.t_UNDEFINED);
     return _type;
   }
 

--- a/src/dev/flang/ast/If.java
+++ b/src/dev/flang/ast/If.java
@@ -189,10 +189,8 @@ public class If extends ExprWithPos
    * type returns the type of this expression or Types.t_ERROR if the type is
    * still unknown, i.e., before or during type resolution.
    *
-   * @return this Expr's type or t_ERROR in case it is not known
-   * yet. t_UNDEFINED in case Expr depends on the inferred result type of a
-   * feature that is not available yet (or never will due to circular
-   * inference).
+   * @return this Expr's type or t_ERROR in case it is not known yet.
+   * t_FORWARD_CYCLIC in case the type can not be inferred due to circular inference.
    */
   @Override
   public AbstractType type()
@@ -208,6 +206,9 @@ public class If extends ExprWithPos
               branches());
           }
       }
+    if (POSTCONDITIONS) ensure
+      (_type != null,
+       _type != Types.t_UNDEFINED);
     return _type;
   }
 


### PR DESCRIPTION
This PR changes the contract of `Expr.type` and the comment.