### PR TITLE
lib: remove envir.vars.get

### DIFF
--- a/modules/base/src/envir/vars.fz
+++ b/modules/base/src/envir/vars.fz
@@ -34,13 +34,6 @@ public vars (p Vars_Handler) : effect is
     p.get v
 
 
-  # If set, get the environment variable corresponding to v.
-  # Otherwise, return default
-  #
-  public get(v String, default String) String =>
-    (get v).or_else get.this.default
-
-
   # install default instance of vars
   #
   type.install_default =>

--- a/modules/base/src/internationalization/provide.fz
+++ b/modules/base/src/internationalization/provide.fz
@@ -45,7 +45,7 @@ public provide ref : effect is
     public type.install_default unit =>
 
         if !internationalization.provide.is_instated
-            l := envir.vars.get "LANG" ""
+            l := (envir.vars.get "LANG").get ""
 
             p internationalization.provide :=
                 if l.starts_with "de"


### PR DESCRIPTION
This reinvents the wheel a little, so proposing to remove this.
