### PR TITLE
ast: AbstractType replace refOrVal by mode

### DIFF
--- a/src/dev/flang/ast/AbstractFeature.java
+++ b/src/dev/flang/ast/AbstractFeature.java
@@ -699,7 +699,7 @@ public abstract class AbstractFeature extends Expr implements Comparable<Abstrac
 
     if (POSTCONDITIONS) ensure
       (selfType != null,
-       Errors.any() || selfType.isRef().yes() == isRef(),
+       Errors.any() || selfType.isRef() == isRef(),
        // does not hold if feature is declared repeatedly
        Errors.any() || selfType.feature() == this);
 
@@ -1076,7 +1076,7 @@ public abstract class AbstractFeature extends Expr implements Comparable<Abstrac
 
     if (POSTCONDITIONS) ensure
       (result != null,
-       Errors.any() || result.isRef().yes() == isRef(),
+       Errors.any() || result.isRef() == isRef(),
        // does not hold if feature is declared repeatedly
        Errors.any() || result.feature() == this,
        result.feature().generics().sizeMatches(result.generics()));
@@ -1892,6 +1892,12 @@ public abstract class AbstractFeature extends Expr implements Comparable<Abstrac
              Types.resolved.numericTypes.contains(rt)
              || Types.resolved.legalNativeResultTypes.contains(rt)
              || !rt.isGenericArgument() && rt.feature().mayBeNativeValue());
+  }
+
+
+  public TypeMode defaultTypeMode()
+  {
+    return isRef() ? TypeMode.RefType : TypeMode.ValueType;
   }
 
 

--- a/src/dev/flang/ast/AbstractFeature.java
+++ b/src/dev/flang/ast/AbstractFeature.java
@@ -1894,7 +1894,9 @@ public abstract class AbstractFeature extends Expr implements Comparable<Abstrac
              || !rt.isGenericArgument() && rt.feature().mayBeNativeValue());
   }
 
-
+  /**
+   * @return RefType if Feature is a reference otherwise ValueType
+   */
   public TypeMode defaultTypeMode()
   {
     return isRef() ? TypeMode.RefType : TypeMode.ValueType;

--- a/src/dev/flang/ast/AbstractType.java
+++ b/src/dev/flang/ast/AbstractType.java
@@ -381,7 +381,7 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
   boolean isAssignableFromWithoutTagging(AbstractType actual, Context context)
   {
     return actual.isVoid()
-         || !isChoice() && isAssignableFrom(actual, context)
+         || !isChoice() && (isAssignableFrom(actual, context) || isAssignableFrom(actual.asRef(), context))
          || isChoiceAssignableFrom(actual);
   }
 

--- a/src/dev/flang/ast/AbstractType.java
+++ b/src/dev/flang/ast/AbstractType.java
@@ -135,19 +135,9 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
 
 
   /**
-   * Is this type denoting a reference type?
-   *
-   * yes = reference
-   * no  = value
-   * dontKnow = this-type and not known if boxed or not.
+   * The mode of the type: ThisType, RefType or ValueType.
    */
-  public abstract YesNo isRef();
-
-
-  /**
-   * Is this a this-type?
-   */
-  public abstract boolean isThisType();
+  public abstract TypeMode mode();
 
 
   /**
@@ -238,6 +228,32 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
   public boolean isChoice()
   {
     return !isGenericArgument() && feature().isChoice();
+  }
+
+
+  /**
+   * Is this a ref-type?
+   */
+  public boolean isRef()
+  {
+    return mode() == TypeMode.RefType;
+  }
+
+
+  /**
+   * Is this a value-type?
+   */
+  public boolean isValue()
+  {
+    return mode() == TypeMode.ValueType;
+  }
+
+  /**
+   * Is this a this-type?
+   */
+  public boolean isThisType()
+  {
+    return mode() == TypeMode.ThisType;
   }
 
 
@@ -395,7 +411,7 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
   boolean isAssignableFromWithoutBoxing(AbstractType actual, Context context)
   {
     return actual.isVoid()
-         || !isChoice() && isAssignableFrom(actual, context) && !(isRef().yes() && actual.isRef().no())
+         || !isChoice() && isAssignableFrom(actual, context) && !(isRef() && actual.isValue())
          || isChoiceAssignableFrom(actual);
   }
 
@@ -470,7 +486,7 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
       actual_type.isVoid() ||
       target_type == Types.t_ERROR                      ||
       actual_type == Types.t_ERROR;
-    if (!result && !target_type.isGenericArgument() && isRef().yes() && actual_type.isRef().yes())
+    if (!result && !target_type.isGenericArgument() && isRef() && actual_type.isRef())
       {
         if (actual_type.isGenericArgument())
           {
@@ -485,7 +501,7 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
                 for (var p: actual_type.feature().inherits())
                   {
                     var pt = actual_type.actualType(p.type(), context);
-                    if (actual_type.isRef().yes())
+                    if (actual_type.isRef())
                       {
                         pt = pt.asRef();
                       }
@@ -501,6 +517,13 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
       {
         result = target_type.isChoiceMatch(actual_type, context);
       }
+
+    if (POSTCONDITIONS) ensure
+      (!result
+        || target_type.mode() == actual_type.mode()
+        || actual_type.isVoid()
+        || target_type.isChoiceMatch(actual_type, context));
+
     return result;
   }
 
@@ -520,7 +543,7 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
       (!isGenericArgument() && feature() != null || Errors.any());
 
     boolean result = false;
-    if (!isGenericArgument() && isRef().noOrDontKnow() && feature().isChoice())
+    if (!isGenericArgument() && !isRef() && feature().isChoice())
       {
         for (var t : choiceGenerics(context))
           {
@@ -1226,7 +1249,7 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
       {
         var g = choiceGenerics(context);
         if (CHECKS) check
-          (Errors.any() || isRef().noOrDontKnow());
+          (Errors.any() || !isRef());
 
         int i1 = 0;
         for (var t1 : g)
@@ -1521,9 +1544,9 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
           {
             result = artificialBuiltInID() - other.artificialBuiltInID();
           }
-        if (result == 0 && isRef().yes() ^ other.isRef().yes())
+        if (result == 0 && isRef() ^ other.isRef())
           {
-            result = isRef().yes() ? -1 : 1;
+            result = isRef() ? -1 : 1;
           }
         if (result == 0 && isThisType() ^ other.isThisType())
           {
@@ -1534,6 +1557,10 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
             result = genericArgument().compareTo(other.genericArgument());
           }
       }
+
+    if (POSTCONDITIONS) ensure
+      (result != 0 || mode() == other.mode());
+
     return result;
   }
 
@@ -1623,7 +1650,7 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
         isThisType() && att.feature().inheritsFrom(feature())  // we have abc.this.type with att inheriting from abc, so use tt
         )
       {
-        if (foundRef != null && tt.isRef().yes())
+        if (foundRef != null && tt.isRef())
           {
             foundRef.accept(this, tt);
           }
@@ -1894,7 +1921,7 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
         var tf = tp.outer();
         if (tf.isCotype() && tp == tf.arguments().get(0))
           { // generic used for `abc.this.type` in `abc.type` by `abc.this.type`.
-            result = result.isRef().yes()
+            result = result.isRef()
               ? tf.cotypeOrigin().selfType().asThis().asRef()
               : tf.cotypeOrigin().selfType().asThis();
           }
@@ -2056,7 +2083,7 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
     if (isGenericArgument())
       {
         var ga = genericArgument();
-        result = ga.toLongString(context) + (isRef().yes() ? " (boxed)" : "");
+        result = ga.toLongString(context) + (isRef() ? " (boxed)" : "");
       }
     else
       {
@@ -2088,7 +2115,7 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
           }
 
         result = outer
-              + (!isThisType() && isRef().yes() != feature().isRef() ? (isRef().yes() ? "ref " : "value ") : "" )
+              + (!isThisType() && isRef() != feature().isRef() ? (isRef() ? "ref " : "value ") : "" )
               + fname;
         if (isThisType())
           {

--- a/src/dev/flang/ast/AbstractType.java
+++ b/src/dev/flang/ast/AbstractType.java
@@ -481,11 +481,8 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
       }
     var target_type = this  .remove_type_parameter_used_for_this_type_in_cotype();
     var actual_type = actual.remove_type_parameter_used_for_this_type_in_cotype();
-    var result =
-      target_type.compareTo(actual_type          ) == 0 ||
-      actual_type.isVoid() ||
-      target_type == Types.t_ERROR                      ||
-      actual_type == Types.t_ERROR;
+    var result = target_type.compareTo(actual_type) == 0
+              || actual_type.isVoid();
     if (!result && !target_type.isGenericArgument() && isRef() && actual_type.isRef())
       {
         if (actual_type.isGenericArgument())

--- a/src/dev/flang/ast/AbstractType.java
+++ b/src/dev/flang/ast/AbstractType.java
@@ -392,6 +392,23 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
    * the types may still be or depend on generic parameters.
    *
    * @param actual the actual type.
+   *
+   * @param context the source code context where this Type is used
+   */
+  boolean isAssignableFromWithoutTaggingAndWithoutBoxing(AbstractType actual, Context context)
+  {
+    return actual.isVoid()
+         || !isChoice() && isAssignableFrom(actual, context)
+         || isChoiceAssignableFrom(actual);
+  }
+
+
+  /**
+   * Check if a value of static type actual can be assigned to a field of static
+   * type this without tagging. This performs static type checking, i.e.,
+   * the types may still be or depend on generic parameters.
+   *
+   * @param actual the actual type.
    */
   public boolean isAssignableFromWithoutTagging(AbstractType actual)
   {
@@ -1282,8 +1299,8 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
   {
     return this.isVoid()
       || other.isVoid()
-      ||    !this .isAssignableFromWithoutTagging(other, context)
-         && !other.isAssignableFromWithoutTagging(this , context);
+      ||    !this .isAssignableFromWithoutTaggingAndWithoutBoxing(other, context)
+         && !other.isAssignableFromWithoutTaggingAndWithoutBoxing(this , context);
   }
 
 

--- a/src/dev/flang/ast/AstErrors.java
+++ b/src/dev/flang/ast/AstErrors.java
@@ -470,7 +470,7 @@ public class AstErrors extends ANY
           }
         else
           {
-            remedy = frmlT.isRef().no() && !actlT.isGenericArgument() && !frmlT.isGenericArgument() && actlT.feature().inheritsFrom(frmlT.feature()) ?
+            remedy = frmlT.isValue() && !actlT.isGenericArgument() && !frmlT.isGenericArgument() && actlT.feature().inheritsFrom(frmlT.feature()) ?
                         "To solve this you could:\n" + //
                             (frmlT.isChoice() ? "" : "  • make  " + s(frmlT) + " a reference by adding the " + st("ref")+ " keyword, so all its heirs can be used in place of it,\n") +
                             "  • change the type of the target " + ss(target) + " to " + s(actlT) + ", or\n" +

--- a/src/dev/flang/ast/Box.java
+++ b/src/dev/flang/ast/Box.java
@@ -71,7 +71,7 @@ public class Box extends Expr
     if (PRECONDITIONS) require
       (value != null,
        !frmlT.containsUndefined(false),
-       frmlT.isGenericArgument() || frmlT.isThisType() || value.type().isRef().noOrDontKnow() || value.isCallToOuterRef(),
+       frmlT.isGenericArgument() || frmlT.isThisType() || !value.type().isRef() || value.isCallToOuterRef(),
        !(value instanceof Box));
 
     this._value = value;

--- a/src/dev/flang/ast/BuiltInType.java
+++ b/src/dev/flang/ast/BuiltInType.java
@@ -26,6 +26,8 @@ Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
 
 package dev.flang.ast;
 
+import java.util.Optional;
+
 import dev.flang.util.SourcePosition;
 
 /**
@@ -58,8 +60,8 @@ public class BuiltInType extends ParsedType
   BuiltInType(boolean ref, String n)
   {
     super(SourcePosition.builtIn, n, NONE, null,
-          ref ? RefOrVal.Boxed
-              : RefOrVal.LikeUnderlyingFeature);
+          ref ? Optional.of(TypeMode.RefType)
+              : Optional.empty());
   }
 
 }

--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -1122,7 +1122,7 @@ public class Call extends AbstractCall
     return (_calledFeature instanceof Feature f)
       && f.isAnonymousInnerFeature()
       && f.inherits().getFirst().typeForInferencing() != null
-      && f.inherits().getFirst().typeForInferencing().isRef() == YesNo.yes
+      && f.inherits().getFirst().typeForInferencing().isRef()
       ? f.inherits().getFirst().typeForInferencing()
       : _type;
   }
@@ -2928,7 +2928,7 @@ public class Call extends AbstractCall
         while (o != null && !o.isGenericArgument())
           {
             o = o.outer();
-            if (o != null && o.isRef() == YesNo.yes && !o.feature().isRef())
+            if (o != null && o.isRef() && !o.feature().isRef())
               {
                 AstErrors.illegalCallResultType(this, _type, o);
                 o = null;

--- a/src/dev/flang/ast/Expr.java
+++ b/src/dev/flang/ast/Expr.java
@@ -720,11 +720,11 @@ public abstract class Expr extends ANY implements HasSourcePosition
          */
         return frmlT;
       }
-    else if (t.isRef().yes() && !isCallToOuterRef())
+    else if (t.isRef() && !isCallToOuterRef())
       {
         return null;
       }
-    else if (frmlT.isRef().yes())
+    else if (frmlT.isRef())
       {
         return frmlT;
       }

--- a/src/dev/flang/ast/Feature.java
+++ b/src/dev/flang/ast/Feature.java
@@ -1807,7 +1807,7 @@ A ((Choice)) declaration must not contain a result type.
       {
         if (CHECKS) check
           (Errors.any() || t != null);
-        if (t != null && t.isRef().noOrDontKnow())
+        if (t != null && !t.isRef())
           {
             if (t.compareToIgnoreOuter(selfType()) == 0)
               {

--- a/src/dev/flang/ast/FreeType.java
+++ b/src/dev/flang/ast/FreeType.java
@@ -26,6 +26,8 @@ Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
 
 package dev.flang.ast;
 
+import java.util.Optional;
+
 import dev.flang.util.SourcePosition;
 
 
@@ -57,7 +59,7 @@ public class FreeType extends UnresolvedType
   {
     super(pos,
           name,
-          Call.NO_GENERICS, null, RefOrVal.LikeUnderlyingFeature);
+          Call.NO_GENERICS, null, Optional.empty());
 
     this._constraint = constraint;
   }

--- a/src/dev/flang/ast/ParsedType.java
+++ b/src/dev/flang/ast/ParsedType.java
@@ -26,6 +26,7 @@ Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
 
 package dev.flang.ast;
 
+import java.util.Optional;
 
 import dev.flang.util.HasSourcePosition;
 import dev.flang.util.List;
@@ -75,9 +76,9 @@ public class ParsedType extends UnresolvedType
    *
    * @param outer outer type or null if unqualified.
    *
-   * @param rov UnresolvedType.RefOrVal.Boxed or UnresolvedType.RefOrVal.LikeUnderlyingFeature
+   * @param rov UnresolvedType.TypeMode.Boxed or UnresolvedType.TypeMode.LikeUnderlyingFeature
    */
-  ParsedType(HasSourcePosition pos, String name, List<AbstractType> generics, AbstractType outer, RefOrVal rov)
+  ParsedType(HasSourcePosition pos, String name, List<AbstractType> generics, AbstractType outer, Optional<TypeMode> rov)
   {
     super(pos, name, generics, outer, rov);
   }
@@ -115,7 +116,7 @@ public class ParsedType extends UnresolvedType
    */
   public AbstractType applyTypePars(List<AbstractType> g2, AbstractType o2)
   {
-    return new ParsedType(_pos, name(), g2, o2, _refOrVal);
+    return new ParsedType(_pos, name(), g2, o2, _typeMode);
   }
 
 
@@ -154,7 +155,7 @@ public class ParsedType extends UnresolvedType
     return
       outer() == null      &&
       generics().isEmpty() &&
-      _refOrVal == RefOrVal.LikeUnderlyingFeature;
+      _typeMode.isEmpty();
   }
 
 

--- a/src/dev/flang/ast/QualThisType.java
+++ b/src/dev/flang/ast/QualThisType.java
@@ -26,6 +26,8 @@ Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
 
 package dev.flang.ast;
 
+import java.util.Optional;
+
 import dev.flang.util.List;
 import dev.flang.util.SourcePosition;
 
@@ -50,7 +52,7 @@ public class QualThisType extends UnresolvedType
   {
     super(SourcePosition.range(qual),
           qual.getLast()._name,
-          Call.NO_GENERICS, null, RefOrVal.ThisType);
+          Call.NO_GENERICS, null, Optional.of(TypeMode.ThisType));
   }
 
 

--- a/src/dev/flang/ast/ResolvedParametricType.java
+++ b/src/dev/flang/ast/ResolvedParametricType.java
@@ -154,16 +154,6 @@ public class ResolvedParametricType extends ResolvedType
     return _generic;
   }
 
-  /**
-   * A parametric type is not considered a ref type even it the actual type
-   * might very well be a ref.
-   */
-  public YesNo isRef()
-  {
-    return _isBoxed ? YesNo.yes : YesNo.no;
-  }
-
-
 
   public AbstractType outer()
   {
@@ -214,6 +204,16 @@ public class ResolvedParametricType extends ResolvedType
       {
         genericArgument().typeParameter().resultType().usedFeatures(s);
       }
+  }
+
+
+  /**
+   * The mode of the type: ThisType, RefType or ValueType.
+   */
+  @Override
+  public TypeMode mode()
+  {
+    return _isBoxed ? TypeMode.RefType : TypeMode.ValueType;
   }
 
 

--- a/src/dev/flang/ast/ResolvedType.java
+++ b/src/dev/flang/ast/ResolvedType.java
@@ -64,15 +64,6 @@ public abstract class ResolvedType extends AbstractType
 
 
   /**
-   * isThisType
-   */
-  public boolean isThisType()
-  {
-    return false;
-  }
-
-
-  /**
    * genericArgument gives the Generic instance of a type defined by a generic
    * argument.
    *

--- a/src/dev/flang/ast/TypeMode.java
+++ b/src/dev/flang/ast/TypeMode.java
@@ -20,20 +20,37 @@ Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
  *
  * Tokiwa Software GmbH, Germany
  *
- * Source of enum RefOrVal
+ * Source of enum TypeMode
  *
  *---------------------------------------------------------------------*/
 
 package dev.flang.ast;
 
+
 /**
- * Is this type explicitly a reference or a value type, or whatever the
- * underlying feature is?
+ * for specifying the mode of a type.
+ * May be one of "ThisType", "RefType" or "ValueType".
  */
-enum RefOrVal
-  {
-    Boxed,                  // this is boxed value type or an explicit reference type
-    Value,                  // this is an explicit value type
-    LikeUnderlyingFeature,  // this is ref or value as declared for the underlying feature
-    ThisType,               // this is the type of feature().this.type, i.e., it may be an heir type
+public enum TypeMode {
+
+  ThisType(0x00),
+  RefType(0x01),
+  ValueType(0x02);
+
+  public int num;
+
+  TypeMode(int num) {
+      this.num = num;
   }
+
+  public static TypeMode fromInt(int num)
+  {
+    return switch (num) {
+      case 0x00 -> TypeMode.ThisType;
+      case 0x01 -> TypeMode.RefType;
+      case 0x02 -> TypeMode.ValueType;
+      default   -> throw new Error("Illegal TypeMode: " + num);
+    };
+  }
+
+}

--- a/src/dev/flang/fe/GenericType.java
+++ b/src/dev/flang/fe/GenericType.java
@@ -31,13 +31,13 @@ import dev.flang.ast.AbstractFeature;
 import dev.flang.ast.AbstractType;
 import dev.flang.ast.FeatureVisitor;
 import dev.flang.ast.Generic;
+import dev.flang.ast.TypeMode;
 import dev.flang.ast.UnresolvedType;
 import dev.flang.ast.Types;
 
 import dev.flang.util.Errors;
 import dev.flang.util.List;
 import dev.flang.util.SourcePosition;
-import dev.flang.util.YesNo;
 
 
 /**
@@ -153,25 +153,6 @@ public class GenericType extends LibraryType
   }
 
 
-  /**
-   * A parametric type is not considered a ref type even it the actual type
-   * might very well be a ref.
-   */
-  public YesNo isRef()
-  {
-    return _isBoxed ? YesNo.yes : YesNo.no;
-  }
-
-
-  /**
-   * isThisType
-   */
-  public boolean isThisType()
-  {
-    return false;
-  }
-
-
   public AbstractType outer()
   {
     if (CHECKS) check
@@ -197,6 +178,16 @@ public class GenericType extends LibraryType
   public AbstractType asThis()
   {
     throw new Error("GenericType.asThis() not defined");
+  }
+
+
+  /**
+   * The mode of the type: ThisType, RefType or ValueType.
+   */
+  @Override
+  public TypeMode mode()
+  {
+    return _isBoxed ? TypeMode.RefType : TypeMode.ValueType;
   }
 
 }

--- a/src/dev/flang/fe/LibraryFeature.java
+++ b/src/dev/flang/fe/LibraryFeature.java
@@ -422,13 +422,12 @@ public class LibraryFeature extends AbstractFeature
     var o = outer();
     var ot = o == null ? null : o.selfType();
     AbstractType result = new NormalType(_libModule, -1, this,
-                                         isRef() ? FuzionConstants.MIR_FILE_TYPE_IS_REF
-                                                 : FuzionConstants.MIR_FILE_TYPE_IS_VALUE,
+                                         defaultTypeMode(),
                                          generics().asActuals(), ot);
 
     if (POSTCONDITIONS) ensure
       (result != null,
-       Errors.any() || result.isRef().yes() == isRef(),
+       Errors.any() || result.isRef() == isRef(),
        // does not hold if feature is declared repeatedly
        Errors.any() || result.feature() == this);
 

--- a/src/dev/flang/fe/LibraryModule.java
+++ b/src/dev/flang/fe/LibraryModule.java
@@ -42,6 +42,7 @@ import dev.flang.ast.AbstractType;
 import dev.flang.ast.Expr;
 import dev.flang.ast.FeatureName;
 import dev.flang.ast.Generic;
+import dev.flang.ast.TypeMode;
 import dev.flang.ast.UnresolvedType;
 import dev.flang.ast.Types;
 import dev.flang.ast.Visi;
@@ -525,7 +526,7 @@ public class LibraryModule extends Module implements MirModule
               }
             var outer = type(typeOuterPos(at));
             result = new NormalType(this, at, feature,
-                                    typeValRefOrThis(at),
+                                    TypeMode.fromInt(typeValRefOrThis(at)),
                                     generics, outer);
           }
         _libraryTypes.put(at, result);

--- a/src/dev/flang/fe/LibraryOut.java
+++ b/src/dev/flang/fe/LibraryOut.java
@@ -600,7 +600,7 @@ class LibraryOut extends ANY
         if (t.isGenericArgument())
           {
             if (CHECKS) check
-              (t.isRef().no());
+              (t.isValue());
             _data.writeInt(-1);
             _data.writeOffset(t.genericArgument().typeParameter());
           }
@@ -608,9 +608,7 @@ class LibraryOut extends ANY
           {
             _data.writeInt(t.generics().size());
             _data.writeOffset(t.feature());
-            _data.writeByte(t.isThisType()       ? FuzionConstants.MIR_FILE_TYPE_IS_THIS :
-                            t.isRef().yes() ? FuzionConstants.MIR_FILE_TYPE_IS_REF
-                                                 : FuzionConstants.MIR_FILE_TYPE_IS_VALUE);
+            _data.writeByte(t.mode().num);
             for (var gt : t.generics())
               {
                 type(gt);

--- a/src/dev/flang/fuir/Clazz.java
+++ b/src/dev/flang/fuir/Clazz.java
@@ -1807,13 +1807,14 @@ class Clazz extends ANY implements Comparable<Clazz>
    *
    * @return the outer clazz of this corresponding feature {@code o}.
    */
+  // NYI: UNDER DEVELOPMENT: logic too complicated and likely subtly wrong.
   private Clazz findOuter(AbstractType o)
   {
     /* starting with feature(), follow outer references
      * until we find o.
      */
     var of = o.feature();
-    var isValue = o.isValue();
+    var isValue = !o.isRef() && !of.isRef();
     var isThisValue = o.isThisType() && o.isRef() != of.isRef() && isValue;
     var res = this;
     var i = feature();

--- a/src/dev/flang/fuir/Clazz.java
+++ b/src/dev/flang/fuir/Clazz.java
@@ -309,7 +309,7 @@ class Clazz extends ANY implements Comparable<Clazz>
        type.feature().resultType().isOpenGeneric() == (select >= 0),
        type != Types.t_ERROR,
        // outer clazzes of fields must be values
-       outer == null || outer.isRef() == YesNo.no || !type.feature().isField());
+       outer == null || outer.isValue() || !type.feature().isField());
 
     _fuir = fuir;
     outer = normalizeOuter(type, outer);
@@ -389,7 +389,7 @@ class Clazz extends ANY implements Comparable<Clazz>
   {
     if (PRECONDITIONS) require
       (!_fuir._lookupDone,
-       i.clazzKind() != IR.FeatureKind.Field || isRef() == YesNo.no);
+       i.clazzKind() != IR.FeatureKind.Field || isValue());
 
     _inner.add(i);
   }
@@ -452,7 +452,7 @@ class Clazz extends ANY implements Comparable<Clazz>
   {
     if (// an outer clazz of value type is not normalized (except for
         // universe, which was done already).
-        isRef().no() ||
+        isValue() ||
 
         // optimization: if feature() is already f, there is nothing to
         // normalize anymore
@@ -539,7 +539,7 @@ class Clazz extends ANY implements Comparable<Clazz>
     for (var p: feature().inherits())
       {
         var pt = p.type();
-        var t1 = isRef().yes() && !pt.isVoid() ? pt.asRef() : pt.asValue();
+        var t1 = isRef() && !pt.isVoid() ? pt.asRef() : pt.asValue();
         var t2 = _type.actualType(t1);
         var pc = _fuir.newClazz(t2);
         if (CHECKS) check
@@ -568,7 +568,7 @@ class Clazz extends ANY implements Comparable<Clazz>
               {
                 for (var pp : p.parents())
                   {
-                    if (isRef().yes() && !pp.isVoidType())
+                    if (isRef() && !pp.isVoidType())
                       {
                         pp = pp.asRef();
                       }
@@ -714,18 +714,32 @@ class Clazz extends ANY implements Comparable<Clazz>
 
 
   /**
-   * isRef
+   * Is this clazz denoting a reference type?
    */
-  YesNo isRef()
+  boolean isRef()
   {
-    return _type.isRef();
+    return switch (_type.mode())
+      {
+      case RefType -> true;
+      case ValueType -> false;
+      case ThisType -> throw new Error("unexpected this type");
+      };
+  }
+
+
+  /**
+   * Is this clazz denoting a value type?
+   */
+  boolean isValue()
+  {
+    return !isRef();
   }
 
 
   /**
    * isBoxed is true iff this is a ref value but the underlying feature is a value feature.
    */
-  boolean isBoxed() { return isRef().yes() && !feature().isRef(); }
+  boolean isBoxed() { return isRef() && !feature().isRef(); }
 
 
   /**
@@ -744,7 +758,7 @@ class Clazz extends ANY implements Comparable<Clazz>
       {
         res = YesNo.yes;
       }
-    else if ( _fuir._lookupDone && (isRef().noOrDontKnow()               &&
+    else if ( _fuir._lookupDone && (isValue()                       &&
                                     !feature().isBuiltInPrimitive() &&
                                     !isVoidType()                   &&
                                     !isChoice()                       ))
@@ -840,7 +854,7 @@ class Clazz extends ANY implements Comparable<Clazz>
             {
               for (Clazz c : choiceGenerics())
                 {
-                  if (result == null && c.isRef().noOrDontKnow())
+                  if (result == null && c.isValue())
                     {
                       result = c.layout();
                       if (result != null)
@@ -850,7 +864,7 @@ class Clazz extends ANY implements Comparable<Clazz>
                     }
                 }
             }
-          if (isRef() == YesNo.no)
+          if (isValue())
             {
               for (var fc : fields())
                 {
@@ -881,7 +895,7 @@ class Clazz extends ANY implements Comparable<Clazz>
   {
     List<String> result = null;
     var fieldClazz = field.resultClazz();
-    if (fieldClazz.isRef().noOrDontKnow() &&
+    if (fieldClazz.isValue() &&
         !fieldClazz.feature().isBuiltInPrimitive() &&
         !fieldClazz.isVoidType())
       {
@@ -1269,8 +1283,8 @@ class Clazz extends ANY implements Comparable<Clazz>
           }
 
         result = outer
-          + ( isRef().yes() && !feature().isRef() ? "ref "   : "" )
-          + ( isRef().no()  &&  feature().isRef() ? "value " : "" )
+          + ( isRef()   && !feature().isRef() ? "ref "   : "" )
+          + ( isValue() &&  feature().isRef() ? "value " : "" )
           + fname;
         if (typeType)
           {
@@ -1390,7 +1404,7 @@ class Clazz extends ANY implements Comparable<Clazz>
           oo == null ? +1 : 0;
         if (result == 0)
           {
-            if (to.isRef().yes() && oo.isRef().yes())
+            if (to.isRef() && oo.isRef())
               { // NYI: If outer is normalized for refs as described in the
                 // constructor, there should be no need for special handling of
                 // ref types here.
@@ -1403,8 +1417,8 @@ class Clazz extends ANY implements Comparable<Clazz>
             else
               {
                 result =
-                  to.isRef().noOrDontKnow() && oo.isRef().noOrDontKnow() ? to.compareTo(oo) :
-                  to.isRef().yes() ? +1
+                  to.isValue() && oo.isValue() ? to.compareTo(oo) :
+                  to.isRef() ? +1
                              : -1;
               }
           }
@@ -1455,7 +1469,7 @@ class Clazz extends ANY implements Comparable<Clazz>
   @Override
   public int hashCode()
   {
-    return (_type.isRef().yes() ? 0x777377 : 0) ^ feature().globalIndex();  // NYI: outer and type parameters!
+    return (_type.isRef() ? 0x777377 : 0) ^ feature().globalIndex();  // NYI: outer and type parameters!
   }
 
 
@@ -1599,7 +1613,7 @@ class Clazz extends ANY implements Comparable<Clazz>
       && (_checkingInstantiatedHeirs > 0
           || (isOuterInstantiated()
               || isChoice()
-              || _outer.isRef().yes() && _outer.hasInstantiatedChoiceHeirs()));
+              || _outer.isRef() && _outer.hasInstantiatedChoiceHeirs()));
   }
 
 
@@ -1608,7 +1622,7 @@ class Clazz extends ANY implements Comparable<Clazz>
    */
   Clazz asRef()
   {
-    return isRef().yes()
+    return isRef()
       ? this
       : _fuir.newClazz(_outer, _type.asRef(), _select);
   }
@@ -1799,8 +1813,8 @@ class Clazz extends ANY implements Comparable<Clazz>
      * until we find o.
      */
     var of = o.feature();
-    var isValue = o.isRef().noOrDontKnow();
-    var isThisValue = o.isThisType() && o.isRef().yes() != of.isRef() && isValue;
+    var isValue = o.isValue();
+    var isThisValue = o.isThisType() && o.isRef() != of.isRef() && isValue;
     var res = this;
     var i = feature();
     while (
@@ -2121,7 +2135,7 @@ class Clazz extends ANY implements Comparable<Clazz>
   Clazz[] fields()
   {
     if (PRECONDITIONS) require
-      (isRef() == YesNo.no);
+      (isValue());
 
     if (_fields == null)
       {
@@ -2149,13 +2163,13 @@ class Clazz extends ANY implements Comparable<Clazz>
   {
     if (_asValue == null)
       {
-        _asValue = isRef().yesOrDontKnow() && _type != Types.t_ADDRESS
+        _asValue = isRef() && _type != Types.t_ADDRESS
           ? _fuir.newClazz(_outer, _type.asValue(), _select)
           : this;
       }
 
     if (CHECKS) check
-      (_asValue.isRef().no());
+      (_asValue.isValue());
 
     return _asValue;
   }

--- a/src/dev/flang/fuir/GeneratingFUIR.java
+++ b/src/dev/flang/fuir/GeneratingFUIR.java
@@ -287,7 +287,7 @@ public class GeneratingFUIR extends FUIR
     var ao = actualType.feature().outer();
     while (o != null)
       {
-        if (actualType.isRef().yes() && ao != null && ao.inheritsFrom(o.feature()) && outer.isRef().no())
+        if (actualType.isRef() && ao != null && ao.inheritsFrom(o.feature()) && outer.isValue())
           {
             outer = o;  // short-circuit outer relation if suitable outer was found
           }
@@ -381,7 +381,7 @@ public class GeneratingFUIR extends FUIR
           }
 
         var s = SpecialClazzes.c_NOT_FOUND;
-        if (cl.isRef().yes() == cl.feature().isRef())  // not an boxed or explicit value clazz
+        if (cl.isRef() == cl.feature().isRef())  // not an boxed or explicit value clazz
           {
             // NYI: OPTIMIZATION: Avoid creating all feature qualified names!
             s = switch (cl.feature().qualifiedName())
@@ -878,7 +878,7 @@ public class GeneratingFUIR extends FUIR
 
     var cc = id2clazz(cl);
     var cg = cc.choiceGenerics().get(i);
-    var res = cg.isRef().yes()     ||
+    var res = cg.isRef()     ||
               cg.isInstantiatedChoice() ? cg
                                         : id2clazz(clazz(SpecialClazzes.c_void));
     return res._id;
@@ -1315,7 +1315,7 @@ public class GeneratingFUIR extends FUIR
        cl < CLAZZ_BASE + _clazzes.size());
 
     var c = id2clazz(cl);
-    return c.isRef().yes();
+    return c.isRef();
   }
 
 
@@ -1332,7 +1332,7 @@ public class GeneratingFUIR extends FUIR
        cl < CLAZZ_BASE + _clazzes.size());
 
     var c = id2clazz(cl);
-    return c.isRef().yes() && !c.feature().isRef();
+    return c.isRef() && !c.feature().isRef();
   }
 
 
@@ -1354,7 +1354,7 @@ public class GeneratingFUIR extends FUIR
     var vcc = cc.asValue();
 
     if (CHECKS) check
-      (!vcc.isRef().yes());
+      (vcc.isValue());
 
     var vc = vcc._id;
 
@@ -1461,7 +1461,7 @@ public class GeneratingFUIR extends FUIR
             var f = (LibraryFeature) of.get(of._libModule, s._name, s._argCount);
             result = newClazz(oc, f.selfType(), FuzionConstants.NO_SELECT);
             if (CHECKS) check
-              (f.isRef() == (result.isRef().yes()));
+              (f.isRef() == (result.isRef()));
           }
         _specialClazzes[s.ordinal()] = result;
       }
@@ -1783,7 +1783,7 @@ public class GeneratingFUIR extends FUIR
       // contains no fields
       ac.calledFeature().code().containsOnlyDeclarations() &&
       // we are calling a value type feature
-      ac.calledFeature().selfType().isRef().no() &&
+      ac.calledFeature().selfType().isValue() &&
       // only features without args and no fields may be inherited
       ac.calledFeature().inherits().stream().allMatch(c -> c.calledFeature().arguments().isEmpty() && c.calledFeature().code().containsOnlyDeclarations()) &&
       // no unit   // NYI: UNDER DEVELOPMENT: we could allow units that does not contain declarations
@@ -2049,7 +2049,7 @@ public class GeneratingFUIR extends FUIR
         var b = (Box) getExpr(s);
         Clazz vc = clazz(b._value, outerClazz, _inh.get(s - SITE_BASE));
         var rc = outerClazz.handDown(b.type(), _inh.get(s - SITE_BASE));
-        if (rc.isRef().yes() &&
+        if (rc.isRef() &&
             outerClazz.feature() != Types.resolved.f_type_as_value) // NYI: ugly special case
           {
             rc = vc.asRef();
@@ -2207,7 +2207,7 @@ public class GeneratingFUIR extends FUIR
     Clazz innerClazz = null;
     var cf      = c.calledFeature();
     var callToOuterRef = c.target().isCallToOuterRef();
-    var dynamic = c.isDynamic() && (tclazz.isRef().yes() || callToOuterRef);
+    var dynamic = c.isDynamic() && (tclazz.isRef() || callToOuterRef);
     var needsCode = !dynamic || explicitTarget != null;
     var typePars = outerClazz.actualGenerics(c.actualTypeParameters());
     // NYI: HACK
@@ -2509,10 +2509,10 @@ public class GeneratingFUIR extends FUIR
     var e = getExpr(s);
     var res = switch (e)
       {
-      case AbstractAssign ass  -> id2clazz(accessTargetClazz(s)).isRef().yes();
-      case Clazz          arg  -> outerClazz.isRef().yes() && !arg.feature().isOuterRef(); // assignment to arg field in inherits call (dynamic if outerClazz is ref)
+      case AbstractAssign ass  -> id2clazz(accessTargetClazz(s)).isRef();
+      case Clazz          arg  -> outerClazz.isRef() && !arg.feature().isOuterRef(); // assignment to arg field in inherits call (dynamic if outerClazz is ref)
                                                                                     // or to outer ref field (not dynamic)
-      case AbstractCall   call -> id2clazz(accessTargetClazz(s)).isRef().yes();
+      case AbstractCall   call -> id2clazz(accessTargetClazz(s)).isRef();
       default                  -> { throw new Error("accessIsDynamic found unexpected Expr " + (e == null ? e : e.getClass()) + "."); }
       };
     return res;

--- a/src/dev/flang/lsp/shared/TypeTool.java
+++ b/src/dev/flang/lsp/shared/TypeTool.java
@@ -87,12 +87,12 @@ public class TypeTool extends ANY
 
     if (type.isGenericArgument())
       {
-        return baseName(type) + (type.isRef().yes() ? " (boxed)": "");
+        return baseName(type) + (type.isRef() ? " (boxed)": "");
       }
     else if (type.outer() != null)
       {
-        return (type.isRef().yes() && (type.feature() == null || !type.feature().isRef()) ? "ref "
-                    : !type.isRef().yes() && type.feature() != null && type.feature().isRef() ? "value "
+        return (type.isRef() && (type.feature() == null || !type.feature().isRef()) ? "ref "
+                    : !type.isRef() && type.feature() != null && type.feature().isRef() ? "value "
                     : "")
           + (type.feature() == null
                                           ? baseName(type)

--- a/src/dev/flang/util/FuzionConstants.java
+++ b/src/dev/flang/util/FuzionConstants.java
@@ -469,14 +469,6 @@ public class FuzionConstants extends ANY
 
 
   /**
-   * For a type, the value of the valRefOrThis byte:
-   */
-  public static final int MIR_FILE_TYPE_IS_VALUE = 0x00;
-  public static final int MIR_FILE_TYPE_IS_REF   = 0x01;
-  public static final int MIR_FILE_TYPE_IS_THIS  = 0x02;
-
-
-  /**
    * Fuzion module directory as used in module files instead of absolute or
    * relative path of module directory.
    */

--- a/tests/reg_issue3648/reg_issue3648.fz.expected_err
+++ b/tests/reg_issue3648/reg_issue3648.fz.expected_err
@@ -6,4 +6,16 @@ In call to 'reg_issue3648.b', no actual type parameters are given and inference 
 Expected type parameters: 'T'
 Type inference failed for one type parameter 'T'
 
-one error.
+
+--CURDIR--/reg_issue3648.fz:29:8: error 2: Incompatible types when passing argument in a call
+  say (type_as_value (Node i32))
+-------^^^^^^^^^^^^^
+Actual type for argument #1 's' does not match expected type.
+In call to          : 'say'
+expected formal type: 'Any'
+actual type found   : 'reg_issue3648.type.Node.type i32'
+assignable to       : 'reg_issue3648.type.Node.type i32'
+for value assigned  : '(type_as_value (Node i32))'
+To solve this, you could change the type of the target 's' to 'reg_issue3648.type.Node.type i32' or convert the type of the assigned value to 'Any'.
+
+2 errors.


### PR DESCRIPTION
`mode` of a type is one of `ThisType`, `RefType`, `ValueType`.
`AbstractType.mode` replaces the methods `isRef` and `isThisType`.
For an unresolved type ValueType is returned by mode().

