### PR TITLE
ast: raise better error for `say <| ([0,1,2].map 42)`

### DIFF
--- a/tests/reg_issue4938/Makefile
+++ b/tests/reg_issue4938/Makefile
@@ -1,0 +1,25 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test Makefile
+#
+# -----------------------------------------------------------------------
+
+override NAME = reg_issue4938
+include ../simple.mk

--- a/tests/reg_issue4938/reg_issue4938.fz
+++ b/tests/reg_issue4938/reg_issue4938.fz
@@ -1,0 +1,26 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test reg_issue4938
+#
+# -----------------------------------------------------------------------
+
+say <| ([0,1,2].map 42)
+
+say <| ([0,1,2].map "")

--- a/tests/reg_issue4938/reg_issue4938.fz.expected_err
+++ b/tests/reg_issue4938/reg_issue4938.fz.expected_err
@@ -1,0 +1,30 @@
+
+--CURDIR--/reg_issue4938.fz:24:21: error 1: Incompatible types when passing argument in a call
+say <| ([0,1,2].map 42)
+--------------------^^
+Actual type for argument #1 'f' does not match expected type.
+In call to          : 'Sequence.map'
+expected formal type: 'Unary Sequence.map.B Sequence.T'
+actual type found   : 'i32'
+assignable to       : 'i32'
+for value assigned  : '42'
+To solve this, you could change the type of the target 'f' to 'i32' or convert the type of the assigned value to 'Unary Sequence.map.B Sequence.T'.
+
+
+--CURDIR--/reg_issue4938.fz:26:21: error 2: Incompatible types when passing argument in a call
+say <| ([0,1,2].map "")
+--------------------^^
+Actual type for argument #1 'f' does not match expected type.
+In call to          : 'Sequence.map'
+expected formal type: 'Unary Sequence.map.B Sequence.T'
+actual type found   : 'String'
+assignable to       : 'Any',
+                      'String',
+                      'property.ref equatable',
+                      'property.ref hashable',
+                      'property.ref orderable',
+                      'property.ref partially_orderable'
+for value assigned  : '""'
+To solve this, you could change the type of the target 'f' to 'String' or convert the type of the assigned value to 'Unary Sequence.map.B Sequence.T'.
+
+2 errors.


### PR DESCRIPTION
We now give up earlier on incompatible actual-type/formal-type.

fixes #4938