### PR TITLE
build: suppress makefile output for cleaner output of negative tests

### DIFF
--- a/tests/negative.mk
+++ b/tests/negative.mk
@@ -37,21 +37,21 @@ all: jvm c int
 int:
 	$(FUZION) -interpreter $(NAME) 2>err.txt || true
 # check if for every unique comment containing "should flag an error" an error is reported for a line with that comment
-	printf "RUN negative test $(NAME).fz using interpreter backend "; \
+	@printf "RUN negative test $(NAME).fz using interpreter backend "; \
 	cat err.txt  | grep "should.flag.an.error" | sed "s ^.*\#  g" | sort -n | uniq | wc -l | tr -d ' ' | grep ^$(EXPECTED_ERRORS)$$ > /dev/null && \
 		printf "\033[32;1mPASSED\033[0m.\n" || (printf "\033[31;1m*** FAILED ***\033[0m\n" && exit 1)
 
 jvm:
 	$(FUZION) -jvm $(NAME) 2>err.txt || true
 # check if for every unique comment containing "should flag an error" an error is reported for a line with that comment
-	printf "RUN negative test $(NAME).fz using jvm backend "; \
+	@printf "RUN negative test $(NAME).fz using jvm backend "; \
 	cat err.txt  | grep "should.flag.an.error" | sed "s ^.*\#  g" | sort -n | uniq | wc -l | tr -d ' ' | grep ^$(EXPECTED_ERRORS)$$ > /dev/null && \
 		printf "\033[32;1mPASSED\033[0m.\n" || (printf "\033[31;1m*** FAILED ***\033[0m\n" && exit 1)
 
 c:
 	($(FUZION) -c -o=testbin $(NAME) && ./testbin) 2>err.txt || true
 # check if for every unique comment containing "should flag an error" an error is reported for a line with that comment
-	printf "RUN negative test $(NAME).fz using c backend "; \
+	@printf "RUN negative test $(NAME).fz using c backend "; \
 	cat err.txt  | grep "should.flag.an.error" | sed "s ^.*\#  g" | sort -n | uniq | wc -l | tr -d ' ' | grep ^$(EXPECTED_ERRORS)$$ > /dev/null && \
 		printf "\033[32;1mPASSED\033[0m.\n" || (printf "\033[31;1m*** FAILED ***\033[0m\n" && exit 1)
 


### PR DESCRIPTION
turns this
```
...
printf "RUN negative test reg_issue5095_pre_else_err.fz using jvm backend "; \
cat err.txt  | grep "should.flag.an.error" | sed "s ^.*\#  g" | sort -n | uniq | wc -l | tr -d ' ' | grep ^`cat *.fz | grep "should.flag.an.error"  | sed "s ^.*#  g"| sort -n | uniq | wc -l | tr -d ' '`$ > /dev/null && \
        printf "\033[32;1mPASSED\033[0m.\n" || (printf "\033[31;1m*** FAILED ***\033[0m\n" && exit 1)
RUN negative test reg_issue5095_pre_else_err.fz using jvm backend PASSED.
...
```
into 
```
...
RUN negative test reg_issue5095_pre_else_err.fz using jvm backend PASSED.
...
```