### PR TITLE
fe: cleanup AbstractType.visit

### DIFF
--- a/src/dev/flang/ast/AbstractType.java
+++ b/src/dev/flang/ast/AbstractType.java
@@ -1240,9 +1240,17 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
   }
 
 
+  /**
+   * visit all the expressions within this feature.
+   *
+   * @param v the visitor instance that defines an action to be performed on
+   * visited objects.
+   *
+   * @param outerfeat the feature surrounding this expression.
+   */
   public AbstractType visit(FeatureVisitor v, AbstractFeature outerfeat)
   {
-    throw new Error("AbstractType.visit not implemented by "+getClass());
+    return v.action(this);
   }
 
 

--- a/src/dev/flang/ast/ResolvedNormalType.java
+++ b/src/dev/flang/ast/ResolvedNormalType.java
@@ -459,21 +459,6 @@ public class ResolvedNormalType extends ResolvedType
   }
 
 
-
-  /**
-   * visit all the expressions within this feature.
-   *
-   * @param v the visitor instance that defines an action to be performed on
-   * visited objects.
-   *
-   * @param outerfeat the feature surrounding this expression.
-   */
-  public AbstractType visit(FeatureVisitor v, AbstractFeature outerfeat)
-  {
-    return v.action(this);
-  }
-
-
   /**
    * For a resolved normal type, return the underlying feature.
    *

--- a/src/dev/flang/ast/ResolvedParametricType.java
+++ b/src/dev/flang/ast/ResolvedParametricType.java
@@ -96,20 +96,6 @@ public class ResolvedParametricType extends ResolvedType
 
 
   /**
-   * visit all the expressions within this feature.
-   *
-   * @param v the visitor instance that defines an action to be performed on
-   * visited objects.
-   *
-   * @param outerfeat the feature surrounding this expression.
-   */
-  public AbstractType visit(FeatureVisitor v, AbstractFeature outerfeat)
-  {
-    return v.action(this);
-  }
-
-
-  /**
    * For a resolved normal type, return the underlying feature.
    *
    * @return the underlying feature.

--- a/src/dev/flang/ast/UnresolvedType.java
+++ b/src/dev/flang/ast/UnresolvedType.java
@@ -491,19 +491,6 @@ public abstract class UnresolvedType extends AbstractType implements HasSourcePo
 
 
   /**
-   * visit all the expressions within this feature.
-   *
-   * @param v the visitor instance that defines an action to be performed on
-   * visited objects.
-   *
-   * @param outerfeat the feature surrounding this expression.
-   */
-  public AbstractType visit(FeatureVisitor v, AbstractFeature outerfeat)
-  {
-    return v.action(this);
-  }
-
-  /**
    * resolve this type, i.e., find or create the corresponding instance of
    * ResolvedType of this and all outer types and type arguments this depends on.
    *

--- a/src/dev/flang/fe/GenericType.java
+++ b/src/dev/flang/fe/GenericType.java
@@ -29,7 +29,6 @@ package dev.flang.fe;
 
 import dev.flang.ast.AbstractFeature;
 import dev.flang.ast.AbstractType;
-import dev.flang.ast.FeatureVisitor;
 import dev.flang.ast.Generic;
 import dev.flang.ast.TypeMode;
 import dev.flang.ast.UnresolvedType;
@@ -93,18 +92,6 @@ public class GenericType extends LibraryType
    * unresolved types, the source code position of its use.
    */
   public SourcePosition declarationPos() { return _generic.typeParameter().pos(); }
-
-
-  /**
-   * Dummy visit() for types.
-   *
-   * NYI: This is called during me.MiddleEnd.findUsedFeatures(). It should be
-   * replaced by a different mechanism not using FeatureVisitor.
-   */
-  public AbstractType visit(FeatureVisitor v, AbstractFeature outerfeat)
-  {
-    return this;
-  }
 
 
   /**

--- a/src/dev/flang/fe/LibraryType.java
+++ b/src/dev/flang/fe/LibraryType.java
@@ -29,6 +29,8 @@ package dev.flang.fe;
 import java.util.Set;
 
 import dev.flang.ast.AbstractFeature;
+import dev.flang.ast.AbstractType;
+import dev.flang.ast.FeatureVisitor;
 import dev.flang.ast.ResolvedType;
 
 
@@ -82,6 +84,16 @@ public abstract class LibraryType extends ResolvedType
   protected void usedFeatures(Set<AbstractFeature> s)
   {
     // a library type has already been checked. nothing to be done.
+  }
+
+
+  /**
+   * Dummy visit() for Library types.
+   */
+  @Override
+  public AbstractType visit(FeatureVisitor v, AbstractFeature outerfeat)
+  {
+    return this;
   }
 
 

--- a/src/dev/flang/fe/NormalType.java
+++ b/src/dev/flang/fe/NormalType.java
@@ -29,7 +29,6 @@ package dev.flang.fe;
 
 import dev.flang.ast.AbstractFeature;
 import dev.flang.ast.AbstractType;
-import dev.flang.ast.FeatureVisitor;
 import dev.flang.ast.Generic;
 import dev.flang.ast.TypeMode;
 
@@ -112,18 +111,6 @@ public class NormalType extends LibraryType
    * unresolved types, the source code position of its use.
    */
   public SourcePosition declarationPos() { return feature().pos(); }
-
-
-  /**
-   * Dummy visit() for types.
-   *
-   * NYI: This is called during me.MiddleEnd.findUsedFeatures(). It should be
-   * replaced by a different mechanism not using FeatureVisitor.
-   */
-  public AbstractType visit(FeatureVisitor v, AbstractFeature outerfeat)
-  {
-    return this;
-  }
 
 
   /**


### PR DESCRIPTION
removed all Type.visit implementation except for the one in AbstractType and LibraryType, LibraryType being a no-op.