### PR TITLE
docs: require leading blank line for code blocks in comments

### DIFF
--- a/src/dev/flang/tools/docs/Html.java
+++ b/src/dev/flang/tools/docs/Html.java
@@ -585,15 +585,23 @@ public class Html extends ANY
     var codeLines = new ArrayList<String>();
     var resultLines = new ArrayList<String>();
 
-    s.lines().forEach(l ->
+
+    String prevLine = "not empty";
+    boolean inCodeblock = false;
+
+    for (var l : s.lines().collect(Collectors.toList()))
       {
-        if (l.startsWith("    "))
+        if (l.startsWith("    ") && (prevLine.isBlank() || inCodeblock))
           {
+            inCodeblock = true;
+
             /* code comment */
             codeLines.add(l);
           }
         else if (l.isBlank())
           {
+            inCodeblock = false;
+
             /* avoid adding lots of line breaks after code comments */
             if (codeLines.isEmpty())
               {
@@ -602,6 +610,8 @@ public class Html extends ANY
           }
         else
           {
+            inCodeblock = false;
+
             addCodeLines(name, codeNo, codeLines, resultLines);
 
             /* treat as normal line */
@@ -609,7 +619,8 @@ public class Html extends ANY
 
             resultLines.add(replacedLine);
           }
-      });
+        prevLine = l;
+      }
 
     addCodeLines(name, codeNo, codeLines, resultLines);
 


### PR DESCRIPTION
[skip ci]

This avoids that comments that use indentation for readability get treated as code, e.g.
```
# Note: this is a very long comment, so it contains a line break
#       and uses indentation for readablility
```
