### PR TITLE
lib, doc: Workaround to improve DFA performance: Move local instances to `unit`

### DIFF
--- a/bin/ebnf.fz
+++ b/bin/ebnf.fz
@@ -33,13 +33,19 @@ main =>
   # return what we read from stdout as the result
   #
   Sequence.prefix ! String =>
-    lm : mutate is
-    lm ! ()->
+
+    # NYI: CLEANUP: #5039: Workaround to avoid DFA performance problem: use `unit`
+    # as outer feature for `lm` to reduce number of DFA values for
+    # `lm1` (while `Sequence` has many values).
+    unit.lm1 : mutate is
+    unit.new_lm1 => lm1
+
+    unit.new_lm1 ! ()->
       seq := map x->x.as_string
       match os.process.start seq.first.val (seq.drop 1)
         e error => panic "failed executing {Sequence.this}, error is $e"
         p os.process =>
-          match p.with_out String lm (()->String.from_bytes (io.buffered lm).read_fully)
+          match p.with_out String unit.lm1 (()->String.from_bytes (io.buffered unit.lm1).read_fully)
             e error => panic "failed reading stdout from {Sequence.this}, error is: $e"
             s String => s
 
@@ -48,16 +54,22 @@ main =>
   # return what we read from stdout as the result
   #
   String.infix | (seq Sequence String) String =>
-    lm : mutate is
-    lm ! ()->
+
+    # NYI: CLEANUP: #5039: Workaround to avoid DFA performance problem: use `unit`
+    # as outer feature for `lm` to reduce number of DFA values for
+    # `lm2` (while `String` has many values).
+    unit.lm2 : mutate is
+    unit.new_lm2 => lm2
+
+    unit.new_lm2 ! ()->
       match os.process.start seq.first.val (seq.drop 1)
         e error => panic "failed executing $seq, error is $e"
         p os.process =>
-          _ := p.with_in unit lm ()->
-            _ := (io.buffered lm).writer.env.write String.this.utf8
-            _ := (io.buffered lm).writer.env.flush
+          _ := p.with_in unit unit.lm2 ()->
+            _ := (io.buffered unit.lm2).writer.env.write String.this.utf8
+            _ := (io.buffered unit.lm2).writer.env.flush
             _ := p.wait # close stdin
-          match p.with_out String lm (()->String.from_bytes (io.buffered lm).read_fully)
+          match p.with_out String unit.lm2 (()->String.from_bytes (io.buffered unit.lm2).read_fully)
             e error => panic "failed reading stdout from $seq, error is: $e"
             s String => s
 

--- a/modules/base/src/container/abstract_array.fz
+++ b/modules/base/src/container/abstract_array.fz
@@ -129,7 +129,8 @@ public abstract_array
         if to ≤ from
           nil
         else
-          array_cons from to
+          unit.new_array_cons abstract_array.this from to
+
 
       # get the contents of this slice at the given index
       #
@@ -176,12 +177,18 @@ public abstract_array
   # create a cons cell for a list of this array starting at the given
   # index `i` and up to `to`
   #
-  array_cons (i, to i32) : Cons T (list T)
+  # NYI: CLEANUP: #5039: Workaround to avoid DFA performance problem: use `unit`
+  # as outer feature for `array_const` to reduce number of DFA values for
+  # `array_cons` (while `abstract_array` has many values).
+  #
+  unit.array_cons(a A : container.abstract_array T, i, to i32) : Cons T (list T)
     pre
-      debug: 0 ≤ i < to ≤ length
+      debug: 0 ≤ i < to ≤ a.length
   is
-    public redef head => abstract_array.this[i]
-    public redef tail => (slice i+1 to).as_list
+    public redef head => a[i]
+    public redef tail => (a.slice i+1 to).as_list
+
+  unit.new_array_cons(a A : container.abstract_array T, i, to i32) => array_cons T A a i to
 
 
   # map the array to a new array applying function f to all elements

--- a/modules/base/src/io/file/write.fz
+++ b/modules/base/src/io/file/write.fz
@@ -25,7 +25,13 @@
 # write String `s` to file `f`
 #
 public write(f String, s String) outcome unit =>
-  lm : mutate is
-  lm ! ()->
-    use unit lm f mode.write ()->
-      ((io.buffered lm).writer.env.write s.utf8).error
+
+  # NYI: CLEANUP: #5039: Workaround to avoid DFA performance problem: use `unit`
+  # as outer feature for `lm` to reduce number of DFA values for
+  # `lm` (while `io.file` has many values).
+  unit.lm : mutate is
+  unit.new_lm => lm
+
+  unit.new_lm ! ()->
+    use unit unit.lm f mode.write ()->
+      ((io.buffered unit.lm).writer.env.write s.utf8).error

--- a/modules/base/src/list.fz
+++ b/modules/base/src/list.fz
@@ -159,10 +159,19 @@ public list(public A type) : choice nil (Cons A (list A)), Sequence A is
   # collect the contents of this list into an array
   #
   public redef as_array =>
-    lm : mutate is
+
+    # NYI: CLEANUP: #5039: Workaround to avoid DFA performance problem: use `unit`
+    # as outer feature for `lm` to reduce number of DFA values for `lm` (while `list`
+    # has many values).
+    unit.lm : mutate is
+
+      # redefine `mpanic` here to break endless recursion
       module redef mpanic(msg String) => fuzion.std.panic msg
-    lm ! ()->
-      e := lm.env.new list.this
+
+    unit.new_lm => lm
+
+    unit.new_lm ! ()->
+      e := unit.lm.env.new list.this
       array A count _->
         res := e.get.first.get
         e <- e.get.force_tail


### PR DESCRIPTION
This is a workaround for #5036 in the base library and in `bin/ebnf.fz` to use `unit.lm` instead of a local `lm` instance to simplify the DFA analysis.

Without this, the values of the local instances get duplicated for each outer value, resulting in an explosion of the overhead of the DFA analysis.

This patch reduces the runtime of `ebnf.fz` without argument by more than 30% (from 24s down to 15s on my machine), the biggest part is the change in `ebnf.fz` itself, the others add about 0.5-1sec.
