### PR TITLE
win: fix test process

### DIFF
--- a/tests/process/test_process.fz
+++ b/tests/process/test_process.fz
@@ -65,7 +65,12 @@ test_process =>
     (os.process.start "printenv" [] (container.map_of [("MYENVVAR", "content")])).bind p->
       _ := lm ! ()->
         _ := p.with_out unit lm ()->
-          say ((io.buffered lm).read_string 1E9).val
+          out := ((io.buffered lm).read_string 1E9)
+            .val
+            .split "\n"
+            # for some reason on windows/msys these are included, even though we want empty env...
+            .filter (l -> !(l.starts_with "HOME=" || l.starts_with "TERM="))
+          say (String.join out)
 
 
 

--- a/tests/process/test_process.fz.expected_out
+++ b/tests/process/test_process.fz.expected_out
@@ -6,7 +6,6 @@ eecchhoo
 
 ===  Test: pass environment variable  ===
 MYENVVAR=content
-
 ===  Test: feed output of process 1 to process 2  ===
 'feed me to cat'
 


### PR DESCRIPTION
added workaround for the issue that _empty_ env still contains HOME and TERM on windows/msys. Not sure why this is the case...

win.c: added last_error thread local like in posix.c to ensure we return the last_error we actually want to.
