### PR TITLE
lib: fix precondition of `container.ordered_map`

### DIFF
--- a/modules/base/src/container/ordered_map.fz
+++ b/modules/base/src/container/ordered_map.fz
@@ -38,7 +38,7 @@ public ordered_map(
            k0 Sequence OK,
            v0 Sequence V) : container.Map OK V
 pre
-  k0.count = v0.count
+  debug: k0.count = v0.count
   debug: k0.unique.count = k0.count
 is
 

--- a/modules/base/src/container/ordered_map.fz
+++ b/modules/base/src/container/ordered_map.fz
@@ -39,6 +39,7 @@ public ordered_map(
            v0 Sequence V) : container.Map OK V
 pre
   k0.count = v0.count
+  debug: k0.unique.count = k0.count
 is
 
   ks := k0.as_array


### PR DESCRIPTION
Without this it was possible to create a map, that when printed would show
`(1 => one), (2 => two), (3 => drei), (3 => three), (4 => four), (5 => five)
`
