### PR TITLE
docs: fix links of base module feature displayed in other modules

### DIFF
--- a/src/dev/flang/tools/docs/Html.java
+++ b/src/dev/flang/tools/docs/Html.java
@@ -362,7 +362,7 @@ public class Html extends ANY
 
   private String anchor(AbstractFeature af) {
     return "<div class='font-weight-600 ml-2'>"
-            + (noFeatureLink(af) ? "" : "<a class='fd-feature' href='" + featureAbsoluteURL(af) + "'>")
+            + (noFeatureLink(af) ? "" : "<a class='fd-feature' href='" + featureAbsoluteURL(af, lm) + "'>")
             + typePrfx(af) + htmlEncodedBasename(af)
             + (noFeatureLink(af) ? "" : "</a>")
             + "</div>";
@@ -779,6 +779,16 @@ public class Html extends ANY
   private String featureAbsoluteURL(AbstractFeature f)
   {
     return config.docsRoot() + "/" + libModule(f).name() + featureAbsoluteURL0(f) + "/";
+  }
+
+  /**
+   * the absolute URL of this feature in the given module
+   * @param module the module to which the link should point, e.g. for base module feature String there are different
+   *               pages in base (docs/base/String+(no+arguments)/) and terminal (docs/terminal/String+(no+arguments)/)
+   */
+  private String featureAbsoluteURL(AbstractFeature f, LibraryModule module)
+  {
+    return config.docsRoot() + "/" + module.name() + featureAbsoluteURL0(f) + "/";
   }
 
   private static String featureAbsoluteURL0(AbstractFeature f)


### PR DESCRIPTION
The link of [`String` in module `terminal`](https://fuzion-lang.dev/docs/terminal#String_0) incorrectly points to the [`base` module page of `String`](https://fuzion-lang.dev/docs/base/String+%28no+arguments%29/) but it should point to the [version in `terminal`](https://fuzion-lang.dev/docs/terminal/String+(no+arguments)/) that only lists the features that `terminal` adds to `String`.