### PR TITLE
parser: Fix position for `AstErrors.qualifierExpectedForDotThis`, fix #5156

### DIFF
--- a/src/dev/flang/parser/Parser.java
+++ b/src/dev/flang/parser/Parser.java
@@ -1513,7 +1513,7 @@ callTail    : indexCall  callTail
             var q = result.asQualifier();
             if (q == null)
               {
-                AstErrors.qualifierExpectedForDotThis(tokenSourcePos(), result);
+                AstErrors.qualifierExpectedForDotThis(target.pos(), result);
               }
             else
               {

--- a/tests/reg_issue5156/Makefile
+++ b/tests/reg_issue5156/Makefile
@@ -1,0 +1,25 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test Makefile
+#
+# -----------------------------------------------------------------------
+
+override NAME = reg_issue5156
+include ../simple.mk

--- a/tests/reg_issue5156/reg_issue5156.fz
+++ b/tests/reg_issue5156/reg_issue5156.fz
@@ -1,0 +1,30 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test reg_issue5156
+#
+# -----------------------------------------------------------------------
+
+# Produce error `Qualifier expected for '.this' expression.`, check that
+# it is displayed at the right source position
+#
+reg_issue5156 =>
+
+  a => Any.type.this  # causes error, `A.type` is invalid before `.this`
+  b =>                # before fix #5156, error was wrongly displayed here

--- a/tests/reg_issue5156/reg_issue5156.fz.expected_err
+++ b/tests/reg_issue5156/reg_issue5156.fz.expected_err
@@ -1,0 +1,9 @@
+
+--CURDIR--/reg_issue5156.fz:29:8: error 1: Qualifier expected for '.this' expression.
+  a => Any.type.this  # causes error, `A.type` is invalid before `.this`
+-------^^^^^^^^
+Found expression --CURDIR--/reg_issue5156.fz:29:8:
+  a => Any.type.this  # causes error, `A.type` is invalid before `.this`
+-------^^^^^^^^ where a simple qualifier 'a.b.c' was expected
+
+one error.


### PR DESCRIPTION
Added a test case even though this fix is trivial just because this error is not produced by any of the existing tests.
