### PR TITLE
record_simple_example: read out/err in parallel

### DIFF
--- a/tests/record_simple_example.fz
+++ b/tests/record_simple_example.fz
@@ -52,16 +52,21 @@ record_process(p os.process,
       # the command, for error messages
       cmd String) process_result =>
   lm : mutate is
-  lm ! ()->
-    match p.with_out String lm (()->String.from_bytes (io.buffered lm).read_fully)
-      e error => panic "failed reading stdout from $cmd, error is: $e"
-      out String =>
-        match p.with_err String lm (()->String.from_bytes (io.buffered lm).read_fully)
-          e error => panic "failed reading stderr from $cmd, error is: $e"
-          err String =>
-            match p.wait
-              e error => panic "failed waiting for $cmd, error is: $e"
-              ec u32 => process_result out err ec
+  (concur.thread_pool 2 ()->
+      fout := concur.thread_pool.env.submit _ ()->
+        lm ! ()->
+          match p.with_out String lm (()->String.from_bytes (io.buffered lm).read_fully)
+            e error => panic "failed reading stdout from $cmd, error is: $e"
+            out String => out
+      ferr := concur.thread_pool.env.submit _ ()->
+        lm ! ()->
+          match p.with_err String lm (()->String.from_bytes (io.buffered lm).read_fully)
+            e error => panic "failed reading stderr from $cmd, error is: $e"
+            err String => err
+      match p.wait
+        e error => panic "failed waiting for $cmd, error is: $e"
+        ec u32 => process_result fout.get ferr.get ec)
+    .get
 
 # execute this Sequence of process+args
 #


### PR DESCRIPTION
The problem was that the error output exceedes the OSs pipe buffer. But record_simple_example first read out fully then err, hence this recordings with large error outputs could never complete.

fixes #5310
