### PR TITLE
tests: cleanup in visibility scoping

### DIFF
--- a/tests/uninitialized_field_negative/Makefile
+++ b/tests/uninitialized_field_negative/Makefile
@@ -1,0 +1,25 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test Makefile
+#
+# -----------------------------------------------------------------------
+
+override NAME = uninitialized_field_negative
+include ../simple_and_negative.mk

--- a/tests/uninitialized_field_negative/uninitialized_field_negative.fz
+++ b/tests/uninitialized_field_negative/uninitialized_field_negative.fz
@@ -1,0 +1,35 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test uninitialized_field_negative
+#
+# -----------------------------------------------------------------------
+
+uninitialized_field_negative =>
+
+
+  # this test was originally part of tests/visibility_scoping
+  #
+  case1 is
+    n => m   #  1. should flag an error: reading uninitialized field
+    a := n
+    m := 7
+    say a
+
+  case1

--- a/tests/uninitialized_field_negative/uninitialized_field_negative.fz.expected_err
+++ b/tests/uninitialized_field_negative/uninitialized_field_negative.fz.expected_err
@@ -1,0 +1,16 @@
+
+--CURDIR--/uninitialized_field_negative.fz:30:10: error 1: reading uninitialized field 'uninitialized_field_negative.case1.m' from instance of 'uninitialized_field_negative.case1'
+    n => m   #  1. should flag an error: reading uninitialized field
+---------^
+Callchain that lead to this point:
+
+call 'uninitialized_field_negative.case1.n' at --CURDIR--/uninitialized_field_negative.fz:31:10:
+    a := n
+---------^
+call 'uninitialized_field_negative.case1' at --CURDIR--/uninitialized_field_negative.fz:36:3:
+  case1
+--^^^^^
+call 'uninitialized_field_negative'
+program entry point
+
+one error.

--- a/tests/visibility_scoping/visibility_scoping.fz
+++ b/tests/visibility_scoping/visibility_scoping.fz
@@ -40,16 +40,6 @@ visibility_scoping is
     say x     #  1. should flag an error: feature not found
 
 
-
-  # NYI: BUG:
-  # test2 is
-
-  #   A(b i32) ref is
-  #   c(b i32) is
-  #     d : A b is  #  should NOT flag an error
-
-
-
   test3 =>
     _ := for ar := outcome unit
          while false
@@ -57,8 +47,6 @@ visibility_scoping is
     ref : Function unit is
       public redef call =>
         say ar  #  2. should flag an error: feature not found
-
-
 
 
   test4 is
@@ -70,7 +58,6 @@ visibility_scoping is
     say ((0..1).map y->x)  #  3. should flag an error: feature not found
 
 
-
   test5 is
 
     for q := 3, 4
@@ -79,7 +66,6 @@ visibility_scoping is
     else
       say "in else     : q is $q"
     say "outside else: q is $q"   #  4. should flag an error: feature not found
-
 
 
   test6 is
@@ -95,25 +81,6 @@ visibility_scoping is
     _ := ttt  #  8. should flag an error: feature not found
     _ := tt   #  9. should flag an error: feature not found
     _ := t    # 10. should flag an error: feature not found
-
-
-
-  # NYI: BUG:
-  # test7 is
-  #   x i32 := (3..5).reduce -5 (a,b)->x # should raise an error: feature not found
-  #   say x
-
-
-
-  # NYI: BUG: accessing (non-field) feature (with same outer as field) from field initializer should be forbidden?
-  # test8 is
-  #   n => m
-
-  #   a := n # should raise error: feature not found
-  #   m := 7
-
-  #   say a
-
 
 
   test9 is


### PR DESCRIPTION
`test2` actually works, correctly complains about ambiguity of `b` and if `A.this.` or `C.this.` is added to solve this, correctly complains about uninitialized field in the first case.

`test7` is now issue #5085.

For `test8`, `fz` correctly complains about reading an uninitialized field.
