### PR TITLE
fe: Avoid creation of lambda feature in case of error

### DIFF
--- a/src/dev/flang/ast/Function.java
+++ b/src/dev/flang/ast/Function.java
@@ -304,6 +304,7 @@ public class Function extends AbstractLambda
               {
                 AstErrors.wrongNumberOfArgumentsInLambda(pos(), _names, t);
               }
+            t = Types.t_ERROR;
             result = Types.t_ERROR;
           }
         if (t != Types.t_ERROR)

--- a/src/dev/flang/ast/Function.java
+++ b/src/dev/flang/ast/Function.java
@@ -112,7 +112,8 @@ public class Function extends AbstractLambda
   /**
    * the right hand side of the '->', replaced by Expr.NO_VALUE in case of error.
    */
-  Expr _expr;
+  private Expr _expr;
+  public Expr expr() { return _expr; }
 
 
   /*--------------------------  constructors  ---------------------------*/

--- a/src/dev/flang/ast/Function.java
+++ b/src/dev/flang/ast/Function.java
@@ -104,9 +104,15 @@ public class Function extends AbstractLambda
 
 
   /**
-   * the right hand side of the '->'
+   * the right hand side of the '->', as produced by the parser
    */
-  public final Expr _expr;
+  final Expr _originalExpr;
+
+
+  /**
+   * the right hand side of the '->', replaced by Expr.NO_VALUE in case of error.
+   */
+  Expr _expr;
 
 
   /*--------------------------  constructors  ---------------------------*/
@@ -134,6 +140,7 @@ public class Function extends AbstractLambda
     _namesAsExprs = names;
     _names = names.map2(n->n.asParsedName());
     _names.removeIf(n -> n==null);
+    _originalExpr = e;
     _expr = e;
   }
 
@@ -256,7 +263,6 @@ public class Function extends AbstractLambda
                 AstErrors.expectedFunctionTypeForLambda(pos(), t);
               }
             t = Types.t_ERROR;
-            result = Types.t_ERROR;
           }
 
         /* We have an expression of the form
@@ -283,7 +289,6 @@ public class Function extends AbstractLambda
           {
             if (i < gs.size() && gs.get(i) == Types.t_UNDEFINED)
               {
-                result = Types.t_ERROR;
                 t = Types.t_ERROR;
               }
             else
@@ -305,7 +310,6 @@ public class Function extends AbstractLambda
                 AstErrors.wrongNumberOfArgumentsInLambda(pos(), _names, t);
               }
             t = Types.t_ERROR;
-            result = Types.t_ERROR;
           }
         if (t != Types.t_ERROR)
           {
@@ -355,6 +359,11 @@ public class Function extends AbstractLambda
               }
 
             _call = new Call(pos(), new Current(pos(), context.outerFeature()), _wrapper).resolveTypes(res, context);
+          }
+        else
+          {
+            _expr = Expr.NO_VALUE;
+            result = Types.t_ERROR;
           }
       }
     return result;
@@ -547,7 +556,7 @@ public class Function extends AbstractLambda
    */
   public String toString()
   {
-    return _names + " -> " + _expr;
+    return _names + " -> " + _originalExpr;
   }
 
 

--- a/src/dev/flang/ast/Loop.java
+++ b/src/dev/flang/ast/Loop.java
@@ -583,7 +583,7 @@ public class Loop extends ANY
       @Override
       public Expr action(Function f)
       {
-        f._expr.visit(this, null);
+        f.expr().visit(this, null);
         return super.action(f);
       }
     };

--- a/src/dev/flang/fe/SourceModule.java
+++ b/src/dev/flang/fe/SourceModule.java
@@ -1283,10 +1283,11 @@ A post-condition of a feature that does not redefine an inherited feature must s
           @Override public Expr action(Function lambda){
             if (usage.isEmpty() || definition.isEmpty())
               {
-                stacks.get(0).push(lambda._expr);
+                var e = lambda.expr();
+                stacks.get(0).push(e);
                 var old = visitingInnerFeature[0];
                 visitingInnerFeature[0] = true;
-                lambda._expr.visit(this, null);
+                e.visit(this, null);
                 visitingInnerFeature[0] = old;
                 stacks.get(0).pop();
               }

--- a/tests/reg_issue4694/reg_issue4694.fz.expected_err
+++ b/tests/reg_issue4694/reg_issue4694.fz.expected_err
@@ -7,13 +7,4 @@ Arguments of lambda expression: 'x', 'y'
 Expected function type: Unary --UNDEFINED-- i32
 To solve this, remove one argument from the list 'x', 'y' before the '->' of the lambda expression.
 
-
---CURDIR--/reg_issue4694.fz:26:23: error 2: Wrong number of type parameters
-  0 |> x,y->container.expanding.env.put
-----------------------^^^^^^^^^
-Wrong number of actual type parameters in type:
-Type: container.expanding
-expected one generic argument for 'T'
-found none.
-
-2 errors.
+one error.


### PR DESCRIPTION
Forgot this in #5131, make sure to do as little as possible once an error was found.

Also, suppress more subsequent errors in `Function._expr` in case of previous errors in the argument count.
