### PR TITLE
build: fix suggestion to re-run or re-record tests

### DIFF
--- a/bin/run_tests.fz
+++ b/bin/run_tests.fz
@@ -244,23 +244,22 @@ main =>
   if failed > 0
     say "Failed tests:"
 
-    results_content
-      .for_each t->
-        if t.ends_with "failed"
-          say t
+    failed_tests := results_content.filter (.ends_with "failed")
+
+    failed_tests.for_each say
 
     say "============= run_tests.failures START ============="
     say (read_file_fully failures)
     say "============= run_tests.failures END ============="
 
     say "To re-run all failed tests, use this command:"
-    say <| results_content
+    say <| failed_tests
       .map x->x.split[0]
       .map x->"make $target -C $x"
       .as_string " && "
 
     say "To re-recordord all failed tests, use this command:"
-    say <| results_content
+    say <| failed_tests
       .map x->x.split[0]
       .map x->"make record_$target -C $x"
       .as_string " && "


### PR DESCRIPTION
suggest to re-run or re-record only faild test in run_test script

Before all tests were suggested, see this [test run](https://github.com/tokiwa-software/fuzion/actions/runs/14793379925/job/41535152079?pr=5177)

```
...
549/552 tests passed, 2 skipped, 1 failed in 14m.
...
To re-run all failed tests, use this command:
make jvm -C ./build/tests/argumentcount_negative && make jvm -C ./build/tests/reg_issue1665_nested_lazy && make jvm -C ./build/tests/reg_issue874ff && make jvm -C ./build/tests/reg_issue2304 && make jvm -C ./build/tests/reg_issue2303 && make jvm -C ./build/tests/lib_choice_tag && make jvm -C ./build/tests/reg_issue102 && make jvm -C ./build/tests/reg_issue1572 && make jvm -C ./build/tests/reg_issue3648 && make jvm -C ./build/tests/reg_issue4694 && make jvm -C ./build/tests/reg_issue3683 && make jvm -C ./build/tests/asParsedType && make jvm -C ./build/tests/type_inference_flat_map && make jvm -C ./build/tests/generics && make jvm -C ./build/tests/redef_args && make jvm -C ./build/tests/reg_issue1771 && make jvm -C ./build/tests/ternary && make jvm -C ./build/tests/reg_issue2564 && make jvm -C ./build/tests/reg_issue1183_type_of_a_this && make jvm -C ./build/tests/reg_issue3429 && make jvm -C ./build/tests/reg_issue1588 && make jvm -C ./build/tests/reg_issue4250 && make jvm -C ./build/tests/reg_issue3081 && make jvm -C ./build/tests/reg_issue952 && make jvm -C ./build/tests/reg_issue3518_a && make jvm -C ./build/tests/reg_issue4408 && make jvm -C ./build/tests/reg_issue2368 && make jvm -C ./build/tests/reg_issue4659 && make jvm -C ./build/tests/reg_issue3306_negative && make jvm -C ./build/tests/reg_issue1380_execute_single_field_declaration && make jvm -C ./build/tests/loop_negative && make jvm -C ./build/tests/reg_issue764 && make jvm -C ./build/tests/reg_issue3027 && make jvm -C ./build/tests/reg_issue1158_type_of_type_parameters && make jvm -C ./build/tests/reg_issue3649 && make jvm -C ./build/tests/fixed_alongside_abstract_negative && make jvm -C ./build/tests/reg_issue1777 && make jvm -C ./build/tests/call_with_ambiguous_result_type_negative && make jvm -C ./build/tests/reg_issue3682 && make jvm -C ./build/tests/asParsedType_negative && make jvm -C ./build/tests/reg_issue3676 && make jvm -C ./build/tests/unary && make jvm -C ./build/tests/valWithDynOuter && make jvm -C ./build/tests/reg_issue4233 && make jvm -C ./build/tests/mod_lock_free_Map_threads && make jvm -C ./build/tests/reg_issue1741 && make jvm -C ./build/tests/reg_issue3678 && make jvm -C ./build/tests/mod_sqlite && make jvm -C ./build/tests/reg_issue3812 && make jvm -C ./build/tests/reg_issue3647 && make jvm -C ./build/tests/reg_issue2761 && make jvm -C ./build/tests/semicolon_ambiguity && make jvm -C ./build/tests/process_utf8 && make jvm -C ./build/tests/reg_issue1518 && make jvm -C ./build/tests/redef_with_type_parameters && make jvm -C ./build/tests/hash_map && make jvm -C ./build/tests/strings && make jvm -C ./build/tests/reg_issue1188 && make jvm -C ./build/tests/reg_issue3246 && make jvm -C ./build/tests/reg_issue4251 && make jvm -C ./build/tests/lib_memoize && make jvm -C ./build/tests/reg_issue2967 && make jvm -C ./build/tests/dot_type_call_ambiguity && make jvm -C ./build/tests/reg_issue176_using_inner_field_of_boxed_outer && make jvm -C ./build/tests/reg_issue2367 && make jvm -C ./build/tests/reg_issue4632 && make jvm -C ./build/tests/reg_issue1724 && make jvm -C ./build/tests/reg_issue2358 && make jvm -C ./build/tests/reg_issues455-456_dot_type && make jvm -C ./build/tests/reg_issue3757 && make jvm -C ./build/tests/reg_issue2685 && make jvm -C ./build/tests/reg_issue3565 && make jvm -C ./build/tests/nested_options && make jvm -C ./build/tests/reg_issue1490 && make jvm -C ./build/tests/reg_issue3905 && make jvm -C ./build/tests/choice_negative2 && make jvm -C ./build/tests/lib_fileio_mmap && make jvm -C ./build/tests/inherit_postcondition && make jvm -C ./build/tests/reg_issue2682 && make jvm -C ./build/tests/visibility_modules && make jvm -C ./build/tests/effect_installed && make jvm -C ./build/tests/lib_switch && make jvm -C ./build/tests/reg_issue228 && make jvm -C ./build/tests/typeinference_negative && make jvm -C ./build/tests/reg_issue2224 && make jvm -C ./build/tests/reg_issue2486 && make jvm -C ./build/tests/assignments && make jvm -C ./build/tests/reg_issue3108 && make jvm -C ./build/tests/reg_issue3506_a && make jvm -C ./build/tests/unused_result && make jvm -C ./build/tests/reg_issue1031 && make jvm -C ./build/tests/sockets_thread_pool && make jvm -C ./build/tests/reg_issue1835 && make jvm -C ./build/tests/reg_issue3761 && make jvm -C ./build/tests/reg_issue2647 && make jvm -C ./build/tests/reg_issue3507 && make jvm -C ./build/tests/compile_time_constants && make jvm -C ./build/tests/sequence_scan1 && make jvm -C ./build/tests/reg_issue4180 && make jvm -C ./build/tests/partial_application && make jvm -C ./build/tests/name_but_not_visi_conflict && make jvm -C ./build/tests/local_mutate_negative && make jvm -C ./build/tests/reg_issue627 && make jvm -C ./build/tests/reg_issue7_genericConstraint && make jvm -C ./build/tests/calls_on_ref_and_val_target_negative && make jvm -C ./build/tests/reg_issue3369 && make jvm -C ./build/tests/reg_issue3199 && make jvm -C ./build/tests/reg_issue4348 && make jvm -C ./build/tests/concur_simple && make jvm -C ./build/tests/reg_issue238_array_index_out_of_bounds && make jvm -C ./build/tests/typeinference && make jvm -C ./build/tests/native && make jvm -C ./build/tests/reg_issue3136 && make jvm -C ./build/tests/basicIntegers && make jvm -C ./build/tests/generics_negative && make jvm -C ./build/tests/mutable_hash_map && make jvm -C ./build/tests/reg_issue3932 && make jvm -C ./build/tests/reg_issue1666 && make jvm -C ./build/tests/reg_issue4542 && make jvm -C ./build/tests/mod_lock_free_Map && make jvm -C ./build/tests/lib_concur_thread_pool && make jvm -C ./build/tests/calls_on_ref_and_val_target && make jvm -C ./build/tests/reg_issue29_arrayOfUnitType && make jvm -C ./build/tests/type_feature && make jvm -C ./build/tests/base64url && make jvm -C ./build/tests/reg_issue2683 && make jvm -C ./build/tests/reg_issue2213 && make jvm -C ./build/tests/reg_issue3769 && make jvm -C ./build/tests/reg_issue2489 && make jvm -C ./build/tests/unicode && make jvm -C ./build/tests/assignment_negative && make jvm -C ./build/tests/reg_issue1491 && make jvm -C ./build/tests/reg_issue2214 && make jvm -C ./build/tests/reg_issue4143 && make jvm -C ./build/tests/reg_issue1055 && make jvm -C ./build/tests/reg_issue4518 && make jvm -C ./build/tests/unwrap && make jvm -C ./build/tests/reg_issue3359 && make jvm -C ./build/tests/reg_issue16_chainedBool && make jvm -C ./build/tests/reg_issue3705 && make jvm -C ./build/tests/lists && make jvm -C ./build/tests/sockets && make jvm -C ./build/tests/reg_issue3959 && make jvm -C ./build/tests/visibility && make jvm -C ./build/tests/choice_negative && make jvm -C ./build/tests/reg_issue3733 && make jvm -C ./build/tests/reg_issue1294 && make jvm -C ./build/tests/reg_issue4516 && make jvm -C ./build/tests/reg_issue1886_option_void && make jvm -C ./build/tests/reg_issue4529 && make jvm -C ./build/tests/reg_issue2878 && make jvm -C ./build/tests/tuple && make jvm -C ./build/tests/reg_issue3191 && make jvm -C ./build/tests/reg_issue4988_1 && make jvm -C ./build/tests/fz_cmd && make jvm -C ./build/tests/reg_issue3734 && make jvm -C ./build/tests/reg_issue3730_1 && make jvm -C ./build/tests/constructor_with_return_type && make jvm -C ./build/tests/reg_issue2249 && make jvm -C ./build/tests/reg_issue3961 && make jvm -C ./build/tests/reg_issue1628 && make jvm -C ./build/tests/reg_issue2402 && make jvm -C ./build/tests/reg_issue3140 && make jvm -C ./build/tests/reg_issue3147 && make jvm -C ./build/tests/ryu && make jvm -C ./build/tests/reg_issue5082 && make jvm -C ./build/tests/reg_issue4354 && make jvm -C ./build/tests/reg_issue2262 && make jvm -C ./build/tests/wrap_around_semantics && make jvm -C ./build/tests/effect_signature && make jvm -C ./build/tests/reg_issue4353 && make jvm -C ./build/tests/reg_issue3773 && make jvm -C ./build/tests/reg_issue1023 && make jvm -C ./build/tests/reg_issue2231 && make jvm -C ./build/tests/reg_issue659 && make jvm -C ./build/tests/i18n_default_test && make jvm -C ./build/tests/reg_issue4938 && make jvm -C ./build/tests/reg_issue3577 && make jvm -C ./build/tests/reg_issue3178 && make jvm -C ./build/tests/onesCount && make jvm -C ./build/tests/reg_issue3910 && make jvm -C ./build/tests/effect_installed_negative && make jvm -C ./build/tests/interval && make jvm -C ./build/tests/reg_issue465 && make jvm -C ./build/tests/reg_issue8_optionFalse && make jvm -C ./build/tests/reg_issue350_x_ref_produces_strange_error_message && make jvm -C ./build/tests/qualified_declaration && make jvm -C ./build/tests/string_pad && make jvm -C ./build/tests/reg_issue4963 && make jvm -C ./build/tests/reg_issue1216_precondition_box_constructor && make jvm -C ./build/tests/reg_issue169_backward_type_propagation_array && make jvm -C ./build/tests/else_indentation_reference && make jvm -C ./build/tests/reg_issue4964 && make jvm -C ./build/tests/valWithLongLife && make jvm -C ./build/tests/reg_issue2252 && make jvm -C ./build/tests/reg_issue3973 && make jvm -C ./build/tests/partial_application_negative && make jvm -C ./build/tests/reg_issue4503 && make jvm -C ./build/tests/type_features_must_only_be_declared_in_features_that_define_types && make jvm -C ./build/tests/reg_issue4592 && make jvm -C ./build/tests/visibility_modules_negative && make jvm -C ./build/tests/reg_issue2034 && make jvm -C ./build/tests/reg_issue459_choice_elment_tagged_that_is_never_instantiated && make jvm -C ./build/tests/lib_string && make jvm -C ./build/tests/reg_issue3576 && make jvm -C ./build/tests/reg_issue3744 && make jvm -C ./build/tests/reg_issue19_redef_choice_result && make jvm -C ./build/tests/reg_issue1477 && make jvm -C ./build/tests/reg_issue3786 && make jvm -C ./build/tests/reg_issue3549 && make jvm -C ./build/tests/reg_issue3772 && make jvm -C ./build/tests/reg_issue2492 && make jvm -C ./build/tests/reg_issue4557 && make jvm -C ./build/tests/reg_issue2237 && make jvm -C ./build/tests/mix_inheritance_and_outer && make jvm -C ./build/tests/reg_issue2653 && make jvm -C ./build/tests/nested_choice_negative && make jvm -C ./build/tests/base64 && make jvm -C ./build/tests/reg_issue2345 && make jvm -C ./build/tests/reg_issue1396 && make jvm -C ./build/tests/typeinference_for_formal_args_negative && make jvm -C ./build/tests/reg_issue4422 && make jvm -C ./build/tests/reg_issue4628 && make jvm -C ./build/tests/inheritance_for_value_types && make jvm -C ./build/tests/reg_issue2719 && make jvm -C ./build/tests/reg_issue1391 && make jvm -C ./build/tests/mandelbrot && make jvm -C ./build/tests/nested_lazy && make jvm -C ./build/tests/reg_issue4273 && make jvm -C ./build/tests/reg_issue4621 && make jvm -C ./build/tests/reg_issue2691_c && make jvm -C ./build/tests/reg_issues4992_5001_negative && make jvm -C ./build/tests/reg_issue5156 && make jvm -C ./build/tests/select_clause && make jvm -C ./build/tests/reg_issue3691 && make jvm -C ./build/tests/terminal && make jvm -C ./build/tests/reg_issue2345_1 && make jvm -C ./build/tests/strings_multiline && make jvm -C ./build/tests/reg_issue119 && make jvm -C ./build/tests/reg_issue1559_post_condition && make jvm -C ./build/tests/nested_choice && make jvm -C ./build/tests/reg_issue27_callWithUninstantiatedTarget && make jvm -C ./build/tests/reg_issue2380 && make jvm -C ./build/tests/reg_issue3801 && make jvm -C ./build/tests/reg_issue2775 && make jvm -C ./build/tests/reg_issue293_confusion_of_type_and_value_params && make jvm -C ./build/tests/choice && make jvm -C ./build/tests/reg_issue90 && make jvm -C ./build/tests/doubledeclaration_negative && make jvm -C ./build/tests/reg_issue2386 && make jvm -C ./build/tests/reg_issue4220 && make jvm -C ./build/tests/lib_container_sorted_array && make jvm -C ./build/tests/reg_issue4516_1 && make jvm -C ./build/tests/reg_issue3608 && make jvm -C ./build/tests/covariance && make jvm -C ./build/tests/reg_issue2691_b && make jvm -C ./build/tests/catch_preconditions && make jvm -C ./build/tests/reg_issue5095_pre_else_err && make jvm -C ./build/tests/reg_issue3405 && make jvm -C ./build/tests/reg_issue1352 && make jvm -C ./build/tests/inheritance_negative && make jvm -C ./build/tests/lib_time_date_time && make jvm -C ./build/tests/reg_issue2515 && make jvm -C ./build/tests/reg_issue4272 && make jvm -C ./build/tests/reg_issue4424 && make jvm -C ./build/tests/reg_issue348 && make jvm -C ./build/tests/indentation && make jvm -C ./build/tests/reg_issue2182 && make jvm -C ./build/tests/reg_issue2381 && make jvm -C ./build/tests/reg_issue3004 && make jvm -C ./build/tests/reg_issue4645 && make jvm -C ./build/tests/rosettacode_primes && make jvm -C ./build/tests/reg_issue4281 && make jvm -C ./build/tests/reg_issue3493 && make jvm -C ./build/tests/reg_issue3003 && make jvm -C ./build/tests/this_type_negative && make jvm -C ./build/tests/native_value: && make jvm -C ./build/tests/semicolon_parsing && make jvm -C ./build/tests/choice_mix && make jvm -C ./build/tests/inheritance_cyclic_negative && make jvm -C ./build/tests/property_countable_count && make jvm -C ./build/tests/reg_issue2321 && make jvm -C ./build/tests/incomp_type_in_cases && make jvm -C ./build/tests/reg_issue776 && make jvm -C ./build/tests/reg_issue2745 && make jvm -C ./build/tests/reg_issue4479 && make jvm -C ./build/tests/numliteral_syntax_sugar_issue4754 && make jvm -C ./build/tests/unicode_15 && make jvm -C ./build/tests/open_type_dots && make jvm -C ./build/tests/reg_issue440_incomplete_else_block_confusing_error_message && make jvm -C ./build/tests/atomic && make jvm -C ./build/tests/reg_issue2114 && make jvm -C ./build/tests/function_argument_visibility && make jvm -C ./build/tests/reg_issue118 && make jvm -C ./build/tests/sequence_sliding && make jvm -C ./build/tests/reg_issue197 && make jvm -C ./build/tests/reg_issue1945_ambiguity_for_lambda_result && make jvm -C ./build/tests/reg_issue26_redefAsVoid && make jvm -C ./build/tests/reg_issue2365 && make jvm -C ./build/tests/reg_issue1726 && make jvm -C ./build/tests/reg_issue4637 && make jvm -C ./build/tests/reg_issue2452_abstract_constructor && make jvm -C ./build/tests/compile_time_type_casts_negative2 && make jvm -C ./build/tests/reg_issue2701 && make jvm -C ./build/tests/dot_type_call_on_type_parameter && make jvm -C ./build/tests/reg_issue3518_b && make jvm -C ./build/tests/i18n_test && make jvm -C ./build/tests/reg_issue3552_and_3553 && make jvm -C ./build/tests/tuple_negative && make jvm -C ./build/tests/tailrecursion && make jvm -C ./build/tests/stdin && make jvm -C ./build/tests/reg_issue1943_type_parameter_as_outer_type && make jvm -C ./build/tests/equals && make jvm -C ./build/tests/reg_issue2307 && make jvm -C ./build/tests/inheritance_negative2 && make jvm -C ./build/tests/uninitialized_field_negative && make jvm -C ./build/tests/reg_issue175_int_crash && make jvm -C ./build/tests/reg_issue1918 && make jvm -C ./build/tests/mutable_linked_list && make jvm -C ./build/tests/reg_issue5114 && make jvm -C ./build/tests/choice_inheritance && make jvm -C ./build/tests/int && make jvm -C ./build/tests/reg_issue108 && make jvm -C ./build/tests/reg_issue224_closing_parentheses_of_formal_args_list_not_indented && make jvm -C ./build/tests/reg_issue3674 && make jvm -C ./build/tests/reg_issue2194 && make jvm -C ./build/tests/fallible && make jvm -C ./build/tests/reg_issue2700 && make jvm -C ./build/tests/reg_issue3619 && make jvm -C ./build/tests/tail_call_optimization && make jvm -C ./build/tests/reg_issue4252 && make jvm -C ./build/tests/base32hex && make jvm -C ./build/tests/reg_issue580_match_cases_involvin_generics && make jvm -C ./build/tests/reg_issue4609 && make jvm -C ./build/tests/visibility_scoping && make jvm -C ./build/tests/reg_issue2559 && make jvm -C ./build/tests/floating_point_numbers && make jvm -C ./build/tests/reg_issue960_npe_resolve_syntactic_sugar2 && make jvm -C ./build/tests/inheritance && make jvm -C ./build/tests/process_buffered_writer && make jvm -C ./build/tests/reg_issue932 && make jvm -C ./build/tests/reg_issue4457 && make jvm -C ./build/tests/reg_issue536_if_statement_missing_default_else_branch && make jvm -C ./build/tests/mutate_circular_buffer && make jvm -C ./build/tests/reg_issue1899_if_else_array && make jvm -C ./build/tests/reg_issue1919 && make jvm -C ./build/tests/reg_issue2339 && make jvm -C ./build/tests/buffered_writer && make jvm -C ./build/tests/reg_issue698_np_excep_in_choice_with_call_to_outer_ref && make jvm -C ./build/tests/reg_issue3015 && make jvm -C ./build/tests/listFold && make jvm -C ./build/tests/reg_issue2301 && make jvm -C ./build/tests/reg_issue2273 && make jvm -C ./build/tests/reg_issue957_class_cast_exc && make jvm -C ./build/tests/reg_issue624 && make jvm -C ./build/tests/compile_time_type_casts && make jvm -C ./build/tests/reg_issue3160 && make jvm -C ./build/tests/reg_issue3731 && make jvm -C ./build/tests/universe_dot_call && make jvm -C ./build/tests/reg_issue2274 && make jvm -C ./build/tests/reg_issue3352 && make jvm -C ./build/tests/reg_issue2280 && make jvm -C ./build/tests/call_dot_this && make jvm -C ./build/tests/visibility_negative && make jvm -C ./build/tests/reg_issue1862 && make jvm -C ./build/tests/contracts_negative && make jvm -C ./build/tests/reg_issue3151 && make jvm -C ./build/tests/reg_issue2242 && make jvm -C ./build/tests/base16 && make jvm -C ./build/tests/reg_issue1945_ambiguity_for_lambda_result_neg && make jvm -C ./build/tests/reg_issue3168_parsing_tuples && make jvm -C ./build/tests/reg_issue662_match_cases_missing && make jvm -C ./build/tests/reg_issue2478 && make jvm -C ./build/tests/reg_issue3798 && make jvm -C ./build/tests/reg_issue4549 && make jvm -C ./build/tests/forwardref_negative && make jvm -C ./build/tests/reg_issue1838 && make jvm -C ./build/tests/reg_issue3308 && make jvm -C ./build/tests/reg_issue1004 && make jvm -C ./build/tests/reg_issue3337 && make jvm -C ./build/tests/reg_issue3901 && make jvm -C ./build/tests/reg_issue309_check_constraints_of_types && make jvm -C ./build/tests/reg_issue1236 && make jvm -C ./build/tests/reg_issue3102 && make jvm -C ./build/tests/reg_issue1739_this_type_in_type_feature_choice && make jvm -C ./build/tests/reg_issue3754 && make jvm -C ./build/tests/reg_issue3506_b && make jvm -C ./build/tests/local_mutate && make jvm -C ./build/tests/reg_issue3306 && make jvm -C ./build/tests/envir_vars && make jvm -C ./build/tests/reg_issue4540 && make jvm -C ./build/tests/infer_via_contraints_type_parameter && make jvm -C ./build/tests/reg_issue1051 && make jvm -C ./build/tests/lib_concur_sync && make jvm -C ./build/tests/reg_issue4375 && make jvm -C ./build/tests/reg_issue3362 && make jvm -C ./build/tests/reg_issue3150 && make jvm -C ./build/tests/reg_issue1638 && make jvm -C ./build/tests/reg_issue4988 && make jvm -C ./build/tests/lazy && make jvm -C ./build/tests/sequence_group_map_reduce && make jvm -C ./build/tests/reg_issue4386 && make jvm -C ./build/tests/reg_issue270 && make jvm -C ./build/tests/reg_issue2275 && make jvm -C ./build/tests/reg_issue1636 && make jvm -C ./build/tests/reg_issue1069 && make jvm -C ./build/tests/reg_issue3161 && make jvm -C ./build/tests/reg_issue3502 && make jvm -C ./build/tests/reg_issue356_check_condition_failure_in_call_inferGenericsFromArgs && make jvm -C ./build/tests/reg_issue3996 && make jvm -C ./build/tests/reg_issue2272 && make jvm -C ./build/tests/native_legal_types_negative && make jvm -C ./build/tests/this_type && make jvm -C ./build/tests/reg_issue1033 && make jvm -C ./build/tests/reg_issue5003 && make jvm -C ./build/tests/reg_issue4541 && make jvm -C ./build/tests/loop_scoping && make jvm -C ./build/tests/resource_cleanunp && make jvm -C ./build/tests/typeinference_for_formal_args && make jvm -C ./build/tests/select_clause_negative && make jvm -C ./build/tests/functions && make jvm -C ./build/tests/reg_issue2483 && make jvm -C ./build/tests/reg_issue3567 && make jvm -C ./build/tests/reg_issue2687 && make jvm -C ./build/tests/reg_issue4548 && make jvm -C ./build/tests/reg_issue4745 && make jvm -C ./build/tests/reg_issue3752 && make jvm -C ./build/tests/reg_issue1027 && make jvm -C ./build/tests/reg_issue1698 && make jvm -C ./build/tests/reg_issue4935 && make jvm -C ./build/tests/reg_issue4555 && make jvm -C ./build/tests/compile_time_type_casts_negative && make jvm -C ./build/tests/lib_monad && make jvm -C ./build/tests/inference_choice_generics && make jvm -C ./build/tests/reg_issue4332 && make jvm -C ./build/tests/nom && make jvm -C ./build/tests/reg_issue2203 && make jvm -C ./build/tests/abstractfeatures_negative && make jvm -C ./build/tests/reg_issue263_anoynmous_inner_feature_as_arg && make jvm -C ./build/tests/reg_issue3914 && make jvm -C ./build/tests/reg_issue2182_negative && make jvm -C ./build/tests/free_types && make jvm -C ./build/tests/reg_issue3128 && make jvm -C ./build/tests/hello && make jvm -C ./build/tests/base32 && make jvm -C ./build/tests/reg_issue3730_2 && make jvm -C ./build/tests/i128 && make jvm -C ./build/tests/reg_issue3371 && make jvm -C ./build/tests/reg_issue3527 && make jvm -C ./build/tests/reg_issue25_unbox_outerref && make jvm -C ./build/tests/reg_issue4961 && make jvm -C ./build/tests/lib_property_equatable && make jvm -C ./build/tests/reg_issue3347 && make jvm -C ./build/tests/lib_container_set && make jvm -C ./build/tests/reg_issue4992 && make jvm -C ./build/tests/stack && make jvm -C ./build/tests/reg_issue4959 && make jvm -C ./build/tests/free_types_negative && make jvm -C ./build/tests/equals_negative && make jvm -C ./build/tests/reg_issue1054_incompatible_contraint_generics && make jvm -C ./build/tests/reg_issue1641 && make jvm -C ./build/tests/reg_issue4750 && make jvm -C ./build/tests/reg_issue1781_negative && make jvm -C ./build/tests/reg_issue3324 && make jvm -C ./build/tests/reg_issue5018 && make jvm -C ./build/tests/reg_issue3776 && make jvm -C ./build/tests/catch_postcondition && make jvm -C ./build/tests/overloading_negative && make jvm -C ./build/tests/lock_free_stack && make jvm -C ./build/tests/reg_issue3749 && make jvm -C ./build/tests/reg_issue3771 && make jvm -C ./build/tests/fixed_alongside_abstract && make jvm -C ./build/tests/reg_issue37_inhGenericOuter: && make jvm -C ./build/tests/sequence && make jvm -C ./build/tests/lib_knuth_morris_pratt && make jvm -C ./build/tests/reg_issue1247 && make jvm -C ./build/tests/reg_issue2860 && make jvm -C ./build/tests/reg_issue170_distinct_arg_names && make jvm -C ./build/tests/reg_issue1840 && make jvm -C ./build/tests/modules && make jvm -C ./build/tests/reg_issue3521 && make jvm -C ./build/tests/unused_fields_error && make jvm -C ./build/tests/reg_issue2111 && make jvm -C ./build/tests/reg_issue2251 && make jvm -C ./build/tests/reg_issue122 && make jvm -C ./build/tests/reg_issue1109 && make jvm -C ./build/tests/reg_issue2740 && make jvm -C ./build/tests/reg_issue1932 && make jvm -C ./build/tests/reg_issue3833 && make jvm -C ./build/tests/reg_issue3233 && make jvm -C ./build/tests/reg_issue3659 && make jvm -C ./build/tests/lib_io_file && make jvm -C ./build/tests/outerNormalization && make jvm -C ./build/tests/strings_multiline_negative && make jvm -C ./build/tests/reg_issue761_null_pointer_failed_type_inference && make jvm -C ./build/tests/reg_issue4419 && make jvm -C ./build/tests/reg_issue4426 && make jvm -C ./build/tests/basicIntegers_negative && make jvm -C ./build/tests/lib_io_utf8 && make jvm -C ./build/tests/reg_issue4486 && make jvm -C ./build/tests/reg_issue2187 && make jvm -C ./build/tests/reg_issue4248 && make jvm -C ./build/tests/reg_issue2346 && make jvm -C ./build/tests/if_negative && make jvm -C ./build/tests/lib_lock_free_sieve && make jvm -C ./build/tests/reg_issue2370 && make jvm -C ./build/tests/reg_issue929 && make jvm -C ./build/tests/reg_issue1013_parentheses_ignored_in_operator_calls && make jvm -C ./build/tests/reg_issue1561_incompatible_types && make jvm -C ./build/tests/reg_issue1591 && make jvm -C ./build/tests/reg_issue3007 && make jvm -C ./build/tests/reg_issue292_inherited_open_generics && make jvm -C ./build/tests/reg_issue4480 && make jvm -C ./build/tests/rosettacode_man_or_boy && make jvm -C ./build/tests/loop && make jvm -C ./build/tests/reg_issue2325 && make jvm -C ./build/tests/reg_issue3693 && make jvm -C ./build/tests/reg_issue3658 && make jvm -C ./build/tests/lib_io_dir && make jvm -C ./build/tests/lib_container_ps_map && make jvm -C ./build/tests/reg_issue3036 && make jvm -C ./build/tests/reg_issue1604_cmp_swap_choice && make jvm -C ./build/tests/javaBase && make jvm -C ./build/tests/reg_issue2913 && make jvm -C ./build/tests/reg_issue3895 && make jvm -C ./build/tests/transducers && make jvm -C ./build/tests/reg_issue1610_outer_escapes && make jvm -C ./build/tests/reg_issue2691_a && make jvm -C ./build/tests/typecheck_negative && make jvm -C ./build/tests/reg_issue4247 && make jvm -C ./build/tests/reg_issue1507 && make jvm -C ./build/tests/reg_issue2376 && make jvm -C ./build/tests/reg_issue3406 && make jvm -C ./build/tests/reg_issue3250 && make jvm -C ./build/tests/reg_issue2518 && make jvm -C ./build/tests/indentation_negative && make jvm -C ./build/tests/reg_issue2371 && make jvm -C ./build/tests/reg_issue2715 && make jvm -C ./build/tests/reg_issue2378 && make jvm -C ./build/tests/reg_issue2527 && make jvm -C ./build/tests/reg_issue4420 && make jvm -C ./build/tests/reg_issue2181 && make jvm -C ./build/tests/reg_issue2347 && make jvm -C ./build/tests/pair && make jvm -C ./build/tests/rosettacode_factors_of_an_integer && make jvm -C ./build/tests/reg_issue4418 && make jvm -C ./build/tests/reg_issue1358 && make jvm -C ./build/tests/reg_issue3292 && make jvm -C ./build/tests/reg_issue2340 && make jvm -C ./build/tests/reg_issue3602 && make jvm -C ./build/tests/reg_issue373 && make jvm -C ./build/tests/process
To re-recordord all failed tests, use this command:
make record_jvm -C ./build/tests/argumentcount_negative && make record_jvm -C ./build/tests/reg_issue1665_nested_lazy && make record_jvm -C ./build/tests/reg_issue874ff && make record_jvm -C ./build/tests/reg_issue2304 && make record_jvm -C ./build/tests/reg_issue2303 && make record_jvm -C ./build/tests/lib_choice_tag && make record_jvm -C ./build/tests/reg_issue102 && make record_jvm -C ./build/tests/reg_issue1572 && make record_jvm -C ./build/tests/reg_issue3648 && make record_jvm -C ./build/tests/reg_issue4694 && make record_jvm -C ./build/tests/reg_issue3683 && make record_jvm -C ./build/tests/asParsedType && make record_jvm -C ./build/tests/type_inference_flat_map && make record_jvm -C ./build/tests/generics && make record_jvm -C ./build/tests/redef_args && make record_jvm -C ./build/tests/reg_issue1771 && make record_jvm -C ./build/tests/ternary && make record_jvm -C ./build/tests/reg_issue2564 && make record_jvm -C ./build/tests/reg_issue1183_type_of_a_this && make record_jvm -C ./build/tests/reg_issue3429 && make record_jvm -C ./build/tests/reg_issue1588 && make record_jvm -C ./build/tests/reg_issue4250 && make record_jvm -C ./build/tests/reg_issue3081 && make record_jvm -C ./build/tests/reg_issue952 && make record_jvm -C ./build/tests/reg_issue3518_a && make record_jvm -C ./build/tests/reg_issue4408 && make record_jvm -C ./build/tests/reg_issue2368 && make record_jvm -C ./build/tests/reg_issue4659 && make record_jvm -C ./build/tests/reg_issue3306_negative && make record_jvm -C ./build/tests/reg_issue1380_execute_single_field_declaration && make record_jvm -C ./build/tests/loop_negative && make record_jvm -C ./build/tests/reg_issue764 && make record_jvm -C ./build/tests/reg_issue3027 && make record_jvm -C ./build/tests/reg_issue1158_type_of_type_parameters && make record_jvm -C ./build/tests/reg_issue3649 && make record_jvm -C ./build/tests/fixed_alongside_abstract_negative && make record_jvm -C ./build/tests/reg_issue1777 && make record_jvm -C ./build/tests/call_with_ambiguous_result_type_negative && make record_jvm -C ./build/tests/reg_issue3682 && make record_jvm -C ./build/tests/asParsedType_negative && make record_jvm -C ./build/tests/reg_issue3676 && make record_jvm -C ./build/tests/unary && make record_jvm -C ./build/tests/valWithDynOuter && make record_jvm -C ./build/tests/reg_issue4233 && make record_jvm -C ./build/tests/mod_lock_free_Map_threads && make record_jvm -C ./build/tests/reg_issue1741 && make record_jvm -C ./build/tests/reg_issue3678 && make record_jvm -C ./build/tests/mod_sqlite && make record_jvm -C ./build/tests/reg_issue3812 && make record_jvm -C ./build/tests/reg_issue3647 && make record_jvm -C ./build/tests/reg_issue2761 && make record_jvm -C ./build/tests/semicolon_ambiguity && make record_jvm -C ./build/tests/process_utf8 && make record_jvm -C ./build/tests/reg_issue1518 && make record_jvm -C ./build/tests/redef_with_type_parameters && make record_jvm -C ./build/tests/hash_map && make record_jvm -C ./build/tests/strings && make record_jvm -C ./build/tests/reg_issue1188 && make record_jvm -C ./build/tests/reg_issue3246 && make record_jvm -C ./build/tests/reg_issue4251 && make record_jvm -C ./build/tests/lib_memoize && make record_jvm -C ./build/tests/reg_issue2967 && make record_jvm -C ./build/tests/dot_type_call_ambiguity && make record_jvm -C ./build/tests/reg_issue176_using_inner_field_of_boxed_outer && make record_jvm -C ./build/tests/reg_issue2367 && make record_jvm -C ./build/tests/reg_issue4632 && make record_jvm -C ./build/tests/reg_issue1724 && make record_jvm -C ./build/tests/reg_issue2358 && make record_jvm -C ./build/tests/reg_issues455-456_dot_type && make record_jvm -C ./build/tests/reg_issue3757 && make record_jvm -C ./build/tests/reg_issue2685 && make record_jvm -C ./build/tests/reg_issue3565 && make record_jvm -C ./build/tests/nested_options && make record_jvm -C ./build/tests/reg_issue1490 && make record_jvm -C ./build/tests/reg_issue3905 && make record_jvm -C ./build/tests/choice_negative2 && make record_jvm -C ./build/tests/lib_fileio_mmap && make record_jvm -C ./build/tests/inherit_postcondition && make record_jvm -C ./build/tests/reg_issue2682 && make record_jvm -C ./build/tests/visibility_modules && make record_jvm -C ./build/tests/effect_installed && make record_jvm -C ./build/tests/lib_switch && make record_jvm -C ./build/tests/reg_issue228 && make record_jvm -C ./build/tests/typeinference_negative && make record_jvm -C ./build/tests/reg_issue2224 && make record_jvm -C ./build/tests/reg_issue2486 && make record_jvm -C ./build/tests/assignments && make record_jvm -C ./build/tests/reg_issue3108 && make record_jvm -C ./build/tests/reg_issue3506_a && make record_jvm -C ./build/tests/unused_result && make record_jvm -C ./build/tests/reg_issue1031 && make record_jvm -C ./build/tests/sockets_thread_pool && make record_jvm -C ./build/tests/reg_issue1835 && make record_jvm -C ./build/tests/reg_issue3761 && make record_jvm -C ./build/tests/reg_issue2647 && make record_jvm -C ./build/tests/reg_issue3507 && make record_jvm -C ./build/tests/compile_time_constants && make record_jvm -C ./build/tests/sequence_scan1 && make record_jvm -C ./build/tests/reg_issue4180 && make record_jvm -C ./build/tests/partial_application && make record_jvm -C ./build/tests/name_but_not_visi_conflict && make record_jvm -C ./build/tests/local_mutate_negative && make record_jvm -C ./build/tests/reg_issue627 && make record_jvm -C ./build/tests/reg_issue7_genericConstraint && make record_jvm -C ./build/tests/calls_on_ref_and_val_target_negative && make record_jvm -C ./build/tests/reg_issue3369 && make record_jvm -C ./build/tests/reg_issue3199 && make record_jvm -C ./build/tests/reg_issue4348 && make record_jvm -C ./build/tests/concur_simple && make record_jvm -C ./build/tests/reg_issue238_array_index_out_of_bounds && make record_jvm -C ./build/tests/typeinference && make record_jvm -C ./build/tests/native && make record_jvm -C ./build/tests/reg_issue3136 && make record_jvm -C ./build/tests/basicIntegers && make record_jvm -C ./build/tests/generics_negative && make record_jvm -C ./build/tests/mutable_hash_map && make record_jvm -C ./build/tests/reg_issue3932 && make record_jvm -C ./build/tests/reg_issue1666 && make record_jvm -C ./build/tests/reg_issue4542 && make record_jvm -C ./build/tests/mod_lock_free_Map && make record_jvm -C ./build/tests/lib_concur_thread_pool && make record_jvm -C ./build/tests/calls_on_ref_and_val_target && make record_jvm -C ./build/tests/reg_issue29_arrayOfUnitType && make record_jvm -C ./build/tests/type_feature && make record_jvm -C ./build/tests/base64url && make record_jvm -C ./build/tests/reg_issue2683 && make record_jvm -C ./build/tests/reg_issue2213 && make record_jvm -C ./build/tests/reg_issue3769 && make record_jvm -C ./build/tests/reg_issue2489 && make record_jvm -C ./build/tests/unicode && make record_jvm -C ./build/tests/assignment_negative && make record_jvm -C ./build/tests/reg_issue1491 && make record_jvm -C ./build/tests/reg_issue2214 && make record_jvm -C ./build/tests/reg_issue4143 && make record_jvm -C ./build/tests/reg_issue1055 && make record_jvm -C ./build/tests/reg_issue4518 && make record_jvm -C ./build/tests/unwrap && make record_jvm -C ./build/tests/reg_issue3359 && make record_jvm -C ./build/tests/reg_issue16_chainedBool && make record_jvm -C ./build/tests/reg_issue3705 && make record_jvm -C ./build/tests/lists && make record_jvm -C ./build/tests/sockets && make record_jvm -C ./build/tests/reg_issue3959 && make record_jvm -C ./build/tests/visibility && make record_jvm -C ./build/tests/choice_negative && make record_jvm -C ./build/tests/reg_issue3733 && make record_jvm -C ./build/tests/reg_issue1294 && make record_jvm -C ./build/tests/reg_issue4516 && make record_jvm -C ./build/tests/reg_issue1886_option_void && make record_jvm -C ./build/tests/reg_issue4529 && make record_jvm -C ./build/tests/reg_issue2878 && make record_jvm -C ./build/tests/tuple && make record_jvm -C ./build/tests/reg_issue3191 && make record_jvm -C ./build/tests/reg_issue4988_1 && make record_jvm -C ./build/tests/fz_cmd && make record_jvm -C ./build/tests/reg_issue3734 && make record_jvm -C ./build/tests/reg_issue3730_1 && make record_jvm -C ./build/tests/constructor_with_return_type && make record_jvm -C ./build/tests/reg_issue2249 && make record_jvm -C ./build/tests/reg_issue3961 && make record_jvm -C ./build/tests/reg_issue1628 && make record_jvm -C ./build/tests/reg_issue2402 && make record_jvm -C ./build/tests/reg_issue3140 && make record_jvm -C ./build/tests/reg_issue3147 && make record_jvm -C ./build/tests/ryu && make record_jvm -C ./build/tests/reg_issue5082 && make record_jvm -C ./build/tests/reg_issue4354 && make record_jvm -C ./build/tests/reg_issue2262 && make record_jvm -C ./build/tests/wrap_around_semantics && make record_jvm -C ./build/tests/effect_signature && make record_jvm -C ./build/tests/reg_issue4353 && make record_jvm -C ./build/tests/reg_issue3773 && make record_jvm -C ./build/tests/reg_issue1023 && make record_jvm -C ./build/tests/reg_issue2231 && make record_jvm -C ./build/tests/reg_issue659 && make record_jvm -C ./build/tests/i18n_default_test && make record_jvm -C ./build/tests/reg_issue4938 && make record_jvm -C ./build/tests/reg_issue3577 && make record_jvm -C ./build/tests/reg_issue3178 && make record_jvm -C ./build/tests/onesCount && make record_jvm -C ./build/tests/reg_issue3910 && make record_jvm -C ./build/tests/effect_installed_negative && make record_jvm -C ./build/tests/interval && make record_jvm -C ./build/tests/reg_issue465 && make record_jvm -C ./build/tests/reg_issue8_optionFalse && make record_jvm -C ./build/tests/reg_issue350_x_ref_produces_strange_error_message && make record_jvm -C ./build/tests/qualified_declaration && make record_jvm -C ./build/tests/string_pad && make record_jvm -C ./build/tests/reg_issue4963 && make record_jvm -C ./build/tests/reg_issue1216_precondition_box_constructor && make record_jvm -C ./build/tests/reg_issue169_backward_type_propagation_array && make record_jvm -C ./build/tests/else_indentation_reference && make record_jvm -C ./build/tests/reg_issue4964 && make record_jvm -C ./build/tests/valWithLongLife && make record_jvm -C ./build/tests/reg_issue2252 && make record_jvm -C ./build/tests/reg_issue3973 && make record_jvm -C ./build/tests/partial_application_negative && make record_jvm -C ./build/tests/reg_issue4503 && make record_jvm -C ./build/tests/type_features_must_only_be_declared_in_features_that_define_types && make record_jvm -C ./build/tests/reg_issue4592 && make record_jvm -C ./build/tests/visibility_modules_negative && make record_jvm -C ./build/tests/reg_issue2034 && make record_jvm -C ./build/tests/reg_issue459_choice_elment_tagged_that_is_never_instantiated && make record_jvm -C ./build/tests/lib_string && make record_jvm -C ./build/tests/reg_issue3576 && make record_jvm -C ./build/tests/reg_issue3744 && make record_jvm -C ./build/tests/reg_issue19_redef_choice_result && make record_jvm -C ./build/tests/reg_issue1477 && make record_jvm -C ./build/tests/reg_issue3786 && make record_jvm -C ./build/tests/reg_issue3549 && make record_jvm -C ./build/tests/reg_issue3772 && make record_jvm -C ./build/tests/reg_issue2492 && make record_jvm -C ./build/tests/reg_issue4557 && make record_jvm -C ./build/tests/reg_issue2237 && make record_jvm -C ./build/tests/mix_inheritance_and_outer && make record_jvm -C ./build/tests/reg_issue2653 && make record_jvm -C ./build/tests/nested_choice_negative && make record_jvm -C ./build/tests/base64 && make record_jvm -C ./build/tests/reg_issue2345 && make record_jvm -C ./build/tests/reg_issue1396 && make record_jvm -C ./build/tests/typeinference_for_formal_args_negative && make record_jvm -C ./build/tests/reg_issue4422 && make record_jvm -C ./build/tests/reg_issue4628 && make record_jvm -C ./build/tests/inheritance_for_value_types && make record_jvm -C ./build/tests/reg_issue2719 && make record_jvm -C ./build/tests/reg_issue1391 && make record_jvm -C ./build/tests/mandelbrot && make record_jvm -C ./build/tests/nested_lazy && make record_jvm -C ./build/tests/reg_issue4273 && make record_jvm -C ./build/tests/reg_issue4621 && make record_jvm -C ./build/tests/reg_issue2691_c && make record_jvm -C ./build/tests/reg_issues4992_5001_negative && make record_jvm -C ./build/tests/reg_issue5156 && make record_jvm -C ./build/tests/select_clause && make record_jvm -C ./build/tests/reg_issue3691 && make record_jvm -C ./build/tests/terminal && make record_jvm -C ./build/tests/reg_issue2345_1 && make record_jvm -C ./build/tests/strings_multiline && make record_jvm -C ./build/tests/reg_issue119 && make record_jvm -C ./build/tests/reg_issue1559_post_condition && make record_jvm -C ./build/tests/nested_choice && make record_jvm -C ./build/tests/reg_issue27_callWithUninstantiatedTarget && make record_jvm -C ./build/tests/reg_issue2380 && make record_jvm -C ./build/tests/reg_issue3801 && make record_jvm -C ./build/tests/reg_issue2775 && make record_jvm -C ./build/tests/reg_issue293_confusion_of_type_and_value_params && make record_jvm -C ./build/tests/choice && make record_jvm -C ./build/tests/reg_issue90 && make record_jvm -C ./build/tests/doubledeclaration_negative && make record_jvm -C ./build/tests/reg_issue2386 && make record_jvm -C ./build/tests/reg_issue4220 && make record_jvm -C ./build/tests/lib_container_sorted_array && make record_jvm -C ./build/tests/reg_issue4516_1 && make record_jvm -C ./build/tests/reg_issue3608 && make record_jvm -C ./build/tests/covariance && make record_jvm -C ./build/tests/reg_issue2691_b && make record_jvm -C ./build/tests/catch_preconditions && make record_jvm -C ./build/tests/reg_issue5095_pre_else_err && make record_jvm -C ./build/tests/reg_issue3405 && make record_jvm -C ./build/tests/reg_issue1352 && make record_jvm -C ./build/tests/inheritance_negative && make record_jvm -C ./build/tests/lib_time_date_time && make record_jvm -C ./build/tests/reg_issue2515 && make record_jvm -C ./build/tests/reg_issue4272 && make record_jvm -C ./build/tests/reg_issue4424 && make record_jvm -C ./build/tests/reg_issue348 && make record_jvm -C ./build/tests/indentation && make record_jvm -C ./build/tests/reg_issue2182 && make record_jvm -C ./build/tests/reg_issue2381 && make record_jvm -C ./build/tests/reg_issue3004 && make record_jvm -C ./build/tests/reg_issue4645 && make record_jvm -C ./build/tests/rosettacode_primes && make record_jvm -C ./build/tests/reg_issue4281 && make record_jvm -C ./build/tests/reg_issue3493 && make record_jvm -C ./build/tests/reg_issue3003 && make record_jvm -C ./build/tests/this_type_negative && make record_jvm -C ./build/tests/native_value: && make record_jvm -C ./build/tests/semicolon_parsing && make record_jvm -C ./build/tests/choice_mix && make record_jvm -C ./build/tests/inheritance_cyclic_negative && make record_jvm -C ./build/tests/property_countable_count && make record_jvm -C ./build/tests/reg_issue2321 && make record_jvm -C ./build/tests/incomp_type_in_cases && make record_jvm -C ./build/tests/reg_issue776 && make record_jvm -C ./build/tests/reg_issue2745 && make record_jvm -C ./build/tests/reg_issue4479 && make record_jvm -C ./build/tests/numliteral_syntax_sugar_issue4754 && make record_jvm -C ./build/tests/unicode_15 && make record_jvm -C ./build/tests/open_type_dots && make record_jvm -C ./build/tests/reg_issue440_incomplete_else_block_confusing_error_message && make record_jvm -C ./build/tests/atomic && make record_jvm -C ./build/tests/reg_issue2114 && make record_jvm -C ./build/tests/function_argument_visibility && make record_jvm -C ./build/tests/reg_issue118 && make record_jvm -C ./build/tests/sequence_sliding && make record_jvm -C ./build/tests/reg_issue197 && make record_jvm -C ./build/tests/reg_issue1945_ambiguity_for_lambda_result && make record_jvm -C ./build/tests/reg_issue26_redefAsVoid && make record_jvm -C ./build/tests/reg_issue2365 && make record_jvm -C ./build/tests/reg_issue1726 && make record_jvm -C ./build/tests/reg_issue4637 && make record_jvm -C ./build/tests/reg_issue2452_abstract_constructor && make record_jvm -C ./build/tests/compile_time_type_casts_negative2 && make record_jvm -C ./build/tests/reg_issue2701 && make record_jvm -C ./build/tests/dot_type_call_on_type_parameter && make record_jvm -C ./build/tests/reg_issue3518_b && make record_jvm -C ./build/tests/i18n_test && make record_jvm -C ./build/tests/reg_issue3552_and_3553 && make record_jvm -C ./build/tests/tuple_negative && make record_jvm -C ./build/tests/tailrecursion && make record_jvm -C ./build/tests/stdin && make record_jvm -C ./build/tests/reg_issue1943_type_parameter_as_outer_type && make record_jvm -C ./build/tests/equals && make record_jvm -C ./build/tests/reg_issue2307 && make record_jvm -C ./build/tests/inheritance_negative2 && make record_jvm -C ./build/tests/uninitialized_field_negative && make record_jvm -C ./build/tests/reg_issue175_int_crash && make record_jvm -C ./build/tests/reg_issue1918 && make record_jvm -C ./build/tests/mutable_linked_list && make record_jvm -C ./build/tests/reg_issue5114 && make record_jvm -C ./build/tests/choice_inheritance && make record_jvm -C ./build/tests/int && make record_jvm -C ./build/tests/reg_issue108 && make record_jvm -C ./build/tests/reg_issue224_closing_parentheses_of_formal_args_list_not_indented && make record_jvm -C ./build/tests/reg_issue3674 && make record_jvm -C ./build/tests/reg_issue2194 && make record_jvm -C ./build/tests/fallible && make record_jvm -C ./build/tests/reg_issue2700 && make record_jvm -C ./build/tests/reg_issue3619 && make record_jvm -C ./build/tests/tail_call_optimization && make record_jvm -C ./build/tests/reg_issue4252 && make record_jvm -C ./build/tests/base32hex && make record_jvm -C ./build/tests/reg_issue580_match_cases_involvin_generics && make record_jvm -C ./build/tests/reg_issue4609 && make record_jvm -C ./build/tests/visibility_scoping && make record_jvm -C ./build/tests/reg_issue2559 && make record_jvm -C ./build/tests/floating_point_numbers && make record_jvm -C ./build/tests/reg_issue960_npe_resolve_syntactic_sugar2 && make record_jvm -C ./build/tests/inheritance && make record_jvm -C ./build/tests/process_buffered_writer && make record_jvm -C ./build/tests/reg_issue932 && make record_jvm -C ./build/tests/reg_issue4457 && make record_jvm -C ./build/tests/reg_issue536_if_statement_missing_default_else_branch && make record_jvm -C ./build/tests/mutate_circular_buffer && make record_jvm -C ./build/tests/reg_issue1899_if_else_array && make record_jvm -C ./build/tests/reg_issue1919 && make record_jvm -C ./build/tests/reg_issue2339 && make record_jvm -C ./build/tests/buffered_writer && make record_jvm -C ./build/tests/reg_issue698_np_excep_in_choice_with_call_to_outer_ref && make record_jvm -C ./build/tests/reg_issue3015 && make record_jvm -C ./build/tests/listFold && make record_jvm -C ./build/tests/reg_issue2301 && make record_jvm -C ./build/tests/reg_issue2273 && make record_jvm -C ./build/tests/reg_issue957_class_cast_exc && make record_jvm -C ./build/tests/reg_issue624 && make record_jvm -C ./build/tests/compile_time_type_casts && make record_jvm -C ./build/tests/reg_issue3160 && make record_jvm -C ./build/tests/reg_issue3731 && make record_jvm -C ./build/tests/universe_dot_call && make record_jvm -C ./build/tests/reg_issue2274 && make record_jvm -C ./build/tests/reg_issue3352 && make record_jvm -C ./build/tests/reg_issue2280 && make record_jvm -C ./build/tests/call_dot_this && make record_jvm -C ./build/tests/visibility_negative && make record_jvm -C ./build/tests/reg_issue1862 && make record_jvm -C ./build/tests/contracts_negative && make record_jvm -C ./build/tests/reg_issue3151 && make record_jvm -C ./build/tests/reg_issue2242 && make record_jvm -C ./build/tests/base16 && make record_jvm -C ./build/tests/reg_issue1945_ambiguity_for_lambda_result_neg && make record_jvm -C ./build/tests/reg_issue3168_parsing_tuples && make record_jvm -C ./build/tests/reg_issue662_match_cases_missing && make record_jvm -C ./build/tests/reg_issue2478 && make record_jvm -C ./build/tests/reg_issue3798 && make record_jvm -C ./build/tests/reg_issue4549 && make record_jvm -C ./build/tests/forwardref_negative && make record_jvm -C ./build/tests/reg_issue1838 && make record_jvm -C ./build/tests/reg_issue3308 && make record_jvm -C ./build/tests/reg_issue1004 && make record_jvm -C ./build/tests/reg_issue3337 && make record_jvm -C ./build/tests/reg_issue3901 && make record_jvm -C ./build/tests/reg_issue309_check_constraints_of_types && make record_jvm -C ./build/tests/reg_issue1236 && make record_jvm -C ./build/tests/reg_issue3102 && make record_jvm -C ./build/tests/reg_issue1739_this_type_in_type_feature_choice && make record_jvm -C ./build/tests/reg_issue3754 && make record_jvm -C ./build/tests/reg_issue3506_b && make record_jvm -C ./build/tests/local_mutate && make record_jvm -C ./build/tests/reg_issue3306 && make record_jvm -C ./build/tests/envir_vars && make record_jvm -C ./build/tests/reg_issue4540 && make record_jvm -C ./build/tests/infer_via_contraints_type_parameter && make record_jvm -C ./build/tests/reg_issue1051 && make record_jvm -C ./build/tests/lib_concur_sync && make record_jvm -C ./build/tests/reg_issue4375 && make record_jvm -C ./build/tests/reg_issue3362 && make record_jvm -C ./build/tests/reg_issue3150 && make record_jvm -C ./build/tests/reg_issue1638 && make record_jvm -C ./build/tests/reg_issue4988 && make record_jvm -C ./build/tests/lazy && make record_jvm -C ./build/tests/sequence_group_map_reduce && make record_jvm -C ./build/tests/reg_issue4386 && make record_jvm -C ./build/tests/reg_issue270 && make record_jvm -C ./build/tests/reg_issue2275 && make record_jvm -C ./build/tests/reg_issue1636 && make record_jvm -C ./build/tests/reg_issue1069 && make record_jvm -C ./build/tests/reg_issue3161 && make record_jvm -C ./build/tests/reg_issue3502 && make record_jvm -C ./build/tests/reg_issue356_check_condition_failure_in_call_inferGenericsFromArgs && make record_jvm -C ./build/tests/reg_issue3996 && make record_jvm -C ./build/tests/reg_issue2272 && make record_jvm -C ./build/tests/native_legal_types_negative && make record_jvm -C ./build/tests/this_type && make record_jvm -C ./build/tests/reg_issue1033 && make record_jvm -C ./build/tests/reg_issue5003 && make record_jvm -C ./build/tests/reg_issue4541 && make record_jvm -C ./build/tests/loop_scoping && make record_jvm -C ./build/tests/resource_cleanunp && make record_jvm -C ./build/tests/typeinference_for_formal_args && make record_jvm -C ./build/tests/select_clause_negative && make record_jvm -C ./build/tests/functions && make record_jvm -C ./build/tests/reg_issue2483 && make record_jvm -C ./build/tests/reg_issue3567 && make record_jvm -C ./build/tests/reg_issue2687 && make record_jvm -C ./build/tests/reg_issue4548 && make record_jvm -C ./build/tests/reg_issue4745 && make record_jvm -C ./build/tests/reg_issue3752 && make record_jvm -C ./build/tests/reg_issue1027 && make record_jvm -C ./build/tests/reg_issue1698 && make record_jvm -C ./build/tests/reg_issue4935 && make record_jvm -C ./build/tests/reg_issue4555 && make record_jvm -C ./build/tests/compile_time_type_casts_negative && make record_jvm -C ./build/tests/lib_monad && make record_jvm -C ./build/tests/inference_choice_generics && make record_jvm -C ./build/tests/reg_issue4332 && make record_jvm -C ./build/tests/nom && make record_jvm -C ./build/tests/reg_issue2203 && make record_jvm -C ./build/tests/abstractfeatures_negative && make record_jvm -C ./build/tests/reg_issue263_anoynmous_inner_feature_as_arg && make record_jvm -C ./build/tests/reg_issue3914 && make record_jvm -C ./build/tests/reg_issue2182_negative && make record_jvm -C ./build/tests/free_types && make record_jvm -C ./build/tests/reg_issue3128 && make record_jvm -C ./build/tests/hello && make record_jvm -C ./build/tests/base32 && make record_jvm -C ./build/tests/reg_issue3730_2 && make record_jvm -C ./build/tests/i128 && make record_jvm -C ./build/tests/reg_issue3371 && make record_jvm -C ./build/tests/reg_issue3527 && make record_jvm -C ./build/tests/reg_issue25_unbox_outerref && make record_jvm -C ./build/tests/reg_issue4961 && make record_jvm -C ./build/tests/lib_property_equatable && make record_jvm -C ./build/tests/reg_issue3347 && make record_jvm -C ./build/tests/lib_container_set && make record_jvm -C ./build/tests/reg_issue4992 && make record_jvm -C ./build/tests/stack && make record_jvm -C ./build/tests/reg_issue4959 && make record_jvm -C ./build/tests/free_types_negative && make record_jvm -C ./build/tests/equals_negative && make record_jvm -C ./build/tests/reg_issue1054_incompatible_contraint_generics && make record_jvm -C ./build/tests/reg_issue1641 && make record_jvm -C ./build/tests/reg_issue4750 && make record_jvm -C ./build/tests/reg_issue1781_negative && make record_jvm -C ./build/tests/reg_issue3324 && make record_jvm -C ./build/tests/reg_issue5018 && make record_jvm -C ./build/tests/reg_issue3776 && make record_jvm -C ./build/tests/catch_postcondition && make record_jvm -C ./build/tests/overloading_negative && make record_jvm -C ./build/tests/lock_free_stack && make record_jvm -C ./build/tests/reg_issue3749 && make record_jvm -C ./build/tests/reg_issue3771 && make record_jvm -C ./build/tests/fixed_alongside_abstract && make record_jvm -C ./build/tests/reg_issue37_inhGenericOuter: && make record_jvm -C ./build/tests/sequence && make record_jvm -C ./build/tests/lib_knuth_morris_pratt && make record_jvm -C ./build/tests/reg_issue1247 && make record_jvm -C ./build/tests/reg_issue2860 && make record_jvm -C ./build/tests/reg_issue170_distinct_arg_names && make record_jvm -C ./build/tests/reg_issue1840 && make record_jvm -C ./build/tests/modules && make record_jvm -C ./build/tests/reg_issue3521 && make record_jvm -C ./build/tests/unused_fields_error && make record_jvm -C ./build/tests/reg_issue2111 && make record_jvm -C ./build/tests/reg_issue2251 && make record_jvm -C ./build/tests/reg_issue122 && make record_jvm -C ./build/tests/reg_issue1109 && make record_jvm -C ./build/tests/reg_issue2740 && make record_jvm -C ./build/tests/reg_issue1932 && make record_jvm -C ./build/tests/reg_issue3833 && make record_jvm -C ./build/tests/reg_issue3233 && make record_jvm -C ./build/tests/reg_issue3659 && make record_jvm -C ./build/tests/lib_io_file && make record_jvm -C ./build/tests/outerNormalization && make record_jvm -C ./build/tests/strings_multiline_negative && make record_jvm -C ./build/tests/reg_issue761_null_pointer_failed_type_inference && make record_jvm -C ./build/tests/reg_issue4419 && make record_jvm -C ./build/tests/reg_issue4426 && make record_jvm -C ./build/tests/basicIntegers_negative && make record_jvm -C ./build/tests/lib_io_utf8 && make record_jvm -C ./build/tests/reg_issue4486 && make record_jvm -C ./build/tests/reg_issue2187 && make record_jvm -C ./build/tests/reg_issue4248 && make record_jvm -C ./build/tests/reg_issue2346 && make record_jvm -C ./build/tests/if_negative && make record_jvm -C ./build/tests/lib_lock_free_sieve && make record_jvm -C ./build/tests/reg_issue2370 && make record_jvm -C ./build/tests/reg_issue929 && make record_jvm -C ./build/tests/reg_issue1013_parentheses_ignored_in_operator_calls && make record_jvm -C ./build/tests/reg_issue1561_incompatible_types && make record_jvm -C ./build/tests/reg_issue1591 && make record_jvm -C ./build/tests/reg_issue3007 && make record_jvm -C ./build/tests/reg_issue292_inherited_open_generics && make record_jvm -C ./build/tests/reg_issue4480 && make record_jvm -C ./build/tests/rosettacode_man_or_boy && make record_jvm -C ./build/tests/loop && make record_jvm -C ./build/tests/reg_issue2325 && make record_jvm -C ./build/tests/reg_issue3693 && make record_jvm -C ./build/tests/reg_issue3658 && make record_jvm -C ./build/tests/lib_io_dir && make record_jvm -C ./build/tests/lib_container_ps_map && make record_jvm -C ./build/tests/reg_issue3036 && make record_jvm -C ./build/tests/reg_issue1604_cmp_swap_choice && make record_jvm -C ./build/tests/javaBase && make record_jvm -C ./build/tests/reg_issue2913 && make record_jvm -C ./build/tests/reg_issue3895 && make record_jvm -C ./build/tests/transducers && make record_jvm -C ./build/tests/reg_issue1610_outer_escapes && make record_jvm -C ./build/tests/reg_issue2691_a && make record_jvm -C ./build/tests/typecheck_negative && make record_jvm -C ./build/tests/reg_issue4247 && make record_jvm -C ./build/tests/reg_issue1507 && make record_jvm -C ./build/tests/reg_issue2376 && make record_jvm -C ./build/tests/reg_issue3406 && make record_jvm -C ./build/tests/reg_issue3250 && make record_jvm -C ./build/tests/reg_issue2518 && make record_jvm -C ./build/tests/indentation_negative && make record_jvm -C ./build/tests/reg_issue2371 && make record_jvm -C ./build/tests/reg_issue2715 && make record_jvm -C ./build/tests/reg_issue2378 && make record_jvm -C ./build/tests/reg_issue2527 && make record_jvm -C ./build/tests/reg_issue4420 && make record_jvm -C ./build/tests/reg_issue2181 && make record_jvm -C ./build/tests/reg_issue2347 && make record_jvm -C ./build/tests/pair && make record_jvm -C ./build/tests/rosettacode_factors_of_an_integer && make record_jvm -C ./build/tests/reg_issue4418 && make record_jvm -C ./build/tests/reg_issue1358 && make record_jvm -C ./build/tests/reg_issue3292 && make record_jvm -C ./build/tests/reg_issue2340 && make record_jvm -C ./build/tests/reg_issue3602 && make record_jvm -C ./build/tests/reg_issue373 && make record_jvm -C ./build/tests/process
```