### PR TITLE
lib: fix indentation of code examples in comments

### DIFF
--- a/examples/webserver/webserver_native.fz
+++ b/examples/webserver/webserver_native.fz
@@ -26,13 +26,13 @@
 #
 # To start this webserver, use:
 #
-#   fz webserver_native.fz
+#     fz webserver_native.fz
 #
 # Alternatively, compile it using the C backend and run the resulting
 # executable:
 #
-#   fz -c webserver_native.fz
-#   ./webserver
+#     fz -c webserver_native.fz
+#     ./webserver
 #
 webserver_native is
 

--- a/modules/base/src/Function.fz
+++ b/modules/base/src/Function.fz
@@ -37,14 +37,14 @@ public Function(public R type,
 
 # NYI: would be nice to have schönfinkeling defined here, could work like this:
 #
-#  curry(x A.0) Function(R, A.1...) is
-#    curried Function(R, A1...) is
-#      call(a A1...) is Function.this.call x a...
-#    curried
+#     curry(x A.0) Function(R, A.1...) is
+#       curried Function(R, A1...) is
+#         call(a A1...) is Function.this.call x a...
+#       curried
 #
 # --or, with different syntax sugar--
 #
-#  curry(x A.0) R->A.1... is x,a... -> call x a...
+#     curry(x A.0) R->A.1... is x,a... -> call x a...
 #
 # where A.1... is the tail of type argument A (might be empty), and A.0 is the first element,
 # void (or unit?) if it does not exist.

--- a/modules/base/src/Sequence.fz
+++ b/modules/base/src/Sequence.fz
@@ -153,10 +153,10 @@ public Sequence(public T type) ref : property.countable is
   #
   # example:
   #
-  # [1,2,3,4,5]
-  #   .filter is_prime
-  #   .peek say
-  #   .drop_while <10
+  #     [1,2,3,4,5]
+  #       .filter is_prime
+  #       .peek say
+  #       .drop_while <10
   #
   public peek (f T -> unit) Sequence T =>
     map x->
@@ -374,17 +374,17 @@ public Sequence(public T type) ref : property.countable is
   #
   # This is an infix operator alias of map enabling piping code like
   #
-  #   l := 1..10 | *10 | 300-
+  #     l := 1..10 | *10 | 300-
   #
   # to obtain 290,280,270,...200
   #
   # Note that map and therefore also this operator is lazy, so
   #
-  #   _ := (1..10 | say)
+  #     _ := (1..10 | say)
   #
   # will not print anything while
   #
-  #   (1..10 | say).for_each _->unit
+  #     (1..10 | say).for_each _->unit
   #
   # will print the elements since `for_each` is not lazy.
   #
@@ -407,7 +407,7 @@ public Sequence(public T type) ref : property.countable is
   #
   # ex. to obtain a Sequence of differences, you may use `map_pairs (-)`:
   #
-  #   [2,3,5,7,11,13,17,19,23,29].map_pairs a,b->b-a
+  #     [2,3,5,7,11,13,17,19,23,29].map_pairs a,b->b-a
   #
   # results in `[1,2,2,4,2,4,2,4,6]`
   #
@@ -565,16 +565,16 @@ public Sequence(public T type) ref : property.countable is
   # elements all combinations of elements of this Sequence and
   # all elements of 'b' iterating of 'b' repeatedly as follows
   #
-  #   Sequence.this[0]  , b[0]
-  #   Sequence.this[0]  , b[1]
-  #   Sequence.this[0]  , b[2]
-  #   Sequence.this[0]  , ...
-  #   Sequence.this[0]  , b.last
-  #   Sequence.this[1]  , b[0]
-  #   Sequence.this[1]  , b[1]
-  #   Sequence.this[1]  , ...
-  #   ...               , ...
-  #   Sequence.this.last, b.last
+  #     Sequence.this[0]  , b[0]
+  #     Sequence.this[0]  , b[1]
+  #     Sequence.this[0]  , b[2]
+  #     Sequence.this[0]  , ...
+  #     Sequence.this[0]  , b.last
+  #     Sequence.this[1]  , b[0]
+  #     Sequence.this[1]  , b[1]
+  #     Sequence.this[1]  , ...
+  #     ...               , ...
+  #     Sequence.this.last, b.last
   #
   public combine(U, V type, b Sequence U, f (T,U)->V) Sequence V =>
     flat_map x->
@@ -585,16 +585,16 @@ public Sequence(public T type) ref : property.countable is
   # of this Sequence and all elements of 'b' iterating of 'b' repeatedly
   # as follows
   #
-  #   (Sequence.this[0]  , b[0]  )
-  #   (Sequence.this[0]  , b[1]  )
-  #   (Sequence.this[0]  , b[2]  )
-  #   (Sequence.this[0]  , ...   )
-  #   (Sequence.this[0]  , b.last)
-  #   (Sequence.this[1]  , b[0]  )
-  #   (Sequence.this[1]  , b[1]  )
-  #   (Sequence.this[1]  , ...   )
-  #   (...               , ...   )
-  #   (Sequence.this.last, b.last)
+  #     (Sequence.this[0]  , b[0]  )
+  #     (Sequence.this[0]  , b[1]  )
+  #     (Sequence.this[0]  , b[2]  )
+  #     (Sequence.this[0]  , ...   )
+  #     (Sequence.this[0]  , b.last)
+  #     (Sequence.this[1]  , b[0]  )
+  #     (Sequence.this[1]  , b[1]  )
+  #     (Sequence.this[1]  , ...   )
+  #     (...               , ...   )
+  #     (Sequence.this.last, b.last)
   #
   public pairs(U type, b Sequence U) Sequence ((T, U)) =>
     combine b tuple2
@@ -694,7 +694,7 @@ public Sequence(public T type) ref : property.countable is
   #
   # ex.
   #
-  #   [1,2,3,4,5].tuples produces [(1,2),(3,4)]
+  #     [1,2,3,4,5].tuples produces [(1,2),(3,4)]
   #
   public as_tuples Sequence (T, T)
   =>
@@ -712,7 +712,7 @@ public Sequence(public T type) ref : property.countable is
   #
   # ex.
   #
-  #   [1,2,3,4,5,6,7].tuples3 produces [(1,2,3),(4,5,6)]
+  #     [1,2,3,4,5,6,7].tuples3 produces [(1,2,3),(4,5,6)]
   #
   public as_3tuples Sequence (T, T, T)
   =>
@@ -730,7 +730,7 @@ public Sequence(public T type) ref : property.countable is
   #
   # ex.
   #
-  #   [1,2,3,4,5].tuples4 produces [(1,2,3,4)]
+  #     [1,2,3,4,5].tuples4 produces [(1,2,3,4)]
   #
   public as_4tuples Sequence (T, T, T, T)
   =>
@@ -748,7 +748,7 @@ public Sequence(public T type) ref : property.countable is
   #
   # ex.
   #
-  #   [1,2,3,4,5,6].tuples5 produces [(1,2,3,4,5)]
+  #     [1,2,3,4,5,6].tuples5 produces [(1,2,3,4,5)]
   #
   public as_5tuples Sequence (T, T, T, T, T)
   =>
@@ -766,7 +766,7 @@ public Sequence(public T type) ref : property.countable is
   #
   # ex.
   #
-  #   [1,2,3,4,5,6,7].tuples6 produces [(1,2,3,4,5,6)]
+  #     [1,2,3,4,5,6,7].tuples6 produces [(1,2,3,4,5,6)]
   #
   public as_6tuples Sequence (T,T, T, T, T, T)
   =>
@@ -782,10 +782,10 @@ public Sequence(public T type) ref : property.countable is
   #
   # ex.
   #
-  #   [1,2,3,4,5].as_tuple  produces (1,2)
-  #   [1,2].as_tuple        produces (1,2)
-  #   [1].as_tuple          breaks the pre condition
-  #   [].as_tuple           breaks the pre condition
+  #     [1,2,3,4,5].as_tuple  produces (1,2)
+  #     [1,2].as_tuple        produces (1,2)
+  #     [1].as_tuple          breaks the pre condition
+  #     [].as_tuple           breaks the pre condition
   #
   public as_tuple() (T, T)
     pre
@@ -803,11 +803,11 @@ public Sequence(public T type) ref : property.countable is
   #
   # ex.
   #
-  #   [1,2,3,4,5].as_3tuple  produces (1,2,3)
-  #   [1,2,3].as_3tuple      produces (1,2,3)
-  #   [1,2].as_3tuple        breaks the pre condition
-  #   [1].as_3tuple          breaks the pre condition
-  #   [].as_3tuple           breaks the pre condition
+  #     [1,2,3,4,5].as_3tuple  produces (1,2,3)
+  #     [1,2,3].as_3tuple      produces (1,2,3)
+  #     [1,2].as_3tuple        breaks the pre condition
+  #     [1].as_3tuple          breaks the pre condition
+  #     [].as_3tuple           breaks the pre condition
   #
   public as_3tuple() (T, T, T)
     pre
@@ -829,12 +829,12 @@ public Sequence(public T type) ref : property.countable is
   #
   # ex.
   #
-  #   [1,2,3,4,5].as_4tuple  produces (1,2,3,4)
-  #   [1,2,3,4].as_4tuple    produces (1,2,3,4)
-  #   [1,2,3].as_4tuple      breaks the pre condition
-  #   [1,2].as_4tuple        breaks the pre condition
-  #   [1].as_4tuple          breaks the pre condition
-  #   [].as_4tuple           breaks the pre condition
+  #     [1,2,3,4,5].as_4tuple  produces (1,2,3,4)
+  #     [1,2,3,4].as_4tuple    produces (1,2,3,4)
+  #     [1,2,3].as_4tuple      breaks the pre condition
+  #     [1,2].as_4tuple        breaks the pre condition
+  #     [1].as_4tuple          breaks the pre condition
+  #     [].as_4tuple           breaks the pre condition
   #
   public as_4tuple() (T, T, T, T)
     pre
@@ -859,12 +859,12 @@ public Sequence(public T type) ref : property.countable is
   #
   # ex.
   #
-  #   [1,2,3,4,5,6].as_5tuple  produces (1,2,3,4,5)
-  #   [1,2,3,4,5].as_5tuple    produces (1,2,3,4,5)
-  #   [1,2,3,4].as_5tuple      breaks the pre condition
-  #   [1,2,3].as_5tuple        breaks the pre condition
-  #    ...
-  #   [].as_5tuple             breaks the pre condition
+  #     [1,2,3,4,5,6].as_5tuple  produces (1,2,3,4,5)
+  #     [1,2,3,4,5].as_5tuple    produces (1,2,3,4,5)
+  #     [1,2,3,4].as_5tuple      breaks the pre condition
+  #     [1,2,3].as_5tuple        breaks the pre condition
+  #      ...
+  #     [].as_5tuple             breaks the pre condition
   #
   public as_5tuple() (T, T, T, T, T)
     pre
@@ -892,12 +892,12 @@ public Sequence(public T type) ref : property.countable is
   #
   # ex.
   #
-  #   [1,2,3,4,5,6,7].as_6tuple  produces (1,2,3,4,5,6)
-  #   [1,2,3,4,5,6].as_6tuple    produces (1,2,3,4,5,6)
-  #   [1,2,3,4,5].as_6tuple      breaks the pre condition
-  #   [1,2,3,4].as_6tuple        breaks the pre condition
-  #    ...
-  #   [].as_6tuple               breaks the pre condition
+  #     [1,2,3,4,5,6,7].as_6tuple  produces (1,2,3,4,5,6)
+  #     [1,2,3,4,5,6].as_6tuple    produces (1,2,3,4,5,6)
+  #     [1,2,3,4,5].as_6tuple      breaks the pre condition
+  #     [1,2,3,4].as_6tuple        breaks the pre condition
+  #      ...
+  #     [].as_6tuple               breaks the pre condition
   #
   public as_6tuple() (T, T, T, T, T, T)
     pre
@@ -1120,7 +1120,8 @@ public Sequence(public T type) ref : property.countable is
   # Keep the order of elements unchanged.
   #
   # ex.
-  #   [1,2,2,3,2,2,2,4].dedup = [1,2,3,2,4]
+  #
+  #     [1,2,2,3,2,2,2,4].dedup = [1,2,3,2,4]
   #
   public dedup Sequence T
     pre
@@ -1135,8 +1136,9 @@ public Sequence(public T type) ref : property.countable is
   # Keep the order of elements unchanged.
   #
   # ex.
-  #   [4,2,2,6,2,1,2,4].dedup (a,b -> a%2=b%2) = [4,1,2]
-  #   [4,2,2,6,2,1,2,4].dedup (<=) = [4,2,1]
+  #
+  #     [4,2,2,6,2,1,2,4].dedup (a,b -> a%2=b%2) = [4,1,2]
+  #     [4,2,2,6,2,1,2,4].dedup (<=) = [4,2,1]
   #
   public dedup(by (T,T) -> bool) Sequence T
     pre
@@ -1153,7 +1155,8 @@ public Sequence(public T type) ref : property.countable is
   # or `nub` (Haskell).
   #
   # ex.
-  #   [4,1,2,2,3,2,2,2,4].unique = [4, 1, 2, 3]
+  #
+  #     [4,1,2,2,3,2,2,2,4].unique = [4, 1, 2, 3]
   #
   public unique Sequence T
     pre
@@ -1299,11 +1302,11 @@ public Sequence(public T type) ref : property.countable is
   #
   # example: count occurrences of letters, numbers and other characters
   #
-  #    values array codepoint := ["A", "1", "b", "?", "X", "4"]
+  #     values array codepoint := ["A", "1", "b", "?", "X", "4"]
   #
-  #    classify (c codepoint) String => c.is_ascii_letter ? "letter" : c.is_ascii_digit ? "digit" : "other"
+  #     classify (c codepoint) String => c.is_ascii_letter ? "letter" : c.is_ascii_digit ? "digit" : "other"
   #
-  #    values.group_map_reduce String i32 classify (_->1) (+)
+  #     values.group_map_reduce String i32 classify (_->1) (+)
   #
   # => {(digit => 2), (letter => 3), (other => 1)}
   #
@@ -1444,8 +1447,8 @@ public Sequence(public T type) ref : property.countable is
   #
   # This allows summing the elements of a list, as in
   #
-  #   l := [1,2,3]
-  #   say <| l.sum     # '6'
+  #     l := [1,2,3]
+  #     say <| l.sum     # '6'
   #
   #
   public sum T
@@ -1458,8 +1461,8 @@ public Sequence(public T type) ref : property.countable is
   #
   # This allows multiplying the elements of a list, as in
   #
-  #   l := [1,2,3]
-  #   say <| l.product     # '6'
+  #     l := [1,2,3]
+  #     say <| l.product     # '6'
   #
   #
   public product T

--- a/modules/base/src/Type.fz
+++ b/modules/base/src/Type.fz
@@ -69,31 +69,31 @@ module:public Type ref is
   # The result of this is a compile-time constant that can be used to specialize
   # code for a particular type.
   #
-  #   is_of_integer_type(n T : numeric) => T : integer
-  #   say (is_of_integer_type 1234)    # true
-  #   say (is_of_integer_type 3.14)    # false
+  #     is_of_integer_type(n T : numeric) => T : integer
+  #     say (is_of_integer_type 1234)    # true
+  #     say (is_of_integer_type 3.14)    # false
   #
   # it is most useful in conjunction preconditions or `if` statements as in
   #
-  #   pair(a,b T) is
-  #     same
-  #       pre T : property.equatable
-  #   =>
-  #     a = b
+  #     pair(a,b T) is
+  #       same
+  #         pre T : property.equatable
+  #     =>
+  #       a = b
   #
   # or
   #
-  #   val(n T) is
+  #     val(n T) is
   #
-  #     # check if T is numeric, if so
-  #     # return true if n > zero,
-  #     # return nil if T is not numeric
-  #     #
-  #     more_than_zero option bool =>
-  #       if T : numeric then
-  #         n > T.zero
-  #       else
-  #         nil
+  #       # check if T is numeric, if so
+  #       # return true if n > zero,
+  #       # return nil if T is not numeric
+  #       #
+  #       more_than_zero option bool =>
+  #         if T : numeric then
+  #           n > T.zero
+  #         else
+  #           nil
   #
   public infix : (T type) bool =>
 
@@ -138,7 +138,7 @@ public type_as_value(T type) Type => T
 #
 # examples:
 #
-#   `type_of "bla"` is `String`
-#   `type_of (panic "***")` will terminate
+#     `type_of "bla"` is `String`
+#     `type_of (panic "***")` will terminate
 #
 public type_of(T type, _ Lazy T) Type => T

--- a/modules/base/src/bool.fz
+++ b/modules/base/src/bool.fz
@@ -140,7 +140,7 @@ public bool : choice false_ true_, property.equatable, java_primitive is
 # Note that this value is of unit type >>false_<<, not of type >>bool<<, i.e.,
 # if it is used for type inference as in
 #
-#    my_boolean := false_
+#     my_boolean := false_
 #
 # you will get a variable of type >>false_<<, it will not be possible to assign
 # >>true_<< to it.  You can use >>false<< as an alternative to get type >>bool<<.
@@ -154,7 +154,7 @@ module:public false_ is
 # Note that this value is of unit type >>true_<<, not of type >>bool<<, i.e.,
 # if it is used for type inference as in
 #
-#    my_boolean := true_
+#     my_boolean := true_
 #
 # you will get a variable of type >>true_<<, it will not be possible to assign
 # >>false_<< to it.  You can use >>true<< as an alternative to get type >>bool<<.

--- a/modules/base/src/choice.fz
+++ b/modules/base/src/choice.fz
@@ -33,11 +33,11 @@
 # Syntactic sugar of the Fuzion language permits an alternative notation
 # for choice types with actual generics as follows
 #
-#   A | B | C | ...
+#     A | B | C | ...
 #
 # which is equivalent to
 #
-#   choice A B C ...
+#     choice A B C ...
 #
 # The parser will directly convert the first notation into a choice type
 # with actual generics.
@@ -51,7 +51,7 @@
 #
 # Named choice types can be constructed through inheritance, i.e.,
 #
-#   C : choice A B is {}
+#     C : choice A B is {}
 #
 # creates a choice type of A and B with the name C.  Two named choice types
 # D and E that inherit from choice with the same actual generic arguments in
@@ -73,32 +73,32 @@
 # in degrees centigrade or degrees Fahrenheit.  So we define two wrapper
 # features
 #
-#   centigrade(degrees i32) is {}
-#   fahrenheit(degrees i32) is {}
+#     centigrade(degrees i32) is {}
+#     fahrenheit(degrees i32) is {}
 #
 # Now we define the choice type using the wrapped i32 types, which are
 # distinct:
 #
-#   has_fever(temp centigrade | fahrenheit) bool is ...
+#     has_fever(temp centigrade | fahrenheit) bool is ...
 #
 # When passing arguments to this feature, we need to wrap them accordingly:
 #
-#   has_fever (centigrade 37)
-#   has_fever (fahrenheit 99)
+#     has_fever (centigrade 37)
+#     has_fever (fahrenheit 99)
 #
 # When matching the choice type, we use the wrapper types and access the
 # argument field 'degrees' to access the i32 stored inside
 #
-#   match temp
-#     c centigrade => say "it's " + c.degrees + "°C"
-#     f fahrenheit => say "it's " + f.degrees + "°F"
+#     match temp
+#       c centigrade => say "it's " + c.degrees + "°C"
+#       f fahrenheit => say "it's " + f.degrees + "°F"
 #
 # NYI: Once Fuzion's match expression supports destructuring as well, we should
 # be able to extract the degrees directly as in
 #
-#   match temp
-#     centigrade d => say "it's " + d + "°C"
-#     fahrenheit d => say "it's " + d + "°F"
+#     match temp
+#       centigrade d => say "it's " + d + "°C"
+#       fahrenheit d => say "it's " + d + "°F"
 #
 # A choice type with no actual generic arguments is isomorphic to 'void', i.e, it
 # is a type that has an empty set of possible values.

--- a/modules/base/src/composition.fz
+++ b/modules/base/src/composition.fz
@@ -243,10 +243,10 @@ public composition is
   #
   # this can be used as follows:
   #
-  #   f (Lazy i32)->i32 := x->3
-  #   say <| fix i32 f
+  #     f (Lazy i32)->i32 := x->3
+  #     say <| fix i32 f
   #
-  #   g (Lazy (list i32))->list i32 := x->3:x
-  #   say <| (fix (list i32) g).take 10
+  #     g (Lazy (list i32))->list i32 := x->3:x
+  #     say <| (fix (list i32) g).take 10
   #
   fix(A type, f Lazy ((Lazy A)->A)) => f.call (fix A f)

--- a/modules/base/src/container/Buffer.fz
+++ b/modules/base/src/container/Buffer.fz
@@ -55,8 +55,8 @@ is
   # a sequence of all valid indices to access this array. Useful e.g., for
   # `for`-loops:
   #
-  #   for i in arr.indices do
-  #     say arr[i]
+  #     for i in arr.indices do
+  #       say arr[i]
   #
   public indices interval i64 => (i64 0)..length-1
 

--- a/modules/base/src/container/abstract_array.fz
+++ b/modules/base/src/container/abstract_array.fz
@@ -77,8 +77,8 @@ public abstract_array
   # a sequence of all valid indices to access this array. Useful e.g., for
   # `for`-loops:
   #
-  #   for i in arr.indices do
-  #     say arr[i]
+  #     for i in arr.indices do
+  #       say arr[i]
   #
   public indices interval i32 => 0..length-1
 

--- a/modules/base/src/container/expanding_array.fz
+++ b/modules/base/src/container/expanding_array.fz
@@ -217,7 +217,7 @@ is
 
   # create an empty `expanding_array` of the type this is applied to, e.g.
   #
-  #   floats := (container.expanding_array f64).empty
+  #     floats := (container.expanding_array f64).empty
   #
   # Complexity: O(1)
   #
@@ -228,7 +228,7 @@ is
 
   # create an empty `expanding_array` of the type this is applied to, e.g.
   #
-  #   floats := (container.expanding_array f64).empty
+  #     floats := (container.expanding_array f64).empty
   #
   # Complexity: O(1)
   #

--- a/modules/base/src/container/sorted_array.fz
+++ b/modules/base/src/container/sorted_array.fz
@@ -48,9 +48,9 @@ public sorted_array
   #
   # must satisfy:
   #
-  #   for_all a,b: less_or_equal(a, b) <=> (a = b)
-  #   for_all a,b: less_or_equal(a, b) || less_or_equal(b, a)
-  #   for_all a,b,c: (less_or_equal(a, b) && less_or_equal(b, c)): less_or_equal(a, c)
+  #     for_all a,b: less_or_equal(a, b) <=> (a = b)
+  #     for_all a,b: less_or_equal(a, b) || less_or_equal(b, a)
+  #     for_all a,b,c: (less_or_equal(a, b) && less_or_equal(b, c)): less_or_equal(a, c)
   #
   less_or_equal (T, T) -> bool
 

--- a/modules/base/src/eff/fallible.fz
+++ b/modules/base/src/eff/fallible.fz
@@ -54,14 +54,14 @@ public fallible(ERROR type, h ERROR->void) : effect is
   #
   # This enables Java-like try-catch syntax as follows
   #
-  #   res := FALLIBLE_TYPE.try ()->
-  #             code
-  #          .catch s->
-  #             handle failure `s`
+  #     res := FALLIBLE_TYPE.try ()->
+  #               code
+  #            .catch s->
+  #               handle failure `s`
   #
   # or even
   #
-  #   res := FALLIBLE_TYPE.try code || (s->handle failure `s`)
+  #     res := FALLIBLE_TYPE.try code || (s->handle failure `s`)
   #
   # Note that the code is not executed unless `.catch` or `infix ||` is applied
   # to the result of the call to `try`.

--- a/modules/base/src/eff/try.fz
+++ b/modules/base/src/eff/try.fz
@@ -27,14 +27,14 @@
 #
 # This feature allows Java-like try-catch syntax for fallible
 #
-#   res := try ERROR_TYPE FALLIBLE_TYPE RESULT_TYPE ()->
-#             code
-#          .catch s->
-#             handle failure condition `s`
+#     res := try ERROR_TYPE FALLIBLE_TYPE RESULT_TYPE ()->
+#               code
+#            .catch s->
+#               handle failure condition `s`
 #
 # or even
 #
-#   res := try ERROR_TYPE FALLIBLE_TYPE RESULT_TYPE code || (s->handle post condition failure `s`)
+#     res := try ERROR_TYPE FALLIBLE_TYPE RESULT_TYPE code || (s->handle post condition failure `s`)
 #
 public try(ERROR type, F type : fallible ERROR, T type, code_try ()->T) is
 

--- a/modules/base/src/equals.fz
+++ b/modules/base/src/equals.fz
@@ -48,9 +48,9 @@ public infix !=(T type : property.equatable, a, b T) bool => !equals a b
 #
 # This should usually be called using type inference as in
 #
-#   my_set := set_of ["A","B","C"]
-#   say <| "B" ∈ my_set
-#   say <| "D" ∈ my_set
+#     my_set := set_of ["A","B","C"]
+#     say <| "B" ∈ my_set
+#     say <| "D" ∈ my_set
 #
 public infix ∈ (T type : property.equatable,
                 a T,
@@ -63,9 +63,9 @@ public infix ∈ (T type : property.equatable,
 #
 # This should usually be called using type inference as in
 #
-#   my_set := set_of ["A","B","C"]
-#   say <| "B" ∉ my_set
-#   say <| "D" ∉ my_set
+#     my_set := set_of ["A","B","C"]
+#     say <| "B" ∉ my_set
+#     say <| "D" ∉ my_set
 #
 public infix ∉ (T type : property.equatable,
                 a T,

--- a/modules/base/src/i128.fz
+++ b/modules/base/src/i128.fz
@@ -126,8 +126,9 @@ public i128(public hi i64, public lo u64) : num.wrap_around, has_interval is
 
   # arithmetic (signed) right shift
   # examples:
-  #   10..0 >> 127 = 1..1
-  #   10..0 >> 128 = 10..0
+  #
+  #     10..0 >> 127 = 1..1
+  #     10..0 >> 128 = 10..0
   #
   public fixed redef infix >> (other i128) i128 =>
     n := other.as_u64

--- a/modules/base/src/id.fz
+++ b/modules/base/src/id.fz
@@ -40,17 +40,16 @@ public id(T type, x T) T => x
 # create a Function instance, e.g. you can use any of these to produce the same
 # result
 #
-#   all_true(s Sequence bool) => s ∀ id
-#   all_true(s Sequence bool) => s ∀ (x -> id bool x)
-#   all_true(s Sequence bool) => s ∀ (x -> id x)
-#   all_true(s Sequence bool) => s ∀ (identity bool)
+#     all_true(s Sequence bool) => s ∀ id
+#     all_true(s Sequence bool) => s ∀ (x -> id bool x)
+#     all_true(s Sequence bool) => s ∀ (x -> id x)
+#     all_true(s Sequence bool) => s ∀ (identity bool)
 #
 # or, using an intermediate field,
 #
-#   all_true(s Sequence bool) => { f (bool)->bool := id;               s ∀ f }
-#   all_true(s Sequence bool) => { f (bool)->bool := (x -> id bool x); s ∀ f }
-#   all_true(s Sequence bool) => { f (bool)->bool := (x -> id x);      s ∀ f }
-#   all_true(s Sequence bool) => { f (bool)->bool := identity bool;    s ∀ f }
+#     all_true(s Sequence bool) => { f (bool)->bool := id;               s ∀ f }
+#     all_true(s Sequence bool) => { f (bool)->bool := (x -> id bool x); s ∀ f }
+#     all_true(s Sequence bool) => { f (bool)->bool := (x -> id x);      s ∀ f }
+#     all_true(s Sequence bool) => { f (bool)->bool := identity bool;    s ∀ f }
 #
 public identity(T type) T->T => id
-

--- a/modules/base/src/ignore.fz
+++ b/modules/base/src/ignore.fz
@@ -31,20 +31,20 @@
 #
 # Ex. with these features
 #
-#   hello is
-#     say "Hello!"
+#     hello is
+#       say "Hello!"
 #
-#   say_and_inc(x i32) i32 =>
-#     say x
-#     x+1
+#     say_and_inc(x i32) i32 =>
+#       say x
+#       x+1
 #
 # the results can be ignored as follows
 #
-#   hello |> ignore
-#   (say_and_inc 42) |> ignore
-#   ignore hello
-#   ignore (say_and_inc 42)
-#   _ := hello
-#   _ := say_and_inc 42
+#     hello |> ignore
+#     (say_and_inc 42) |> ignore
+#     ignore hello
+#     ignore (say_and_inc 42)
+#     _ := hello
+#     _ := say_and_inc 42
 #
 public ignore(T type, x T) unit =>

--- a/modules/base/src/interval.fz
+++ b/modules/base/src/interval.fz
@@ -136,9 +136,9 @@ public has_interval : integer is
   #
   # special cases of interval a..b:
   #
-  #   a <  b: the interval from a to b, both inclusive
-  #   a == b: the interval containing only one element, a
-  #   a >  b: an empty interval
+  #     a <  b: the interval from a to b, both inclusive
+  #     a == b: the interval containing only one element, a
+  #     a >  b: an empty interval
   public infix .. (through has_interval.this) interval has_interval.this =>
     interval has_interval.this through has_interval.this.one
 

--- a/modules/base/src/io/file/open.fz
+++ b/modules/base/src/io/file/open.fz
@@ -49,9 +49,10 @@ module:public open(fd File_Descriptor,
   # note: offset+size must not exceed size of file
   #
   # example usage:
-  # _ := io.file.use unit "/some_file" io.file.mode.append ()->
-  #   io.file.open.mmap (i64 0) (i64 100) ()->
-  #     io.file.open.mmap[99] := 42
+  #
+  #     _ := io.file.use unit "/some_file" io.file.mode.append ()->
+  #       io.file.open.mmap (i64 0) (i64 100) ()->
+  #         io.file.open.mmap[99] := 42
   #
   public mmap(R type, offset i64, size i64, code ()->R) outcome R
   pre safety: offset % 4096 = 0 # NYI: UNDER DEVELOPMENT: get real page size instead of 4096.

--- a/modules/base/src/io/stdin.fz
+++ b/modules/base/src/io/stdin.fz
@@ -29,20 +29,20 @@
 #
 # usage example using a local mutate instance:
 #
-#  LM : mutate is
-#  LM ! ()->
-#    io.stdin.reader LM ! ()->
-#      for l := (io.buffered LM).read_line
-#          i in 1..
-#      while l??
-#        say "$i: $l"
+#     LM : mutate is
+#     LM ! ()->
+#       io.stdin.reader LM ! ()->
+#         for l := (io.buffered LM).read_line
+#             i in 1..
+#         while l??
+#           say "$i: $l"
 #
 # usage example using read_lines:
 #
-# for l in io.stdin.read_lines
-#     i in 1..
-# do
-#   say "$i: $l"
+#     for l in io.stdin.read_lines
+#         i in 1..
+#     do
+#       say "$i: $l"
 #
 # NYI: UNDER DEVELOPMENT: It would be good to move features reader, read_fully,
 # etc. to a parent feature and have other features, e.g., for reading files, inherit

--- a/modules/base/src/list.fz
+++ b/modules/base/src/list.fz
@@ -577,16 +577,16 @@ public list(public A type) : choice nil (Cons A (list A)), Sequence A is
   # elements all combinations of elements of this list and
   # all elements of 'b' iterating of 'b' repeatedly as follows
   #
-  #   list.this[0]  , b[0]
-  #   list.this[0]  , b[1]
-  #   list.this[0]  , b[2]
-  #   list.this[0]  , ...
-  #   list.this[0]  , b.last
-  #   list.this[1]  , b[0]
-  #   list.this[1]  , b[1]
-  #   list.this[1]  , ...
-  #   ...           , ...
-  #   list.this.last, b.last
+  #     list.this[0]  , b[0]
+  #     list.this[0]  , b[1]
+  #     list.this[0]  , b[2]
+  #     list.this[0]  , ...
+  #     list.this[0]  , b.last
+  #     list.this[1]  , b[0]
+  #     list.this[1]  , b[1]
+  #     list.this[1]  , ...
+  #     ...           , ...
+  #     list.this.last, b.last
   #
   public combine_list(U, V type, b Sequence U, f (A,U)->V)  Sequence V =>
     flat_map x->(b.map y->(f x y))
@@ -597,7 +597,8 @@ public list(public A type) : choice nil (Cons A (list A)), Sequence A is
   # Keep the order of elements unchanged.
   #
   # ex.
-  #   [1,2,2,3,2,2,2,4].dedup_list = [1,2,3,2,4]
+  #
+  #     [1,2,2,3,2,2,2,4].dedup_list = [1,2,3,2,4]
   #
   public dedup_list list A
     pre
@@ -614,8 +615,9 @@ public list(public A type) : choice nil (Cons A (list A)), Sequence A is
   # Keep the order of elements unchanged.
   #
   # ex.
-  #   [4,2,2,6,2,1,2,4].dedup_list (a,b -> a%2=b%2) = [4,1,2]
-  #   [4,2,2,6,2,1,2,4].dedup_list (<=) = [4,2,1]
+  #
+  #     [4,2,2,6,2,1,2,4].dedup_list (a,b -> a%2=b%2) = [4,1,2]
+  #     [4,2,2,6,2,1,2,4].dedup_list (<=) = [4,2,1]
   #
   public dedup_list(by (A,A) -> bool) list A
     pre
@@ -633,7 +635,8 @@ public list(public A type) : choice nil (Cons A (list A)), Sequence A is
   # Other languages call this 'distinct', e.g. Java, C# or Kotlin
   #
   # ex.
-  #   [4,1,2,2,3,2,2,2,4].unique_list = [4, 1, 2, 3]
+  #
+  #     [4,1,2,2,3,2,2,2,4].unique_list = [4, 1, 2, 3]
   #
   public unique_list list A
     pre
@@ -711,16 +714,16 @@ public list(T type, h T, t Lazy (list T)) list T =>
 #
 # This is convenient to append an element before a list as in
 #
-#   0 : [1,2,3,4].as_list
+#     0 : [1,2,3,4].as_list
 #
 # or
 #
-#   0 : 1 : 2 : 3 : 4 : nil
+#     0 : 1 : 2 : 3 : 4 : nil
 #
 # or to create lists by recursion, e.g., an endless list containing
 # integer 1 repeatedly can be created as follows
 #
-#   ones => 1 : ones
+#     ones => 1 : ones
 #
 public infix_right : (A type, h A, t Lazy (list A)) list A=>
   list h t
@@ -733,19 +736,19 @@ public infix_right : (A type, h A, t Lazy (list A)) list A=>
 #
 # Ex1: the identity can be used to repeat the same element
 #
-#   1 :: x->x
+#     1 :: x->x
 #
 # will create 1,1,1,1,...
 #
 # Ex2: To create a list of all integers, use
 #
-#   0 :: +1
+#     0 :: +1
 #
 # which will produce 0,1,2,3,4,5,...
 #
 # Ex3: The call
 #
-#   1 :: p->p+p
+#     1 :: p->p+p
 #
 # will produce the powers of two: 1,2,4,8,16,32,...
 #

--- a/modules/base/src/mutate.fz
+++ b/modules/base/src/mutate.fz
@@ -28,28 +28,28 @@
 # This effect is typically used to work with mutable values. You can create
 # a mutable value as follows
 #
-#   v := mutate.env.new i32 42
+#     v := mutate.env.new i32 42
 #
 # and then modify it using
 #
-#   v <- 666
+#     v <- 666
 #
 # To read it, call 'get' as in
 #
-#   say "v is {v.get}"
+#     say "v is {v.get}"
 #
 # Convenience feature 'mut' and type inference allow the creation to be
 # written as
 #
-#   v := mut 42
+#     v := mut 42
 #
 # NYI: syntax sugar to read mutable field using
 #
-#   w := v + 1
+#     w := v + 1
 #
 # instead of
 #
-#   w := v.get + 1
+#     w := v.get + 1
 #
 # is not supported yet.
 #

--- a/modules/base/src/option.fz
+++ b/modules/base/src/option.fz
@@ -214,10 +214,10 @@ is
 #
 # Using this enables to write
 #
-#   o := option x
+#     o := option x
 #
 # instead of
 #
-#   o option TypeOfX := x
+#     o option TypeOfX := x
 #
 public option(T type, o option T) option T => o

--- a/modules/base/src/outcome.fz
+++ b/modules/base/src/outcome.fz
@@ -31,14 +31,14 @@
 # Several error conditions are needed if there are several very different
 # reasons for an operation to fail, e.g.
 #
-#   get_data (u User, t Type) outcome data IO_Error Permission_Error is
-#     if u.allowed_to_access T
-#       (read_file t.file_name)?
-#     else
-#       Permission_Error u, t
+#     get_data (u User, t Type) outcome data IO_Error Permission_Error is
+#       if u.allowed_to_access T
+#         (read_file t.file_name)?
+#       else
+#         Permission_Error u, t
 #
-#   read_file t Type outcome data IO_Error is
-#     [..]
+#     read_file t Type outcome data IO_Error is
+#       [..]
 #
 # Note that 'outcome data IO_Error' is not assignment compatible with
 # 'outcome data IO_Error Permission_Error', it has to be unwrapped first.
@@ -125,10 +125,10 @@ is
 #
 # Using this enables to write
 #
-#   o := outcome x
+#     o := outcome x
 #
 # instead of
 #
-#   o outcome TypeOfX := x
+#     o outcome TypeOfX := x
 #
 public outcome(T type, o outcome T) outcome T => o

--- a/modules/base/src/pipes.fz
+++ b/modules/base/src/pipes.fz
@@ -28,11 +28,11 @@
 #
 # This allows changing the order of function application: instead of
 #
-#   l := sum ([1,2,3,4].map **2)
+#     l := sum ([1,2,3,4].map **2)
 #
 # you can write
 #
-#   l := [1,2,3,4].map **2 |> sum
+#     l := [1,2,3,4].map **2 |> sum
 #
 # which often correponds more naturally to the data flow through the code.
 #
@@ -44,18 +44,18 @@ public infix |> (A, R type, a A, f A->R) R =>
 #
 # This allows changing the order of function application: instead of
 #
-#   f(a,b i32) => a+b
-#   l1 := [1,2,3,4]
-#   l2 := [4,3,2,1]
-#   l := l1.pairs l2
-#          .map p->{(p1,p2) := p; f p1 p2}
+#     f(a,b i32) => a+b
+#     l1 := [1,2,3,4]
+#     l2 := [4,3,2,1]
+#     l := l1.pairs l2
+#            .map p->{(p1,p2) := p; f p1 p2}
 #
 # you can write
 #
-#   l1 := [1,2,3,4]
-#   l2 := [4,3,2,1]
-#   l := l1.pairs l2
-#          .map (p -> p ||> f)
+#     l1 := [1,2,3,4]
+#     l2 := [4,3,2,1]
+#     l := l1.pairs l2
+#            .map (p -> p ||> f)
 #
 # which often corresponds more naturally to the data flow through the code.
 #
@@ -67,15 +67,15 @@ public infix ||> (A, B, R type, a (A,B), f (A,B)->R) R =>
 #
 # This allows changing the order of function application: instead of
 #
-#   f(a,b,c i32) => a+b+c
-#   t := (1,2,3)
-#   r := f t.0 t.1 t.2
+#     f(a,b,c i32) => a+b+c
+#     t := (1,2,3)
+#     r := f t.0 t.1 t.2
 #
 # you can write
 #
-#   f(a,b,c i32) => a+b+c
-#   t := (1,2,3)
-#   r := t |||> f
+#     f(a,b,c i32) => a+b+c
+#     t := (1,2,3)
+#     r := t |||> f
 #
 # which often correponds more naturally to the data flow through the code.
 #
@@ -87,15 +87,15 @@ public infix |||> (A, B, C, R type, a (A,B,C), f (A,B,C)->R) R =>
 #
 # This allows changing the order of function application: instead of
 #
-#   f(a,b,c,d i32) => a+b+c+d
-#   t := (1,2,3,4)
-#   r := f t.0 t.1 t.2 t.3
+#     f(a,b,c,d i32) => a+b+c+d
+#     t := (1,2,3,4)
+#     r := f t.0 t.1 t.2 t.3
 #
 # you can write
 #
-#   f(a,b,c,d i32) => a+b+c+d
-#   t := (1,2,3,4)
-#   r := t ||||> f
+#     f(a,b,c,d i32) => a+b+c+d
+#     t := (1,2,3,4)
+#     r := t ||||> f
 #
 # which often correponds more naturally to the data flow through the code.
 #
@@ -107,15 +107,15 @@ public infix ||||> (A, B, C, D, R type, a (A,B,C,D), f (A,B,C,D)->R) R =>
 #
 # This allows changing the order of function application: instead of
 #
-#   f(a,b,c,d,e i32) => a+b+c+d+e
-#   t := (1,2,3,4,5)
-#   r := f t.0 t.1 t.2 t.3 t.4
+#     f(a,b,c,d,e i32) => a+b+c+d+e
+#     t := (1,2,3,4,5)
+#     r := f t.0 t.1 t.2 t.3 t.4
 #
 # you can write
 #
-#   f(a,b,c,d,e i32) => a+b+c+d+e
-#   t := (1,2,3,4,5)
-#   r := t |||||> f
+#     f(a,b,c,d,e i32) => a+b+c+d+e
+#     t := (1,2,3,4,5)
+#     r := t |||||> f
 #
 # which often correponds more naturally to the data flow through the code.
 #
@@ -127,15 +127,15 @@ public infix |||||> (A, B, C, D, E, R type, a (A,B,C,D,E), f (A,B,C,D,E)->R) R =
 #
 # This allows changing the order of function application: instead of
 #
-#   f(a,b,c,d,e,f i32) => a+b+c+d+e+f
-#   t := (1,2,3,4,5,6)
-#   r := f t.0 t.1 t.2 t.3 t.4 t.5
+#     f(a,b,c,d,e,f i32) => a+b+c+d+e+f
+#     t := (1,2,3,4,5,6)
+#     r := f t.0 t.1 t.2 t.3 t.4 t.5
 #
 # you can write
 #
-#   f(a,b,c,d,e,f i32) => a+b+c+d+e+f
-#   t := (1,2,3,4,5,6)
-#   r := t ||||||> f
+#     f(a,b,c,d,e,f i32) => a+b+c+d+e+f
+#     t := (1,2,3,4,5,6)
+#     r := t ||||||> f
 #
 # which often correponds more naturally to the data flow through the code.
 #
@@ -151,11 +151,11 @@ public infix ||||||> (A, B, C, D, E, F, R type, a (A,B,C,D,E,F), f (A,B,C,D,E,F)
 # This operation is seldom useful, it is provided only for reasons of symmetry with |>.
 # Instead of
 #
-#   l := [1,2,3,4].map **2 |> sum
+#     l := [1,2,3,4].map **2 |> sum
 #
 # you can also write
 #
-#   l := sum <| [1,2,3,4].map **2
+#     l := sum <| [1,2,3,4].map **2
 #
 # which often correponds more naturally to the data flow through the code.
 #
@@ -167,18 +167,18 @@ public infix_right <| (A, R type, f A->R, a A) R =>
 #
 # This allows destructuring of tuples as actual arguments: instead of
 #
-#   f(a,b i32) => a+b
-#   l1 := [1,2,3,4]
-#   l2 := [4,3,2,1]
-#   l := l1.pairs l2
-#          .map p->{(p1,p2) := p; f p1 p2}
+#     f(a,b i32) => a+b
+#     l1 := [1,2,3,4]
+#     l2 := [4,3,2,1]
+#     l := l1.pairs l2
+#            .map p->{(p1,p2) := p; f p1 p2}
 #
 # you can write
 #
-#   l1 := [1,2,3,4]
-#   l2 := [4,3,2,1]
-#   l := l1.pairs l2
-#          .map (p -> f <|| p)
+#     l1 := [1,2,3,4]
+#     l2 := [4,3,2,1]
+#     l := l1.pairs l2
+#            .map (p -> f <|| p)
 #
 # .
 #
@@ -190,15 +190,15 @@ public infix_right <|| (A, B, R type, f (A,B)->R, a (A,B)) R =>
 #
 # This allows destructuring of 3-tuples as actual arguments: instead of
 #
-#   f(a,b,c i32) => a+b+c
-#   t := (1,2,3)
-#   r := f t.0 t.1 t.2
+#     f(a,b,c i32) => a+b+c
+#     t := (1,2,3)
+#     r := f t.0 t.1 t.2
 #
 # you can write
 #
-#   f(a,b,c i32) => a+b+c
-#   t := (1,2,3)
-#   r := f <||| t
+#     f(a,b,c i32) => a+b+c
+#     t := (1,2,3)
+#     r := f <||| t
 #
 # which often correponds more naturally to the data flow through the code.
 #
@@ -210,15 +210,15 @@ public infix_right <||| (A, B, C, R type, f (A,B,C)->R, a (A,B,C)) R =>
 #
 # This allows destructuring of 4-tuples as actual arguments: instead of
 #
-#   f(a,b,c,d i32) => a+b+c+d
-#   t := (1,2,3,4)
-#   r := f t.0 t.1 t.2 t.3
+#     f(a,b,c,d i32) => a+b+c+d
+#     t := (1,2,3,4)
+#     r := f t.0 t.1 t.2 t.3
 #
 # you can write
 #
-#   f(a,b,c,d i32) => a+b+c+d
-#   t := (1,2,3,4)
-#   r := f <|||| t
+#     f(a,b,c,d i32) => a+b+c+d
+#     t := (1,2,3,4)
+#     r := f <|||| t
 #
 # which often correponds more naturally to the data flow through the code.
 #
@@ -230,15 +230,15 @@ public infix_right <|||| (A, B, C, D, R type, f (A,B,C,D)->R, a (A,B,C,D)) R =>
 #
 # This allows destructuring of 5-tuples as actual arguments: instead of
 #
-#   f(a,b,c,d,e i32) => a+b+c+d+e
-#   t := (1,2,3,4,5)
-#   r := f t.0 t.1 t.2 t.3 t.4
+#     f(a,b,c,d,e i32) => a+b+c+d+e
+#     t := (1,2,3,4,5)
+#     r := f t.0 t.1 t.2 t.3 t.4
 #
 # you can write
 #
-#   f(a,b,c,d,e i32) => a+b+c+d+e
-#   t := (1,2,3,4,5)
-#   r := f <||||| t
+#     f(a,b,c,d,e i32) => a+b+c+d+e
+#     t := (1,2,3,4,5)
+#     r := f <||||| t
 #
 # which often correponds more naturally to the data flow through the code.
 #
@@ -250,17 +250,17 @@ public infix_right <||||| (A, B, C, D, E, R type, f (A,B,C,D,E)->R, a (A,B,C,D,E
 #
 # This allows destructuring of 6-tuples as actual arguments: instead of
 #
-#   f(a,b,c,d,e,f i32) => a+b+c+d+e+f
-#   t := (1,2,3,4,5,6)
-#   r := f t.0 t.1 t.2 t.3 t.4 t.5
+#     f(a,b,c,d,e,f i32) => a+b+c+d+e+f
+#     t := (1,2,3,4,5,6)
+#     r := f t.0 t.1 t.2 t.3 t.4 t.5
 #
 # you can write
 #
-#   f(a,b,c,d,e,f i32) => a+b+c+d+e+f
-#   t := (1,2,3,4,5,6)
-#   r := f <|||||| t
+#     f(a,b,c,d,e,f i32) => a+b+c+d+e+f
+#     t := (1,2,3,4,5,6)
+#     r := f <|||||| t
 #
-# which often correponds more naturally to the data flow through the code.
+# which often corresponds more naturally to the data flow through the code.
 #
 public infix_right <|||||| (A, B, C, D, E, F, R type, f (A,B,C,D,E,F)->R, a (A,B,C,D,E,F)) R =>
   a ||||||> f

--- a/modules/base/src/tuple.fz
+++ b/modules/base/src/tuple.fz
@@ -35,11 +35,11 @@
 # Syntactic sugar of the Fuzion language permits an alternative notation
 # to create values of tuple types as follows
 #
-#   t := (a, b, c, ... )
+#     t := (a, b, c, ... )
 #
 # is equivalent to
 #
-#   t := tuple a b c ...
+#     t := tuple a b c ...
 #
 # The actual generic types are inferred from the static types of the values
 # 'a', 'b', 'c', ... the tuple is created from.
@@ -47,7 +47,7 @@
 # Similarly, syntactic sugar for the destructuring of tuples can be used
 # to access the values as in
 #
-#   (a, b, c, ...) := t
+#     (a, b, c, ...) := t
 #
 # In destructurings, we can denote values we are not interested in using
 # '_' as in
@@ -59,40 +59,40 @@
 # As an example, say we want to identify a person by its name and its age,
 # so we can define
 #
-#   a := ("Alice" , 11)
-#   b := ("Bob"   , 22)
-#   c := ("Claire", 33)
+#     a := ("Alice" , 11)
+#     b := ("Bob"   , 22)
+#     c := ("Claire", 33)
 #
 # Then, we could extract Bob's age using
 #
-#   (_, age) := b
+#     (_, age) := b
 #
 # or Claire's name using
 #
-#   (name, _) := c
+#     (name, _) := c
 #
 # Destructuring also works for general features, e.g.
 #
-#   point (x,y i32) is {}
+#     point (x,y i32) is {}
 #
-#   p := point 3, 4
-#   (px, py) := p       # will set px to 3 and py to 4
+#     p := point 3, 4
+#     (px, py) := p       # will set px to 3 and py to 4
 #
 # and the destructured value can then be used to create a tuple
 #
-#   t := (px, py)       # will create tuple<i32,i32> instance
+#     t := (px, py)       # will create tuple<i32,i32> instance
 #
 # however, tuples are not assignment compatible with general features even
 # if they would destructure into the same types, i.e.,
 #
-#   u tuple i32 i32 = p  # will cause compile time error
-#   q point = (7, 12)      # will cause compile time error
+#     u tuple i32 i32 = p  # will cause compile time error
+#     q point = (7, 12)      # will cause compile time error
 #
 # The unit tuple '()' can be used as a short-hand to create the empty tuple
 # 'tuple'.  The empty tuple can be destructured like any other tuple
 # using
 #
-#   () := ()
+#     () := ()
 #
 # even though this has no effect.
 #
@@ -100,11 +100,11 @@
 # be created using syntactic sugar '(a)', this will produce the plain
 # value of 'a' instead. However, destructuring of a single tuple is possible:
 #
-#  (a0) := tuple a
+#    (a0) := tuple a
 #
 # which is equivalent to
 #
-#   a0 := a
+#     a0 := a
 #
 # NYI: A single tuple 'tuple A' is currently not assignment compatible with
 # type 'A', which would make handling of general tuples easier.
@@ -112,8 +112,8 @@
 # tuples and destructuring can be used to swap two elements or create a
 # permutation as in
 #
-#   (a, b) := (b, a)
-#   (o, t, a, n) := (n, a, t, o)
+#     (a, b) := (b, a)
+#     (o, t, a, n) := (n, a, t, o)
 #
 # A tuple type with no actual generic arguments is isomorphic to 'unit', i.e, it
 # is a type that has only one single value: '()'.

--- a/modules/base/src/unit.fz
+++ b/modules/base/src/unit.fz
@@ -31,20 +31,20 @@
 # a result value.  These are features that typically have an outside effect
 # such as
 #
-#   println(String s) unit => ...
+#     println(String s) unit => ...
 #
 # or features that change the state of an instance such as
 #
-#   increment(delta i64) unit =>
-#     set counter := counter + delta
+#     increment(delta i64) unit =>
+#       set counter := counter + delta
 #
 # The Fuzion language implementation automatically inserts code that returns the
 # unit value as a result of these features, there is no need for an explicit unit
 # result as in
 #
-#   increment(delta i64) unit =>
-#     set counter := counter + delta
-#     unit
+#     increment(delta i64) unit =>
+#       set counter := counter + delta
+#       unit
 #
 # but it is allowed to return unit explicitly if desired.
 #
@@ -67,13 +67,13 @@
 #
 # Please note the fundamental difference between
 #
-#   red is {}
-#   red => {}
+#     red is {}
+#     red => {}
 #
 # The first declares a feature red that defines a new unit type red, the second
 # declares a feature red with result type unit, i.e., a synonym for unit as in
 #
-#   red unit => {}
+#     red unit => {}
 #
 # The memory required to store a value of unit type is 0 bits, so you can use
 # plenty without worrying about space constraints.  The Fuzion code generators

--- a/modules/base/src/void.fz
+++ b/modules/base/src/void.fz
@@ -41,7 +41,7 @@
 #
 # void is the result type of the endless loop
 #
-#   do { <loop body> }
+#     do { <loop body> }
 #
 # If used as the result type of a field, the field can never be assigned a value,
 # since no such value can be produced, and the field can never be read since it
@@ -50,7 +50,7 @@
 # Type void is assignable to all other types, e.g, we can assign void to a value
 # of type i32:
 #
-#   i i32 := exit 1
+#     i i32 := exit 1
 #
 # Since no value of type void can ever be produced, the assignment is dead code that
 # will be removed by the fuzion implementation.
@@ -62,12 +62,12 @@
 # well).  An example could be a stack of capacity zero: stack void 0 with an
 # absurd
 #
-#   stack.push(void)
+#     stack.push(void)
 #
 # and a pop function with a precondition that is always false
 #
-#   pop void
-#     pre size > 0
+#     pop void
+#       pre size > 0
 #
 # The memory required to store a value of void type is not defined since these
 # values do not exist.  The Fuzion code generators typically will not generate


### PR DESCRIPTION
need to be indented by five spaces to be put in a code box on the website
