### PR TITLE
parser: require base prefix to be repeated after dot in float literals

### DIFF
--- a/src/dev/flang/parser/Lexer.java
+++ b/src/dev/flang/parser/Lexer.java
@@ -2282,7 +2282,7 @@ HEX_TAIL    : ".0x" HEX_DIGITS
           var f = new Lexer(Lexer.this);
           f.nextCodePoint();
           var fd = f.curCodePoint();
-          if (isDigit(fd))
+          if (b == null ? isDigit(fd) : fd == '0')
             {
               // match base prefix (base prefix must be repeated after dot in floating point literal)
               if (b != null)

--- a/src/dev/flang/parser/Lexer.java
+++ b/src/dev/flang/parser/Lexer.java
@@ -2282,7 +2282,7 @@ HEX_TAIL    : ".0x" HEX_DIGITS
           var f = new Lexer(Lexer.this);
           f.nextCodePoint();
           var fd = f.curCodePoint();
-          if (b == null ? isDigit(fd) : fd == '0')
+          if (kind(fd) == K_DIGIT)
             {
               // match base prefix (base prefix must be repeated after dot in floating point literal)
               if (b != null)

--- a/src/dev/flang/parser/Lexer.java
+++ b/src/dev/flang/parser/Lexer.java
@@ -1895,9 +1895,20 @@ PLUSMINUS   : "+"
       {
         if (kind(p) == K_LETTER)
         {
+          var c = curCodePoint();
+          var possiblePrefixError = (c == 'b' || c == 'o' || c == 'd' || c == 'x')
+                                    && codePointAt(bytePos()-1) == '0'
+                                    && codePointAt(bytePos()-2) == '.';
           Errors.error(sourcePos(),
                        "Broken numeric literal, expected anything but a letter following a numeric literal.",
-                       null);
+                       possiblePrefixError
+                       ? "Fractional part must not have base prefix '0" + (char) c + "' if integer part has none."
+                       : null);
+          // skip parts of broken num literal to avoid subsequent errors
+          while (kind(curCodePoint()) == K_LETTER || kind(curCodePoint()) == K_DIGIT)
+            {
+              nextCodePoint();
+            }
         }
         yield new Literal(m);
       }};

--- a/src/dev/flang/parser/Lexer.java
+++ b/src/dev/flang/parser/Lexer.java
@@ -2141,7 +2141,7 @@ fragment
 BIN_DIGITS  : BIN_DIGIT BIN_DIGITS
             |
             ;
-BIN_TAIL    : "." BIN_DIGITS
+BIN_TAIL    : ".0b" BIN_DIGITS
             ;
 OCT_DIGIT   : "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7"
             ;
@@ -2155,7 +2155,7 @@ fragment
 OCT_DIGITS  : OCT_DIGIT OCT_DIGITS
             |
             ;
-OCT_TAIL    : "." OCT_DIGITS
+OCT_TAIL    : ".0o" OCT_DIGITS
             ;
 DEC_DIGIT   : "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9"
             ;
@@ -2169,7 +2169,8 @@ fragment
 DEC_DIGITS  : DEC_DIGIT DEC_DIGITS
             |
             ;
-DEC_TAIL    : "." DEC_DIGITS
+DEC_TAIL    : "."   DEC_DIGITS
+            | ".0d" DEC_DIGITS
             ;
 HEX_DIGIT   : "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9"
             | "a" | "b" | "c" | "d" | "e" | "f" | "g" | "h" | "i" | "j" | "k" | "l" | "m" | "n" | "o" | "p" | "q" | "r" | "s" | "t" | "u" | "v" | "w" | "x" | "y" | "z"
@@ -2185,7 +2186,7 @@ fragment
 HEX_DIGITS  : HEX_DIGIT HEX_DIGITS
             |
             ;
-HEX_TAIL    : "." HEX_DIGITS
+HEX_TAIL    : ".0x" HEX_DIGITS
             ;
      */
     Digits(int firstDigit, boolean allowDot, boolean negative)
@@ -2283,6 +2284,24 @@ HEX_TAIL    : "." HEX_DIGITS
           var fd = f.curCodePoint();
           if (isDigit(fd))
             {
+              // match base prefix (base prefix must be repeated after dot in floating point literal)
+              if (b != null)
+                {
+                  nextCodePoint();
+                  var ok = matchBasePrefix('0', b);
+                  nextCodePoint();
+                  if (ok)
+                    {
+                      switch (b)
+                        {
+                          case Base.bin -> matchBasePrefix('b', b);
+                          case Base.oct -> matchBasePrefix('o', b);
+                          case Base.dec -> matchBasePrefix('d', b);
+                          case Base.hex -> matchBasePrefix('x', b);
+                        };
+                    }
+                }
+
               nextCodePoint();
               d = curCodePoint();
               while (isDigit(d))
@@ -2303,6 +2322,28 @@ HEX_TAIL    : "." HEX_DIGITS
           _hasError = true;
         }
       _digits = digits.toString();
+    }
+
+    /**
+     * Match the current code point against the expected base prefix character
+     * and create an error if the don't match
+     *
+     * @param c the expected base prefix character
+     * @param b the expected base of the num literal
+     * @return true iff c matched current code point and no error was created
+     */
+    boolean matchBasePrefix(Character c, Base b)
+    {
+      var result = true;
+      if (curCodePoint() != c)
+        {
+          result = false;
+          Errors.error(null, sourcePos(bytePos()), "Base prefix must be repeated after dot in floating point literal",
+                       "Expected '" + c + "' but found '"
+                       + new String(Character.toChars(curCodePoint()))
+                       + "' in " + b._name + " floating point number. Base prefixes in integer and fractional part must be the same.");
+        }
+      return result;
     }
 
     void checkAndAppendDigit(StringBuilder digits, int d)

--- a/tests/reg_issue2386/reg_issue2386.fz.expected_err
+++ b/tests/reg_issue2386/reg_issue2386.fz.expected_err
@@ -3,17 +3,4 @@
 say 4abc
 -----^
 
-
---CURDIR--/reg_issue2386.fz:24:1: error 2: Different count of arguments needed when calling feature
-say 4abc
-^^^
-Feature not found: 'say' (2 arguments)
-Target feature: 'universe'
-In call: 'say 4abc'
-To solve this, you might change the actual number of arguments to match the feature 'say' (one value argument) at {base.fum}/say.fz:31:8:
-public say(s Any) unit => io.out.println s
--------^^^
-To call 'say' you must provide one argument.
-
-
-2 errors.
+one error.

--- a/tests/reg_issue5199_float_base_prefix/Makefile
+++ b/tests/reg_issue5199_float_base_prefix/Makefile
@@ -1,0 +1,25 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test Makefile
+#
+# -----------------------------------------------------------------------
+
+override NAME = reg_issue5199_float_base_prefix
+include ../simple_and_negative.mk

--- a/tests/reg_issue5199_float_base_prefix/reg_issue5199_float_base_prefix.fz
+++ b/tests/reg_issue5199_float_base_prefix/reg_issue5199_float_base_prefix.fz
@@ -23,6 +23,19 @@
 
 reg_issue5199_float_base_prefix =>
 
+  say 1.as_string   # ok
+  say 0b1.as_string # ok
+  say 0o1.as_string # ok
+  say 0d1.as_string # ok
+  say 0x1.as_string # ok
+
+  say 1.01.as_string     # ok
+  say 0b1.0b01.as_string # ok
+  say 0o1.0o01.as_string # ok
+  say 0d1.0d01.as_string # ok
+  say 0x1.0x01.as_string # ok
+
+  
   _ i32 := 0   # ok
   _ i32 := 0b0 # ok
   _ i32 := 0o0 # ok
@@ -52,6 +65,7 @@ reg_issue5199_float_base_prefix =>
   _ f64 := -0o7.0o567           # ok
   _ f64 := -0d2.0d71828         # ok
   _ f64 := -0xabba_affee.0xcafe # ok
+
 
   _ f64 := 0.0d1                #  1. should flag an error: no prefix expected
   _ f64 := 0b0.1                #  2. should flag an error: prefix missing

--- a/tests/reg_issue5199_float_base_prefix/reg_issue5199_float_base_prefix.fz
+++ b/tests/reg_issue5199_float_base_prefix/reg_issue5199_float_base_prefix.fz
@@ -35,7 +35,7 @@ reg_issue5199_float_base_prefix =>
   say 0d1.0d01.as_string # ok
   say 0x1.0x01.as_string # ok
 
-  
+
   _ i32 := 0   # ok
   _ i32 := 0b0 # ok
   _ i32 := 0o0 # ok
@@ -100,3 +100,7 @@ reg_issue5199_float_base_prefix =>
   _ f64 := 0x10.0b1             # 25. should flag an error: non matching prefixes
   _ f64 := 0x10.0o1             # 26. should flag an error: non matching prefixes
   _ f64 := 0x10.0d1             # 27. should flag an error: non matching prefixes
+
+
+  _ f64 := 0x10.0x1a0xcd        # 28. should flag an error: broken num literal
+  _ f64 := 12.30d1001010        # 29. should flag an error: broken num literal

--- a/tests/reg_issue5199_float_base_prefix/reg_issue5199_float_base_prefix.fz
+++ b/tests/reg_issue5199_float_base_prefix/reg_issue5199_float_base_prefix.fz
@@ -1,0 +1,88 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test reg_issue5199_float_base_prefix
+#
+# -----------------------------------------------------------------------
+
+reg_issue5199_float_base_prefix =>
+
+  _ i32 := 0   # ok
+  _ i32 := 0b0 # ok
+  _ i32 := 0o0 # ok
+  _ i32 := 0d0 # ok
+  _ i32 := 0x0 # ok
+
+  _ i32 := 1   # ok
+  _ i32 := 0b1 # ok
+  _ i32 := 0o1 # ok
+  _ i32 := 0d1 # ok
+  _ i32 := 0x1 # ok
+
+  _ f64 := 0.1     # ok
+  _ f64 := 0b0.0b1 # ok
+  _ f64 := 0o0.0o1 # ok
+  _ f64 := 0d0.0d1 # ok
+  _ f64 := 0x0.0x1 # ok
+
+  _ f64 := 2.71828             # ok
+  _ f64 := 0b101.0b010         # ok
+  _ f64 := 0o7.0o567           # ok
+  _ f64 := 0d2.0d71828         # ok
+  _ f64 := 0xabba_affee.0xcafe # ok
+
+  _ f64 := -2.71828             # ok
+  _ f64 := -0b101.0b010         # ok
+  _ f64 := -0o7.0o567           # ok
+  _ f64 := -0d2.0d71828         # ok
+  _ f64 := -0xabba_affee.0xcafe # ok
+
+  _ f64 := 0.0d1                #  1. should flag an error: no prefix expected
+  _ f64 := 0b0.1                #  2. should flag an error: prefix missing
+  _ f64 := 0o0.1                #  3. should flag an error: prefix missing
+  _ f64 := 0d0.1                #  4. should flag an error: prefix missing
+  _ f64 := 0x0.1                #  5. should flag an error: prefix missing
+
+  _ f64 := 2.0d71828            #  6. should flag an error: no prefix expected
+  _ f64 := 0b101.010            #  7. should flag an error: prefix missing
+  _ f64 := 0o7.567              #  8. should flag an error: prefix missing
+  _ f64 := 0d2.71828            #  9. should flag an error: prefix missing
+  _ f64 := 0xabba_affee.cafe    # 10. should flag an error: prefix missing
+
+  _ f64 := -2.0d71828           # 11. should flag an error: no prefix expected
+  _ f64 := -0b101.010           # 12. should flag an error: prefix missing
+  _ f64 := -0o7.567             # 13. should flag an error: prefix missing
+  _ f64 := -0d2.71828           # 14. should flag an error: prefix missing
+  _ f64 := -0xabba_affee.cafe   # 15. should flag an error: prefix missing
+
+  _ f64 := 0b10.0o1             # 16. should flag an error: non matching prefixes
+  _ f64 := 0b10.0d1             # 17. should flag an error: non matching prefixes
+  _ f64 := 0b10.0x1             # 18. should flag an error: non matching prefixes
+
+  _ f64 := 0o10.0b1             # 19. should flag an error: non matching prefixes
+  _ f64 := 0o10.0d1             # 20. should flag an error: non matching prefixes
+  _ f64 := 0o10.0x1             # 21. should flag an error: non matching prefixes
+
+  _ f64 := 0d10.0b1             # 22. should flag an error: non matching prefixes
+  _ f64 := 0d10.0o1             # 23. should flag an error: non matching prefixes
+  _ f64 := 0d10.0x1             # 24. should flag an error: non matching prefixes
+
+  _ f64 := 0x10.0b1             # 25. should flag an error: non matching prefixes
+  _ f64 := 0x10.0o1             # 26. should flag an error: non matching prefixes
+  _ f64 := 0x10.0d1             # 27. should flag an error: non matching prefixes

--- a/tests/reg_issue5199_float_base_prefix/reg_issue5199_float_base_prefix.fz.expected_err
+++ b/tests/reg_issue5199_float_base_prefix/reg_issue5199_float_base_prefix.fz.expected_err
@@ -1,0 +1,202 @@
+
+--CURDIR--/reg_issue5199_float_base_prefix.fz:56:15: error 1: Broken numeric literal, expected anything but a letter following a numeric literal.
+  _ f64 := 0.0d1                #  1. should flag an error: no prefix expected
+--------------^
+
+
+--CURDIR--/reg_issue5199_float_base_prefix.fz:56:15: error 2: Syntax error: expected semicolon ';', found identifier 'd1'
+  _ f64 := 0.0d1                #  1. should flag an error: no prefix expected
+--------------^
+While parsing: semicolon or flat line break, parse stack: semiOrFlatLF, exprs, block (twice), implRout, implFldOrRout, routOrField, feature, expr, exprs, block (twice), unit
+
+
+--CURDIR--/reg_issue5199_float_base_prefix.fz:57:16: error 3: Base prefix must be repeated after dot in floating point literal
+  _ f64 := 0b0.1                #  2. should flag an error: prefix missing
+---------------^
+Expected '0' but found '1' in binary floating point number. Base prefixes in integer and fractional part must be the same.
+
+
+--CURDIR--/reg_issue5199_float_base_prefix.fz:58:16: error 4: Base prefix must be repeated after dot in floating point literal
+  _ f64 := 0o0.1                #  3. should flag an error: prefix missing
+---------------^
+Expected '0' but found '1' in octal floating point number. Base prefixes in integer and fractional part must be the same.
+
+
+--CURDIR--/reg_issue5199_float_base_prefix.fz:59:16: error 5: Base prefix must be repeated after dot in floating point literal
+  _ f64 := 0d0.1                #  4. should flag an error: prefix missing
+---------------^
+Expected '0' but found '1' in decimal floating point number. Base prefixes in integer and fractional part must be the same.
+
+
+--CURDIR--/reg_issue5199_float_base_prefix.fz:60:16: error 6: Base prefix must be repeated after dot in floating point literal
+  _ f64 := 0x0.1                #  5. should flag an error: prefix missing
+---------------^
+Expected '0' but found '1' in hex floating point number. Base prefixes in integer and fractional part must be the same.
+
+
+--CURDIR--/reg_issue5199_float_base_prefix.fz:62:15: error 7: Broken numeric literal, expected anything but a letter following a numeric literal.
+  _ f64 := 2.0d71828            #  6. should flag an error: no prefix expected
+--------------^
+
+
+--CURDIR--/reg_issue5199_float_base_prefix.fz:62:15: error 8: Syntax error: expected semicolon ';', found identifier 'd71828'
+  _ f64 := 2.0d71828            #  6. should flag an error: no prefix expected
+--------------^
+While parsing: semicolon or flat line break, parse stack: semiOrFlatLF, exprs, block (twice), implRout, implFldOrRout, routOrField, feature, expr, exprs, block (twice), unit
+
+
+--CURDIR--/reg_issue5199_float_base_prefix.fz:63:19: error 9: Base prefix must be repeated after dot in floating point literal
+  _ f64 := 0b101.010            #  7. should flag an error: prefix missing
+------------------^
+Expected 'b' but found '1' in binary floating point number. Base prefixes in integer and fractional part must be the same.
+
+
+--CURDIR--/reg_issue5199_float_base_prefix.fz:64:16: error 10: Base prefix must be repeated after dot in floating point literal
+  _ f64 := 0o7.567              #  8. should flag an error: prefix missing
+---------------^
+Expected '0' but found '5' in octal floating point number. Base prefixes in integer and fractional part must be the same.
+
+
+--CURDIR--/reg_issue5199_float_base_prefix.fz:65:16: error 11: Base prefix must be repeated after dot in floating point literal
+  _ f64 := 0d2.71828            #  9. should flag an error: prefix missing
+---------------^
+Expected '0' but found '7' in decimal floating point number. Base prefixes in integer and fractional part must be the same.
+
+
+--CURDIR--/reg_issue5199_float_base_prefix.fz:66:25: error 12: Base prefix must be repeated after dot in floating point literal
+  _ f64 := 0xabba_affee.cafe    # 10. should flag an error: prefix missing
+------------------------^
+Expected '0' but found 'c' in hex floating point number. Base prefixes in integer and fractional part must be the same.
+
+
+--CURDIR--/reg_issue5199_float_base_prefix.fz:68:16: error 13: Broken numeric literal, expected anything but a letter following a numeric literal.
+  _ f64 := -2.0d71828           # 11. should flag an error: no prefix expected
+---------------^
+
+
+--CURDIR--/reg_issue5199_float_base_prefix.fz:68:16: error 14: Syntax error: expected semicolon ';', found identifier 'd71828'
+  _ f64 := -2.0d71828           # 11. should flag an error: no prefix expected
+---------------^
+While parsing: semicolon or flat line break, parse stack: semiOrFlatLF, exprs, block (twice), implRout, implFldOrRout, routOrField, feature, expr, exprs, block (twice), unit
+
+
+--CURDIR--/reg_issue5199_float_base_prefix.fz:69:20: error 15: Base prefix must be repeated after dot in floating point literal
+  _ f64 := -0b101.010           # 12. should flag an error: prefix missing
+-------------------^
+Expected 'b' but found '1' in binary floating point number. Base prefixes in integer and fractional part must be the same.
+
+
+--CURDIR--/reg_issue5199_float_base_prefix.fz:70:17: error 16: Base prefix must be repeated after dot in floating point literal
+  _ f64 := -0o7.567             # 13. should flag an error: prefix missing
+----------------^
+Expected '0' but found '5' in octal floating point number. Base prefixes in integer and fractional part must be the same.
+
+
+--CURDIR--/reg_issue5199_float_base_prefix.fz:71:17: error 17: Base prefix must be repeated after dot in floating point literal
+  _ f64 := -0d2.71828           # 14. should flag an error: prefix missing
+----------------^
+Expected '0' but found '7' in decimal floating point number. Base prefixes in integer and fractional part must be the same.
+
+
+--CURDIR--/reg_issue5199_float_base_prefix.fz:72:26: error 18: Base prefix must be repeated after dot in floating point literal
+  _ f64 := -0xabba_affee.cafe   # 15. should flag an error: prefix missing
+-------------------------^
+Expected '0' but found 'c' in hex floating point number. Base prefixes in integer and fractional part must be the same.
+
+
+--CURDIR--/reg_issue5199_float_base_prefix.fz:74:18: error 19: Base prefix must be repeated after dot in floating point literal
+  _ f64 := 0b10.0o1             # 16. should flag an error: non matching prefixes
+-----------------^
+Expected 'b' but found 'o' in binary floating point number. Base prefixes in integer and fractional part must be the same.
+
+
+--CURDIR--/reg_issue5199_float_base_prefix.fz:75:18: error 20: Base prefix must be repeated after dot in floating point literal
+  _ f64 := 0b10.0d1             # 17. should flag an error: non matching prefixes
+-----------------^
+Expected 'b' but found 'd' in binary floating point number. Base prefixes in integer and fractional part must be the same.
+
+
+--CURDIR--/reg_issue5199_float_base_prefix.fz:76:18: error 21: Base prefix must be repeated after dot in floating point literal
+  _ f64 := 0b10.0x1             # 18. should flag an error: non matching prefixes
+-----------------^
+Expected 'b' but found 'x' in binary floating point number. Base prefixes in integer and fractional part must be the same.
+
+
+--CURDIR--/reg_issue5199_float_base_prefix.fz:78:18: error 22: Base prefix must be repeated after dot in floating point literal
+  _ f64 := 0o10.0b1             # 19. should flag an error: non matching prefixes
+-----------------^
+Expected 'o' but found 'b' in octal floating point number. Base prefixes in integer and fractional part must be the same.
+
+
+--CURDIR--/reg_issue5199_float_base_prefix.fz:79:18: error 23: Base prefix must be repeated after dot in floating point literal
+  _ f64 := 0o10.0d1             # 20. should flag an error: non matching prefixes
+-----------------^
+Expected 'o' but found 'd' in octal floating point number. Base prefixes in integer and fractional part must be the same.
+
+
+--CURDIR--/reg_issue5199_float_base_prefix.fz:80:18: error 24: Base prefix must be repeated after dot in floating point literal
+  _ f64 := 0o10.0x1             # 21. should flag an error: non matching prefixes
+-----------------^
+Expected 'o' but found 'x' in octal floating point number. Base prefixes in integer and fractional part must be the same.
+
+
+--CURDIR--/reg_issue5199_float_base_prefix.fz:82:18: error 25: Base prefix must be repeated after dot in floating point literal
+  _ f64 := 0d10.0b1             # 22. should flag an error: non matching prefixes
+-----------------^
+Expected 'd' but found 'b' in decimal floating point number. Base prefixes in integer and fractional part must be the same.
+
+
+--CURDIR--/reg_issue5199_float_base_prefix.fz:83:18: error 26: Base prefix must be repeated after dot in floating point literal
+  _ f64 := 0d10.0o1             # 23. should flag an error: non matching prefixes
+-----------------^
+Expected 'd' but found 'o' in decimal floating point number. Base prefixes in integer and fractional part must be the same.
+
+
+--CURDIR--/reg_issue5199_float_base_prefix.fz:84:18: error 27: Base prefix must be repeated after dot in floating point literal
+  _ f64 := 0d10.0x1             # 24. should flag an error: non matching prefixes
+-----------------^
+Expected 'd' but found 'x' in decimal floating point number. Base prefixes in integer and fractional part must be the same.
+
+
+--CURDIR--/reg_issue5199_float_base_prefix.fz:86:18: error 28: Base prefix must be repeated after dot in floating point literal
+  _ f64 := 0x10.0b1             # 25. should flag an error: non matching prefixes
+-----------------^
+Expected 'x' but found 'b' in hex floating point number. Base prefixes in integer and fractional part must be the same.
+
+
+--CURDIR--/reg_issue5199_float_base_prefix.fz:87:18: error 29: Base prefix must be repeated after dot in floating point literal
+  _ f64 := 0x10.0o1             # 26. should flag an error: non matching prefixes
+-----------------^
+Expected 'x' but found 'o' in hex floating point number. Base prefixes in integer and fractional part must be the same.
+
+
+--CURDIR--/reg_issue5199_float_base_prefix.fz:88:18: error 30: Base prefix must be repeated after dot in floating point literal
+  _ f64 := 0x10.0d1             # 27. should flag an error: non matching prefixes
+-----------------^
+Expected 'x' but found 'd' in hex floating point number. Base prefixes in integer and fractional part must be the same.
+
+
+--CURDIR--/reg_issue5199_float_base_prefix.fz:56:15: error 31: Could not find called feature
+  _ f64 := 0.0d1                #  1. should flag an error: no prefix expected
+--------------^^
+Feature not found: 'd1' (no arguments)
+Target feature: 'reg_issue5199_float_base_prefix'
+In call: 'd1'
+
+
+--CURDIR--/reg_issue5199_float_base_prefix.fz:62:15: error 32: Could not find called feature
+  _ f64 := 2.0d71828            #  6. should flag an error: no prefix expected
+--------------^^^^^^
+Feature not found: 'd71828' (no arguments)
+Target feature: 'reg_issue5199_float_base_prefix'
+In call: 'd71828'
+
+
+--CURDIR--/reg_issue5199_float_base_prefix.fz:68:16: error 33: Could not find called feature
+  _ f64 := -2.0d71828           # 11. should flag an error: no prefix expected
+---------------^^^^^^
+Feature not found: 'd71828' (no arguments)
+Target feature: 'reg_issue5199_float_base_prefix'
+In call: 'd71828'
+
+33 errors.

--- a/tests/reg_issue5199_float_base_prefix/reg_issue5199_float_base_prefix.fz.expected_err
+++ b/tests/reg_issue5199_float_base_prefix/reg_issue5199_float_base_prefix.fz.expected_err
@@ -1,182 +1,194 @@
 
---CURDIR--/reg_issue5199_float_base_prefix.fz:56:15: error 1: Broken numeric literal, expected anything but a letter following a numeric literal.
+--CURDIR--/reg_issue5199_float_base_prefix.fz:69:15: error 1: Broken numeric literal, expected anything but a letter following a numeric literal.
   _ f64 := 0.0d1                #  1. should flag an error: no prefix expected
 --------------^
 
 
---CURDIR--/reg_issue5199_float_base_prefix.fz:56:15: error 2: Syntax error: expected semicolon ';', found identifier 'd1'
+--CURDIR--/reg_issue5199_float_base_prefix.fz:69:15: error 2: Syntax error: expected semicolon ';', found identifier 'd1'
   _ f64 := 0.0d1                #  1. should flag an error: no prefix expected
 --------------^
 While parsing: semicolon or flat line break, parse stack: semiOrFlatLF, exprs, block (twice), implRout, implFldOrRout, routOrField, feature, expr, exprs, block (twice), unit
 
 
---CURDIR--/reg_issue5199_float_base_prefix.fz:57:16: error 3: Base prefix must be repeated after dot in floating point literal
-  _ f64 := 0b0.1                #  2. should flag an error: prefix missing
----------------^
-Expected '0' but found '1' in binary floating point number. Base prefixes in integer and fractional part must be the same.
-
-
---CURDIR--/reg_issue5199_float_base_prefix.fz:58:16: error 4: Base prefix must be repeated after dot in floating point literal
-  _ f64 := 0o0.1                #  3. should flag an error: prefix missing
----------------^
-Expected '0' but found '1' in octal floating point number. Base prefixes in integer and fractional part must be the same.
-
-
---CURDIR--/reg_issue5199_float_base_prefix.fz:59:16: error 5: Base prefix must be repeated after dot in floating point literal
-  _ f64 := 0d0.1                #  4. should flag an error: prefix missing
----------------^
-Expected '0' but found '1' in decimal floating point number. Base prefixes in integer and fractional part must be the same.
-
-
---CURDIR--/reg_issue5199_float_base_prefix.fz:60:16: error 6: Base prefix must be repeated after dot in floating point literal
-  _ f64 := 0x0.1                #  5. should flag an error: prefix missing
----------------^
-Expected '0' but found '1' in hex floating point number. Base prefixes in integer and fractional part must be the same.
-
-
---CURDIR--/reg_issue5199_float_base_prefix.fz:62:15: error 7: Broken numeric literal, expected anything but a letter following a numeric literal.
+--CURDIR--/reg_issue5199_float_base_prefix.fz:75:15: error 3: Broken numeric literal, expected anything but a letter following a numeric literal.
   _ f64 := 2.0d71828            #  6. should flag an error: no prefix expected
 --------------^
 
 
---CURDIR--/reg_issue5199_float_base_prefix.fz:62:15: error 8: Syntax error: expected semicolon ';', found identifier 'd71828'
+--CURDIR--/reg_issue5199_float_base_prefix.fz:75:15: error 4: Syntax error: expected semicolon ';', found identifier 'd71828'
   _ f64 := 2.0d71828            #  6. should flag an error: no prefix expected
 --------------^
 While parsing: semicolon or flat line break, parse stack: semiOrFlatLF, exprs, block (twice), implRout, implFldOrRout, routOrField, feature, expr, exprs, block (twice), unit
 
 
---CURDIR--/reg_issue5199_float_base_prefix.fz:63:19: error 9: Base prefix must be repeated after dot in floating point literal
+--CURDIR--/reg_issue5199_float_base_prefix.fz:76:19: error 5: Base prefix must be repeated after dot in floating point literal
   _ f64 := 0b101.010            #  7. should flag an error: prefix missing
 ------------------^
 Expected 'b' but found '1' in binary floating point number. Base prefixes in integer and fractional part must be the same.
 
 
---CURDIR--/reg_issue5199_float_base_prefix.fz:64:16: error 10: Base prefix must be repeated after dot in floating point literal
-  _ f64 := 0o7.567              #  8. should flag an error: prefix missing
----------------^
-Expected '0' but found '5' in octal floating point number. Base prefixes in integer and fractional part must be the same.
-
-
---CURDIR--/reg_issue5199_float_base_prefix.fz:65:16: error 11: Base prefix must be repeated after dot in floating point literal
-  _ f64 := 0d2.71828            #  9. should flag an error: prefix missing
----------------^
-Expected '0' but found '7' in decimal floating point number. Base prefixes in integer and fractional part must be the same.
-
-
---CURDIR--/reg_issue5199_float_base_prefix.fz:66:25: error 12: Base prefix must be repeated after dot in floating point literal
-  _ f64 := 0xabba_affee.cafe    # 10. should flag an error: prefix missing
-------------------------^
-Expected '0' but found 'c' in hex floating point number. Base prefixes in integer and fractional part must be the same.
-
-
---CURDIR--/reg_issue5199_float_base_prefix.fz:68:16: error 13: Broken numeric literal, expected anything but a letter following a numeric literal.
+--CURDIR--/reg_issue5199_float_base_prefix.fz:81:16: error 6: Broken numeric literal, expected anything but a letter following a numeric literal.
   _ f64 := -2.0d71828           # 11. should flag an error: no prefix expected
 ---------------^
 
 
---CURDIR--/reg_issue5199_float_base_prefix.fz:68:16: error 14: Syntax error: expected semicolon ';', found identifier 'd71828'
+--CURDIR--/reg_issue5199_float_base_prefix.fz:81:16: error 7: Syntax error: expected semicolon ';', found identifier 'd71828'
   _ f64 := -2.0d71828           # 11. should flag an error: no prefix expected
 ---------------^
 While parsing: semicolon or flat line break, parse stack: semiOrFlatLF, exprs, block (twice), implRout, implFldOrRout, routOrField, feature, expr, exprs, block (twice), unit
 
 
---CURDIR--/reg_issue5199_float_base_prefix.fz:69:20: error 15: Base prefix must be repeated after dot in floating point literal
+--CURDIR--/reg_issue5199_float_base_prefix.fz:82:20: error 8: Base prefix must be repeated after dot in floating point literal
   _ f64 := -0b101.010           # 12. should flag an error: prefix missing
 -------------------^
 Expected 'b' but found '1' in binary floating point number. Base prefixes in integer and fractional part must be the same.
 
 
---CURDIR--/reg_issue5199_float_base_prefix.fz:70:17: error 16: Base prefix must be repeated after dot in floating point literal
-  _ f64 := -0o7.567             # 13. should flag an error: prefix missing
-----------------^
-Expected '0' but found '5' in octal floating point number. Base prefixes in integer and fractional part must be the same.
-
-
---CURDIR--/reg_issue5199_float_base_prefix.fz:71:17: error 17: Base prefix must be repeated after dot in floating point literal
-  _ f64 := -0d2.71828           # 14. should flag an error: prefix missing
-----------------^
-Expected '0' but found '7' in decimal floating point number. Base prefixes in integer and fractional part must be the same.
-
-
---CURDIR--/reg_issue5199_float_base_prefix.fz:72:26: error 18: Base prefix must be repeated after dot in floating point literal
-  _ f64 := -0xabba_affee.cafe   # 15. should flag an error: prefix missing
--------------------------^
-Expected '0' but found 'c' in hex floating point number. Base prefixes in integer and fractional part must be the same.
-
-
---CURDIR--/reg_issue5199_float_base_prefix.fz:74:18: error 19: Base prefix must be repeated after dot in floating point literal
+--CURDIR--/reg_issue5199_float_base_prefix.fz:87:18: error 9: Base prefix must be repeated after dot in floating point literal
   _ f64 := 0b10.0o1             # 16. should flag an error: non matching prefixes
 -----------------^
 Expected 'b' but found 'o' in binary floating point number. Base prefixes in integer and fractional part must be the same.
 
 
---CURDIR--/reg_issue5199_float_base_prefix.fz:75:18: error 20: Base prefix must be repeated after dot in floating point literal
+--CURDIR--/reg_issue5199_float_base_prefix.fz:88:18: error 10: Base prefix must be repeated after dot in floating point literal
   _ f64 := 0b10.0d1             # 17. should flag an error: non matching prefixes
 -----------------^
 Expected 'b' but found 'd' in binary floating point number. Base prefixes in integer and fractional part must be the same.
 
 
---CURDIR--/reg_issue5199_float_base_prefix.fz:76:18: error 21: Base prefix must be repeated after dot in floating point literal
+--CURDIR--/reg_issue5199_float_base_prefix.fz:89:18: error 11: Base prefix must be repeated after dot in floating point literal
   _ f64 := 0b10.0x1             # 18. should flag an error: non matching prefixes
 -----------------^
 Expected 'b' but found 'x' in binary floating point number. Base prefixes in integer and fractional part must be the same.
 
 
---CURDIR--/reg_issue5199_float_base_prefix.fz:78:18: error 22: Base prefix must be repeated after dot in floating point literal
+--CURDIR--/reg_issue5199_float_base_prefix.fz:91:18: error 12: Base prefix must be repeated after dot in floating point literal
   _ f64 := 0o10.0b1             # 19. should flag an error: non matching prefixes
 -----------------^
 Expected 'o' but found 'b' in octal floating point number. Base prefixes in integer and fractional part must be the same.
 
 
---CURDIR--/reg_issue5199_float_base_prefix.fz:79:18: error 23: Base prefix must be repeated after dot in floating point literal
+--CURDIR--/reg_issue5199_float_base_prefix.fz:92:18: error 13: Base prefix must be repeated after dot in floating point literal
   _ f64 := 0o10.0d1             # 20. should flag an error: non matching prefixes
 -----------------^
 Expected 'o' but found 'd' in octal floating point number. Base prefixes in integer and fractional part must be the same.
 
 
---CURDIR--/reg_issue5199_float_base_prefix.fz:80:18: error 24: Base prefix must be repeated after dot in floating point literal
+--CURDIR--/reg_issue5199_float_base_prefix.fz:93:18: error 14: Base prefix must be repeated after dot in floating point literal
   _ f64 := 0o10.0x1             # 21. should flag an error: non matching prefixes
 -----------------^
 Expected 'o' but found 'x' in octal floating point number. Base prefixes in integer and fractional part must be the same.
 
 
---CURDIR--/reg_issue5199_float_base_prefix.fz:82:18: error 25: Base prefix must be repeated after dot in floating point literal
+--CURDIR--/reg_issue5199_float_base_prefix.fz:95:18: error 15: Base prefix must be repeated after dot in floating point literal
   _ f64 := 0d10.0b1             # 22. should flag an error: non matching prefixes
 -----------------^
 Expected 'd' but found 'b' in decimal floating point number. Base prefixes in integer and fractional part must be the same.
 
 
---CURDIR--/reg_issue5199_float_base_prefix.fz:83:18: error 26: Base prefix must be repeated after dot in floating point literal
+--CURDIR--/reg_issue5199_float_base_prefix.fz:96:18: error 16: Base prefix must be repeated after dot in floating point literal
   _ f64 := 0d10.0o1             # 23. should flag an error: non matching prefixes
 -----------------^
 Expected 'd' but found 'o' in decimal floating point number. Base prefixes in integer and fractional part must be the same.
 
 
---CURDIR--/reg_issue5199_float_base_prefix.fz:84:18: error 27: Base prefix must be repeated after dot in floating point literal
+--CURDIR--/reg_issue5199_float_base_prefix.fz:97:18: error 17: Base prefix must be repeated after dot in floating point literal
   _ f64 := 0d10.0x1             # 24. should flag an error: non matching prefixes
 -----------------^
 Expected 'd' but found 'x' in decimal floating point number. Base prefixes in integer and fractional part must be the same.
 
 
---CURDIR--/reg_issue5199_float_base_prefix.fz:86:18: error 28: Base prefix must be repeated after dot in floating point literal
+--CURDIR--/reg_issue5199_float_base_prefix.fz:99:18: error 18: Base prefix must be repeated after dot in floating point literal
   _ f64 := 0x10.0b1             # 25. should flag an error: non matching prefixes
 -----------------^
 Expected 'x' but found 'b' in hex floating point number. Base prefixes in integer and fractional part must be the same.
 
 
---CURDIR--/reg_issue5199_float_base_prefix.fz:87:18: error 29: Base prefix must be repeated after dot in floating point literal
+--CURDIR--/reg_issue5199_float_base_prefix.fz:100:18: error 19: Base prefix must be repeated after dot in floating point literal
   _ f64 := 0x10.0o1             # 26. should flag an error: non matching prefixes
 -----------------^
 Expected 'x' but found 'o' in hex floating point number. Base prefixes in integer and fractional part must be the same.
 
 
---CURDIR--/reg_issue5199_float_base_prefix.fz:88:18: error 30: Base prefix must be repeated after dot in floating point literal
+--CURDIR--/reg_issue5199_float_base_prefix.fz:101:18: error 20: Base prefix must be repeated after dot in floating point literal
   _ f64 := 0x10.0d1             # 27. should flag an error: non matching prefixes
 -----------------^
 Expected 'x' but found 'd' in hex floating point number. Base prefixes in integer and fractional part must be the same.
 
 
---CURDIR--/reg_issue5199_float_base_prefix.fz:56:15: error 31: Could not find called feature
+--CURDIR--/reg_issue5199_float_base_prefix.fz:70:16: error 21: Use of selector requires call to either a feature whose type is an open type parameter or a feature with an inner feature whose type is an open type parameter
+  _ f64 := 0b0.1                #  2. should flag an error: prefix missing
+---------------^
+Selected variant: '1'
+Type of called feature: 'i32'
+
+
+--CURDIR--/reg_issue5199_float_base_prefix.fz:71:16: error 22: Use of selector requires call to either a feature whose type is an open type parameter or a feature with an inner feature whose type is an open type parameter
+  _ f64 := 0o0.1                #  3. should flag an error: prefix missing
+---------------^
+Selected variant: '1'
+Type of called feature: 'i32'
+
+
+--CURDIR--/reg_issue5199_float_base_prefix.fz:72:16: error 23: Use of selector requires call to either a feature whose type is an open type parameter or a feature with an inner feature whose type is an open type parameter
+  _ f64 := 0d0.1                #  4. should flag an error: prefix missing
+---------------^
+Selected variant: '1'
+Type of called feature: 'i32'
+
+
+--CURDIR--/reg_issue5199_float_base_prefix.fz:73:16: error 24: Use of selector requires call to either a feature whose type is an open type parameter or a feature with an inner feature whose type is an open type parameter
+  _ f64 := 0x0.1                #  5. should flag an error: prefix missing
+---------------^
+Selected variant: '1'
+Type of called feature: 'i32'
+
+
+--CURDIR--/reg_issue5199_float_base_prefix.fz:77:16: error 25: Use of selector requires call to either a feature whose type is an open type parameter or a feature with an inner feature whose type is an open type parameter
+  _ f64 := 0o7.567              #  8. should flag an error: prefix missing
+---------------^^^
+Selected variant: '567'
+Type of called feature: 'i32'
+
+
+--CURDIR--/reg_issue5199_float_base_prefix.fz:78:16: error 26: Use of selector requires call to either a feature whose type is an open type parameter or a feature with an inner feature whose type is an open type parameter
+  _ f64 := 0d2.71828            #  9. should flag an error: prefix missing
+---------------^^^^^
+Selected variant: '71828'
+Type of called feature: 'i32'
+
+
+--CURDIR--/reg_issue5199_float_base_prefix.fz:83:17: error 27: Use of selector requires call to either a feature whose type is an open type parameter or a feature with an inner feature whose type is an open type parameter
+  _ f64 := -0o7.567             # 13. should flag an error: prefix missing
+----------------^^^
+Selected variant: '567'
+Type of called feature: 'i32'
+
+
+--CURDIR--/reg_issue5199_float_base_prefix.fz:84:17: error 28: Use of selector requires call to either a feature whose type is an open type parameter or a feature with an inner feature whose type is an open type parameter
+  _ f64 := -0d2.71828           # 14. should flag an error: prefix missing
+----------------^^^^^
+Selected variant: '71828'
+Type of called feature: 'i32'
+
+
+--CURDIR--/reg_issue5199_float_base_prefix.fz:85:26: error 29: Could not find called feature
+  _ f64 := -0xabba_affee.cafe   # 15. should flag an error: prefix missing
+-------------------------^^^^
+Feature not found: 'cafe' (no arguments)
+Target feature: 'i32'
+In call: '0xabba_affee.cafe'
+
+
+--CURDIR--/reg_issue5199_float_base_prefix.fz:79:25: error 30: Could not find called feature
+  _ f64 := 0xabba_affee.cafe    # 10. should flag an error: prefix missing
+------------------------^^^^
+Feature not found: 'cafe' (no arguments)
+Target feature: 'i32'
+In call: '0xabba_affee.cafe'
+
+
+--CURDIR--/reg_issue5199_float_base_prefix.fz:69:15: error 31: Could not find called feature
   _ f64 := 0.0d1                #  1. should flag an error: no prefix expected
 --------------^^
 Feature not found: 'd1' (no arguments)
@@ -184,7 +196,7 @@ Target feature: 'reg_issue5199_float_base_prefix'
 In call: 'd1'
 
 
---CURDIR--/reg_issue5199_float_base_prefix.fz:62:15: error 32: Could not find called feature
+--CURDIR--/reg_issue5199_float_base_prefix.fz:75:15: error 32: Could not find called feature
   _ f64 := 2.0d71828            #  6. should flag an error: no prefix expected
 --------------^^^^^^
 Feature not found: 'd71828' (no arguments)
@@ -192,7 +204,7 @@ Target feature: 'reg_issue5199_float_base_prefix'
 In call: 'd71828'
 
 
---CURDIR--/reg_issue5199_float_base_prefix.fz:68:16: error 33: Could not find called feature
+--CURDIR--/reg_issue5199_float_base_prefix.fz:81:16: error 33: Could not find called feature
   _ f64 := -2.0d71828           # 11. should flag an error: no prefix expected
 ---------------^^^^^^
 Feature not found: 'd71828' (no arguments)

--- a/tests/reg_issue5199_float_base_prefix/reg_issue5199_float_base_prefix.fz.expected_err
+++ b/tests/reg_issue5199_float_base_prefix/reg_issue5199_float_base_prefix.fz.expected_err
@@ -1,178 +1,165 @@
 
---CURDIR--/reg_issue5199_float_base_prefix.fz:69:15: error 1: Broken numeric literal, expected anything but a letter following a numeric literal.
+--CURDIR--/reg_issue5199_float_base_prefix.fz:70:15: error 1: Broken numeric literal, expected anything but a letter following a numeric literal.
   _ f64 := 0.0d1                #  1. should flag an error: no prefix expected
 --------------^
+Fractional part must not have base prefix '0d' if integer part has none.
 
 
---CURDIR--/reg_issue5199_float_base_prefix.fz:69:15: error 2: Syntax error: expected semicolon ';', found identifier 'd1'
-  _ f64 := 0.0d1                #  1. should flag an error: no prefix expected
---------------^
-While parsing: semicolon or flat line break, parse stack: semiOrFlatLF, exprs, block (twice), implRout, implFldOrRout, routOrField, feature, expr, exprs, block (twice), unit
+--CURDIR--/reg_issue5199_float_base_prefix.fz:71:16: error 2: Base prefix must be repeated after dot in floating point literal
+  _ f64 := 0b0.1                #  2. should flag an error: prefix missing
+---------------^
+Expected '0' but found '1' in binary floating point number. Base prefixes in integer and fractional part must be the same.
 
 
---CURDIR--/reg_issue5199_float_base_prefix.fz:75:15: error 3: Broken numeric literal, expected anything but a letter following a numeric literal.
+--CURDIR--/reg_issue5199_float_base_prefix.fz:72:16: error 3: Base prefix must be repeated after dot in floating point literal
+  _ f64 := 0o0.1                #  3. should flag an error: prefix missing
+---------------^
+Expected '0' but found '1' in octal floating point number. Base prefixes in integer and fractional part must be the same.
+
+
+--CURDIR--/reg_issue5199_float_base_prefix.fz:73:16: error 4: Base prefix must be repeated after dot in floating point literal
+  _ f64 := 0d0.1                #  4. should flag an error: prefix missing
+---------------^
+Expected '0' but found '1' in decimal floating point number. Base prefixes in integer and fractional part must be the same.
+
+
+--CURDIR--/reg_issue5199_float_base_prefix.fz:74:16: error 5: Base prefix must be repeated after dot in floating point literal
+  _ f64 := 0x0.1                #  5. should flag an error: prefix missing
+---------------^
+Expected '0' but found '1' in hex floating point number. Base prefixes in integer and fractional part must be the same.
+
+
+--CURDIR--/reg_issue5199_float_base_prefix.fz:76:15: error 6: Broken numeric literal, expected anything but a letter following a numeric literal.
   _ f64 := 2.0d71828            #  6. should flag an error: no prefix expected
 --------------^
+Fractional part must not have base prefix '0d' if integer part has none.
 
 
---CURDIR--/reg_issue5199_float_base_prefix.fz:75:15: error 4: Syntax error: expected semicolon ';', found identifier 'd71828'
-  _ f64 := 2.0d71828            #  6. should flag an error: no prefix expected
---------------^
-While parsing: semicolon or flat line break, parse stack: semiOrFlatLF, exprs, block (twice), implRout, implFldOrRout, routOrField, feature, expr, exprs, block (twice), unit
-
-
---CURDIR--/reg_issue5199_float_base_prefix.fz:76:19: error 5: Base prefix must be repeated after dot in floating point literal
+--CURDIR--/reg_issue5199_float_base_prefix.fz:77:19: error 7: Base prefix must be repeated after dot in floating point literal
   _ f64 := 0b101.010            #  7. should flag an error: prefix missing
 ------------------^
 Expected 'b' but found '1' in binary floating point number. Base prefixes in integer and fractional part must be the same.
 
 
---CURDIR--/reg_issue5199_float_base_prefix.fz:81:16: error 6: Broken numeric literal, expected anything but a letter following a numeric literal.
+--CURDIR--/reg_issue5199_float_base_prefix.fz:78:16: error 8: Base prefix must be repeated after dot in floating point literal
+  _ f64 := 0o7.567              #  8. should flag an error: prefix missing
+---------------^
+Expected '0' but found '5' in octal floating point number. Base prefixes in integer and fractional part must be the same.
+
+
+--CURDIR--/reg_issue5199_float_base_prefix.fz:79:16: error 9: Base prefix must be repeated after dot in floating point literal
+  _ f64 := 0d2.71828            #  9. should flag an error: prefix missing
+---------------^
+Expected '0' but found '7' in decimal floating point number. Base prefixes in integer and fractional part must be the same.
+
+
+--CURDIR--/reg_issue5199_float_base_prefix.fz:82:16: error 10: Broken numeric literal, expected anything but a letter following a numeric literal.
   _ f64 := -2.0d71828           # 11. should flag an error: no prefix expected
 ---------------^
+Fractional part must not have base prefix '0d' if integer part has none.
 
 
---CURDIR--/reg_issue5199_float_base_prefix.fz:81:16: error 7: Syntax error: expected semicolon ';', found identifier 'd71828'
-  _ f64 := -2.0d71828           # 11. should flag an error: no prefix expected
----------------^
-While parsing: semicolon or flat line break, parse stack: semiOrFlatLF, exprs, block (twice), implRout, implFldOrRout, routOrField, feature, expr, exprs, block (twice), unit
-
-
---CURDIR--/reg_issue5199_float_base_prefix.fz:82:20: error 8: Base prefix must be repeated after dot in floating point literal
+--CURDIR--/reg_issue5199_float_base_prefix.fz:83:20: error 11: Base prefix must be repeated after dot in floating point literal
   _ f64 := -0b101.010           # 12. should flag an error: prefix missing
 -------------------^
 Expected 'b' but found '1' in binary floating point number. Base prefixes in integer and fractional part must be the same.
 
 
---CURDIR--/reg_issue5199_float_base_prefix.fz:87:18: error 9: Base prefix must be repeated after dot in floating point literal
+--CURDIR--/reg_issue5199_float_base_prefix.fz:84:17: error 12: Base prefix must be repeated after dot in floating point literal
+  _ f64 := -0o7.567             # 13. should flag an error: prefix missing
+----------------^
+Expected '0' but found '5' in octal floating point number. Base prefixes in integer and fractional part must be the same.
+
+
+--CURDIR--/reg_issue5199_float_base_prefix.fz:85:17: error 13: Base prefix must be repeated after dot in floating point literal
+  _ f64 := -0d2.71828           # 14. should flag an error: prefix missing
+----------------^
+Expected '0' but found '7' in decimal floating point number. Base prefixes in integer and fractional part must be the same.
+
+
+--CURDIR--/reg_issue5199_float_base_prefix.fz:88:18: error 14: Base prefix must be repeated after dot in floating point literal
   _ f64 := 0b10.0o1             # 16. should flag an error: non matching prefixes
 -----------------^
 Expected 'b' but found 'o' in binary floating point number. Base prefixes in integer and fractional part must be the same.
 
 
---CURDIR--/reg_issue5199_float_base_prefix.fz:88:18: error 10: Base prefix must be repeated after dot in floating point literal
+--CURDIR--/reg_issue5199_float_base_prefix.fz:89:18: error 15: Base prefix must be repeated after dot in floating point literal
   _ f64 := 0b10.0d1             # 17. should flag an error: non matching prefixes
 -----------------^
 Expected 'b' but found 'd' in binary floating point number. Base prefixes in integer and fractional part must be the same.
 
 
---CURDIR--/reg_issue5199_float_base_prefix.fz:89:18: error 11: Base prefix must be repeated after dot in floating point literal
+--CURDIR--/reg_issue5199_float_base_prefix.fz:90:18: error 16: Base prefix must be repeated after dot in floating point literal
   _ f64 := 0b10.0x1             # 18. should flag an error: non matching prefixes
 -----------------^
 Expected 'b' but found 'x' in binary floating point number. Base prefixes in integer and fractional part must be the same.
 
 
---CURDIR--/reg_issue5199_float_base_prefix.fz:91:18: error 12: Base prefix must be repeated after dot in floating point literal
+--CURDIR--/reg_issue5199_float_base_prefix.fz:92:18: error 17: Base prefix must be repeated after dot in floating point literal
   _ f64 := 0o10.0b1             # 19. should flag an error: non matching prefixes
 -----------------^
 Expected 'o' but found 'b' in octal floating point number. Base prefixes in integer and fractional part must be the same.
 
 
---CURDIR--/reg_issue5199_float_base_prefix.fz:92:18: error 13: Base prefix must be repeated after dot in floating point literal
+--CURDIR--/reg_issue5199_float_base_prefix.fz:93:18: error 18: Base prefix must be repeated after dot in floating point literal
   _ f64 := 0o10.0d1             # 20. should flag an error: non matching prefixes
 -----------------^
 Expected 'o' but found 'd' in octal floating point number. Base prefixes in integer and fractional part must be the same.
 
 
---CURDIR--/reg_issue5199_float_base_prefix.fz:93:18: error 14: Base prefix must be repeated after dot in floating point literal
+--CURDIR--/reg_issue5199_float_base_prefix.fz:94:18: error 19: Base prefix must be repeated after dot in floating point literal
   _ f64 := 0o10.0x1             # 21. should flag an error: non matching prefixes
 -----------------^
 Expected 'o' but found 'x' in octal floating point number. Base prefixes in integer and fractional part must be the same.
 
 
---CURDIR--/reg_issue5199_float_base_prefix.fz:95:18: error 15: Base prefix must be repeated after dot in floating point literal
+--CURDIR--/reg_issue5199_float_base_prefix.fz:96:18: error 20: Base prefix must be repeated after dot in floating point literal
   _ f64 := 0d10.0b1             # 22. should flag an error: non matching prefixes
 -----------------^
 Expected 'd' but found 'b' in decimal floating point number. Base prefixes in integer and fractional part must be the same.
 
 
---CURDIR--/reg_issue5199_float_base_prefix.fz:96:18: error 16: Base prefix must be repeated after dot in floating point literal
+--CURDIR--/reg_issue5199_float_base_prefix.fz:97:18: error 21: Base prefix must be repeated after dot in floating point literal
   _ f64 := 0d10.0o1             # 23. should flag an error: non matching prefixes
 -----------------^
 Expected 'd' but found 'o' in decimal floating point number. Base prefixes in integer and fractional part must be the same.
 
 
---CURDIR--/reg_issue5199_float_base_prefix.fz:97:18: error 17: Base prefix must be repeated after dot in floating point literal
+--CURDIR--/reg_issue5199_float_base_prefix.fz:98:18: error 22: Base prefix must be repeated after dot in floating point literal
   _ f64 := 0d10.0x1             # 24. should flag an error: non matching prefixes
 -----------------^
 Expected 'd' but found 'x' in decimal floating point number. Base prefixes in integer and fractional part must be the same.
 
 
---CURDIR--/reg_issue5199_float_base_prefix.fz:99:18: error 18: Base prefix must be repeated after dot in floating point literal
+--CURDIR--/reg_issue5199_float_base_prefix.fz:100:18: error 23: Base prefix must be repeated after dot in floating point literal
   _ f64 := 0x10.0b1             # 25. should flag an error: non matching prefixes
 -----------------^
 Expected 'x' but found 'b' in hex floating point number. Base prefixes in integer and fractional part must be the same.
 
 
---CURDIR--/reg_issue5199_float_base_prefix.fz:100:18: error 19: Base prefix must be repeated after dot in floating point literal
+--CURDIR--/reg_issue5199_float_base_prefix.fz:101:18: error 24: Base prefix must be repeated after dot in floating point literal
   _ f64 := 0x10.0o1             # 26. should flag an error: non matching prefixes
 -----------------^
 Expected 'x' but found 'o' in hex floating point number. Base prefixes in integer and fractional part must be the same.
 
 
---CURDIR--/reg_issue5199_float_base_prefix.fz:101:18: error 20: Base prefix must be repeated after dot in floating point literal
+--CURDIR--/reg_issue5199_float_base_prefix.fz:102:18: error 25: Base prefix must be repeated after dot in floating point literal
   _ f64 := 0x10.0d1             # 27. should flag an error: non matching prefixes
 -----------------^
 Expected 'x' but found 'd' in hex floating point number. Base prefixes in integer and fractional part must be the same.
 
 
---CURDIR--/reg_issue5199_float_base_prefix.fz:70:16: error 21: Use of selector requires call to either a feature whose type is an open type parameter or a feature with an inner feature whose type is an open type parameter
-  _ f64 := 0b0.1                #  2. should flag an error: prefix missing
----------------^
-Selected variant: '1'
-Type of called feature: 'i32'
+--CURDIR--/reg_issue5199_float_base_prefix.fz:105:22: error 26: Invalid digit 'x' for base 16.
+  _ f64 := 0x10.0x1a0xcd        # 28. should flag an error: broken num literal
+---------------------^
 
 
---CURDIR--/reg_issue5199_float_base_prefix.fz:71:16: error 22: Use of selector requires call to either a feature whose type is an open type parameter or a feature with an inner feature whose type is an open type parameter
-  _ f64 := 0o0.1                #  3. should flag an error: prefix missing
----------------^
-Selected variant: '1'
-Type of called feature: 'i32'
+--CURDIR--/reg_issue5199_float_base_prefix.fz:106:17: error 27: Broken numeric literal, expected anything but a letter following a numeric literal.
+  _ f64 := 12.30d1001010        # 29. should flag an error: broken num literal
+----------------^
 
 
---CURDIR--/reg_issue5199_float_base_prefix.fz:72:16: error 23: Use of selector requires call to either a feature whose type is an open type parameter or a feature with an inner feature whose type is an open type parameter
-  _ f64 := 0d0.1                #  4. should flag an error: prefix missing
----------------^
-Selected variant: '1'
-Type of called feature: 'i32'
-
-
---CURDIR--/reg_issue5199_float_base_prefix.fz:73:16: error 24: Use of selector requires call to either a feature whose type is an open type parameter or a feature with an inner feature whose type is an open type parameter
-  _ f64 := 0x0.1                #  5. should flag an error: prefix missing
----------------^
-Selected variant: '1'
-Type of called feature: 'i32'
-
-
---CURDIR--/reg_issue5199_float_base_prefix.fz:77:16: error 25: Use of selector requires call to either a feature whose type is an open type parameter or a feature with an inner feature whose type is an open type parameter
-  _ f64 := 0o7.567              #  8. should flag an error: prefix missing
----------------^^^
-Selected variant: '567'
-Type of called feature: 'i32'
-
-
---CURDIR--/reg_issue5199_float_base_prefix.fz:78:16: error 26: Use of selector requires call to either a feature whose type is an open type parameter or a feature with an inner feature whose type is an open type parameter
-  _ f64 := 0d2.71828            #  9. should flag an error: prefix missing
----------------^^^^^
-Selected variant: '71828'
-Type of called feature: 'i32'
-
-
---CURDIR--/reg_issue5199_float_base_prefix.fz:83:17: error 27: Use of selector requires call to either a feature whose type is an open type parameter or a feature with an inner feature whose type is an open type parameter
-  _ f64 := -0o7.567             # 13. should flag an error: prefix missing
-----------------^^^
-Selected variant: '567'
-Type of called feature: 'i32'
-
-
---CURDIR--/reg_issue5199_float_base_prefix.fz:84:17: error 28: Use of selector requires call to either a feature whose type is an open type parameter or a feature with an inner feature whose type is an open type parameter
-  _ f64 := -0d2.71828           # 14. should flag an error: prefix missing
-----------------^^^^^
-Selected variant: '71828'
-Type of called feature: 'i32'
-
-
---CURDIR--/reg_issue5199_float_base_prefix.fz:85:26: error 29: Could not find called feature
+--CURDIR--/reg_issue5199_float_base_prefix.fz:86:26: error 28: Could not find called feature
   _ f64 := -0xabba_affee.cafe   # 15. should flag an error: prefix missing
 -------------------------^^^^
 Feature not found: 'cafe' (no arguments)
@@ -180,35 +167,11 @@ Target feature: 'i32'
 In call: '0xabba_affee.cafe'
 
 
---CURDIR--/reg_issue5199_float_base_prefix.fz:79:25: error 30: Could not find called feature
+--CURDIR--/reg_issue5199_float_base_prefix.fz:80:25: error 29: Could not find called feature
   _ f64 := 0xabba_affee.cafe    # 10. should flag an error: prefix missing
 ------------------------^^^^
 Feature not found: 'cafe' (no arguments)
 Target feature: 'i32'
 In call: '0xabba_affee.cafe'
 
-
---CURDIR--/reg_issue5199_float_base_prefix.fz:69:15: error 31: Could not find called feature
-  _ f64 := 0.0d1                #  1. should flag an error: no prefix expected
---------------^^
-Feature not found: 'd1' (no arguments)
-Target feature: 'reg_issue5199_float_base_prefix'
-In call: 'd1'
-
-
---CURDIR--/reg_issue5199_float_base_prefix.fz:75:15: error 32: Could not find called feature
-  _ f64 := 2.0d71828            #  6. should flag an error: no prefix expected
---------------^^^^^^
-Feature not found: 'd71828' (no arguments)
-Target feature: 'reg_issue5199_float_base_prefix'
-In call: 'd71828'
-
-
---CURDIR--/reg_issue5199_float_base_prefix.fz:81:16: error 33: Could not find called feature
-  _ f64 := -2.0d71828           # 11. should flag an error: no prefix expected
----------------^^^^^^
-Feature not found: 'd71828' (no arguments)
-Target feature: 'reg_issue5199_float_base_prefix'
-In call: 'd71828'
-
-33 errors.
+29 errors.


### PR DESCRIPTION
fix #5199
