### PR TITLE
fe: allow partial application for empty block, fix #5352

### DIFF
--- a/src/dev/flang/ast/Block.java
+++ b/src/dev/flang/ast/Block.java
@@ -394,6 +394,23 @@ public class Block extends AbstractBlock
 
 
   /**
+   * @see Expr.propagateExpectedTypeForPartial
+   */
+  @Override
+  Expr propagateExpectedTypeForPartial(Resolution res, Context context, AbstractType expectedType)
+  {
+    var r = resultExpression();
+    return
+      r != null                        ? r.propagateExpectedTypeForPartial(res, context, expectedType) :
+      expectedType
+        .isFunctionTypeExcludingLazy() ? // r == null means we have an empty block. If assigned
+                                         // to a function, we try to partially apply this:
+                                         new Function(pos(), NO_EXPRS, this)
+                                       : this;
+  }
+
+
+  /**
    * check that each expression in this block
    * results in either unit or void.
    */

--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -1950,9 +1950,8 @@ public class Call extends AbstractCall
             var t = frml.resultTypeIfPresent(res);
             if (t != null && t.isFunctionTypeExcludingLazy())
               {
-                var a = resultExpression(actual);
-                Expr l = a.propagateExpectedTypeForPartial(res, context, t);
-                if (l != a)
+                Expr l = actual.propagateExpectedTypeForPartial(res, context, t);
+                if (l != actual)
                   {
                     if (CHECKS) check
                       (l != Universe.instance);

--- a/src/dev/flang/fuir/Clazz.java
+++ b/src/dev/flang/fuir/Clazz.java
@@ -944,13 +944,7 @@ class Clazz extends ANY implements Comparable<Clazz>
       }
 
     // first look in the feature itself
-    AbstractFeature result = _fuir._mainModule.lookupFeature(feature(), fn, f);
-
-    if (!result.redefinesFull().contains(f) && result != f)
-      {
-        // feature with same name, but not a redefinition
-        result = null;
-      }
+    AbstractFeature result =_fuir._mainModule.lookupFeature(feature(), fn, f);
 
     // the inherited feature might not be
     // visible to the inheriting feature

--- a/tests/reg_issue5352/Makefile
+++ b/tests/reg_issue5352/Makefile
@@ -1,0 +1,25 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test Makefile
+#
+# -----------------------------------------------------------------------
+
+override NAME = reg_issue5352
+include ../simple.mk

--- a/tests/reg_issue5352/reg_issue5352.fz
+++ b/tests/reg_issue5352/reg_issue5352.fz
@@ -1,0 +1,42 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test reg_issue5352
+#
+# -----------------------------------------------------------------------
+
+# partial application of an empty (or effectively empty) block
+#
+reg_issue5352 =>
+
+  # a feature expecting a Nullary that produces unit type
+  q(f ()->unit) =>
+    say "in q, calling f"
+    f()
+    say "in q, called f"
+
+  # original test from #5352: since the field `_` is unused, it will be removed
+  # creating an empty block
+  q ({_:=1})
+
+  # same thing, but using an empty block right way
+  q ({})
+
+  # same thing, but using an empty block right way
+  q ({_ := ignore (say "this should run")})

--- a/tests/reg_issue5352/reg_issue5352.fz
+++ b/tests/reg_issue5352/reg_issue5352.fz
@@ -38,5 +38,5 @@ reg_issue5352 =>
   # same thing, but using an empty block right way
   q ({})
 
-  # same thing, but using an empty block right way
+  # using a non-empty block with a side effect
   q ({_ := ignore (say "this should run")})

--- a/tests/reg_issue5352/reg_issue5352.fz.expected_out
+++ b/tests/reg_issue5352/reg_issue5352.fz.expected_out
@@ -1,0 +1,7 @@
+in q, calling f
+in q, called f
+in q, calling f
+in q, called f
+in q, calling f
+this should run
+in q, called f


### PR DESCRIPTION
An empty or effectively empty block may now be assigned to a nullary lambda expression that produces a unit type result like `()->unit`.

Also added a test using the examples form #5352 and one more.

The test reveiled one more bug in the feature lookup code that could be solved by deleting code in `Clazz.findRedefinition`.
