### PR TITLE
remove (un)setenv

### DIFF
--- a/bin/aspell.dict
+++ b/bin/aspell.dict
@@ -1023,7 +1023,6 @@ semiOrFlatLF
 semiSepElmts
 sep
 setElse
-setenv
 setField
 setFieldSlot
 setjmp
@@ -1223,7 +1222,6 @@ UnicodeData
 unistd
 unitValue
 unsafeIntrinsics
-unsetenv
 UnsupportedOperationException
 untagged
 Unterminated

--- a/include/fz.h
+++ b/include/fz.h
@@ -80,26 +80,6 @@ int64_t fzE_last_error(void);
 int fzE_mkdir(const char *pathname);
 
 /**
- * set environment variable
- *
- * @param name a pointer to zero terminated utf8 bytes.
- *
- * @param value a pointer to zero terminated utf8 bytes.
- *
- * @return 0 on success, -1 on error.
- */
-int fzE_setenv(const char *name, const char *value);
-
-/**
- * unset environment variable
- *
- * @param name a pointer to zero terminated utf8 bytes.
- *
- * @return 0 on success, -1 on error.
- */
-int fzE_unsetenv(const char *name);
-
-/**
  * open a directory for traversal.
  *
  * @param pathname a pointer to zero terminated utf8 bytes.

--- a/include/posix.c
+++ b/include/posix.c
@@ -32,7 +32,7 @@ Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
 #endif
 
 #include <stdio.h>
-#include <stdlib.h>     // setenv, unsetenv
+#include <stdlib.h>
 #include <errno.h>
 #include <stdint.h>
 #include <stdbool.h>
@@ -96,19 +96,6 @@ void fzE_mem_zero_secure(void *dest, size_t sz)
 int fzE_mkdir(const char *pathname){
   return mkdir(pathname, S_IRWXU);
 }
-
-
-// set environment variable, return zero on success
-int fzE_setenv(const char *name, const char *value){
-  return setenv(name, value, 1);
-}
-
-
-// unset environment variable, return zero on success
-int fzE_unsetenv(const char *name){
-  return unsetenv(name);
-}
-
 
 void * fzE_opendir(const char *pathname, int64_t * result) {
   errno = 0;

--- a/include/win.c
+++ b/include/win.c
@@ -36,7 +36,7 @@ Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
 #endif
 
 #include <stdio.h>
-#include <stdlib.h>     // setenv, unsetenv
+#include <stdlib.h>
 #include <errno.h>
 #include <stdint.h>
 #include <stdbool.h>
@@ -105,19 +105,6 @@ int fzE_mkdir(const char *pathname){
   free(wideStr);
   return result;
 }
-
-
-// set environment variable, return zero on success
-int fzE_setenv(const char *name, const char *value){
-  return -1;
-}
-
-
-// unset environment variable, return zero on success
-int fzE_unsetenv(const char *name){
-  return -1;
-}
-
 
 
 typedef struct {

--- a/modules/base/src/envir/vars.fz
+++ b/modules/base/src/envir/vars.fz
@@ -40,23 +40,6 @@ public vars (p Vars_Handler) : effect is
   public get(v String, default String) =>
     (get v).or_else get.this.default
 
-  # Set the environment variable corresponding to n to have the
-  # value v.
-  #
-  # This will overwrite the value of the environment variable, if
-  # it is set already.
-  public set1(n String, v String) =>
-    vars.this.env.replace
-    p.set1 n v
-
-  # Unset the environment variable corresponding to n.
-  #
-  # This will also return success (unit) if the variable was not
-  # set anyway.
-  public unset(n String) =>
-    vars.this.env.replace
-    p.unset n
-
 
   # install default instance of vars
   #
@@ -69,8 +52,6 @@ public vars (p Vars_Handler) : effect is
   type.default_vars_handler =>
     ref : envir.Vars_Handler is
       public redef get(v String) => fuzion.sys.env_vars.get v
-      public redef set1(n String, v String) => fuzion.sys.env_vars.set1 n v
-      public redef unset(n String) => fuzion.sys.env_vars.unset n
 
 
 # short-hand for accessing envir.args effect in current environment
@@ -90,16 +71,3 @@ public Vars_Handler ref is
   # If set, get the environment variable corresponding to v
   #
   public get(v String) option String => abstract
-
-  # Set the environment variable corresponding to n to have the
-  # value v.
-  #
-  # This will overwrite the value of the environment variable, if
-  # it is set already.
-  public set1(n String, v String) outcome unit => abstract
-
-  # Unset the environment variable corresponding to n.
-  #
-  # This will also return success (unit) if the variable was not
-  # set anyway.
-  public unset(n String) outcome unit => abstract

--- a/modules/base/src/fuzion/sys/env_vars.fz
+++ b/modules/base/src/fuzion/sys/env_vars.fz
@@ -42,13 +42,6 @@ module env_vars is
   get0(s Array) String
   => intrinsic
 
-  # intrinsic to set env var
-  set0(s Array, t Array) bool => intrinsic
-
-  # intrinsic to unset env var
-  unset0(s Array) bool => intrinsic
-
-
   # check if env var with given name exists
   #
   module has(s String) bool =>
@@ -63,21 +56,3 @@ module env_vars is
       get0 a
     else
       nil
-
-  # set the value of the env var with given name to the given new value
-  # will overwrite the current value, if it is set
-  # NYI: #627: rename to set once set keyword is removed
-  module set1(name String, val String) outcome unit =>
-    k := c_string name
-    v := c_string val
-
-    if !(set0 k v)
-      error "failed to set env var"
-
-  # unset the env var with the given name
-  # note this returns success (unit) if the given env var did not exist
-  module unset(name String) outcome unit =>
-    k := c_string name
-
-    if !(unset0 k)
-      error "failed to unset env var"

--- a/src/dev/flang/be/c/Intrinsics.java
+++ b/src/dev/flang/be/c/Intrinsics.java
@@ -588,21 +588,6 @@ public class Intrinsics extends ANY
                             str.assign(CExpr.call("getenv",new List<>(A0.castTo("char*")))),
                             c.boxedConstString(str, CExpr.call("strlen",new List<>(str))).ret());
         });
-    put("fuzion.sys.env_vars.set0", (c,cl,outer,in) ->
-        {
-          return CStmnt.seq(CStmnt.iff(CExpr.call("fzE_setenv",new List<>(A0.castTo("char*") /* name */,
-                                                                      A1.castTo("char*") /* value */))
-                                            .eq(CExpr.int32const(0)),
-                                       c._names.FZ_TRUE.ret()),
-                            c._names.FZ_FALSE.ret());
-        });
-     put("fuzion.sys.env_vars.unset0", (c,cl,outer,in) ->
-        {
-          return CStmnt.seq(CStmnt.iff(CExpr.call("fzE_unsetenv",new List<>(A0.castTo("char*") /* name */))
-                                            .eq(CExpr.int32const(0)),
-                                       c._names.FZ_TRUE.ret()),
-                            c._names.FZ_FALSE.ret());
-        });
      put("fuzion.sys.thread.spawn0", (c,cl,outer,in) ->
         {
           var oc = c._fuir.clazzActualGeneric(cl, 0);

--- a/src/dev/flang/be/interpreter/Intrinsics.java
+++ b/src/dev/flang/be/interpreter/Intrinsics.java
@@ -463,10 +463,6 @@ public class Intrinsics extends ANY
         });
     put("fuzion.sys.env_vars.has0", (executor, innerClazz) -> args -> new boolValue(System.getenv(utf8ByteArrayDataToString(args.get(1))) != null));
     put("fuzion.sys.env_vars.get0", (executor, innerClazz) -> args -> Interpreter.boxedConstString(System.getenv(utf8ByteArrayDataToString(args.get(1)))));
-    // setting env variable not supported in java
-    put("fuzion.sys.env_vars.set0"  , (executor, innerClazz) -> args -> new boolValue(false));
-    // unsetting env variable not supported in java
-    put("fuzion.sys.env_vars.unset0", (executor, innerClazz) -> args -> new boolValue(false));
     put("fuzion.sys.thread.spawn0", (executor, innerClazz) -> args ->
         {
           var oc   = executor.fuir().clazzArgClazz(innerClazz, 0);

--- a/src/dev/flang/be/jvm/Intrinsix.java
+++ b/src/dev/flang/be/jvm/Intrinsix.java
@@ -876,18 +876,6 @@ public class Intrinsix extends ANY implements ClassFileConstants
             methodDescriptor(Runtime.class, "fuzion_sys_env_vars_get0"),
             PrimitiveType.type_byte.array())));
     });
-    put("fuzion.sys.env_vars.set0", (jvm, si, cc, tvalue, args) -> {
-      var res =
-        tvalue.drop()
-          .andThen(Expr.iconst(0)); // false
-      return new Pair<>(res, Expr.UNIT);
-    });
-    put("fuzion.sys.env_vars.unset0", (jvm, si, cc, tvalue, args) -> {
-      var res =
-        tvalue.drop()
-          .andThen(Expr.iconst(0)); // false
-      return new Pair<>(res, Expr.UNIT);
-    });
 
     put("fuzion.sys.thread.spawn0",
         (jvm, si, cc, tvalue, args) ->

--- a/src/dev/flang/fuir/analysis/dfa/DFA.java
+++ b/src/dev/flang/fuir/analysis/dfa/DFA.java
@@ -2053,8 +2053,6 @@ public class DFA extends ANY
                                          , cl -> Value.UNIT);
     put("fuzion.sys.env_vars.has0"       , cl -> cl._dfa.bool() );
     put("fuzion.sys.env_vars.get0"       , cl -> cl._dfa.newConstString(null, cl) );
-    put("fuzion.sys.env_vars.set0"       , cl -> cl._dfa.bool() );
-    put("fuzion.sys.env_vars.unset0"     , cl -> cl._dfa.bool() );
     put("fuzion.sys.thread.spawn0"       , cl ->
         {
           var oc = fuir(cl).clazzActualGeneric(cl._cc, 0);

--- a/src/dev/flang/fuir/cfg/CFG.java
+++ b/src/dev/flang/fuir/cfg/CFG.java
@@ -436,8 +436,6 @@ public class CFG extends ANY
                                          , (cfg, cl) -> { } );
     put("fuzion.sys.env_vars.has0"       , (cfg, cl) -> { } );
     put("fuzion.sys.env_vars.get0"       , (cfg, cl) -> { } );
-    put("fuzion.sys.env_vars.set0"       , (cfg, cl) -> { } );
-    put("fuzion.sys.env_vars.unset0"     , (cfg, cl) -> { } );
     put("fuzion.sys.thread.spawn0"       , (cfg, cl) -> { } );
     put("fuzion.sys.thread.join0"        , (cfg, cl) -> { } );
 

--- a/tests/envir_vars/envir_vars.fz
+++ b/tests/envir_vars/envir_vars.fz
@@ -23,27 +23,8 @@
 
 envir_vars is
 
-  match envir.vars.set1 "FUZION_ENVIR_VARS_TEST_SET" "world"
-    unit => yak "setting FUZION_ENVIR_VARS_TEST_SET to world"
-    error =>
-      # NYI we are probably windows?
-      say "setting FUZION_ENVIR_VARS_TEST_SET to world successful"
-      say "unsetting FUZION_ENVIR_VARS_TEST_SET successful"
-      exit 0
-
-  match envir.vars.get "FUZION_ENVIR_VARS_TEST_SET"
+  match envir.vars.get "PATH"
     val String =>
-      if val = "world"
-        say " successful"
-      else
-        exit 1
-    nil => exit 1
-
-
-  match envir.vars.unset "FUZION_ENVIR_VARS_TEST_SET"
-    unit => yak "unsetting FUZION_ENVIR_VARS_TEST_SET"
-    error => exit 1
-
-  match envir.vars.get "FUZION_ENVIR_VARS_TEST_SET"
-    String => exit 1
-    nil    => say " successful"
+      if !val.is_empty
+        say "successful"
+    nil =>

--- a/tests/envir_vars/envir_vars.fz.expected_out
+++ b/tests/envir_vars/envir_vars.fz.expected_out
@@ -1,2 +1,1 @@
-setting FUZION_ENVIR_VARS_TEST_SET to world successful
-unsetting FUZION_ENVIR_VARS_TEST_SET successful
+successful


### PR DESCRIPTION
I don't see the point for this anymore, java does not have this either.

When starting a process we can give it a custom map of environment variables.

