### PR TITLE
lib: fix hierarchy of faults

### DIFF
--- a/modules/base/src/fuzion/runtime/check_fault.fz
+++ b/modules/base/src/fuzion/runtime/check_fault.fz
@@ -36,7 +36,7 @@ is
   # install default check_fault handler
   type.install_default =>
     (fuzion.runtime.check_fault msg->
-      fuzion.runtime.fault.cause ("check", msg)).default
+      fuzion.runtime.contract_fault.cause ("check", msg)).default
 
 
   # create an instance of `check_fault` with the given error handler.

--- a/modules/base/src/fuzion/runtime/contract_fault.fz
+++ b/modules/base/src/fuzion/runtime/contract_fault.fz
@@ -24,7 +24,7 @@
 # -----------------------------------------------------------------------
 
 # contract_fault -- effect that terminates a computation due to a failed
-# condition in a check statement
+# condition in a pre, post or check statement
 #
 public contract_fault (
   # the handler this effect uses to fail

--- a/modules/base/src/fuzion/runtime/post_fault.fz
+++ b/modules/base/src/fuzion/runtime/post_fault.fz
@@ -36,7 +36,7 @@ is
   # install default post_fault handler
   type.install_default =>
     (fuzion.runtime.post_fault msg->
-      fuzion.runtime.fault.cause ("postcondition", msg)).default
+      fuzion.runtime.contract_fault.cause ("postcondition", msg)).default
 
 
   # create an instance of `post_fault` with the given error handler.

--- a/modules/base/src/fuzion/runtime/pre_fault.fz
+++ b/modules/base/src/fuzion/runtime/pre_fault.fz
@@ -36,7 +36,7 @@ is
   # install default pre_fault handler
   type.install_default =>
     (fuzion.runtime.pre_fault msg->
-      fuzion.runtime.fault.cause ("precondition", msg)).default
+      fuzion.runtime.contract_fault.cause ("precondition", msg)).default
 
 
   # create an instance of `pre_fault` with the given error handler.

--- a/tests/assignments/assignments.fz.effect
+++ b/tests/assignments/assignments.fz.effect
@@ -1,6 +1,7 @@
 mutate
 io.Out
 fuzion.runtime.pre_fault
+fuzion.runtime.contract_fault
 fuzion.runtime.fault
 fuzion.runtime.post_fault
 io.Err

--- a/tests/atomic/test_atomic.fz.effect
+++ b/tests/atomic/test_atomic.fz.effect
@@ -1,5 +1,6 @@
 concur.atomic_access
 fuzion.runtime.pre_fault
+fuzion.runtime.contract_fault
 fuzion.runtime.fault
 fuzion.runtime.post_fault
 io.Err

--- a/tests/catch_postcondition/catch_postcondition.fz.expected_err_int
+++ b/tests/catch_postcondition/catch_postcondition.fz.expected_err_int
@@ -7,9 +7,15 @@ fuzion.type.runtime.type.fault.type.install_default.λ.call#1: {base.fum}/fuzion
 fuzion.runtime.fault.cause#1: {base.fum}/eff/fallible.fz:35:6:
   => h e
 -----^
+fuzion.type.runtime.type.contract_fault.type.install_default.λ.call#1: {base.fum}/fuzion/runtime/contract_fault.fz:39:7:
+      fuzion.runtime.fault.cause kind_and_msg).default
+------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+fuzion.runtime.contract_fault.cause#1: {base.fum}/eff/fallible.fz:35:6:
+  => h e
+-----^
 fuzion.type.runtime.type.post_fault.type.install_default.λ.call#1: {base.fum}/fuzion/runtime/post_fault.fz:39:7:
-      fuzion.runtime.fault.cause ("postcondition", msg)).default
-------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      fuzion.runtime.contract_fault.cause ("postcondition", msg)).default
+------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 fuzion.runtime.post_fault.cause#1: {base.fum}/eff/fallible.fz:35:6:
   => h e
 -----^
@@ -30,9 +36,17 @@ public postcondition_fault(msg String) => post_fault.cause msg
 catch_postcondition.test#1 i32: --CURDIR--/catch_postcondition.fz:43:5:
     for v := T.one, double v
 ----^
-(catch_postcondition.test#1 i16).loop: --CURDIR--/catch_postcondition.fz:291:7:
+(catch_postcondition.test#1 i16).post double: --CURDIR--/catch_postcondition.fz:291:7:
   say (test i32)
 ------^^^^^^^^^^
+(catch_postcondition.test#1 i16).double#1: --CURDIR--/catch_postcondition.fz:37:7:
+      post
+------^^^^
+        equals result-x x
+--------^^^^^^^^^^^^^^^^^
+(catch_postcondition.test#1 i16).loop: --CURDIR--/catch_postcondition.fz:43:21:
+    for v := T.one, double v
+--------------------^^^^^^^^
 catch_postcondition.test#1 i16: --CURDIR--/catch_postcondition.fz:43:5:
     for v := T.one, double v
 ----^
@@ -77,7 +91,7 @@ fuzion.type.runtime.type.fault.type.instate#4 (option String): <source position 
 ----------------^^^^^^^
       F.instate T v code_try (_ -> code_catch m.get.get)
 ------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-(catch_postcondition.test#1 i32).double#1: --CURDIR--/catch_postcondition.fz:275:10:
+fuzion.runtime.postcondition_fault#1: --CURDIR--/catch_postcondition.fz:275:10:
     r := fuzion.runtime.fault.try ()->
 ---------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
            option tries[c].call
@@ -88,6 +102,14 @@ fuzion.type.runtime.type.fault.type.instate#4 (option String): <source position 
 -----------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
            nil
 -----------^^^
+(catch_postcondition.test#1 i32).post double: --CURDIR--/catch_postcondition.fz:38:9:
+        equals result-x x
+--------^^^^^^^^^^^^^^^^^
+(catch_postcondition.test#1 i32).double#1: --CURDIR--/catch_postcondition.fz:37:7:
+      post
+------^^^^
+        equals result-x x
+--------^^^^^^^^^^^^^^^^^
 (catch_postcondition.test#1 i32).loop: --CURDIR--/catch_postcondition.fz:43:21:
     for v := T.one, double v
 --------------------^^^^^^^^

--- a/tests/catch_postcondition/catch_postcondition.fz.expected_err_jvm
+++ b/tests/catch_postcondition/catch_postcondition.fz.expected_err_jvm
@@ -4,6 +4,8 @@ Call stack:
 fuzion.sys.fatal_fault#2
 fuzion.type.runtime.type.fault.type.install_default.λ.call#1
 fuzion.runtime.fault.cause#1
+fuzion.type.runtime.type.contract_fault.type.install_default.λ.call#1
+fuzion.runtime.contract_fault.cause#1
 fuzion.type.runtime.type.post_fault.type.install_default.λ.call#1
 fuzion.runtime.post_fault.cause#1
 fuzion.runtime.postcondition_fault#1

--- a/tests/compile_time_type_casts_negative2/compile_time_type_casts_negative2.fz.expected_err_int
+++ b/tests/compile_time_type_casts_negative2/compile_time_type_casts_negative2.fz.expected_err_int
@@ -7,9 +7,15 @@ fuzion.type.runtime.type.fault.type.install_default.λ.call#1: {base.fum}/fuzion
 fuzion.runtime.fault.cause#1: {base.fum}/eff/fallible.fz:35:6:
   => h e
 -----^
+fuzion.type.runtime.type.contract_fault.type.install_default.λ.call#1: {base.fum}/fuzion/runtime/contract_fault.fz:39:7:
+      fuzion.runtime.fault.cause kind_and_msg).default
+------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+fuzion.runtime.contract_fault.cause#1: {base.fum}/eff/fallible.fz:35:6:
+  => h e
+-----^
 fuzion.type.runtime.type.pre_fault.type.install_default.λ.call#1: {base.fum}/fuzion/runtime/pre_fault.fz:39:7:
-      fuzion.runtime.fault.cause ("precondition", msg)).default
-------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      fuzion.runtime.contract_fault.cause ("precondition", msg)).default
+------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 fuzion.runtime.pre_fault.cause#1: {base.fum}/eff/fallible.fz:35:6:
   => h e
 -----^

--- a/tests/compile_time_type_casts_negative2/compile_time_type_casts_negative2.fz.expected_err_jvm
+++ b/tests/compile_time_type_casts_negative2/compile_time_type_casts_negative2.fz.expected_err_jvm
@@ -4,6 +4,8 @@ Call stack:
 fuzion.sys.fatal_fault#2
 fuzion.type.runtime.type.fault.type.install_default.λ.call#1
 fuzion.runtime.fault.cause#1
+fuzion.type.runtime.type.contract_fault.type.install_default.λ.call#1
+fuzion.runtime.contract_fault.cause#1
 fuzion.type.runtime.type.pre_fault.type.install_default.λ.call#1
 fuzion.runtime.pre_fault.cause#1
 fuzion.runtime.precondition_fault#1

--- a/tests/contracts_negative/SquareRoot.fz.expected_err_int
+++ b/tests/contracts_negative/SquareRoot.fz.expected_err_int
@@ -7,9 +7,15 @@ fuzion.type.runtime.type.fault.type.install_default.λ.call#1: {base.fum}/fuzion
 fuzion.runtime.fault.cause#1: {base.fum}/eff/fallible.fz:35:6:
   => h e
 -----^
+fuzion.type.runtime.type.contract_fault.type.install_default.λ.call#1: {base.fum}/fuzion/runtime/contract_fault.fz:39:7:
+      fuzion.runtime.fault.cause kind_and_msg).default
+------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+fuzion.runtime.contract_fault.cause#1: {base.fum}/eff/fallible.fz:35:6:
+  => h e
+-----^
 fuzion.type.runtime.type.pre_fault.type.install_default.λ.call#1: {base.fum}/fuzion/runtime/pre_fault.fz:39:7:
-      fuzion.runtime.fault.cause ("precondition", msg)).default
-------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      fuzion.runtime.contract_fault.cause ("precondition", msg)).default
+------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 fuzion.runtime.pre_fault.cause#1: {base.fum}/eff/fallible.fz:35:6:
   => h e
 -----^

--- a/tests/contracts_negative/SquareRoot.fz.expected_err_jvm
+++ b/tests/contracts_negative/SquareRoot.fz.expected_err_jvm
@@ -4,6 +4,8 @@ Call stack:
 fuzion.sys.fatal_fault#2
 fuzion.type.runtime.type.fault.type.install_default.λ.call#1
 fuzion.runtime.fault.cause#1
+fuzion.type.runtime.type.contract_fault.type.install_default.λ.call#1
+fuzion.runtime.contract_fault.cause#1
 fuzion.type.runtime.type.pre_fault.type.install_default.λ.call#1
 fuzion.runtime.pre_fault.cause#1
 fuzion.runtime.precondition_fault#1

--- a/tests/hello/HelloWorld.fz.effect
+++ b/tests/hello/HelloWorld.fz.effect
@@ -1,5 +1,6 @@
 io.Out
 fuzion.runtime.pre_fault
+fuzion.runtime.contract_fault
 fuzion.runtime.fault
 io.Err
 fuzion.runtime.post_fault

--- a/tests/i18n_default_test/i18n_default_test.fz.effect
+++ b/tests/i18n_default_test/i18n_default_test.fz.effect
@@ -1,6 +1,7 @@
 envir.vars
 internationalization.provide
 fuzion.runtime.pre_fault
+fuzion.runtime.contract_fault
 fuzion.runtime.fault
 io.Err
 fuzion.runtime.post_fault

--- a/tests/lib_concur_sync/lib_concur_sync.fz.effect
+++ b/tests/lib_concur_sync/lib_concur_sync.fz.effect
@@ -1,6 +1,7 @@
 concur.atomic_access
 concur.threads
 fuzion.runtime.check_fault
+fuzion.runtime.contract_fault
 fuzion.runtime.fault
 fuzion.runtime.pre_fault
 io.Err

--- a/tests/lib_fileio_mmap/mmap_test.fz.effect
+++ b/tests/lib_fileio_mmap/mmap_test.fz.effect
@@ -1,5 +1,6 @@
 io.Err
 fuzion.runtime.pre_fault
+fuzion.runtime.contract_fault
 fuzion.runtime.fault
 io.Out
 io.file.delete

--- a/tests/lib_io_dir/lib_io_dir.fz.effect
+++ b/tests/lib_io_dir/lib_io_dir.fz.effect
@@ -1,9 +1,10 @@
 io.Err
 fuzion.runtime.pre_fault
+fuzion.runtime.contract_fault
 fuzion.runtime.fault
 io.file.delete
 io.dir.make
 io.Out
+fuzion.runtime.post_fault
 io.dir.read
 panic
-fuzion.runtime.post_fault

--- a/tests/lib_io_file/fileiotests.fz.effect
+++ b/tests/lib_io_file/fileiotests.fz.effect
@@ -1,5 +1,6 @@
 io.Err
 fuzion.runtime.pre_fault
+fuzion.runtime.contract_fault
 fuzion.runtime.fault
 fileiotests.f.stat
 io.Out

--- a/tests/lib_memoize/lib_memoize.fz.effect
+++ b/tests/lib_memoize/lib_memoize.fz.effect
@@ -1,6 +1,7 @@
 unique_id
 concur.atomic_access
 fuzion.runtime.pre_fault
+fuzion.runtime.contract_fault
 fuzion.runtime.fault
 io.Err
 mutate

--- a/tests/mod_lock_free_Map/ctrie_test.fz.effect
+++ b/tests/mod_lock_free_Map/ctrie_test.fz.effect
@@ -1,6 +1,7 @@
 unique_id
 concur.atomic_access
 fuzion.runtime.pre_fault
+fuzion.runtime.contract_fault
 fuzion.runtime.fault
 io.Err
 panic

--- a/tests/mod_lock_free_Map_threads/ctrie_threads.fz.effect
+++ b/tests/mod_lock_free_Map_threads/ctrie_threads.fz.effect
@@ -1,4 +1,5 @@
 fuzion.runtime.pre_fault
+fuzion.runtime.contract_fault
 fuzion.runtime.fault
 io.Err
 concur.atomic_access

--- a/tests/reg_issue2194/reg_issue2194.fz.expected_err_int
+++ b/tests/reg_issue2194/reg_issue2194.fz.expected_err_int
@@ -7,9 +7,15 @@ fuzion.type.runtime.type.fault.type.install_default.λ.call#1: {base.fum}/fuzion
 fuzion.runtime.fault.cause#1: {base.fum}/eff/fallible.fz:35:6:
   => h e
 -----^
+fuzion.type.runtime.type.contract_fault.type.install_default.λ.call#1: {base.fum}/fuzion/runtime/contract_fault.fz:39:7:
+      fuzion.runtime.fault.cause kind_and_msg).default
+------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+fuzion.runtime.contract_fault.cause#1: {base.fum}/eff/fallible.fz:35:6:
+  => h e
+-----^
 fuzion.type.runtime.type.pre_fault.type.install_default.λ.call#1: {base.fum}/fuzion/runtime/pre_fault.fz:39:7:
-      fuzion.runtime.fault.cause ("precondition", msg)).default
-------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      fuzion.runtime.contract_fault.cause ("precondition", msg)).default
+------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 fuzion.runtime.pre_fault.cause#1: {base.fum}/eff/fallible.fz:35:6:
   => h e
 -----^

--- a/tests/reg_issue2194/reg_issue2194.fz.expected_err_jvm
+++ b/tests/reg_issue2194/reg_issue2194.fz.expected_err_jvm
@@ -4,6 +4,8 @@ Call stack:
 fuzion.sys.fatal_fault#2
 fuzion.type.runtime.type.fault.type.install_default.λ.call#1
 fuzion.runtime.fault.cause#1
+fuzion.type.runtime.type.contract_fault.type.install_default.λ.call#1
+fuzion.runtime.contract_fault.cause#1
 fuzion.type.runtime.type.pre_fault.type.install_default.λ.call#1
 fuzion.runtime.pre_fault.cause#1
 fuzion.runtime.precondition_fault#1

--- a/tests/reg_issue2325/reg_issue2325.fz.expected_err_int
+++ b/tests/reg_issue2325/reg_issue2325.fz.expected_err_int
@@ -7,9 +7,15 @@ fuzion.type.runtime.type.fault.type.install_default.λ.call#1: {base.fum}/fuzion
 fuzion.runtime.fault.cause#1: {base.fum}/eff/fallible.fz:35:6:
   => h e
 -----^
+fuzion.type.runtime.type.contract_fault.type.install_default.λ.call#1: {base.fum}/fuzion/runtime/contract_fault.fz:39:7:
+      fuzion.runtime.fault.cause kind_and_msg).default
+------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+fuzion.runtime.contract_fault.cause#1: {base.fum}/eff/fallible.fz:35:6:
+  => h e
+-----^
 fuzion.type.runtime.type.pre_fault.type.install_default.λ.call#1: {base.fum}/fuzion/runtime/pre_fault.fz:39:7:
-      fuzion.runtime.fault.cause ("precondition", msg)).default
-------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      fuzion.runtime.contract_fault.cause ("precondition", msg)).default
+------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 fuzion.runtime.pre_fault.cause#1: {base.fum}/eff/fallible.fz:35:6:
   => h e
 -----^
@@ -24,16 +30,16 @@ i32.precall infix +: {base.fum}/numeric.fz:47:5:
 ----^^^
       debug: (numeric.this +! other)
 ------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-i32.type.sum.anonymous.infix ∙#2: {base.fum}/numeric.fz:240:51:
+i32.type.sum.anonymous.infix ∙#2: {base.fum}/numeric.fz:226:51:
       public redef infix ∙ (a, b numeric.this) => a + b
 --------------------------------------------------^^^^^
 i32.type.sum.anonymous.op#2: {base.fum}/Monoid.fz:60:24:
   public op(a, b T) => infix ∙  a b
 -----------------------^^^^^^^^^^^^
-(list i32).fold#2: {base.fum}/list.fz:217:39:
+(list i32).fold#2: {base.fum}/list.fz:226:39:
               | c Cons => c.tail.fold (m.op s c.head) m
 --------------------------------------^^^^^^^^^^^^^^^
-(interval i32).fold#1: {base.fum}/Sequence.fz:397:31:
+(interval i32).fold#1: {base.fum}/Sequence.fz:432:31:
   public fold (m Monoid T) => as_list.fold m.e m
 ------------------------------^^^^^^^^^^^^^^^^^^
 reg_issue2325: --CURDIR--/reg_issue2325.fz:25:8:

--- a/tests/reg_issue2325/reg_issue2325.fz.expected_err_jvm
+++ b/tests/reg_issue2325/reg_issue2325.fz.expected_err_jvm
@@ -4,6 +4,8 @@ Call stack:
 fuzion.sys.fatal_fault#2
 fuzion.type.runtime.type.fault.type.install_default.λ.call#1
 fuzion.runtime.fault.cause#1
+fuzion.type.runtime.type.contract_fault.type.install_default.λ.call#1
+fuzion.runtime.contract_fault.cause#1
 fuzion.type.runtime.type.pre_fault.type.install_default.λ.call#1
 fuzion.runtime.pre_fault.cause#1
 fuzion.runtime.precondition_fault#1

--- a/tests/reg_issue270/issue270.fz.expected_err_int
+++ b/tests/reg_issue270/issue270.fz.expected_err_int
@@ -7,9 +7,15 @@ fuzion.type.runtime.type.fault.type.install_default.λ.call#1: {base.fum}/fuzion
 fuzion.runtime.fault.cause#1: {base.fum}/eff/fallible.fz:35:6:
   => h e
 -----^
+fuzion.type.runtime.type.contract_fault.type.install_default.λ.call#1: {base.fum}/fuzion/runtime/contract_fault.fz:39:7:
+      fuzion.runtime.fault.cause kind_and_msg).default
+------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+fuzion.runtime.contract_fault.cause#1: {base.fum}/eff/fallible.fz:35:6:
+  => h e
+-----^
 fuzion.type.runtime.type.pre_fault.type.install_default.λ.call#1: {base.fum}/fuzion/runtime/pre_fault.fz:39:7:
-      fuzion.runtime.fault.cause ("precondition", msg)).default
-------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      fuzion.runtime.contract_fault.cause ("precondition", msg)).default
+------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 fuzion.runtime.pre_fault.cause#1: {base.fum}/eff/fallible.fz:35:6:
   => h e
 -----^

--- a/tests/reg_issue270/issue270.fz.expected_err_jvm
+++ b/tests/reg_issue270/issue270.fz.expected_err_jvm
@@ -4,6 +4,8 @@ Call stack:
 fuzion.sys.fatal_fault#2
 fuzion.type.runtime.type.fault.type.install_default.λ.call#1
 fuzion.runtime.fault.cause#1
+fuzion.type.runtime.type.contract_fault.type.install_default.λ.call#1
+fuzion.runtime.contract_fault.cause#1
 fuzion.type.runtime.type.pre_fault.type.install_default.λ.call#1
 fuzion.runtime.pre_fault.cause#1
 fuzion.runtime.precondition_fault#1

--- a/tests/reg_issue2745/reg_issue2745.fz.expected_err_int
+++ b/tests/reg_issue2745/reg_issue2745.fz.expected_err_int
@@ -7,19 +7,25 @@ fuzion.type.runtime.type.fault.type.install_default.λ.call#1: {base.fum}/fuzion
 fuzion.runtime.fault.cause#1: {base.fum}/eff/fallible.fz:35:6:
   => h e
 -----^
+fuzion.type.runtime.type.contract_fault.type.install_default.λ.call#1: {base.fum}/fuzion/runtime/contract_fault.fz:39:7:
+      fuzion.runtime.fault.cause kind_and_msg).default
+------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+fuzion.runtime.contract_fault.cause#1: {base.fum}/eff/fallible.fz:35:6:
+  => h e
+-----^
 fuzion.type.runtime.type.pre_fault.type.install_default.λ.call#1: {base.fum}/fuzion/runtime/pre_fault.fz:39:7:
-      fuzion.runtime.fault.cause ("precondition", msg)).default
-------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      fuzion.runtime.contract_fault.cause ("precondition", msg)).default
+------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 fuzion.runtime.pre_fault.cause#1: {base.fum}/eff/fallible.fz:35:6:
   => h e
 -----^
 fuzion.runtime.precondition_fault#1: {base.fum}/fuzion/runtime/pre_fault.fz:58:42:
 public precondition_fault(msg String) => pre_fault.cause msg
 -----------------------------------------^^^^^^^^^^^^^^^^^^^
-fuzion.java.pre array_to_java_object codepoint: {base.fum}/fuzion/java.fz:276:7:
+fuzion.java.pre array_to_java_object codepoint: {base.fum}/fuzion/java.fz:277:7:
       T : java_primitive
 ------^^^^^^^^^^^^^^^^^^
-fuzion.java.precall array_to_java_object codepoint: {base.fum}/fuzion/java.fz:275:5:
+fuzion.java.precall array_to_java_object codepoint: {base.fum}/fuzion/java.fz:276:5:
     pre
 ----^^^
       T : java_primitive

--- a/tests/reg_issue2745/reg_issue2745.fz.expected_err_jvm
+++ b/tests/reg_issue2745/reg_issue2745.fz.expected_err_jvm
@@ -4,6 +4,8 @@ Call stack:
 fuzion.sys.fatal_fault#2
 fuzion.type.runtime.type.fault.type.install_default.λ.call#1
 fuzion.runtime.fault.cause#1
+fuzion.type.runtime.type.contract_fault.type.install_default.λ.call#1
+fuzion.runtime.contract_fault.cause#1
 fuzion.type.runtime.type.pre_fault.type.install_default.λ.call#1
 fuzion.runtime.pre_fault.cause#1
 fuzion.runtime.precondition_fault#1

--- a/tests/reg_issue3178/reg_issue3178.fz.expected_err_c
+++ b/tests/reg_issue3178/reg_issue3178.fz.expected_err_c
@@ -1,0 +1,1 @@
+*** failed precondition: `debug: !(overflow_on_add other)`

--- a/tests/reg_issue3178/reg_issue3178.fz.expected_err_jvm
+++ b/tests/reg_issue3178/reg_issue3178.fz.expected_err_jvm
@@ -4,6 +4,8 @@ Call stack:
 fuzion.sys.fatal_fault#2
 fuzion.type.runtime.type.fault.type.install_default.λ.call#1
 fuzion.runtime.fault.cause#1
+fuzion.type.runtime.type.contract_fault.type.install_default.λ.call#1
+fuzion.runtime.contract_fault.cause#1
 fuzion.type.runtime.type.pre_fault.type.install_default.λ.call#1
 fuzion.runtime.pre_fault.cause#1
 fuzion.runtime.precondition_fault#1

--- a/tests/reg_issue3178/skip_c
+++ b/tests/reg_issue3178/skip_c
@@ -1,1 +1,1 @@
-# NYI: BUG: c backend should also result in precondition failure, but does not seem to terminate?
+# NYI: BUG: c backend for some reason very slow

--- a/tests/reg_issue4353/reg_issue4353.fz.expected_err_int
+++ b/tests/reg_issue4353/reg_issue4353.fz.expected_err_int
@@ -7,9 +7,15 @@ fuzion.type.runtime.type.fault.type.install_default.λ.call#1: {base.fum}/fuzion
 fuzion.runtime.fault.cause#1: {base.fum}/eff/fallible.fz:35:6:
   => h e
 -----^
+fuzion.type.runtime.type.contract_fault.type.install_default.λ.call#1: {base.fum}/fuzion/runtime/contract_fault.fz:39:7:
+      fuzion.runtime.fault.cause kind_and_msg).default
+------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+fuzion.runtime.contract_fault.cause#1: {base.fum}/eff/fallible.fz:35:6:
+  => h e
+-----^
 fuzion.type.runtime.type.pre_fault.type.install_default.λ.call#1: {base.fum}/fuzion/runtime/pre_fault.fz:39:7:
-      fuzion.runtime.fault.cause ("precondition", msg)).default
-------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      fuzion.runtime.contract_fault.cause ("precondition", msg)).default
+------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 fuzion.runtime.pre_fault.cause#1: {base.fum}/eff/fallible.fz:35:6:
   => h e
 -----^

--- a/tests/reg_issue4353/reg_issue4353.fz.expected_err_jvm
+++ b/tests/reg_issue4353/reg_issue4353.fz.expected_err_jvm
@@ -4,6 +4,8 @@ Call stack:
 fuzion.sys.fatal_fault#2
 fuzion.type.runtime.type.fault.type.install_default.λ.call#1
 fuzion.runtime.fault.cause#1
+fuzion.type.runtime.type.contract_fault.type.install_default.λ.call#1
+fuzion.runtime.contract_fault.cause#1
 fuzion.type.runtime.type.pre_fault.type.install_default.λ.call#1
 fuzion.runtime.pre_fault.cause#1
 fuzion.runtime.precondition_fault#1

--- a/tests/reg_issue4609/reg_issue4609.fz.expected_err_int
+++ b/tests/reg_issue4609/reg_issue4609.fz.expected_err_int
@@ -7,16 +7,22 @@ fuzion.type.runtime.type.fault.type.install_default.λ.call#1: {base.fum}/fuzion
 fuzion.runtime.fault.cause#1: {base.fum}/eff/fallible.fz:35:6:
   => h e
 -----^
+fuzion.type.runtime.type.contract_fault.type.install_default.λ.call#1: {base.fum}/fuzion/runtime/contract_fault.fz:39:7:
+      fuzion.runtime.fault.cause kind_and_msg).default
+------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+fuzion.runtime.contract_fault.cause#1: {base.fum}/eff/fallible.fz:35:6:
+  => h e
+-----^
 fuzion.type.runtime.type.check_fault.type.install_default.λ.call#1: {base.fum}/fuzion/runtime/check_fault.fz:39:7:
-      fuzion.runtime.fault.cause ("check", msg)).default
-------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      fuzion.runtime.contract_fault.cause ("check", msg)).default
+------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 fuzion.runtime.check_fault.cause#1: {base.fum}/eff/fallible.fz:35:6:
   => h e
 -----^
 fuzion.runtime.checkcondition_fault#1: {base.fum}/fuzion/runtime/check_fault.fz:58:44:
 public checkcondition_fault(msg String) => check_fault.cause msg
 -------------------------------------------^^^^^^^^^^^^^^^^^^^^^
-reg_issue4609.s.call: --CURDIR--/reg_issue4609.fz:33:25:
+reg_issue4609.s.call: --CURDIR--/reg_issue4609.fz:33:32:
     public redef call => check false
 -------------------------------^^^^^
 reg_issue4609.r#1: --CURDIR--/reg_issue4609.fz:36:20:

--- a/tests/reg_issue4609/reg_issue4609.fz.expected_err_jvm
+++ b/tests/reg_issue4609/reg_issue4609.fz.expected_err_jvm
@@ -4,6 +4,8 @@ Call stack:
 fuzion.sys.fatal_fault#2
 fuzion.type.runtime.type.fault.type.install_default.λ.call#1
 fuzion.runtime.fault.cause#1
+fuzion.type.runtime.type.contract_fault.type.install_default.λ.call#1
+fuzion.runtime.contract_fault.cause#1
 fuzion.type.runtime.type.check_fault.type.install_default.λ.call#1
 fuzion.runtime.check_fault.cause#1
 fuzion.runtime.checkcondition_fault#1

--- a/tests/sequence_sliding/sequence_sliding.fz.expected_err_int
+++ b/tests/sequence_sliding/sequence_sliding.fz.expected_err_int
@@ -7,26 +7,32 @@ fuzion.type.runtime.type.fault.type.install_default.λ.call#1: {base.fum}/fuzion
 fuzion.runtime.fault.cause#1: {base.fum}/eff/fallible.fz:35:6:
   => h e
 -----^
+fuzion.type.runtime.type.contract_fault.type.install_default.λ.call#1: {base.fum}/fuzion/runtime/contract_fault.fz:39:7:
+      fuzion.runtime.fault.cause kind_and_msg).default
+------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+fuzion.runtime.contract_fault.cause#1: {base.fum}/eff/fallible.fz:35:6:
+  => h e
+-----^
 fuzion.type.runtime.type.pre_fault.type.install_default.λ.call#1: {base.fum}/fuzion/runtime/pre_fault.fz:39:7:
-      fuzion.runtime.fault.cause ("precondition", msg)).default
-------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      fuzion.runtime.contract_fault.cause ("precondition", msg)).default
+------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 fuzion.runtime.pre_fault.cause#1: {base.fum}/eff/fallible.fz:35:6:
   => h e
 -----^
 fuzion.runtime.precondition_fault#1: {base.fum}/fuzion/runtime/pre_fault.fz:58:42:
 public precondition_fault(msg String) => pre_fault.cause msg
 -----------------------------------------^^^^^^^^^^^^^^^^^^^
-(interval i32).pre sliding: {base.fum}/Sequence.fz:1244:7:
+(interval i32).pre sliding: {base.fum}/Sequence.fz:1279:7:
       debug: size > 0
 ------^^^^^^^^^^^^^^^
-(interval i32).precall sliding: {base.fum}/Sequence.fz:1243:5:
+(interval i32).precall sliding: {base.fum}/Sequence.fz:1278:5:
     pre
 ----^^^
       debug: size > 0
 ------^^^^^^^^^^^^^^^
       debug: step > 0
 ------^^^^^^^^^^^^^^^
-(interval i32).sliding#1: {base.fum}/Sequence.fz:1229:5:
+(interval i32).sliding#1: {base.fum}/Sequence.fz:1264:5:
     sliding size 1
 ----^^^^^^^^^^^^^^
 sequence_sliding: --CURDIR--/sequence_sliding.fz:41:10:

--- a/tests/sequence_sliding/sequence_sliding.fz.expected_err_jvm
+++ b/tests/sequence_sliding/sequence_sliding.fz.expected_err_jvm
@@ -4,6 +4,8 @@ Call stack:
 fuzion.sys.fatal_fault#2
 fuzion.type.runtime.type.fault.type.install_default.λ.call#1
 fuzion.runtime.fault.cause#1
+fuzion.type.runtime.type.contract_fault.type.install_default.λ.call#1
+fuzion.runtime.contract_fault.cause#1
 fuzion.type.runtime.type.pre_fault.type.install_default.λ.call#1
 fuzion.runtime.pre_fault.cause#1
 fuzion.runtime.precondition_fault#1


### PR DESCRIPTION
contract_fault was not used at all.

hierarchy is now:

0) fault
1) contractfault
2) pre, post, checkfault

The example that did not work was:
```
  _ := (fuzion.runtime.contract_fault.try ()->
       say 1/0
    )
    .catch msg->
```

