### PR TITLE
skip native_value test on jvm backend because of #5026

### DIFF
--- a/tests/native_value/skip_jvm
+++ b/tests/native_value/skip_jvm
@@ -1,0 +1,2 @@
+# NYI: BUG: #5026
+test native_value fails in github action with exit code 134


### PR DESCRIPTION
[ci skip]
