### PR TITLE
win: fix fzE_dir_read, exclude NULL-byte from length

### DIFF
--- a/include/win.c
+++ b/include/win.c
@@ -161,7 +161,7 @@ int fzE_dir_read(intptr_t * dir, void * result) {
     assert (sizeNeeded != 0);
     assert(sizeNeeded >= 0 && sizeNeeded<1024); // NYI:
 
-    int len = WideCharToMultiByte(CP_UTF8, 0, d->findData.cFileName, -1, result, sizeNeeded, NULL, NULL);
+    int len = WideCharToMultiByte(CP_UTF8, 0, d->findData.cFileName, -1, result, sizeNeeded, NULL, NULL) - 1;
 
     return len == 0
       ? -1


### PR DESCRIPTION
[ci skip]
