### PR TITLE
tests: process_utf8, move target all to beginning

### DIFF
--- a/tests/process_utf8/Makefile
+++ b/tests/process_utf8/Makefile
@@ -24,10 +24,10 @@
 
 override PATH := $(PATH):$(shell pwd)
 
+all: jvm c int
+
 compile_unicode_feature:
 	../../bin/fz -c unicode_feature.fz
-
-all: jvm c int
 
 jvm: compile_unicode_feature
 


### PR DESCRIPTION
this way make -C test... executes all target and not compile_unicode_feature
