### PR TITLE
docs: fix ArrayIndexOutOfBoundsException in Util.java

### DIFF
--- a/src/dev/flang/tools/docs/Util.java
+++ b/src/dev/flang/tools/docs/Util.java
@@ -78,11 +78,11 @@ public class Util
       }
     var line = af.pos().line() - 1;
     var commentLines = new ArrayList<String>();
-    while (true)
+    while (line > 0)
       {
         var pos = new SourcePosition(af.pos()._sourceFile, af.pos()._sourceFile.lineStartPos(line));
         var strline = Util.lineAt((LibraryFeature) af, pos);
-        if (line < 1 || !strline.matches("^\\s*#.*"))
+        if (!strline.matches("^\\s*#.*"))
           {
             break;
           }


### PR DESCRIPTION
Error happened when a file had no empty lines or comments at the beginning.

```
❯ rm -f build/apidocs/index.html && make build/apidocs/index.html
java --enable-preview --enable-native-access=ALL-UNNAMED --class-path ./build/classes -Xss64m -Dfuzion.home=./build dev.flang.tools.docs.Docs -bare -api-src=/api build/apidocs
Exception in thread "main" java.lang.Error: require-condition2 failed: SourcePosition.java:118 "(sourceFile != null, bytePos >= 0, bytePos <= sourceFile._bytes.length);"
        at dev.flang.util.ANY.require(ANY.java:135)
        at dev.flang.util.SourcePosition.<init>(SourcePosition.java:118)
        at dev.flang.tools.docs.Util.commentOf(Util.java:83)
        at dev.flang.tools.docs.Html.lambda$mainSection0$16(Html.java:505)
        at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
        at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
        at java.base/java.util.stream.SortedOps$RefSortingSink.end(SortedOps.java:395)
        at java.base/java.util.stream.Sink$ChainedReference.end(Sink.java:261)
        at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:510)
        at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
        at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:921)
        at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
        at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:682)
        at dev.flang.tools.docs.Html.mainSection0(Html.java:508)
        at dev.flang.tools.docs.Html.mainSection(Html.java:466)
        at dev.flang.tools.docs.Html.content(Html.java:976)
        at dev.flang.tools.docs.Docs.lambda$run$19(Docs.java:394)
        at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.accept(ForEachOps.java:184)
        at java.base/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:179)
        at java.base/java.util.HashMap$KeySpliterator.forEachRemaining(HashMap.java:1715)
        at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
        at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
        at java.base/java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:151)
        at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:174)
        at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
        at java.base/java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:596)
        at dev.flang.tools.docs.Docs.run(Docs.java:384)
        at dev.flang.tools.docs.Docs.main(Docs.java:438)
make: *** [Makefile:1213: build/apidocs/index.html] Error 1
```