### PR TITLE
ast: Improve error for lambda or partial assigned to non-function, fix #5243

### DIFF
--- a/src/dev/flang/ast/AbstractAssign.java
+++ b/src/dev/flang/ast/AbstractAssign.java
@@ -195,7 +195,7 @@ public abstract class AbstractAssign extends Expr
           {
             _value = _value.propagateExpectedTypeForPartial(res, context, rt);
           }
-        _value = _value.propagateExpectedType(res, context, rt);
+        _value = _value.propagateExpectedType(res, context, rt, null);
       }
   }
 

--- a/src/dev/flang/ast/AbstractLambda.java
+++ b/src/dev/flang/ast/AbstractLambda.java
@@ -26,6 +26,8 @@ Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
 
 package dev.flang.ast;
 
+import java.util.function.Supplier;
+
 import dev.flang.util.SourcePosition;
 
 
@@ -72,7 +74,7 @@ public abstract class AbstractLambda extends ExprWithPos
    */
   AbstractType inferLambdaResultType(Resolution res, Context context, AbstractType t)
   {
-    return propagateTypeAndInferResult(res, context, t, true);
+    return propagateTypeAndInferResult(res, context, t, true, null);
   }
 
 
@@ -90,6 +92,9 @@ public abstract class AbstractLambda extends ExprWithPos
    * @param inferResultType true if the result type of this lambda should be
    * inferred.
    *
+   * @param from for error output: if non-null, produces a String describing
+   * where the expected type came from.
+   *
    * @return if inferResultType, the result type inferred from this lambda or
    * Types.t_UNDEFINED if not result type available.  if !inferResultType, t. In
    * case of error, return Types.t_ERROR.
@@ -97,7 +102,8 @@ public abstract class AbstractLambda extends ExprWithPos
   abstract AbstractType propagateTypeAndInferResult(Resolution res,
                                                     Context context,
                                                     AbstractType t,
-                                                    boolean inferResultType);
+                                                    boolean inferResultType,
+                                                    Supplier<String> from);
 
 }
 

--- a/src/dev/flang/ast/AstErrors.java
+++ b/src/dev/flang/ast/AstErrors.java
@@ -30,6 +30,7 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import dev.flang.util.ANY;
@@ -1594,7 +1595,17 @@ public class AstErrors extends ANY
           );
   }
 
-  static void expectedFunctionTypeForLambda(SourcePosition pos, AbstractType t)
+  /**
+   * Produce error in case a lambda expression is not assigned to a function type.
+   *
+   * @param pos position of the error
+   *
+   * @param t expected type that is not a function type.
+   *
+   * @param from for error output: if non-null, produces a String describing
+   * where the expected type came from.
+   */
+  static void expectedFunctionTypeForLambda(SourcePosition pos, AbstractType t, Supplier<String> from)
   {
     if (CHECKS) check
       (any() || t != Types.t_ERROR);
@@ -1605,7 +1616,7 @@ public class AstErrors extends ANY
               "Target type of a lambda expression must be " + s(Types.resolved.f_Function) + ".",
               "A lambda expression can only be used if assigned to a field or argument of type "+ s(Types.resolved.f_Function) + "\n" +
               "with argument count of the lambda expression equal to the number of type parameters of the type.\n" +
-              "Target type: " + s(t) + "\n" +
+              "Target type: " + s(t) + (from == null ? "" : " from " + from.get()) + "\n" +
               "To solve this, assign the lambda expression to a field of function type, e.g., " + ss("f (i32, i32) -> bool := x, y -> x > y") + ".");
       }
   }

--- a/src/dev/flang/ast/Block.java
+++ b/src/dev/flang/ast/Block.java
@@ -27,6 +27,7 @@ Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
 package dev.flang.ast;
 
 import java.util.ListIterator;
+import java.util.function.Supplier;
 
 import dev.flang.util.FuzionConstants;
 import dev.flang.util.List;
@@ -358,11 +359,14 @@ public class Block extends AbstractBlock
    *
    * @param type the expected type.
    *
+   * @param from for error output: if non-null, produces a String describing
+   * where the expected type came from.
+   *
    * @return either this or a new Expr that replaces thiz and produces the
    * result. In particular, if the result is assigned to a temporary field, this
    * will be replaced by the expression that reads the field.
    */
-  Expr propagateExpectedType(Resolution res, Context context, AbstractType type)
+  Expr propagateExpectedType(Resolution res, Context context, AbstractType type, Supplier<String> from)
   {
     if (type.compareTo(Types.resolved.t_unit) == 0 && hasImplicitResult())
       { // return unit if this is expected even if we would implicitly return
@@ -377,7 +381,7 @@ public class Block extends AbstractBlock
 
     if (resExpr != null)
       {
-        var x = resExpr.propagateExpectedType(res, context, type);
+        var x = resExpr.propagateExpectedType(res, context, type, from);
         _expressions.remove(idx);
         _expressions.add(x);
       }

--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -28,6 +28,7 @@ package dev.flang.ast;
 
 import java.util.Arrays;
 import java.util.ListIterator;
+import java.util.function.Supplier;
 
 import dev.flang.util.Errors;
 import dev.flang.util.FuzionConstants;
@@ -1746,7 +1747,7 @@ public class Call extends AbstractCall
                 var t = _generics.get(g.index());
                 if (t != Types.t_UNDEFINED)
                   {
-                    actual = actual.propagateExpectedType(res, context, t);
+                    actual = actual.propagateExpectedType(res, context, t, null);
                   }
               }
           }
@@ -2775,7 +2776,11 @@ public class Call extends AbstractCall
    */
   void propagateExpectedType(Resolution res, Context context)
   {
-    applyToActualsAndFormalTypes((actual, formalType) -> actual.propagateExpectedType(res, context, formalType));
+    applyToActualsAndFormalTypes
+      ((actual, formalType) -> actual.propagateExpectedType(res,
+                                                            context,
+                                                            formalType,
+                                                            () -> "formal argument type in call to " + AstErrors.s(_calledFeature)));
 
     if (_target != null)
       {
@@ -2792,7 +2797,7 @@ public class Call extends AbstractCall
         var t = _target.typeForInferencing();
         if (t != null)
           {
-            _target = _target.propagateExpectedType(res, context, t);
+            _target = _target.propagateExpectedType(res, context, t, null);
           }
       }
   }
@@ -2811,11 +2816,14 @@ public class Call extends AbstractCall
    *
    * @param t the expected type.
    *
+   * @param from for error output: if non-null, produces a String describing
+   * where the expected type came from.
+   *
    * @return either this or a new Expr that replaces this and produces the
    * result. In particular, if the result is assigned to a temporary field, this
    * will be replaced by the expression that reads the field.
    */
-  Expr propagateExpectedType(Resolution res, Context context, AbstractType t)
+  Expr propagateExpectedType(Resolution res, Context context, AbstractType t, Supplier<String> from)
   {
     Expr r = this;
     if (t.isFunctionTypeExcludingLazy()         &&
@@ -2826,7 +2834,7 @@ public class Call extends AbstractCall
         r = propagateExpectedTypeForPartial(res, context, t);
         if (r != this)
           {
-            var r2 = r.propagateExpectedType(res, context, t);
+            var r2 = r.propagateExpectedType(res, context, t, from);
             if (CHECKS) check
               (r == r2);
           }
@@ -3068,30 +3076,30 @@ public class Call extends AbstractCall
         var cf = _calledFeature;
         // need to do a propagateExpectedType since this might add a result field
         // example where this results in an issue: `_ := [false: true]`
-        if      (cf == Types.resolved.f_bool_AND    ) { result = newIf(_target, _actuals.get(0), BoolConst.FALSE).propagateExpectedType(res, context, Types.resolved.t_bool); }
-        else if (cf == Types.resolved.f_bool_OR     ) { result = newIf(_target, BoolConst.TRUE , _actuals.get(0)).propagateExpectedType(res, context, Types.resolved.t_bool); }
-        else if (cf == Types.resolved.f_bool_IMPLIES) { result = newIf(_target, _actuals.get(0), BoolConst.TRUE ).propagateExpectedType(res, context, Types.resolved.t_bool); }
-        else if (cf == Types.resolved.f_bool_NOT    ) { result = newIf(_target, BoolConst.FALSE, BoolConst.TRUE ).propagateExpectedType(res, context, Types.resolved.t_bool); }
+        if      (cf == Types.resolved.f_bool_AND    ) { result = newIf(_target, _actuals.get(0), BoolConst.FALSE).propagateExpectedType(res, context, Types.resolved.t_bool, null); }
+        else if (cf == Types.resolved.f_bool_OR     ) { result = newIf(_target, BoolConst.TRUE , _actuals.get(0)).propagateExpectedType(res, context, Types.resolved.t_bool, null); }
+        else if (cf == Types.resolved.f_bool_IMPLIES) { result = newIf(_target, _actuals.get(0), BoolConst.TRUE ).propagateExpectedType(res, context, Types.resolved.t_bool, null); }
+        else if (cf == Types.resolved.f_bool_NOT    ) { result = newIf(_target, BoolConst.FALSE, BoolConst.TRUE ).propagateExpectedType(res, context, Types.resolved.t_bool, null); }
         else if (cf == Types.resolved.f_bool_TERNARY)
           {
             result = newIf(_target, _actuals.get(0), _actuals.get(1));
             if (!_generics.get(0).containsUndefined(false))
               {
-                result = result.propagateExpectedType(res, context, _generics.get(0));
+                result = result.propagateExpectedType(res, context, _generics.get(0), null);
               }
           }
 
         // replace e.g. i16 7 by just the NumLiteral 7. This is necessary for syntaxSugar2 of InlineArray to work correctly.
-        else if (cf == Types.resolved.t_i8 .feature()) { result = this._actuals.get(0).propagateExpectedType(res, context, Types.resolved.t_i8 ); }
-        else if (cf == Types.resolved.t_i16.feature()) { result = this._actuals.get(0).propagateExpectedType(res, context, Types.resolved.t_i16); }
-        else if (cf == Types.resolved.t_i32.feature()) { result = this._actuals.get(0).propagateExpectedType(res, context, Types.resolved.t_i32); }
-        else if (cf == Types.resolved.t_i64.feature()) { result = this._actuals.get(0).propagateExpectedType(res, context, Types.resolved.t_i64); }
-        else if (cf == Types.resolved.t_u8 .feature()) { result = this._actuals.get(0).propagateExpectedType(res, context, Types.resolved.t_u8 ); }
-        else if (cf == Types.resolved.t_u16.feature()) { result = this._actuals.get(0).propagateExpectedType(res, context, Types.resolved.t_u16); }
-        else if (cf == Types.resolved.t_u32.feature()) { result = this._actuals.get(0).propagateExpectedType(res, context, Types.resolved.t_u32); }
-        else if (cf == Types.resolved.t_u64.feature()) { result = this._actuals.get(0).propagateExpectedType(res, context, Types.resolved.t_u64); }
-        else if (cf == Types.resolved.t_f32.feature()) { result = this._actuals.get(0).propagateExpectedType(res, context, Types.resolved.t_f32); }
-        else if (cf == Types.resolved.t_f64.feature()) { result = this._actuals.get(0).propagateExpectedType(res, context, Types.resolved.t_f64); }
+        else if (cf == Types.resolved.t_i8 .feature()) { result = this._actuals.get(0).propagateExpectedType(res, context, Types.resolved.t_i8 , null); }
+        else if (cf == Types.resolved.t_i16.feature()) { result = this._actuals.get(0).propagateExpectedType(res, context, Types.resolved.t_i16, null); }
+        else if (cf == Types.resolved.t_i32.feature()) { result = this._actuals.get(0).propagateExpectedType(res, context, Types.resolved.t_i32, null); }
+        else if (cf == Types.resolved.t_i64.feature()) { result = this._actuals.get(0).propagateExpectedType(res, context, Types.resolved.t_i64, null); }
+        else if (cf == Types.resolved.t_u8 .feature()) { result = this._actuals.get(0).propagateExpectedType(res, context, Types.resolved.t_u8 , null); }
+        else if (cf == Types.resolved.t_u16.feature()) { result = this._actuals.get(0).propagateExpectedType(res, context, Types.resolved.t_u16, null); }
+        else if (cf == Types.resolved.t_u32.feature()) { result = this._actuals.get(0).propagateExpectedType(res, context, Types.resolved.t_u32, null); }
+        else if (cf == Types.resolved.t_u64.feature()) { result = this._actuals.get(0).propagateExpectedType(res, context, Types.resolved.t_u64, null); }
+        else if (cf == Types.resolved.t_f32.feature()) { result = this._actuals.get(0).propagateExpectedType(res, context, Types.resolved.t_f32, null); }
+        else if (cf == Types.resolved.t_f64.feature()) { result = this._actuals.get(0).propagateExpectedType(res, context, Types.resolved.t_f64, null); }
         else if (cf != null && cf.preAndCallFeature() != null && !preChecked())
           {
             _calledFeature = cf.preAndCallFeature();

--- a/src/dev/flang/ast/Expr.java
+++ b/src/dev/flang/ast/Expr.java
@@ -26,6 +26,7 @@ Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
 
 package dev.flang.ast;
 
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import dev.flang.util.ANY;
@@ -436,7 +437,7 @@ public abstract class Expr extends ANY implements HasSourcePosition
                                   new List<>(),
                                   result);
 
-            result = fn.propagateExpectedType(res, context, t);
+            result = fn.propagateExpectedType(res, context, t, null);
             fn.resolveTypes(res, context);
             fn.updateTarget(res);
           }
@@ -462,11 +463,14 @@ public abstract class Expr extends ANY implements HasSourcePosition
    *
    * @param t the expected type.
    *
+   * @param from for error output: if non-null, produces a String describing
+   * where the expected type came from.
+   *
    * @return either this or a new Expr that replaces thiz and produces the
    * result. In particular, if the result is assigned to a temporary field, this
    * will be replaced by the expression that reads the field.
    */
-  Expr propagateExpectedType(Resolution res, Context context, AbstractType t)
+  Expr propagateExpectedType(Resolution res, Context context, AbstractType t, Supplier<String> from)
   {
     return this;
   }

--- a/src/dev/flang/ast/Function.java
+++ b/src/dev/flang/ast/Function.java
@@ -26,6 +26,8 @@ Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
 
 package dev.flang.ast;
 
+import java.util.function.Supplier;
+
 import dev.flang.util.Errors;
 import dev.flang.util.FuzionConstants;
 import dev.flang.util.List;
@@ -187,13 +189,16 @@ public class Function extends AbstractLambda
    *
    * @param t the expected type.
    *
+   * @param from for error output: if non-null, produces a String describing
+   * where the expected type came from.
+   *
    * @return either this or a new Expr that replaces thiz and produces the
    * result. In particular, if the result is assigned to a temporary field, this
    * will be replaced by the expression that reads the field.
    */
-  Expr propagateExpectedType(Resolution res, Context context, AbstractType t)
+  Expr propagateExpectedType(Resolution res, Context context, AbstractType t, Supplier<String> from)
   {
-    _type = propagateTypeAndInferResult(res, context, t.functionTypeFromChoice(context), false);
+    _type = propagateTypeAndInferResult(res, context, t.functionTypeFromChoice(context), false, from);
     return this;
   }
 
@@ -246,12 +251,15 @@ public class Function extends AbstractLambda
    * @param inferResultType true if the result type of this lambda should be
    * inferred.
    *
+   * @param from for error output: if non-null, produces a String describing
+   * where the expected type came from.
+   *
    * @return if inferResultType, the result type inferred from this lambda or
    * Types.t_UNDEFINED if no result type available.  if !inferResultType, t. In
    * case of error, return Types.t_ERROR.
    */
   @Override
-  AbstractType propagateTypeAndInferResult(Resolution res, Context context, AbstractType t, boolean inferResultType)
+  AbstractType propagateTypeAndInferResult(Resolution res, Context context, AbstractType t, boolean inferResultType, Supplier<String> from)
   {
     AbstractType result = inferResultType ? Types.t_UNDEFINED : t;
     if (_call == null)
@@ -261,7 +269,7 @@ public class Function extends AbstractLambda
             // suppress error for t_UNDEFINED, but only if other error was already reported
             if (t != Types.t_UNDEFINED || !Errors.any())
               {
-                AstErrors.expectedFunctionTypeForLambda(pos(), t);
+                AstErrors.expectedFunctionTypeForLambda(pos(), t, from);
               }
             t = Types.t_ERROR;
           }

--- a/src/dev/flang/ast/Impl.java
+++ b/src/dev/flang/ast/Impl.java
@@ -375,7 +375,7 @@ public class Impl extends ANY
   {
     if (needsImplicitAssignmentToResult(context.outerFeature()))
       {
-        _expr = _expr.propagateExpectedType(res, context, context.outerFeature().resultType());
+        _expr = _expr.propagateExpectedType(res, context, context.outerFeature().resultType(), null);
       }
   }
 
@@ -392,7 +392,7 @@ public class Impl extends ANY
    */
   void propagateExpectedType(Resolution res, Context context, AbstractType t)
   {
-    _expr = _expr.propagateExpectedType(res, context, t);
+    _expr = _expr.propagateExpectedType(res, context, t, null);
   }
 
 

--- a/src/dev/flang/ast/InlineArray.java
+++ b/src/dev/flang/ast/InlineArray.java
@@ -28,6 +28,7 @@ package dev.flang.ast;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.util.function.Supplier;
 
 import dev.flang.util.Errors;
 import dev.flang.util.FuzionConstants;
@@ -164,7 +165,7 @@ public class InlineArray extends ExprWithPos
    * will be replaced by the expression that reads the field.
    */
   @Override
-  Expr propagateExpectedType(Resolution res, Context context, AbstractType t)
+  Expr propagateExpectedType(Resolution res, Context context, AbstractType t, Supplier<String> from)
   {
     if (_type == null)
       {
@@ -178,7 +179,7 @@ public class InlineArray extends ExprWithPos
             var li = _elements.listIterator();
             while (li.hasNext())
               {
-                li.set(li.next().propagateExpectedType(res, context, elementType));
+                li.set(li.next().propagateExpectedType(res, context, elementType, null));
               }
             var arr = Types.resolved.f_array;
             _type = arr.resultType()

--- a/src/dev/flang/ast/Match.java
+++ b/src/dev/flang/ast/Match.java
@@ -28,6 +28,7 @@ package dev.flang.ast;
 
 import java.util.Iterator;
 import java.util.Stack;
+import java.util.function.Supplier;
 
 import dev.flang.util.Errors;
 import dev.flang.util.FuzionConstants;
@@ -228,12 +229,15 @@ public class Match extends AbstractMatch
    *
    * @param t the expected type.
    *
+   * @param from for error output: if non-null, produces a String describing
+   * where the expected type came from.
+   *
    * @return either this or a new Expr that replaces thiz and produces the
    * result. In particular, if the result is assigned to a temporary field, this
    * will be replaced by the expression that reads the field.
    */
   @Override
-  Expr propagateExpectedType(Resolution res, Context context, AbstractType t)
+  Expr propagateExpectedType(Resolution res, Context context, AbstractType t, Supplier<String> from)
   {
     // NYI: CLEANUP: there should be another mechanism, for
     // adding missing result fields instead of misusing
@@ -285,7 +289,7 @@ public class Match extends AbstractMatch
    */
   void addFieldsForSubject(Resolution res, Context context)
   {
-    _subject = subject().propagateExpectedType(res, context, subject().type());
+    _subject = subject().propagateExpectedType(res, context, subject().type(), null);
   }
 
 

--- a/src/dev/flang/ast/NumLiteral.java
+++ b/src/dev/flang/ast/NumLiteral.java
@@ -35,6 +35,7 @@ import java.math.BigInteger;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 /**
@@ -834,11 +835,14 @@ public class NumLiteral extends Constant
    *
    * @param t the expected type.
    *
+   * @param from for error output: if non-null, produces a String describing
+   * where the expected type came from.
+   *
    * @return either this or a new Expr that replaces thiz and produces the
    * result. In particular, if the result is assigned to a temporary field, this
    * will be replaced by the expression that reads the field.
    */
-  Expr propagateExpectedType(Resolution res, Context context, AbstractType t)
+  Expr propagateExpectedType(Resolution res, Context context, AbstractType t, Supplier<String> from)
   {
     // if expected type is choice, examine if there is exactly one numeric
     // constant type in choice generics, if so use that for further type
@@ -869,7 +873,7 @@ public class NumLiteral extends Constant
   {
     if (t.isLazyType())
       {
-        propagateExpectedType(res, context, t.generics().get(0));
+        propagateExpectedType(res, context, t.generics().get(0), null);
       }
     return super.wrapInLazy(res, context, t);
   }

--- a/src/dev/flang/ast/ParsedCall.java
+++ b/src/dev/flang/ast/ParsedCall.java
@@ -27,6 +27,7 @@ Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
 package dev.flang.ast;
 
 import java.util.ListIterator;
+import java.util.function.Supplier;
 
 import dev.flang.util.Errors;
 import dev.flang.util.FuzionConstants;
@@ -555,9 +556,9 @@ public class ParsedCall extends Call
                               this)
           {
             @Override
-            AbstractType propagateTypeAndInferResult(Resolution res, Context context, AbstractType t, boolean inferResultType)
+            AbstractType propagateTypeAndInferResult(Resolution res, Context context, AbstractType t, boolean inferResultType, Supplier<String> from)
             {
-              var rs = super.propagateTypeAndInferResult(res, context, t, inferResultType);
+              var rs = super.propagateTypeAndInferResult(res, context, t, inferResultType, from);
               if (rs != Types.t_ERROR)
                 {
                   updateTarget(res);
@@ -659,13 +660,13 @@ public class ParsedCall extends Call
           return wasLazy ? ParsedCall.this : super.originalLazyValue();
         }
         @Override
-        Expr propagateExpectedType(Resolution res, Context context, AbstractType expectedType)
+        Expr propagateExpectedType(Resolution res, Context context, AbstractType expectedType, Supplier<String> from)
         {
           if (expectedType.isFunctionTypeExcludingLazy())
             { // produce an error if the original call is ambiguous with partial application
               ParsedCall.this.checkPartialAmbiguity(res, context, expectedType);
             }
-          return super.propagateExpectedType(res, context, expectedType);
+          return super.propagateExpectedType(res, context, expectedType, null);
         }
       };
     _movedTo = result;

--- a/tests/reg_issue5243/Makefile
+++ b/tests/reg_issue5243/Makefile
@@ -1,0 +1,25 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test Makefile
+#
+# -----------------------------------------------------------------------
+
+override NAME = reg_issue5243
+include ../simple.mk

--- a/tests/reg_issue5243/reg_issue5243.fz
+++ b/tests/reg_issue5243/reg_issue5243.fz
@@ -1,0 +1,46 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test reg_issue5243
+#
+# -----------------------------------------------------------------------
+
+# Test that errors are produced if a lambda or partial call is assigned to a
+# non-function argument in a call to an infix operator.
+#
+reg_issue5243 =>
+
+  # this works
+  say ((1..) .filter %%2)
+
+  # this produces an error since it is parsed as `1.infix .. (.filter  %%2)`
+  #
+  # We might decide to parse this as `(1.postfix ..).filter %%2` and accept this.
+  #
+  say (1.. .filter %%2)   # should fail (at least for now)
+
+  # these should always produce an error
+  say (1 .. .filter %%2)  # should fail
+  say (1 +  .filter %%2)  # should fail
+
+  # these should always work
+  say (1..10 ∀ %%2)
+  say (1..10 ∀ .is_even)
+
+  i32.is_even => val %% 2

--- a/tests/reg_issue5243/reg_issue5243.fz.expected_err
+++ b/tests/reg_issue5243/reg_issue5243.fz.expected_err
@@ -1,0 +1,28 @@
+
+--CURDIR--/reg_issue5243.fz:33:13: error 1: Target type of a lambda expression must be 'Function'.
+  say (1.. .filter %%2)   # should fail (at least for now)
+------------^^^^^^
+A lambda expression can only be used if assigned to a field or argument of type 'Function'
+with argument count of the lambda expression equal to the number of type parameters of the type.
+Target type: 'i32' from formal argument type in call to 'has_interval.infix ..'
+To solve this, assign the lambda expression to a field of function type, e.g., 'f (i32, i32) -> bool := x, y -> x > y'.
+
+
+--CURDIR--/reg_issue5243.fz:36:14: error 2: Target type of a lambda expression must be 'Function'.
+  say (1 .. .filter %%2)  # should fail
+-------------^^^^^^
+A lambda expression can only be used if assigned to a field or argument of type 'Function'
+with argument count of the lambda expression equal to the number of type parameters of the type.
+Target type: 'i32' from formal argument type in call to 'has_interval.infix ..'
+To solve this, assign the lambda expression to a field of function type, e.g., 'f (i32, i32) -> bool := x, y -> x > y'.
+
+
+--CURDIR--/reg_issue5243.fz:37:14: error 3: Target type of a lambda expression must be 'Function'.
+  say (1 +  .filter %%2)  # should fail
+-------------^^^^^^
+A lambda expression can only be used if assigned to a field or argument of type 'Function'
+with argument count of the lambda expression equal to the number of type parameters of the type.
+Target type: 'i32' from formal argument type in call to 'num.wrap_around.precall infix +'
+To solve this, assign the lambda expression to a field of function type, e.g., 'f (i32, i32) -> bool := x, y -> x > y'.
+
+3 errors.


### PR DESCRIPTION
In case the expected type is the actual type of a call, it is now shown what feature is called.

Since this error did not occur anywhere in the tests, I have added a regression test for this.

A better solution that would allow `1.. .filter %%2` is suggested in #5252.

