### PR TITLE
ast: omit generics for this type in toString

### DIFF
--- a/src/dev/flang/ast/AbstractType.java
+++ b/src/dev/flang/ast/AbstractType.java
@@ -2098,14 +2098,17 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
           {
             result = result + ".type";
           }
-        var skip = typeType;
-        for (var g : generics())
+        if (!isThisType())
           {
-            if (!skip) // skip first generic 'THIS#TYPE' for types of type features.
+            var skip = typeType;
+            for (var g : generics())
               {
-                result = result + " " + g.toStringWrapped(humanReadable, context);
+                if (!skip) // skip first generic 'THIS#TYPE' for types of type features.
+                  {
+                    result = result + " " + g.toStringWrapped(humanReadable, context);
+                  }
+                skip = false;
               }
-            skip = false;
           }
       }
     return result;

--- a/tests/reg_issue2111/reg_issue2111.fz.expected_err
+++ b/tests/reg_issue2111/reg_issue2111.fz.expected_err
@@ -3,6 +3,6 @@
   test my_switch on
 --^^^^
 formal type parameter 'T' with constraint 'property.equatable'
-actual type parameter '(test.this test.T).my_switch'
+actual type parameter 'test.this.my_switch'
 
 one error.


### PR DESCRIPTION
toString now emits e.g. just: `list.this` not `list.this list.A`