### PR TITLE
fe: suppress subsequent error on argument count in #5114

### DIFF
--- a/src/dev/flang/ast/AbstractFeature.java
+++ b/src/dev/flang/ast/AbstractFeature.java
@@ -94,6 +94,13 @@ public abstract class AbstractFeature extends Expr implements Comparable<Abstrac
   static { _NO_FEATURES_.freeze(); }
 
 
+  /**
+   * Result of `handDown(Resolution, AbstractType[], AbstractFeature) in case of
+   * failure due to previous errors.
+   */
+  public static final AbstractType[] HAND_DOWN_FAILED = new AbstractType[0];
+
+
   /*------------------------  static variables  -------------------------*/
 
 
@@ -1285,13 +1292,16 @@ public abstract class AbstractFeature extends Expr implements Comparable<Abstrac
    * @param heir a feature that inherits from outer()
    *
    * @return the types from the argument array a has seen this within
-   * heir. Their number might have changed due to open generics.
+   * heir. Their number might have changed due to open generics.  Result may be
+   * HAND_DOWN_FAILED in case of previous errors.
    */
   public AbstractType[] handDown(Resolution res, AbstractType[] a, AbstractFeature heir)  // NYI: This does not distinguish different inheritance chains yet
   {
     if (PRECONDITIONS) require
       (heir != null,
        state().atLeast(State.RESOLVING_TYPES));
+
+    var result = HAND_DOWN_FAILED;
 
     if (heir != Types.f_ERROR)
       {
@@ -1301,10 +1311,10 @@ public abstract class AbstractFeature extends Expr implements Comparable<Abstrac
 
         if (inh != null)
           {
-            a = AbstractFeature.handDownInheritance(res, inh, a, heir);
+            result = AbstractFeature.handDownInheritance(res, inh, a, heir);
           }
       }
-    return a;
+    return result;
   }
 
 

--- a/src/dev/flang/ast/AstErrors.java
+++ b/src/dev/flang/ast/AstErrors.java
@@ -766,7 +766,7 @@ public class AstErrors extends ANY
     error(redefinedFeature.pos(),
           "Wrong number of arguments in redefined feature",
           "In " + s(redefinedFeature) + " that redefines " + s(originalFeature) + " " +
-          "argument count is " + actualNumArgs + ", argument count should be " + originalNumArgs + " " +
+          "argument count is " + actualNumArgs + ", argument count should be " + originalNumArgs + ".\n" +
           "Original feature declared at " + originalFeature.pos().show());
   }
 

--- a/src/dev/flang/ast/Function.java
+++ b/src/dev/flang/ast/Function.java
@@ -298,9 +298,12 @@ public class Function extends AbstractLambda
                 i++;
               }
           }
-        if (t != Types.t_ERROR && i != gs.size())
+        if (i != gs.size())
           {
-            AstErrors.wrongNumberOfArgumentsInLambda(pos(), _names, t);
+            if (t != Types.t_ERROR)
+              {
+                AstErrors.wrongNumberOfArgumentsInLambda(pos(), _names, t);
+              }
             result = Types.t_ERROR;
           }
         if (t != Types.t_ERROR)

--- a/src/dev/flang/fe/SourceModule.java
+++ b/src/dev/flang/fe/SourceModule.java
@@ -1609,9 +1609,14 @@ A post-condition of a feature that does not redefine an inherited feature must s
     var fixed = (f.modifiers() & FuzionConstants.MODIFIER_FIXED) != 0;
     for (var o : f.redefines())
       {
-        var ta = o.handDown(_res, argTypes(o), f.outer());
         var ra = argTypes(f);
-        if (ta.length != ra.length)
+        var ta = o.handDown(_res, argTypes(o), f.outer());
+        if (ta == AbstractFeature.HAND_DOWN_FAILED)
+          {
+            if (CHECKS) check
+              (Errors.any());
+          }
+        else if (ta.length != ra.length)
           {
             AstErrors.argumentLengthsMismatch(o, ta.length, f, ra.length);
           }


### PR DESCRIPTION
With the null pointer fixed (#5129), the example from #5114 results in two additional errors on the argument count of the redefintion of Function.call not matching, which are just caused because `handDown` could did not operate properly.

Now, `handDown` uses a special empty array as result value in case it failed due to previous errors.

Also made the code in `Function` more robust against subsequent errors in case the argument count of a lambda does not match.

Fixed a missing `".\n"` in error for argument count mismatch in redefinition.
