### PR TITLE
docs: api: improve alignment in feature list 

### DIFF
--- a/assets/docs/style.css
+++ b/assets/docs/style.css
@@ -61,6 +61,10 @@ Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
   margin-right: .5em;
 }
 
+.ml-2{
+  margin-left: .2em;
+}
+
 .container{
   padding: 15px;
 }
@@ -136,8 +140,9 @@ Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
 }
 
 .fd-anchor-sign{
-  color: rgba(0,0,0,0.6);
+  color: rgba(0,0,0,0.3);
   opacity: 0;
+  margin-left: .3em;
 }
 
 .fd summary:hover .fd-anchor-sign{

--- a/assets/docs/style.css
+++ b/assets/docs/style.css
@@ -65,6 +65,10 @@ Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
   margin-left: .2em;
 }
 
+.ml-10{
+  margin-left: 1em;
+}
+
 .container{
   padding: 15px;
 }

--- a/src/dev/flang/tools/docs/Html.java
+++ b/src/dev/flang/tools/docs/Html.java
@@ -250,7 +250,7 @@ public class Html extends ANY
       {
         String anchorParent = "<a class='' href='" + featureAbsoluteURL(af.outer()) + "'>"
                               + htmlEncodedBasename(af.outer()) + "</a>";
-        return "&nbsp;&nbsp;<div class='fd-parent'>[Inherited from&nbsp; <span class=fz-code>$0</span>]</div>"
+        return "<div class='fd-parent ml-10'>[Inherited from&nbsp; <span class=fz-code>$0</span>]</div>"
           .replace("$0", anchorParent);
       }
   }
@@ -286,7 +286,7 @@ public class Html extends ANY
 
     return redefs.isEmpty()
             ? ""
-            : "&nbsp;&nbsp;<div class='fd-parent'>[Redefinition of&nbsp; <span class=fz-code>$0</span>]</div>"
+            : "<div class='fd-parent ml-10'>[Redefinition of&nbsp; <span class=fz-code>$0</span>]</div>"
               .replace("$0", (redefs.stream()
                                     .map(f->"<a class='' href='" + featureAbsoluteURL(f) + "'>" +
                                               htmlEncodedQualifiedName(f) + "</a>")
@@ -302,7 +302,7 @@ public class Html extends ANY
   private String annotateAbstract(AbstractFeature af)
   {
     return af.isAbstract()
-             ? "&nbsp;&nbsp;<div class='fd-parent' title='An abstract feature is a feature declared using ⇒ abstract. " +
+             ? "<div class='fd-parent ml-10' title='An abstract feature is a feature declared using ⇒ abstract. " +
                "To be able to call it, it needs to be implemented (redefined) in an heir.'>[Abstract feature]</div>"
              : "";
   }
@@ -316,7 +316,7 @@ public class Html extends ANY
   private String annotatePrivateConstructor(AbstractFeature af)
   {
     return af.visibility().eraseTypeVisibility() != Visi.PUB && af.isConstructor()
-             ? "&nbsp;<div class='fd-parent' title='This feature can not be called to construct a new instance of itself, " +
+             ? "<div class='fd-parent ml-10' title='This feature can not be called to construct a new instance of itself, " +
                "only the type it defines is visible.'>[Private constructor]</div>" // NYI: replace title attribute with proper tooltip
              : "";
   }
@@ -333,7 +333,7 @@ public class Html extends ANY
     lm.forEachDeclaredOrInheritedFeature(af, f -> allInner.add(f));
 
     return allInner.stream().filter(f->isVisible(f)).anyMatch(f->f.isAbstract())
-             ? "&nbsp;&nbsp;<div class='fd-parent' title='This feature contains inner or inherited features " +
+             ? "<div class='fd-parent ml-10' title='This feature contains inner or inherited features " +
                "which are abstract.'>[Contains abstract features]</div>"
              : "";
   }
@@ -349,7 +349,7 @@ public class Html extends ANY
     var afModule = libModule(af);
 
     // don't add annotation for features of own module
-    return afModule == lm ? "" : "&nbsp;<div class='fd-parent'>[Module " + afModule.name() + "]</div>";
+    return afModule == lm ? "" : "<div class='fd-parent ml-10'>[Module " + afModule.name() + "]</div>";
   }
 
   private boolean isVisible(AbstractFeature af)

--- a/src/dev/flang/tools/docs/Html.java
+++ b/src/dev/flang/tools/docs/Html.java
@@ -210,7 +210,6 @@ public class Html extends ANY
     return
       "<div class='d-grid' style='grid-template-columns: 1fr min-content;'>"
         + "<div class='d-flex flex-wrap word-break-break-word'>"
-          + "<a class='fd-anchor-sign mr-2' href='#" + htmlID(af) + "'>§</a>"
           + "<div class='d-flex flex-wrap word-break-break-word fz-code'>"
             + anchor(af)
             + arguments(af)
@@ -226,6 +225,7 @@ public class Html extends ANY
             + annotateContainsAbstract(af)
             + annotatePrivateConstructor(af)
             + annotateModule(af)
+            + "<a class='fd-anchor-sign mr-2' href='#" + htmlID(af) + "'>¶</a>"
             // fills remaining space
             + "<div class='flex-grow-1'></div>"
           + "</div>"
@@ -361,7 +361,7 @@ public class Html extends ANY
 
 
   private String anchor(AbstractFeature af) {
-    return "<div class='font-weight-600'>"
+    return "<div class='font-weight-600 ml-2'>"
             + (noFeatureLink(af) ? "" : "<a class='fd-feature' href='" + featureAbsoluteURL(af) + "'>")
             + typePrfx(af) + htmlEncodedBasename(af)
             + (noFeatureLink(af) ? "" : "</a>")


### PR DESCRIPTION
Avoids strange line breaks, when content does not fit in horizontal space.
Use pilcrow (¶) to generate anchor links.

Changes this
![apidocs_old](https://github.com/user-attachments/assets/71ccb691-005b-4f22-80b1-3051364ca724)
into this
![apidocs_new](https://github.com/user-attachments/assets/32b1dccd-da46-458b-ab11-3bb1795f62b8)

