### PR TITLE
tests: change test process to print complete env

### DIFF
--- a/tests/process/test_process.fz
+++ b/tests/process/test_process.fz
@@ -62,7 +62,7 @@ test_process =>
 
 
   test "pass environment variable" ()->
-    (os.process.start "printenv" ["MYENVVAR"] (container.map_of [("MYENVVAR", "content")])).bind p->
+    (os.process.start "printenv" [] (container.map_of [("MYENVVAR", "content")])).bind p->
       _ := lm ! ()->
         _ := p.with_out unit lm ()->
           say ((io.buffered lm).read_string 1E9).val

--- a/tests/process/test_process.fz.expected_out
+++ b/tests/process/test_process.fz.expected_out
@@ -5,7 +5,7 @@ Hello from the other side.
 eecchhoo
 
 ===  Test: pass environment variable  ===
-content
+MYENVVAR=content
 
 ===  Test: feed output of process 1 to process 2  ===
 'feed me to cat'


### PR DESCRIPTION
Reason for the change is that I stumbled over a difference in the semantics of posix_spawnp and CreateProcess. I want to make sure behaviours on posix/windows match. Thus changing the test.

```
CreateProcessW uses the environment block both to:

    Set the environment for the new process, and

    Determine the %PATH%, %PATHEXT%, etc. when resolving the executable if lpApplicationName is NULL and you're passing a command line instead.
```