### PR TITLE
ast: add error when calling effect.finally from user code

### DIFF
--- a/src/dev/flang/ast/AstErrors.java
+++ b/src/dev/flang/ast/AstErrors.java
@@ -2428,6 +2428,12 @@ public class AstErrors extends ANY
           "To solve this, remove the field or move its declaration into a parent feature.");
   }
 
+  public static void mustNotCallEffectFinally(Call call)
+  {
+    error(call.pos(), "Must not call " + ss("<effect>.finally") + ".",
+      ss("<effect>.finally") + " is called automatically when deinstating the effect.");
+  }
+
 }
 
 /* end of file */

--- a/src/dev/flang/ast/AstErrors.java
+++ b/src/dev/flang/ast/AstErrors.java
@@ -2431,7 +2431,7 @@ public class AstErrors extends ANY
   public static void mustNotCallEffectFinally(Call call)
   {
     error(call.pos(), "Must not call " + ss("<effect>.finally") + ".",
-      ss("<effect>.finally") + " is called automatically when deinstating the effect.");
+      ss("<effect>.finally") + " is called automatically.");
   }
 
 }

--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -2945,6 +2945,15 @@ public class Call extends AbstractCall
     if (CHECKS) check
       (res._options.isLanguageServer() || Errors.any() || _type != null);
 
+    if (_calledFeature != null &&
+        context.outerFeature() != Types.resolved.f_effect_static_finally &&
+        (_calledFeature == Types.resolved.f_effect_finally ||
+         _calledFeature.redefinesFull().contains(Types.resolved.f_effect_finally))
+       )
+      {
+        AstErrors.mustNotCallEffectFinally(this);
+      }
+
     if (_type != null && _type != Types.t_ERROR)
       {
         var o = _type;

--- a/src/dev/flang/ast/Types.java
+++ b/src/dev/flang/ast/Types.java
@@ -188,6 +188,7 @@ public class Types extends ANY
     public final AbstractFeature f_array;
     public final AbstractFeature f_array_internal_array;
     public final AbstractFeature f_effect;
+    public final AbstractFeature f_effect_finally;
     public final AbstractFeature f_effect_static_finally;
     public final AbstractFeature f_error;
     public final AbstractFeature f_error_msg;
@@ -254,6 +255,7 @@ public class Types extends ANY
       f_array                   = universe.get(mod, FuzionConstants.ARRAY_NAME, 5);
       f_array_internal_array    = f_array.get(mod, "internal_array", 0);
       f_effect                  = universe.get(mod, "effect", 0);
+      f_effect_finally          = f_effect.get(mod, "finally", 0);
       f_effect_static_finally   = f_effect.get(mod, "static_finally", 0);
       f_error                   = universe.get(mod, "error", 1);
       f_error_msg               = f_error.get(mod, "msg", 0);

--- a/tests/must_not_call_effect_finally/Makefile
+++ b/tests/must_not_call_effect_finally/Makefile
@@ -1,0 +1,25 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test Makefile
+#
+# -----------------------------------------------------------------------
+
+override NAME = must_not_call_effect_finally
+include ../simple.mk

--- a/tests/must_not_call_effect_finally/must_not_call_effect_finally.fz
+++ b/tests/must_not_call_effect_finally/must_not_call_effect_finally.fz
@@ -1,0 +1,30 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test must_not_call_effect_finally
+#
+# -----------------------------------------------------------------------
+
+must_not_call_effect_finally =>
+
+  lm : mutate is
+  lm.finally
+
+  lm ! ()->
+    lm.env.finally

--- a/tests/must_not_call_effect_finally/must_not_call_effect_finally.fz.expected_err
+++ b/tests/must_not_call_effect_finally/must_not_call_effect_finally.fz.expected_err
@@ -1,0 +1,13 @@
+
+--CURDIR--/must_not_call_effect_finally.fz:27:6: error 1: Must not call '<effect>.finally'.
+  lm.finally
+-----^^^^^^^
+'<effect>.finally' is called automatically when deinstating the effect.
+
+
+--CURDIR--/must_not_call_effect_finally.fz:30:12: error 2: Must not call '<effect>.finally'.
+    lm.env.finally
+-----------^^^^^^^
+'<effect>.finally' is called automatically when deinstating the effect.
+
+2 errors.

--- a/tests/must_not_call_effect_finally/must_not_call_effect_finally.fz.expected_err
+++ b/tests/must_not_call_effect_finally/must_not_call_effect_finally.fz.expected_err
@@ -2,12 +2,12 @@
 --CURDIR--/must_not_call_effect_finally.fz:27:6: error 1: Must not call '<effect>.finally'.
   lm.finally
 -----^^^^^^^
-'<effect>.finally' is called automatically when deinstating the effect.
+'<effect>.finally' is called automatically.
 
 
 --CURDIR--/must_not_call_effect_finally.fz:30:12: error 2: Must not call '<effect>.finally'.
     lm.env.finally
 -----------^^^^^^^
-'<effect>.finally' is called automatically when deinstating the effect.
+'<effect>.finally' is called automatically.
 
 2 errors.


### PR DESCRIPTION
This is meant to ensures that `finally` is called exactly once when effect is deinstated.