### PR TITLE
fe: allow setting feature name for features with arguments

### DIFF
--- a/src/dev/flang/ast/Feature.java
+++ b/src/dev/flang/ast/Feature.java
@@ -2454,13 +2454,13 @@ A ((Choice)) declaration must not contain a result type.
    *
    *   x := 42
    *   x := x + 1
+   *
+   * or when distinguishing features with same name from different modules.
    */
   public void setFeatureName(FeatureName newFeatureName)
   {
     if (PRECONDITIONS) require
-      (_featureName.baseName() == newFeatureName.baseName(),
-       _featureName.argCount() == 0,
-       newFeatureName.argCount() == 0);
+      (_featureName.baseName() == newFeatureName.baseName());
 
     _featureName = newFeatureName;
   }

--- a/src/dev/flang/fe/SourceModule.java
+++ b/src/dev/flang/fe/SourceModule.java
@@ -1002,7 +1002,7 @@ A post-condition of a feature that does not redefine an inherited feature must s
            || visibilityPreventsConflict(f, existing) || Feature.isAbstractAndFixedPair(f, existing))
           {
             var existingFeatures = FeatureName.getAll(df, fn.baseName(), 0);
-            fn = FeatureName.get(fn.baseName(), 0, existingFeatures.size());
+            fn = FeatureName.get(fn.baseName(), fn.argCount(), existingFeatures.size());
             f.setFeatureName(fn);
           }
         else

--- a/tests/reg_issue4963/Makefile
+++ b/tests/reg_issue4963/Makefile
@@ -1,0 +1,25 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test Makefile
+#
+# -----------------------------------------------------------------------
+
+override NAME = reg_issue4963
+include ../simple.mk

--- a/tests/reg_issue4963/reg_issue4963.fz
+++ b/tests/reg_issue4963/reg_issue4963.fz
@@ -1,0 +1,24 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test reg_issue4963
+#
+# -----------------------------------------------------------------------
+
+f16(a i32) =>

--- a/tests/reg_issue4963/reg_issue4963.fz.expected_err
+++ b/tests/reg_issue4963/reg_issue4963.fz.expected_err
@@ -1,0 +1,8 @@
+
+--CURDIR--/reg_issue4963.fz:24:1: error 1: Main feature must not have arguments
+f16(a i32) =>
+^^^
+Main feature has one argument ('f16.a'), but should have no arguments to be used as main feature in an application
+To solve this, remove the arguments from feature 'f16'
+
+one error.


### PR DESCRIPTION
fixes #4963

We need this when we have an existing feature with the same name in a module that is not visible outside of the module.
