### PR TITLE
fix windows build

### DIFF
--- a/include/win.c
+++ b/include/win.c
@@ -156,7 +156,7 @@ int fzE_dir_read(intptr_t * dir, int8_t * result) {
     assert (sizeNeeded != 0);
     assert(sizeNeeded >= 0 && sizeNeeded<1024); // NYI:
 
-    int len = WideCharToMultiByte(CP_UTF8, 0, d->findData.cFileName, -1, result, sizeNeeded, NULL, NULL) - 1;
+    int len = WideCharToMultiByte(CP_UTF8, 0, d->findData.cFileName, -1, (void *)result, sizeNeeded, NULL, NULL) - 1;
 
     return len == 0
       ? -1


### PR DESCRIPTION
```
./build/include/win.c:159:74: error: passing 'int8_t *' (aka 'signed char *') to parameter of type 'LPSTR' (aka 'char *') converts between pointers to integer types where one is of the unique plain 'char' type and the other is not [-Werror,-Wpointer-sign]
  159 |     int len = WideCharToMultiByte(CP_UTF8, 0, d->findData.cFileName, -1, result, sizeNeeded, NULL, NULL) - 1;
      |                                                                          ^~~~~~
D:/a/_temp/msys64/ucrt64/include/stringapiset.h:42:121: note: passing argument to parameter 'lpMultiByteStr' here
   42 |   WINBASEAPI int WINAPI WideCharToMultiByte (UINT CodePage, DWORD dwFlags, LPCWCH lpWideCharStr, int cchWideChar, LPSTR lpMultiByteStr, int cbMultiByte, LPCCH lpDefaultChar, LPBOOL lpUsedDefaultChar);
      |             
```