### PR TITLE
ast: fix require-condition when generic sizes don't match

### DIFF
--- a/modules/base/src/fuzion/jvm.fz
+++ b/modules/base/src/fuzion/jvm.fz
@@ -34,8 +34,6 @@ private:public jvm : effect is
   # short-hand to for jvm with no additional class path
   #
   public type.use(T type, code ()->T) T =>
-    # NYI: BUG: java.lang.Error: require-condition1 failed: AbstractType.java:875 "(Errors.any() || f.generics().sizeMatches(actualGenerics), Errors.any() || !isOpenGeneric() || genericArgument().formalGenerics() != f.generics());"
-    # fuzion.jvm.jvm "" code
     fuzion.jvm.use T "" code
 
 

--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -1451,10 +1451,6 @@ public class Call extends AbstractCall
       {
         result = Types.resolved.t_void; // a recursive call will not return and execute further
       }
-    else if (!genericSizesMatch())
-      {
-        result = Types.t_ERROR;
-      }
     else
       {
         _recursiveResolveType = true;
@@ -2658,6 +2654,10 @@ public class Call extends AbstractCall
                   {
                     r.run();
                   }
+              }
+            if (!genericSizesMatch())
+              {
+                setToErrorState();
               }
             inferFormalArgTypesFromActualArgs();
             setActualResultType(res, context);


### PR DESCRIPTION
fix is to check for matching generic sizes earlies in the resolveTypes phase.
