### PR TITLE
lib: mark `bind` in `outcome` as fixed, so `parse_result` can reuse the name

### DIFF
--- a/modules/base/src/outcome.fz
+++ b/modules/base/src/outcome.fz
@@ -105,7 +105,7 @@ is
   #
   #     (open "example.txt").bind (fd->read fd 42)
   #
-  public bind(B type, f T -> outcome B) outcome B =>
+  public fixed bind(B type, f T -> outcome B) outcome B =>
     outcome.this ? v T => f v
                  | e error => e
 

--- a/modules/nom/src/nom.fz
+++ b/modules/nom/src/nom.fz
@@ -45,7 +45,7 @@ public nom is
     #
     public map(OM type, mapper O -> outcome OM) Parser I R OM =>
       parser I R OM i->
-        Parser.this.call i .bind2 s->
+        Parser.this.call i .bind s->
           id (parse_result R OM) (match mapper s.out
                                     o OM => success s.rest o
                                     e2 error => e2)
@@ -85,6 +85,6 @@ public nom is
   # the result of Parser.call()
   #
   public parse_result(I, O type) : outcome (success I O) is
-    public bind2(f (success I O) -> parse_result I2 O2) parse_result I2 O2 =>
+    public fixed bind(f (success I O) -> parse_result I2 O2) parse_result I2 O2 =>
       parse_result.this ? v (success I O) => f v
                         | e error => e

--- a/modules/nom/src/nom/multi.fz
+++ b/modules/nom/src/nom/multi.fz
@@ -35,7 +35,7 @@ module multi is
   #
   public many1 (I, O type, p Parser I I O) =>
     parser I I (Sequence O) input->
-      p.call input .bind2 _->
+      p.call input .bind _->
         (many0 p).call input
 
 
@@ -78,7 +78,7 @@ module multi is
   #
   public separated_list1(I, O, D type, p_sep Parser I I D, p_value () -> (Parser I I O)) =>
     parse(input I) parse_result I (Sequence O) =>
-      p_value().call input .bind2 s1->
+      p_value().call input .bind s1->
         match (many0 (sequence.preceded p_sep p_value())).call s1.rest
           s2 success => id (parse_result I (Sequence O)) (success s2.rest [s1.out]++s2.out)
           error => panic "invalid state, many0 always succeeds"

--- a/modules/nom/src/nom/sequence.fz
+++ b/modules/nom/src/nom/sequence.fz
@@ -21,8 +21,8 @@ module sequence is
   #
   public tuple2(I, O1, O2 type, p1 Parser I I O1, p2 Parser I I O2) =>
     parse(input I) parse_result I (tuple O1 O2) =>
-      p1.call input .bind2 s1->
-        p2.call s1.rest .bind2 s2->
+      p1.call input .bind s1->
+        p2.call s1.rest .bind s2->
           id (parse_result I (tuple O1 O2)) (success s2.rest (s1.out, s2.out))
     parser I _ _ (input -> parse input)
 
@@ -31,9 +31,9 @@ module sequence is
   #
   public tuple3(I, O1, O2, O3 type, p1 Parser I I O1, p2 Parser I I O2, p3 Parser I I O3) =>
     parse(input I) parse_result I (tuple O1 O2 O3) =>
-      p1.call input .bind2 s1->
-        p2.call s1.rest .bind2 s2->
-          p3.call s2.rest .bind2 s3->
+      p1.call input .bind s1->
+        p2.call s1.rest .bind s2->
+          p3.call s2.rest .bind s3->
             id (parse_result I (tuple O1 O2 O3)) (success s3.rest (s1.out, s2.out, s3.out))
 
     parser I _ _ (input -> parse input)
@@ -48,10 +48,10 @@ module sequence is
     p4 Parser I I O4
     ) =>
     parse(input I) parse_result I (tuple O1 O2 O3 O4) =>
-      p1.call input .bind2 s1->
-        p2.call s1.rest .bind2 s2->
-          p3.call s2.rest .bind2 s3->
-            p4.call s3.rest .bind2 s4->
+      p1.call input .bind s1->
+        p2.call s1.rest .bind s2->
+          p3.call s2.rest .bind s3->
+            p4.call s3.rest .bind s4->
               id (parse_result I (tuple O1 O2 O3 O4)) (success s4.rest (s1.out, s2.out, s3.out, s4.out))
     parser I _ _ (input -> parse input)
 
@@ -60,7 +60,7 @@ module sequence is
   #
   public preceded(I, O1, O2 type, p1 Parser I I O1, p2 Parser I I O2) =>
     parse(input I) parse_result I O2 =>
-      p1.call input .bind2 s1->
+      p1.call input .bind s1->
         p2.call s1.rest
     parser I _ _ (input -> parse input)
 
@@ -69,9 +69,9 @@ module sequence is
   #
   public delimited(I, O1, O2, O3 type, p1 Parser I I O1, p2 Parser I I O2, p3 Parser I I O3) =>
     parse(input I) parse_result I O2 =>
-      p1.call input .bind2 s1->
-        p2.call s1.rest .bind2 s2->
-          p3.call s2.rest .bind2 s3->
+      p1.call input .bind s1->
+        p2.call s1.rest .bind s2->
+          p3.call s2.rest .bind s3->
             id (parse_result I O2) (success s3.rest s2.out)
     parser I _ _ (input -> parse input)
 
@@ -80,7 +80,7 @@ module sequence is
   #
   public separated_pair(I type, R1, R2, R3, O1, O2, O3 type, p1 Parser I R1 O1, p_sep Parser R1 R2 O2, p2 () -> (Parser R2 R3 O3)) =>
     parser I R3 (tuple O1 O3) input->
-      p1.call input .bind2 s1->
-         p_sep.call s1.rest .bind2 s2->
-           p2().call s2.rest .bind2 s3->
+      p1.call input .bind s1->
+         p_sep.call s1.rest .bind s2->
+           p2().call s2.rest .bind s3->
              id (parse_result R3 (tuple O1 O3)) (success s3.rest (s1.out, s3.out))


### PR DESCRIPTION
fix #4909