### PR TITLE
ast: Fix position of inheritance calls generated for cotype, fix #5003

### DIFF
--- a/src/dev/flang/ast/AbstractCall.java
+++ b/src/dev/flang/ast/AbstractCall.java
@@ -151,9 +151,8 @@ public abstract class AbstractCall extends Expr
 
 
   /**
-   * For a type feature, create the inheritance call for a parent type feature.
-   *
-   * @param p the source position
+   * For a type feature, create the inheritance call for a parent type feature
+   * from this original inheritance call.
    *
    * @param res Resolution instance used to resolve types in this call.
    *
@@ -161,7 +160,7 @@ public abstract class AbstractCall extends Expr
    *
    * @return instance of Call to be used for the parent call in cotype().
    */
-  Call typeCall(SourcePosition p, Resolution res, AbstractFeature that)
+  Call cotypeInheritanceCall(Resolution res, AbstractFeature that)
   {
     var selfType = new ParsedType(pos(),
                                   FuzionConstants.COTYPE_THIS_TYPE,
@@ -203,7 +202,7 @@ public abstract class AbstractCall extends Expr
           }
       }
 
-    return calledFeature().typeCall(p, typeParameters, res, that, target());
+    return calledFeature().cotypeInheritanceCall(pos(), typeParameters, res, that, target());
   }
 
 

--- a/src/dev/flang/ast/AbstractFeature.java
+++ b/src/dev/flang/ast/AbstractFeature.java
@@ -791,14 +791,14 @@ public abstract class AbstractFeature extends Expr implements Comparable<Abstrac
    *
    * @return instance of Call to be used for the parent call in cotype().
    */
-  Call typeCall(SourcePosition p, List<AbstractType> typeParameters, Resolution res, AbstractFeature that, Expr target)
+  Call cotypeInheritanceCall(SourcePosition p, List<AbstractType> typeParameters, Resolution res, AbstractFeature that, Expr target)
   {
     var o = outer();
     var oc = o == null || o.isUniverse()                            ? Universe.instance
-      : target instanceof AbstractCall ac && !ac.isCallToOuterRef() ? ac.typeCall(p, res, that)
-      : o.typeCall(p, new List<>(o.selfType(),
-                                 o.generics().asActuals().map(that::rebaseTypeForCotype)),
-                   res, that, null);
+      : target instanceof AbstractCall ac && !ac.isCallToOuterRef() ? ac.cotypeInheritanceCall(res, that)
+      : o.cotypeInheritanceCall(p, new List<>(o.selfType(),
+                                              o.generics().asActuals().map(that::rebaseTypeForCotype)),
+                                res, that, null);
 
     var tf = cotype(res);
     return new Call(p,
@@ -953,7 +953,7 @@ public abstract class AbstractFeature extends Expr implements Comparable<Abstrac
     return inherits()
       .stream()
       .filter(pc -> pc.calledFeature() != Types.f_ERROR)
-      .map(pc -> pc.typeCall(pos(), res, this))
+      .map(pc -> pc.cotypeInheritanceCall(res, this))
       .collect(List.collector());
   }
 

--- a/tests/reg_issue5003/Makefile
+++ b/tests/reg_issue5003/Makefile
@@ -1,0 +1,25 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test Makefile
+#
+# -----------------------------------------------------------------------
+
+override NAME = reg_issue5003
+include ../simple.mk

--- a/tests/reg_issue5003/reg_issue5003.fz
+++ b/tests/reg_issue5003/reg_issue5003.fz
@@ -1,0 +1,38 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test reg_issue5003
+#
+# -----------------------------------------------------------------------
+
+# this used to produce two errors that only differ in the source code position.
+# Only one error should be produced, even though the same problem is detected
+# for the inheritance of `z' as well as the automatically generated inheritance
+# call for `z`'s cotype.
+#
+reg_issue5003 =>
+
+  A is
+  B : A is
+  C is
+
+  x(T type : A) is
+
+  y : x B is
+  z : x C is  # incompatible type parameter `C` should create error here

--- a/tests/reg_issue5003/reg_issue5003.fz.expected_err
+++ b/tests/reg_issue5003/reg_issue5003.fz.expected_err
@@ -1,0 +1,8 @@
+
+--CURDIR--/reg_issue5003.fz:38:7: error 1: Incompatible type parameter
+  z : x C is  # incompatible type parameter `C` should create error here
+------^
+formal type parameter 'T' with constraint 'reg_issue5003.this.A'
+actual type parameter 'reg_issue5003.this.C'
+
+one error.


### PR DESCRIPTION
This avoids redundant errors in case there are errors in the inheritance calls that also appear in the corresponding cotype.

Renamed `typeCall` (2x) as `cotypeInheritanceCall` since this is only used for inheritance calls for cotypes. Remove the position argument in `AbstractCall.cotypeInheritanceCall` since the original call's position must be used. 

Also added a test for this.

