### PR TITLE
ast: avoid NullPointerException in #5114

### DIFF
--- a/src/dev/flang/ast/AbstractCall.java
+++ b/src/dev/flang/ast/AbstractCall.java
@@ -218,8 +218,8 @@ public abstract class AbstractCall extends Expr
             ? ""
             : target().toString() + ".")
       + (this instanceof Call c && !c.calledFeatureKnown() ? c._name : calledFeature().featureName().baseNameHuman())
-      + actualTypeParameters().toString(" ", " ", "", t -> t.toStringWrapped())
-      + actuals().toString(" ", " ", "", e -> e.toStringWrapped())
+      + actualTypeParameters().toString(" ", " ", "", t -> (t == null ? "--null--" : t.toStringWrapped()))
+      + actuals()             .toString(" ", " ", "", e -> (e == null ? "--null--" : e.toStringWrapped()))
       + (select() < 0        ? "" : " ." + select());
   }
 

--- a/src/dev/flang/ast/Function.java
+++ b/src/dev/flang/ast/Function.java
@@ -451,9 +451,8 @@ public class Function extends AbstractLambda
 
         if (f != null)
           {
-            generics.add(f instanceof Feature ff && ff.hasResult()  // NYI: Cast!
-                         ? ff.resultTypeIfPresent(res)
-                         : new BuiltInType(FuzionConstants.UNIT_NAME));
+            res.resolveTypes(f);
+            generics.add(f.resultType());
             for (var a : f.arguments())
               {
                 res.resolveTypes(a);


### PR DESCRIPTION
Use `AbstractFeature.resultType()` instead of `resultTypeIfPresent` and avoid special handling for unit type result (which was required only in early versions of Fuzion).

Also made `AbstractCall.toString()` more robust against null pointer exceptions.
