### PR TITLE
base: rename `handle0`/`handle2_0` as `handle_id`/`handle2_id`

### DIFF
--- a/modules/base/src/handles.fz
+++ b/modules/base/src/handles.fz
@@ -27,11 +27,11 @@
 # cells.
 #
 # handles is a state monad.  It provides features to create several
-# handles that refer to modifiable value and features to 'get', 'put' or
-# 'update' this value.
+# handles that refer to modifiable value and features to `get`, `put` or
+# `update` this value.
 #
 # an example of using handles is shown below, handle (singular) is an
-# alias to initialize a new handle with the given initial value. handle0 T
+# alias to initialize a new handle with the given initial value. `handle_id T`
 # is the type that allows passing around handles.
 #
 #     ex_handles is
@@ -39,7 +39,7 @@
 #
 #       say hdl.get
 #
-#       x(h handle0 i32) unit =>
+#       x(h handle_id i32) unit =>
 #         b := hdl.put 17
 #         say b
 #         say hdl.get
@@ -78,7 +78,7 @@ is
 
   # create a new instance with one additional handle
   #
-  # the new handle can be accessed by 'result.last'
+  # the new handle can be accessed by `result.last`
   #
   public new (
     # initial value referred to by the new handle
@@ -91,18 +91,18 @@ is
     handles v na mode.next
 
 
-  # has one element been created using 'new'?
+  # has one element been created using `new`?
   #
   public has_last bool => count > 0
 
 
-  # return the last handle that was created by 'new'
+  # return the last handle that was created by `new`
   #
-  public last handle0 T
+  public last handle_id T
     pre
       debug: has_last
   =>
-    handle0 T count-1
+    handle_id T count-1
 
 
   # a one-way feature to create a new handle and update the monad
@@ -112,7 +112,7 @@ is
   public create (
     # initial value referred to by the new handle
     w T
-    ) handle0 T
+    ) handle_id T
   =>
     (new w).last
 
@@ -120,8 +120,8 @@ is
   # get the value referred to by a given handle
   #
   public get (
-    # a handle created by 'new'
-    h handle0 T
+    # a handle created by `new`
+    h handle_id T
     ) T
   =>
     ar[h.x]
@@ -130,10 +130,10 @@ is
   # create a new instance with new value referred to by a given handle
   #
   public put (
-    # a handle created by 'new'
-    h handle0 T,
+    # a handle created by `new`
+    h handle_id T,
 
-    # the new value to be stored with 'h'
+    # the new value to be stored with `h`
     w T) handles T X
   =>
     handles v (ar.put h.x w) mode.next
@@ -143,8 +143,8 @@ is
   # updated.
   #
   public update (
-    # a handle created by 'new'
-    h handle0 T,
+    # a handle created by `new`
+    h handle_id T,
 
     # function calculating the new value from the old value
     f T->T
@@ -157,7 +157,7 @@ is
   # updated.
   #
   update0 (
-    # a handle created by 'new'
+    # a handle created by `new`
     x i32,
 
     # function calculating the new value from the old value
@@ -194,9 +194,9 @@ public handles(T type) handles T unit =>
 # type of the reference to the cell that holds a value of type T which can be updated
 # using the handles interface
 #
-private:public handle0(
+private:public handle_id(
   T type,
-  # the index in 'handles.ar'
+  # the index in `handles.ar`
   x i32
   )
 is
@@ -232,4 +232,4 @@ handles_type(T type) is
 #
 # this uses the handles instance from the current environment
 #
-public handle(T type, v T) handle0 T => (handles T).create v
+public handle(T type, v T) handle_id T => (handles T).create v

--- a/modules/base/src/handles2.fz
+++ b/modules/base/src/handles2.fz
@@ -27,11 +27,11 @@
 # cells.
 #
 # handles is a state monad.  It provides features to create several
-# handles that refer to modifiable value and features to 'get', 'put' or
-# 'update' this value.
+# handles that refer to modifiable value and features to `get`, `put` or
+# `update` this value.
 #
 # For performance, this implementation uses mutable state. It can consequently
-# only be used as a one-way monad.
+# only be used as an effect (oneway_monad).
 #
 private:public handles2(
   T, X type,
@@ -39,7 +39,7 @@ private:public handles2(
   # the inner value of this monad
   public v X,
 
-  last_opt option (handle2_0 T),
+  last_opt option (handle2_id T),
 
   # `plain` monad or effect to be `inst`alled or `repl`aced by new value?
   mode oneway_monad_mode.val
@@ -48,7 +48,7 @@ is
 
   # create a new instance with one additional handle
   #
-  # the new handle can be accessed by 'result.last'
+  # the new handle can be accessed by `result.last`
   #
   public new (
     # initial value referred to by the new handle
@@ -57,17 +57,17 @@ is
   post
     debug: result.has_last
   =>
-    handles2 v (handle2_0 w) mode.next
+    handles2 v (handle2_id w) mode.next
 
 
-  # has one element been created using 'new'?
+  # has one element been created using `new`?
   #
   public has_last bool => last_opt??
 
 
-  # return the last handle that was created by 'new'
+  # return the last handle that was created by `new`
   #
-  public last handle2_0 T
+  public last handle2_id T
     pre
       debug: has_last
   =>
@@ -81,7 +81,7 @@ is
   public create (
     # initial value referred to by the new handle
     w T
-    ) handle2_0 T
+    ) handle2_id T
   =>
     (new w).last
 
@@ -89,8 +89,8 @@ is
   # get the value referred to by a given handle
   #
   public get (
-    # a handle created by 'new'
-    h handle2_0 T
+    # a handle created by `new`
+    h handle2_id T
     ) T
   =>
     h.get
@@ -99,10 +99,10 @@ is
   # create a new instance with new value referred to by a given handle
   #
   public put (
-    # a handle created by 'new'
-    h handle2_0 T,
+    # a handle created by `new`
+    h handle2_id T,
 
-    # the new value to be stored with 'h'
+    # the new value to be stored with `h`
     w T) handles2 T X
   =>
     h.put w
@@ -113,8 +113,8 @@ is
   # updated.
   #
   public update (
-    # a handle created by 'new'
-    h handle2_0 T,
+    # a handle created by `new`
+    h handle2_id T,
 
     # function calculating the new value from the old value
     f T->T
@@ -148,9 +148,9 @@ handles2(T type) =>
   (handles2 T unit).env
 
 
-# handle value created by 'handles2.new'
+# handle value created by `handles2.new`
 #
-private:public handle2_0(
+private:public handle2_id(
   T type,
 
   # get value stored in this handle
@@ -184,4 +184,4 @@ handles2_type(T type) is
 
 # create a new handle2 using the handles2 instance from the current environment
 #
-public handle2(T type, v T) handle2_0 T => (handles2 T).create v
+public handle2(T type, v T) handle2_id T => (handles2 T).create v


### PR DESCRIPTION
This is IMHO less confusing.

I also fixed some comments by replacing "'" with "`" to be more like markdown and replaced the term `oneway monad` be effect, we might want to drop `oneway monad` at some point altogether.
