### PR TITLE
lib: add means to compose effects more easily

### DIFF
--- a/modules/base/src/Functional.fz
+++ b/modules/base/src/Functional.fz
@@ -1,0 +1,52 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion standard library feature Functional
+#
+# -----------------------------------------------------------------------
+
+# NYI: UNDER DEVELOPMENT: name Functional might be misleading?
+#
+# a Functional is a special type of unary that takes
+# a Function R and produces a value R.
+#
+public Functional(R type) ref : Unary R (Function R) is
+
+
+  # infix variant of call
+  #
+  public infix ! (code ()->R) =>
+    call code
+
+
+  # NYI: UNDER DEVELOPMENT: name compose might be misleading?
+  #
+  # compose this Functional with another Functional
+  #
+  public compose(other Functional R) Functional R =>
+    ref : Functional R is
+      public redef call(code Function R) =>
+        Functional.this.call ()->
+          other.call code
+
+
+  # fluent interface for using multiple effects together
+  #
+  public and(E type: effect, e Lazy E) =>
+    compose (e.as_functional R)

--- a/modules/base/src/effect.fz
+++ b/modules/base/src/effect.fz
@@ -226,6 +226,25 @@ public effect is
     instate_self code
 
 
+  # fluent interface for using multiple effects together
+  #
+  public and(R type, E type : effect, e Lazy E) =>
+    as_functional R
+      .compose (e.as_functional R)
+
+
+  # this effect reinterpreted as a Functional
+  # which allows composition of effects
+  #
+  public as_functional(R type) Functional R =>
+
+    # NYI: BUG: does not work: Wrong number of arguments in lambda expression
+    # code -> instate_self code
+
+    ref : Functional R is
+      public redef call(code Function R) =>
+        instate_self code
+
 
   # infix variant of effect.instate
   #

--- a/modules/base/src/net/connection.fz
+++ b/modules/base/src/net/connection.fz
@@ -36,29 +36,40 @@ module:public connection(desc i32) is
   public with(T type, LM type : mutate, fn ()->T) T
   =>
 
+    reader =>
+      # helper feature to create a read handler
+      # for a given descriptor
+      #
+      read_handler : io.Read_Handler is
+        public redef read(count i32) choice (array u8) io.end_of_file error =>
+          match fuzion.sys.net.read desc count.as_i64
+            a array => a
+            e error => e
+      (io.buffered LM)
+        .reader read_handler 1024
 
-    # helper feature to create a read handler
-    # for a given descriptor
-    #
-    read_handler : io.Read_Handler is
-      public redef read(count i32) choice (array u8) io.end_of_file error =>
-        match fuzion.sys.net.read desc count.as_i64
-          a array => a
-          e error => e
+    writer =>
+
+      # helper feature to create a read handler
+      # for a given descriptor
+      #
+      write_handler : io.Write_Handler is
+        public redef write(data Sequence u8) outcome unit =>
+          fuzion.sys.net.write desc data.as_array
+
+      (io.buffered LM)
+        .writer write_handler 1024
+
+    channel_ =>
+      net
+        .channel desc
+
+    reader
+      .and T _ writer
+      .and channel_
+      .call fn
 
 
-    # helper feature to create a read handler
-    # for a given descriptor
-    #
-    write_handler : io.Write_Handler is
-      public redef write(data Sequence u8) outcome unit =>
-        fuzion.sys.net.write desc data.as_array
-
-
-    (io.buffered LM).reader read_handler 1024 ! ()->
-      (io.buffered LM).writer write_handler 1024 ! ()->
-        (net.channel desc) ! ()->
-          fn.call
 
 
   # this installs reader, writer and channel for the given connection


### PR DESCRIPTION
before:
```
   (io.buffered LM).reader read_handler 1024 ! ()->
      (io.buffered LM).writer write_handler 1024 ! ()->
        (net.channel desc) ! ()->
          fn.call
```
after:

```
((io.buffered LM).reader read_handler 1024)
  .and T _ (io.buffered LM).writer write_handler 1024)
  .and (net.channel desc)
  .call fn
```
