### PR TITLE
fuzion_rt: change fzE_last_error to i64

### DIFF
--- a/include/fz.h
+++ b/include/fz.h
@@ -46,7 +46,7 @@ void fzE_memcpy(void *restrict dest, const void *restrict src, size_t sz);
 
 // returns the latest error number of
 // the current thread
-int fzE_last_error(void);
+int64_t fzE_last_error(void);
 
 // NYI: UNDER DEVELOPMENT: fzE_last_error_as_string, returning the error as a human readable string
 

--- a/include/posix.c
+++ b/include/posix.c
@@ -61,12 +61,12 @@ Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
 
 // thread local to hold the last
 // error that occurred in fuzion runtime.
-_Thread_local int last_error = 0;
+_Thread_local int64_t last_error = 0;
 
 
 // returns the latest error number of
 // the current thread
-int fzE_last_error(void){
+int64_t fzE_last_error(void){
   return last_error;
 }
 

--- a/include/win.c
+++ b/include/win.c
@@ -82,12 +82,12 @@ void fzE_mem_zero(void *dest, size_t sz)
 
 // thread local to hold the last
 // error that occurred in fuzion runtime.
-_Thread_local int last_error = 0;
+_Thread_local int64_t last_error = 0;
 
 
 // returns the latest error number of
 // the current thread
-int fzE_last_error(void){
+int64_t fzE_last_error(void){
   // NYI: CLEANUP:
   return last_error == 0
     ? GetLastError()

--- a/modules/base/src/native.fz
+++ b/modules/base/src/native.fz
@@ -31,7 +31,7 @@ module fzE_init unit => native
 # returns the latest error number of
 # the current thread
 #
-module fzE_last_error i32 => native
+module fzE_last_error i64 => native
 
 
 # intrinsic that returns true in case of success or false in case of failure during dir creation


### PR DESCRIPTION
windows GetLastError returns DWORD which is unsigned. So changing this to i64 to be able to contain this.


