### PR TITLE
doc: fix asciidoc code for Match entry in fum file

### DIFF
--- a/src/dev/flang/fe/LibraryModule.java
+++ b/src/dev/flang/fe/LibraryModule.java
@@ -2009,7 +2009,7 @@ Match
    |cond.     | repeat | type          | what
 
 .2+| true     | 1      | int           | number of cases
-   |          | n      | Case          | cases
+              | n      | Case          | cases
 |====
 
 --asciidoc--


### PR DESCRIPTION
The vertical span of `true` in this `Match` table is `2`, so we must not use the `|` in the next line. This results in the following bug, where the bottom row is shifted one cell to the right: 

![grafik](https://github.com/user-attachments/assets/fe7d4a82-f72d-4c4f-ae1d-9eb1f5dd2092)

Also, this produces an error during build (on MacOS/github): 

```
asciidoctor --attribute FZ_SRC=/Users/runner/work/fuzion/fuzion --attribute GENERATED=/Users/runner/work/fuzion/fuzion/build/generated --attribute FUZION_EBNF=/Users/runner/work/fuzion/fuzion/build/fuzion.ebnf --attribute UNICODE_SOURCE=https://www.unicode.org/Public/UCD/latest/ucd/UnicodeData.txt --out-file=build/doc/reference_manual/html/index.html ./doc/ref_manual/fuzion_reference_manual.adoc
asciidoctor: ERROR: ../../build/generated/doc/fum_file.adoc: line 247: dropping cells from incomplete row detected end of table
```


