### PR TITLE
run_tests: add `OS` env var to inherited env vars

### DIFF
--- a/bin/run_tests.fz
+++ b/bin/run_tests.fz
@@ -39,7 +39,8 @@ envir_var_kv := [
   "dev_flang_tools_serializeFUIR",
   "CPATH",
   "LIBRARY_PATH",
-  "FUZION_CLANG_INSTALLED_DIR"
+  "FUZION_CLANG_INSTALLED_DIR",
+  "OS"
 ].map k->
   (envir.vars.get k).bind v->
     (k,v)


### PR DESCRIPTION
check_simple_example uses `OS` to determine if iconv hack needs to be used. (#2586)
