### PR TITLE
parser: allow multiple lines in lambda block using parentheses (without extra code)

### DIFF
--- a/src/dev/flang/parser/Parser.java
+++ b/src/dev/flang/parser/Parser.java
@@ -353,14 +353,14 @@ field       : returnType
    */
   boolean skipFeaturePrefix()
   {
-    if (!skipQual())
+    do
       {
-        return false;
+        if (!skipQual())
+          {
+            return false;
+          }
       }
-    if (skipComma())
-      {
-        return true;
-      }
+    while (skipComma());
     switch (skipFormArgsNotActualArgs())
       {
       case formal: return true;
@@ -1913,7 +1913,7 @@ klammerLambd: tuple lambda
                        () -> {
                          do
                            {
-                             tupleElements.add(operatorExpr());
+                             tupleElements.add(block());
                            }
                          while (skipComma());
                          return Void.TYPE;


### PR DESCRIPTION
fix #4425

alternative solution in #5104