### PR TITLE
ast: Match, fix conflict in replacing subject field

### DIFF
--- a/src/dev/flang/ast/Feature.java
+++ b/src/dev/flang/ast/Feature.java
@@ -2174,10 +2174,11 @@ A ((Choice)) declaration must not contain a result type.
     _state = State.RESOLVING_SUGAR2;
 
     visit(new ContextVisitor(context()) {
-        @Override public Expr  action(Function    f) { return f.resolveSyntacticSugar2(res); }
-        @Override public Expr  action(InlineArray i) { return i.resolveSyntacticSugar2(res, _context); }
-        @Override public void  action(Impl        i) {        i.resolveSyntacticSugar2(res, _context); }
-        @Override public Expr  action(Constant    c) { return c.resolveSyntacticSugar2(res, _context); }
+        @Override public Expr action(Function    f) { return f.resolveSyntacticSugar2(res); }
+        @Override public Expr action(InlineArray i) { return i.resolveSyntacticSugar2(res, _context); }
+        @Override public void action(Impl        i) {        i.resolveSyntacticSugar2(res, _context); }
+        @Override public Expr action(Constant    c) { return c.resolveSyntacticSugar2(res, _context); }
+        @Override public void action(AbstractMatch am){ if (am instanceof Match m) { m.addFieldsForSubject(res, _context); } }
       });
 
     _state = State.RESOLVED_SUGAR2;

--- a/src/dev/flang/ast/Match.java
+++ b/src/dev/flang/ast/Match.java
@@ -113,7 +113,11 @@ public class Match extends AbstractMatch
    */
   public Match visit(FeatureVisitor v, AbstractFeature outer)
   {
-    _subject = _subject.visit(v, outer);
+    var os = _subject;
+    var ns = _subject.visit(v, outer);
+    if (CHECKS) check
+      (os == _subject);
+    _subject = ns;
     v.action(this);
     for (var c: cases())
       {
@@ -226,12 +230,23 @@ public class Match extends AbstractMatch
     // adding missing result fields instead of misusing
     // `propagateExpectedType`.
     //
-
-    // This will trigger addFieldForResult in some cases, e.g.:
-    // `match (if true then true else true) * =>`
-    _subject = subject().propagateExpectedType(res, context, subject().type());
-
     return addFieldForResult(res, context, t);
+  }
+
+
+  /**
+   * This will trigger addFieldForResult in some cases, e.g.:
+   * `match (if true then true else true) * =>`
+   *
+   * @param res this is called during type inference, res gives the resolution
+   * instance.
+   *
+   * @param context the source code context where this Expr is used
+   *
+   */
+  void addFieldsForSubject(Resolution res, Context context)
+  {
+    _subject = subject().propagateExpectedType(res, context, subject().type());
   }
 
 

--- a/tests/reg_issue5197/Makefile
+++ b/tests/reg_issue5197/Makefile
@@ -1,0 +1,25 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test Makefile
+#
+# -----------------------------------------------------------------------
+
+override NAME = reg_issue5197
+include ../simple.mk

--- a/tests/reg_issue5197/reg_issue5197.fz
+++ b/tests/reg_issue5197/reg_issue5197.fz
@@ -1,0 +1,36 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test reg_issue5197
+#
+# -----------------------------------------------------------------------
+
+m := container.ordered_map [ "Hund", "Katze", "Maus" ] [ "dog", "cat", "mouse" ]
+
+c := "cat"
+if (for x in m.values until c = x)
+  say "$c was found"
+else
+  say "$c not found"
+
+b := "budgie"
+if (for x in m.values until b = x)
+  say "$b was found"
+else
+  say "$b not found"

--- a/tests/reg_issue5197/reg_issue5197.fz.expected_out
+++ b/tests/reg_issue5197/reg_issue5197.fz.expected_out
@@ -1,0 +1,2 @@
+cat was found
+budgie not found


### PR DESCRIPTION
both `visit`/`propagateExpectedType` modified field `_subject` resulting in a conflict.

fixes #5197


