### PR TITLE
lib: cleanup, remove `type_of_lazy`

### DIFF
--- a/modules/base/src/Type.fz
+++ b/modules/base/src/Type.fz
@@ -141,26 +141,5 @@ public type_as_value(T type) => T
 #   `type_of "bla"` is `String`
 #   `type_of (panic "***")` will terminate
 #
-public type_of(T type, _ T) => T
+public type_of(T type, _ Lazy T) => T
 
-
-# universe feature to determine the compile-time type of an expression.
-#
-# This is to be called without an actual type passed to `T`, but `T` should be
-# inferred from the result type of the actual value argument `_`.
-#
-# The function passed as value argument is ignored, it is not called.
-#
-# The result is the result type of the value argument boxed into a ref value and
-# returned as a value of type `Type`.
-#
-# examples:
-#
-#   `type_of_lazy ()->"bla"` is Type of `String`
-#   `type_of_lazy ()->(panic "***")` is Type of `void`.
-#
-# NYI: Fuzion should have better syntax sugar for lazy value arguments such that
-# we do not need the `()->` prefix to create a lambda.  Then, `type_of` could
-# have a lazy argument and `type_of_lazy` could be removed.
-#
-public type_of_lazy(T type, _ ()->T) => T

--- a/tests/reg_issue1158_type_of_type_parameters/test_type_of.fz
+++ b/tests/reg_issue1158_type_of_type_parameters/test_type_of.fz
@@ -95,11 +95,11 @@ test_type_of is
   chck_cmp $(type_of "bal"                 ) "Type of 'String'"
 
   # additional tests using base lib's `type_of` with lazy argument:
-  chck_cmp $(type_of_lazy ()->3.14                          ) "Type of 'f64'"
-  chck_cmp $(type_of_lazy ()->(option 42)                   ) "Type of 'option i32'"
-  chck_cmp $(type_of_lazy ()->(type_of_lazy ()->(option 42))) "Type of 'Type'"
-  chck_cmp $(type_of_lazy ()->((option i32).type)           ) "Type of 'Type'"
-  chck_cmp $(type_of_lazy ()->"bal"                         ) "Type of 'String'"
-  chck_cmp $(type_of_lazy ()->(panic "***")                 ) "Type of 'void'"
+  chck_cmp $(type_of ()->3.14                          ) "Type of 'f64'"
+  chck_cmp $(type_of ()->(option 42)                   ) "Type of 'option i32'"
+  chck_cmp $(type_of ()->(type_of ()->(option 42))     ) "Type of 'Type'"
+  chck_cmp $(type_of ()->((option i32).type)           ) "Type of 'Type'"
+  chck_cmp $(type_of ()->"bal"                         ) "Type of 'String'"
+  chck_cmp $(type_of ()->(panic "***")                 ) "Type of 'void'"
 
   exit

--- a/tests/reg_issue197/reg_issue197.fz
+++ b/tests/reg_issue197/reg_issue197.fz
@@ -57,14 +57,14 @@ reg_issue197 =>
     b(U type) a U => do
     v a T => (a u8).b T
 
-  say "a.v: {type_of_lazy (a f32 .v)} (expecting a f32)"
+  say "a.v: {type_of (a f32 .v)} (expecting a f32)"
 
   # smallest example that I found:
   a0(T type) is
     b(U type) U => do
     v T => (a0 u8).b T
 
-  say "a0.v: {type_of_lazy (a0 i16 .v)} expecting (i16)"
+  say "a0.v: {type_of (a0 i16 .v)} expecting (i16)"
 
   a1(T type) is
     b(U type) (T,U,option T,Sequence U) => do
@@ -73,7 +73,7 @@ reg_issue197 =>
   q : a1 unit is
 
   x() (unit, i64, option unit, Sequence i64) => q.b i64
-  say "q.b: {type_of_lazy (q.b u128)} (expecting (unit, u128, option unit, Sequence u128)"
+  say "q.b: {type_of (q.b u128)} (expecting (unit, u128, option unit, Sequence u128)"
 
 
   # same example as `a1`, but using the type `T` and `U` as an argument

--- a/tests/reg_issue4557/reg_issue4557.fz
+++ b/tests/reg_issue4557/reg_issue4557.fz
@@ -23,7 +23,7 @@
 
 test_callany is
 
-  Any.f => say "called {type_of Any.this}.f"
+  Any.f => say "called {type_as_value Any.this}.f"
 
   unit.f
   "hi".f

--- a/tests/visibility_scoping/visibility_scoping.fz.expected_err
+++ b/tests/visibility_scoping/visibility_scoping.fz.expected_err
@@ -31,7 +31,15 @@ Target feature: 'visibility_scoping.test9'
 In call: 'x'
 
 
---CURDIR--/visibility_scoping.fz:97:10: error 5: Could not find called feature
+--CURDIR--/visibility_scoping.fz:96:10: error 5: Could not find called feature
+    _ := tt   # should flag an error: feature not found
+---------^^
+Feature not found: 'tt' (no arguments)
+Target feature: 'visibility_scoping.test6'
+In call: 'tt'
+
+
+--CURDIR--/visibility_scoping.fz:97:10: error 6: Could not find called feature
     _ := t   # should flag an error: feature not found
 ---------^
 Feature not found: 't' (no arguments)
@@ -39,7 +47,7 @@ Target feature: 'visibility_scoping.test6'
 In call: 't'
 
 
---CURDIR--/visibility_scoping.fz:93:10: error 6: Could not find called feature
+--CURDIR--/visibility_scoping.fz:93:10: error 7: Could not find called feature
     b => tt   # should flag an error: feature not found
 ---------^^
 Feature not found: 'tt' (no arguments)
@@ -47,7 +55,7 @@ Target feature: 'visibility_scoping.test6.b'
 In call: 'tt'
 
 
---CURDIR--/visibility_scoping.fz:94:10: error 7: Could not find called feature
+--CURDIR--/visibility_scoping.fz:94:10: error 8: Could not find called feature
     c => t   # should flag an error: feature not found
 ---------^
 Feature not found: 't' (no arguments)
@@ -55,7 +63,7 @@ Target feature: 'visibility_scoping.test6.c'
 In call: 't'
 
 
---CURDIR--/visibility_scoping.fz:92:10: error 8: Could not find called feature
+--CURDIR--/visibility_scoping.fz:92:10: error 9: Could not find called feature
     a => ttt # should flag an error: feature not found
 ---------^^^
 Feature not found: 'ttt' (no arguments)
@@ -63,20 +71,12 @@ Target feature: 'visibility_scoping.test6.a'
 In call: 'ttt'
 
 
---CURDIR--/visibility_scoping.fz:95:10: error 9: Could not find called feature
+--CURDIR--/visibility_scoping.fz:95:10: error 10: Could not find called feature
     _ := ttt # should flag an error: feature not found
 ---------^^^
 Feature not found: 'ttt' (no arguments)
 Target feature: 'visibility_scoping.test6'
 In call: 'ttt'
-
-
---CURDIR--/visibility_scoping.fz:96:10: error 10: Could not find called feature
-    _ := tt   # should flag an error: feature not found
----------^^
-Feature not found: 'tt' (no arguments)
-Target feature: 'visibility_scoping.test6'
-In call: 'tt'
 
 
 --CURDIR--/visibility_scoping.fz:59:13: error 11: Could not find called feature


### PR DESCRIPTION
type inference is now powerful enough to not need type_of_lazy anymore