### PR TITLE
run_tests: add `skip_win` feature

### DIFF
--- a/bin/run_tests.fz
+++ b/bin/run_tests.fz
@@ -200,7 +200,7 @@ main =>
   _ := concur.thread_pool thread_count ()->
     for test in tests do
       check concur.thread_pool.env.submit ()->
-        if io.file.exists "$test/skip" || io.file.exists "$test/skip_$target"
+        if io.file.exists "$test/skip" || io.file.exists "$test/skip_$target" || (is_windows && (io.file.exists "$test/skip_win"))
           yak "_"
           append_line results "$test: skipped"
         else


### PR DESCRIPTION
bash script has this, was still missing from run_tests.fz
