### PR TITLE
make: Add missing dependency of apidocs on fz_cmd.mod

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1209,7 +1209,7 @@ $(REF_MANUAL_HTML): $(REF_MANUAL_SOURCES) $(BUILD_DIR)/generated/doc/fum_file.ad
 
 
 # NYI integrate into fz: fz -docs
-$(BUILD_DIR)/apidocs/index.html: $(FUZION_BASE) $(CLASS_FILES_TOOLS_DOCS) $(FUZION_FILES)
+$(BUILD_DIR)/apidocs/index.html: $(FUZION_BASE) $(CLASS_FILES_TOOLS_DOCS) $(FUZION_FILES) $(MOD_FZ_CMD)
 	$(JAVA) --class-path $(CLASSES_DIR) -Xss64m -Dfuzion.home=$(BUILD_DIR) dev.flang.tools.docs.Docs -bare -api-src=/api $(@D)
 
 # NYI integrate into fz: fz -docs


### PR DESCRIPTION
Without this and an outdated fz_cmd.mod, I get an error due to incompatible module versions between fz_cmd.mod and base.mod.