### PR TITLE
be/c: zero memory (securely)

### DIFF
--- a/include/fz.h
+++ b/include/fz.h
@@ -40,7 +40,7 @@ static_assert(sizeof(size_t) == 8, "implementation restriction, size_t must be 8
 
 void * fzE_malloc_safe(size_t size);
 
-void fzE_memset(void *dest, int ch, size_t sz);
+void fzE_mem_zero(void *dest, size_t sz);
 
 void fzE_memcpy(void *restrict dest, const void *restrict src, size_t sz);
 

--- a/include/posix.c
+++ b/include/posix.c
@@ -78,6 +78,19 @@ inline int set_last_error(int ret_val)
   return ret_val;
 }
 
+// zero memory
+void fzE_mem_zero(void *dest, size_t sz)
+{
+#ifdef __STDC_LIB_EXT1__
+  memset_s(dest, sz, 0, sz);
+#else
+  volatile unsigned char *p = dest;
+  while (sz--) {
+      *p++ = 0;
+  }
+#endif
+}
+
 
 // make directory, return zero on success
 int fzE_mkdir(const char *pathname){
@@ -219,7 +232,7 @@ int fzE_socket(int family, int type, int protocol){
 int fzE_getaddrinfo(int family, int socktype, int protocol, int flags, char * host, char * port, struct addrinfo ** result){
   struct addrinfo hints;
 
-  fzE_memset(&hints, 0, sizeof hints);
+  fzE_mem_zero(&hints, sizeof hints);
 
   hints.ai_family = fzE_get_family(family);
   hints.ai_socktype = fzE_get_socket_type(socktype);
@@ -313,7 +326,7 @@ int fzE_get_peer_address(int sockfd, void * buf) {
   // sockaddr_storage: A structure at least as large
   // as any other sockaddr_* address structures.
   struct sockaddr_storage peeraddr;
-  fzE_memset(&peeraddr, 0, sizeof(peeraddr));
+  fzE_mem_zero(&peeraddr, sizeof(peeraddr));
   socklen_t peeraddrlen = sizeof(peeraddr);
   if (set_last_error(getpeername(sockfd, (struct sockaddr *)&peeraddr, &peeraddrlen)) == 0) {
     if (peeraddr.ss_family == AF_INET) {
@@ -335,7 +348,7 @@ unsigned short fzE_get_peer_port(int sockfd) {
   // sockaddr_storage: A structure at least as large
   // as any other sockaddr_* address structures.
   struct sockaddr_storage peeraddr;
-  fzE_memset(&peeraddr, 0, sizeof(peeraddr));
+  fzE_mem_zero(&peeraddr, sizeof(peeraddr));
   socklen_t peeraddrlen = sizeof(peeraddr);
   if (set_last_error(getpeername(sockfd, (struct sockaddr *)&peeraddr, &peeraddrlen)) == 0) {
     if (peeraddr.ss_family == AF_INET) {
@@ -508,7 +521,7 @@ void fzE_init()
 
 #ifdef FUZION_ENABLE_THREADS
   pthread_mutexattr_t attr;
-  fzE_memset(&fzE_global_mutex, 0, sizeof(fzE_global_mutex));
+  fzE_mem_zero(&fzE_global_mutex, sizeof(fzE_global_mutex));
   bool res = pthread_mutexattr_init(&attr) == 0 &&
             pthread_mutexattr_setprotocol(&attr, PTHREAD_PRIO_INHERIT) == 0 &&
             pthread_mutex_init(&fzE_global_mutex, &attr) == 0;

--- a/include/shared.c
+++ b/include/shared.c
@@ -97,10 +97,6 @@ void * fzE_malloc_safe(size_t size) {
   return p;
 }
 
-void fzE_memset(void *dest, int ch, size_t sz){
-  // NYI: UNDER DEVELOPMENT: use bounds checked version, e.g. memset_s
-  memset(dest, ch, sz);
-}
 
 void fzE_memcpy(void *restrict dest, const void *restrict src, size_t sz){
   // NYI: UNDER DEVELOPMENT: use bounds checked version, e.g. memcpy_s

--- a/include/win.c
+++ b/include/win.c
@@ -74,6 +74,13 @@ wchar_t* utf8_to_wide_str(const char* str)
   return wideStr;
 }
 
+// zero memory
+void fzE_mem_zero(void *dest, size_t sz)
+{
+  SecureZeroMemory(dest, sz);
+}
+
+
 
 // returns the latest error number of
 // the current thread
@@ -621,7 +628,7 @@ void fzE_init()
 
 #ifdef FUZION_ENABLE_THREADS
   pthread_mutexattr_t attr;
-  fzE_memset(&fzE_global_mutex, 0, sizeof(fzE_global_mutex));
+  fzE_mem_zero(&fzE_global_mutex, sizeof(fzE_global_mutex));
   bool res = pthread_mutexattr_init(&attr) == 0 &&
             // NYI #1646 setprotocol returns EINVAL on windows.
             // pthread_mutexattr_setprotocol(&attr, PTHREAD_PRIO_INHERIT) == 0 &&

--- a/src/dev/flang/be/c/C.java
+++ b/src/dev/flang/be/c/C.java
@@ -1251,7 +1251,7 @@ public class C extends ANY
     var tmp = new CIdent("tmp0");
     return CStmnt.seq(
       CStmnt.decl("struct " + CNames.fzThreadEffectsEnvironment.code(), tmp),
-      CExpr.call("fzE_memset", new List<>(tmp.adrOf(), CExpr.int32const(0), CExpr.sizeOfType("struct " + CNames.fzThreadEffectsEnvironment.code()))),
+      CExpr.call("fzE_mem_zero", new List<>(tmp.adrOf(), CExpr.sizeOfType("struct " + CNames.fzThreadEffectsEnvironment.code()))),
       CNames.fzThreadEffectsEnvironment.assign(tmp.adrOf()),
       CStmnt.seq(
         new List<CStmnt>(
@@ -1953,7 +1953,7 @@ public class C extends ANY
           CStmnt.lineComment("cur does not escape, alloc on stack"),
           CStmnt.decl(_names.struct(cl), CNames.CURRENT),
           // this fixes "variable 'fzCur' is uninitialized when used here" in e.g. reg_issue1188
-          CExpr.call("fzE_memset", new List<>(CNames.CURRENT.adrOf(), CExpr.int32const(0), CNames.CURRENT.sizeOfExpr())));
+          CExpr.call("fzE_mem_zero", new List<>(CNames.CURRENT.adrOf(), CNames.CURRENT.sizeOfExpr())));
       case Unknown   -> CStmnt.seq(CStmnt.lineComment("cur may escape, so use malloc"      ), declareAllocAndInitClazzId(cl, CNames.CURRENT));
       case Undefined -> CExpr.dummy("undefined life time");
       };


### PR DESCRIPTION
> memset may be optimized away (under the as-if rules) if the object modified by this function is not accessed again for the rest of its lifetime

fixes #591

