### PR TITLE
docs: limit annotation `[Contains abstract features]` to current or base module

### DIFF
--- a/src/dev/flang/tools/docs/Docs.java
+++ b/src/dev/flang/tools/docs/Docs.java
@@ -375,7 +375,7 @@ public class Docs extends ANY
     // generate documentation per module
     for (var module : all_modules)
     {
-        var htmlTool = new Html(config, mapOfDeclaredFeatures, universe, module, all_modules);
+        var htmlTool = new Html(config, mapOfDeclaredFeatures, universe, module, all_modules, fe);
 
         mapOfDeclaredFeatures
           .keySet()
@@ -405,7 +405,7 @@ public class Docs extends ANY
       // generate overview page of modules
       var path = config.destination();
       path.toFile().mkdirs();
-      var htmlTool = new Html(config, mapOfDeclaredFeatures, universe, all_modules.getFirst(), all_modules);
+      var htmlTool = new Html(config, mapOfDeclaredFeatures, universe, all_modules.getFirst(), all_modules, fe);
 
       var file = new File(path.toFile(), "index.html");
       try


### PR DESCRIPTION
Currently, every feature in the docs has the annotation because 0e9b57cdd9fc61488a7df03abc2e7cfd6d539a92 in module `json_encode` introduced an abstract feature in `Any`.

This will only show the annotation "[Contains abstract features]" if the abstract feature is in the same module (for which the docs are displayed) or in the base module. This way, [`String` in module `terminal`](https://fuzion-lang.dev/docs/terminal#String_0) will still have the annotation. But it will not work if a module depends on a module other than base.

I think there might be a bug in `Module.declaredOrInheritedFeatures()`, so that it wrongly includes features from other modules.
