### PR TITLE
run_tests: run append_line synchronized

### DIFF
--- a/bin/run_tests.fz
+++ b/bin/run_tests.fz
@@ -108,12 +108,13 @@ String.prefix !! =>
   !split
 
 
-# NYI: UNDER DEVELOPMENT: what about thread safety?
-append_line(dest String, str String) =>
+append_line(mtx concur.sync.mutex, dest String, str String) =>
+
   lm : mutate is
   lm ! ()->
-    check (io.file.use unit lm $dest io.file.mode.append ()->
-             check ("$str\n".write_to lm).ok).ok
+    mtx.synchronized ()->
+      check (io.file.use unit lm $dest io.file.mode.append ()->
+              check ("$str\n".write_to lm).ok).ok
 
 
 # read file f fully
@@ -123,6 +124,10 @@ read_file_fully(f String) outcome String =>
   lm ! ()->
     io.file.use _ lm f io.file.mode.read ()->
       String.from_bytes (io.buffered lm).read_fully
+
+
+is_windows =>
+  ((envir.vars.get "OS").val "").lower_case.contains "windows"
 
 
 ########### run_tests ###############
@@ -146,6 +151,11 @@ find_tests(dir String) array String =>
 
 
 main =>
+
+  mtx := concur.sync.mutex.new.val
+
+  append_line(dest String, str String) =>
+    append_line mtx dest str
 
   # NYI: UNDER DEVELOPMENT: react to Ctrl+c like in bash scripts (trap)
 
@@ -174,6 +184,8 @@ main =>
 
   tests := find_tests "$build_dir/tests"
 
+  check tests.count>500
+
   results := "$build_dir/run_tests.results"
   failures := "$build_dir/run_tests.failures"
 
@@ -193,7 +205,9 @@ main =>
         else
 
           start_time := time.nano.read
-          res := !!"timeout --kill-after=600s 600s make $target --environment-overrides --directory=$test"
+          # NYI: UNDER DEVELOPMENT: use fuzion to do the timeout
+          with_to := if is_windows then "" else "timeout --kill-after=600s 600s "
+          res := !!"{with_to}make $target --environment-overrides --directory=$test"
           end_time := time.nano.read
 
           if res.exit_code = 0 then

--- a/modules/base/src/concur/sync.fz
+++ b/modules/base/src/concur/sync.fz
@@ -45,13 +45,15 @@ public sync is
 
   private:public mutex(module mtx Mutex) is
 
+    public synchronized(T type, code ()->T) T =>
+      check mtx_lock mtx
+      res := code.call
+      check mtx_unlock mtx
+      res
+
     public type.new outcome concur.sync.mutex =>
       concur.sync.mtx_init.bind mtx->
         concur.sync.mutex mtx
-
-    public condition outcome concur.sync.condition =>
-      (concur.sync.cnd_init mtx).bind cnd->
-        concur.sync.condition mtx cnd
 
     # NYI destroy
 
@@ -77,5 +79,10 @@ public sync is
     public wait
     pre is_locked.read
     => cnd_wait cnd mtx
+
+    public type.new outcome concur.sync.condition =>
+      concur.sync.mtx_init.bind mtx->
+        (concur.sync.cnd_init mtx).bind cnd->
+          concur.sync.condition mtx cnd
 
     # NYI destroy

--- a/modules/base/src/concur/thread_pool.fz
+++ b/modules/base/src/concur/thread_pool.fz
@@ -83,12 +83,11 @@ Blocking_Queue(T type, cnd concur.sync.condition) ref is
 # submit a task to the thread_pool.
 #
 public thread_pool(R type, size i32, code ()->R) outcome R =>
-  (concur.sync.mutex.new.bind mtx->
-    mtx.condition.bind cnd->
-      (thread_pool cnd size) ! ()->
-        res := code.call
-        thread_pool.env.await
-        res)
+  (concur.sync.condition.new.bind cnd->
+    (thread_pool cnd size) ! ()->
+      res := code.call
+      thread_pool.env.await
+      res)
     .bind id
 
 
@@ -128,8 +127,7 @@ is
 
     fut ref : concur.Future T is
 
-      fut_mtx := concur.sync.mutex.new.val # NYI: error handling
-      fut_cnd := fut_mtx.condition.val # NYI: error handling
+      fut_cnd := concur.sync.condition.new.val # NYI: error handling
 
       compute_result := concur.atomic (option T) nil
 

--- a/tests/lib_concur_sync/lib_concur_sync.fz
+++ b/tests/lib_concur_sync/lib_concur_sync.fz
@@ -25,51 +25,45 @@ lib_concur_sync =>
 
   test_signal =>
 
-    mtx_res := concur.sync.mutex.new.bind mtx->
-      cnd_res := mtx.condition.bind cnd->
+    cnd_res := concur.sync.condition.new.bind cnd->
+      a := concur.threads.spawn ()->
+        cnd.synchronized ()->
+          check cnd.wait
+          say "Thread proceeding after signal"
 
-        a := concur.threads.spawn ()->
-          cnd.synchronized ()->
-            check cnd.wait
-            say "Thread proceeding after signal"
+      b := concur.threads.spawn ()->
+        say "Thread sleeping"
+        time.nano.sleep (time.duration.ms 100)
+        cnd.synchronized ()->
+          say "Thread sending signal"
+          check cnd.signal
 
-        b := concur.threads.spawn ()->
-          say "Thread sleeping"
-          time.nano.sleep (time.duration.ms 100)
-          cnd.synchronized ()->
-            say "Thread sending signal"
-            check cnd.signal
+      a.join
+      b.join
 
-        a.join
-        b.join
-
-      check cnd_res.ok
-    check mtx_res.ok
+    check cnd_res.ok
 
 
 
   test_broadcast =>
 
-    mtx_res := concur.sync.mutex.new.bind mtx->
-      cnd_res := mtx.condition.bind cnd->
+    cnd_res := concur.sync.condition.new.bind cnd->
+      a := concur.threads.spawn ()->
+        cnd.synchronized ()->
+          check cnd.wait
+          say "Thread proceeding after broadcast"
 
-        a := concur.threads.spawn ()->
-          cnd.synchronized ()->
-            check cnd.wait
-            say "Thread proceeding after broadcast"
+      b := concur.threads.spawn ()->
+        say "Thread sleeping"
+        time.nano.sleep (time.duration.ms 100)
+        cnd.synchronized ()->
+          say "Thread sending broadcast"
+          check cnd.broadcast
 
-        b := concur.threads.spawn ()->
-          say "Thread sleeping"
-          time.nano.sleep (time.duration.ms 100)
-          cnd.synchronized ()->
-            say "Thread sending broadcast"
-            check cnd.broadcast
+      a.join
+      b.join
 
-        a.join
-        b.join
-
-      check cnd_res.ok
-    check mtx_res.ok
+    check cnd_res.ok
 
 
 


### PR DESCRIPTION
Appending lines from multiple threads only works on linux/macOS (not sure why/how). On windows opening the file fails like one would expect. So now we synchronize these writes manually.


