### PR TITLE
ast: change AbstractType.toString for this-types

### DIFF
--- a/src/dev/flang/ast/AbstractType.java
+++ b/src/dev/flang/ast/AbstractType.java
@@ -2067,8 +2067,6 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
       }
     else
       {
-        var o = outer();
-        String outer = o != null && (o.isGenericArgument() || !o.feature().isUniverse()) ? o.toStringWrapped(humanReadable) + "." : "";
         var f = feature();
         var typeType = f.isCotype();
         if (typeType)
@@ -2094,7 +2092,7 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
               ".postcondition";
           }
 
-        result = outer
+        result = outerToString(humanReadable)
               + (!isThisType() && isRef() != feature().isRef() ? (isRef() ? "ref " : "value ") : "" )
               + fname;
         if (isThisType())
@@ -2119,6 +2117,20 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
           }
       }
     return result;
+  }
+
+
+  /**
+   * create String representation of the outer of this type
+   */
+  private String outerToString(boolean humanReadable)
+  {
+    var o = outer();
+    return isThisType()
+        ? (feature().outer().isUniverse() ? "" : feature().outer().qualifiedName() + ".")
+        : o != null && (o.isGenericArgument() || !o.feature().isUniverse())
+        ? o.toStringWrapped(humanReadable) + "."
+        : "";
   }
 
 

--- a/tests/call_with_ambiguous_result_type_negative/call.fz.expected_err
+++ b/tests/call_with_ambiguous_result_type_negative/call.fz.expected_err
@@ -4,9 +4,9 @@
 ---------^
 The result type of this call depends on the target type.  Since the target type is a 'ref' type that may represent a number of different actual dynamic types, the result type is not clearly defined.
 Called feature: 'call_with_ambiguous_result_type.r.g'
-Original result type: 'call_with_ambiguous_result_type.this.r.this.e'
-Type depending on target: 'call_with_ambiguous_result_type.this.r.this'
+Original result type: 'call_with_ambiguous_result_type.r.this.e'
+Type depending on target: 'call_with_ambiguous_result_type.r.this'
 Target type: 'call_with_ambiguous_result_type.this.r'
-To solve this, you could try to use a value type as the target type of the call or change the result type of 'call_with_ambiguous_result_type.r.g' to no longer depend on 'call_with_ambiguous_result_type.this.r.this'.
+To solve this, you could try to use a value type as the target type of the call or change the result type of 'call_with_ambiguous_result_type.r.g' to no longer depend on 'call_with_ambiguous_result_type.r.this'.
 
 one error.

--- a/tests/choice_negative/choice_negative.fz.expected_err
+++ b/tests/choice_negative/choice_negative.fz.expected_err
@@ -61,16 +61,16 @@ Target feature: 'choice_negative.instantiate2'
 In call: 'MyChoice'
 
 
---CURDIR--/choice_negative.fz:170:21: error 10: Ambiguous assignment to 'choice choice_negative.this.ambiguous_assignment_to_choice_via_subtype.this.A choice_negative.this.ambiguous_assignment_to_choice_via_subtype.this.B' from 'choice_negative.this.ambiguous_assignment_to_choice_via_subtype.this.C'
+--CURDIR--/choice_negative.fz:170:21: error 10: Ambiguous assignment to 'choice choice_negative.ambiguous_assignment_to_choice_via_subtype.this.A choice_negative.ambiguous_assignment_to_choice_via_subtype.this.B' from 'choice_negative.ambiguous_assignment_to_choice_via_subtype.this.C'
     _ choice A B := C  # 36. should flag an error, Ambiguous assignment to ...
 --------------------^
-'choice_negative.this.ambiguous_assignment_to_choice_via_subtype.this.C' is assignable to 'choice_negative.this.ambiguous_assignment_to_choice_via_subtype.this.A', 'choice_negative.this.ambiguous_assignment_to_choice_via_subtype.this.B'
+'choice_negative.ambiguous_assignment_to_choice_via_subtype.this.C' is assignable to 'choice_negative.ambiguous_assignment_to_choice_via_subtype.this.A', 'choice_negative.ambiguous_assignment_to_choice_via_subtype.this.B'
 
 
---CURDIR--/choice_negative.fz:171:21: error 11: Ambiguous assignment to 'choice choice_negative.this.ambiguous_assignment_to_choice_via_subtype.this.A choice_negative.this.ambiguous_assignment_to_choice_via_subtype.this.B' from 'choice_negative.this.ambiguous_assignment_to_choice_via_subtype.this.C'
+--CURDIR--/choice_negative.fz:171:21: error 11: Ambiguous assignment to 'choice choice_negative.ambiguous_assignment_to_choice_via_subtype.this.A choice_negative.ambiguous_assignment_to_choice_via_subtype.this.B' from 'choice_negative.ambiguous_assignment_to_choice_via_subtype.this.C'
     t choice A B => C  # 37. should flag an error, Ambiguous assignment to ...
 --------------------^
-'choice_negative.this.ambiguous_assignment_to_choice_via_subtype.this.C' is assignable to 'choice_negative.this.ambiguous_assignment_to_choice_via_subtype.this.A', 'choice_negative.this.ambiguous_assignment_to_choice_via_subtype.this.B'
+'choice_negative.ambiguous_assignment_to_choice_via_subtype.this.C' is assignable to 'choice_negative.ambiguous_assignment_to_choice_via_subtype.this.A', 'choice_negative.ambiguous_assignment_to_choice_via_subtype.this.B'
 
 
 --CURDIR--/choice_negative.fz:137:30: error 12: Could not find called feature
@@ -105,7 +105,7 @@ Matched type: 'i32', which is not a choice type
     A : choice A i32 String is       # 1. should flag an error: cyclic choice
 ----^
 Embedding a choice type in itself would result in an infinitely large type.
-Faulty type parameter: 'choice_negative.this.cyclic1.this.A'
+Faulty type parameter: 'choice_negative.cyclic1.this.A'
 
 
 --CURDIR--/choice_negative.fz:35:5: error 17: Choice feature must not be ref
@@ -118,7 +118,7 @@ A choice feature must be a value type since it is not constructed
     A : choice i32 A String is      # 2. should flag an error: cyclic choice
 ----^
 Embedding a choice type in itself would result in an infinitely large type.
-Faulty type parameter: 'choice_negative.this.cyclic3.this.A'
+Faulty type parameter: 'choice_negative.cyclic3.this.A'
 
 
 --CURDIR--/choice_negative.fz:41:5: error 19: Choice feature must not be ref
@@ -131,7 +131,7 @@ A choice feature must be a value type since it is not constructed
     A : choice i32 String A is      # 3. should flag an error: cyclic choice
 ----^
 Embedding a choice type in itself would result in an infinitely large type.
-Faulty type parameter: 'choice_negative.this.cyclic5.this.A'
+Faulty type parameter: 'choice_negative.cyclic5.this.A'
 
 
 --CURDIR--/choice_negative.fz:47:5: error 21: Choice feature must not be ref
@@ -236,16 +236,16 @@ The following types have overlapping values:
     _ choice R S := any  # 23. should flag an error: generic args to choice must be different
 ------^^^^^^
 The following types have overlapping values:
-'choice_negative.this.args5.this.R'
-'choice_negative.this.args5.this.S'
+'choice_negative.args5.this.R'
+'choice_negative.args5.this.S'
 
 
 --CURDIR--/choice_negative.fz:123:7: error 34: Actual type parameters to choice type must be disjoint types
     _ R | S := any  # 24. should flag an error: generic args to choice must be different
 ------^
 The following types have overlapping values:
-'choice_negative.this.args6.this.R'
-'choice_negative.this.args6.this.S'
+'choice_negative.args6.this.R'
+'choice_negative.args6.this.S'
 
 
 --CURDIR--/choice_negative.fz:126:5: error 35: Choice type must not access features of surrounding scope.

--- a/tests/generics_negative/generics_negative.fz.expected_err
+++ b/tests/generics_negative/generics_negative.fz.expected_err
@@ -402,28 +402,28 @@ Declared at {base.fum}/Function.fz:35:10:
     x2 (A i32 i32   ).B String bool := (A i64 bool).B String bool true  # 45. should flag an error: incompatible types
 ----^^
 assignment to field : 'generics_negative.outerGenerics.x2'
-expected formal type: '(generics_negative.this.outerGenerics.this.A i32 i32).B String bool'
-actual type found   : '(generics_negative.this.outerGenerics.this.A i64 bool).B String bool'
-assignable to       : '(generics_negative.this.outerGenerics.this.A i64 bool).B String bool'
+expected formal type: '(generics_negative.outerGenerics.this.A i32 i32).B String bool'
+actual type found   : '(generics_negative.outerGenerics.this.A i64 bool).B String bool'
+assignable to       : '(generics_negative.outerGenerics.this.A i64 bool).B String bool'
 for value assigned  : '(A i64 bool).B String bool true'
 To solve this you could:
-  • make  '(generics_negative.this.outerGenerics.this.A i32 i32).B String bool' a reference by adding the 'ref' keyword, so all its heirs can be used in place of it,
-  • change the type of the target 'generics_negative.outerGenerics.x2' to '(generics_negative.this.outerGenerics.this.A i64 bool).B String bool', or
-  • convert the type of the assigned value to '(generics_negative.this.outerGenerics.this.A i32 i32).B String bool'.
+  • make  '(generics_negative.outerGenerics.this.A i32 i32).B String bool' a reference by adding the 'ref' keyword, so all its heirs can be used in place of it,
+  • change the type of the target 'generics_negative.outerGenerics.x2' to '(generics_negative.outerGenerics.this.A i64 bool).B String bool', or
+  • convert the type of the assigned value to '(generics_negative.outerGenerics.this.A i32 i32).B String bool'.
 
 
 --CURDIR--/generics_negative.fz:160:5: error 43: Incompatible types in assignment
     x3 (A i32 String).B String bool := x1                               # 46. should flag an error: incompatible types
 ----^^
 assignment to field : 'generics_negative.outerGenerics.x3'
-expected formal type: '(generics_negative.this.outerGenerics.this.A i32 String).B String bool'
-actual type found   : '(generics_negative.this.outerGenerics.this.A i32 bool).B String bool'
-assignable to       : '(generics_negative.this.outerGenerics.this.A i32 bool).B String bool'
+expected formal type: '(generics_negative.outerGenerics.this.A i32 String).B String bool'
+actual type found   : '(generics_negative.outerGenerics.this.A i32 bool).B String bool'
+assignable to       : '(generics_negative.outerGenerics.this.A i32 bool).B String bool'
 for value assigned  : 'x1'
 To solve this you could:
-  • make  '(generics_negative.this.outerGenerics.this.A i32 String).B String bool' a reference by adding the 'ref' keyword, so all its heirs can be used in place of it,
-  • change the type of the target 'generics_negative.outerGenerics.x3' to '(generics_negative.this.outerGenerics.this.A i32 bool).B String bool', or
-  • convert the type of the assigned value to '(generics_negative.this.outerGenerics.this.A i32 String).B String bool'.
+  • make  '(generics_negative.outerGenerics.this.A i32 String).B String bool' a reference by adding the 'ref' keyword, so all its heirs can be used in place of it,
+  • change the type of the target 'generics_negative.outerGenerics.x3' to '(generics_negative.outerGenerics.this.A i32 bool).B String bool', or
+  • convert the type of the assigned value to '(generics_negative.outerGenerics.this.A i32 String).B String bool'.
 
 
 --CURDIR--/generics_negative.fz:176:9: error 44: Incompatible types when passing argument in a call

--- a/tests/reg_issue1004/reg_issue1004.fz.expected_err
+++ b/tests/reg_issue1004/reg_issue1004.fz.expected_err
@@ -1,5 +1,5 @@
 
---CURDIR--/reg_issue1004.fz:27:9: error 1: Illegal '.this' type: 'reg_issue1004.this.b.this'
+--CURDIR--/reg_issue1004.fz:27:9: error 1: Illegal '.this' type: 'reg_issue1004.b.this'
     say b.this.type
 --------^^^^^^^^^^^
 To solve this, either
@@ -8,7 +8,7 @@ or
   - change the type to a legal '.this' type.
 
 
---CURDIR--/reg_issue1004.fz:30:9: error 2: Illegal '.this' type: 'reg_issue1004.this.a.this'
+--CURDIR--/reg_issue1004.fz:30:9: error 2: Illegal '.this' type: 'reg_issue1004.a.this'
     say a.this.type
 --------^^^^^^^^^^^
 To solve this, either

--- a/tests/reg_issue1518/reg_issue1518.fz.expected_err
+++ b/tests/reg_issue1518/reg_issue1518.fz.expected_err
@@ -11,7 +11,7 @@ In call: 'a'
       redef b (f a.this -> unit) unit =>
 ---------------^
 In 'reg_issue1518.a.b' that redefines 'reg_issue1518.c.b'
-argument type is       : 'Unary unit reg_issue1518.this.a.this'
+argument type is       : 'Unary unit reg_issue1518.a.this'
 argument type should be: 'Unary unit reg_issue1518.this.a' (from 'Unary unit reg_issue1518.c.T')
 
 Original argument declared at --CURDIR--/reg_issue1518.fz:29:10:

--- a/tests/reg_issue3619/reg_issue3619.fz.expected_err
+++ b/tests/reg_issue3619/reg_issue3619.fz.expected_err
@@ -4,12 +4,12 @@
 -----------^
 The argument type of this call depends on the target type.  Since the target type is a 'ref' type that may represent a number of different actual dynamic types, the argument type is not clearly defined.
 Called feature: 'reg_issue3619.A.f'
-Original argument type: 'reg_issue3619.this.r reg_issue3619.this.A.this' declared at --CURDIR--/reg_issue3619.fz:35:9:
+Original argument type: 'reg_issue3619.this.r reg_issue3619.A.this' declared at --CURDIR--/reg_issue3619.fz:35:9:
     f(p r A.this) b => b
 --------^
-Type depending on target: 'reg_issue3619.this.A.this'
+Type depending on target: 'reg_issue3619.A.this'
 Target type: 'reg_issue3619.this.A'
-To solve this, you could try to use a value type as the target type of the call or change the argument type of 'reg_issue3619.A.f' to no longer depend on 'reg_issue3619.this.A.this'.
+To solve this, you could try to use a value type as the target type of the call or change the argument type of 'reg_issue3619.A.f' to no longer depend on 'reg_issue3619.A.this'.
 
 
 --CURDIR--/reg_issue3619.fz:64:10: error 2: Call has an ambiguous result type since target of the call is a 'ref' type.
@@ -17,9 +17,9 @@ To solve this, you could try to use a value type as the target type of the call 
 ---------^
 The result type of this call depends on the target type.  Since the target type is a 'ref' type that may represent a number of different actual dynamic types, the result type is not clearly defined.
 Called feature: 'reg_issue3619.r2.g'
-Original result type: 'reg_issue3619.this.r2.this.e'
-Type depending on target: 'reg_issue3619.this.r2.this'
+Original result type: 'reg_issue3619.r2.this.e'
+Type depending on target: 'reg_issue3619.r2.this'
 Target type: 'reg_issue3619.this.r2'
-To solve this, you could try to use a value type as the target type of the call or change the result type of 'reg_issue3619.r2.g' to no longer depend on 'reg_issue3619.this.r2.this'.
+To solve this, you could try to use a value type as the target type of the call or change the result type of 'reg_issue3619.r2.g' to no longer depend on 'reg_issue3619.r2.this'.
 
 2 errors.

--- a/tests/reg_issue4273/reg_issue4273.fz.expected_err
+++ b/tests/reg_issue4273/reg_issue4273.fz.expected_err
@@ -4,10 +4,10 @@
 -------------------------^^^^
 The result type of this call depends on the target type.  Since the target type is a 'ref' type that may represent a number of different actual dynamic types, the result type is not clearly defined.
 Called feature: 'case1.e.me'
-Original result type: 'case1.this.e.this'
-Type depending on target: 'case1.this.e.this'
-Target type: 'case1.this.p.this'
-To solve this, you could try to use a value type as the target type of the call, e,g., 'case1.e', or change the result type of 'case1.e.me' to no longer depend on 'case1.this.e.this'.
+Original result type: 'case1.e.this'
+Type depending on target: 'case1.e.this'
+Target type: 'case1.p.this'
+To solve this, you could try to use a value type as the target type of the call, e,g., 'case1.e', or change the result type of 'case1.e.me' to no longer depend on 'case1.e.this'.
 
 
 --CURDIR--/reg_issue4273.fz:65:26: error 2: Call has an ambiguous result type since target of the call is a 'ref' type.
@@ -15,10 +15,10 @@ To solve this, you could try to use a value type as the target type of the call,
 -------------------------^^^^
 The result type of this call depends on the target type.  Since the target type is a 'ref' type that may represent a number of different actual dynamic types, the result type is not clearly defined.
 Called feature: 'case3.e.me'
-Original result type: 'option case3.this.e.this'
-Type depending on target: 'case3.this.e.this'
-Target type: 'case3.this.p.this'
-To solve this, you could try to use a value type as the target type of the call, e,g., 'case3.e', or change the result type of 'case3.e.me' to no longer depend on 'case3.this.e.this'.
+Original result type: 'option case3.e.this'
+Type depending on target: 'case3.e.this'
+Target type: 'case3.p.this'
+To solve this, you could try to use a value type as the target type of the call, e,g., 'case3.e', or change the result type of 'case3.e.me' to no longer depend on 'case3.e.this'.
 
 
 --CURDIR--/reg_issue4273.fz:85:17: error 3: Call has an ambiguous result type since target of the call is a 'ref' type.
@@ -26,10 +26,10 @@ To solve this, you could try to use a value type as the target type of the call,
 ----------------^^
 The result type of this call depends on the target type.  Since the target type is a 'ref' type that may represent a number of different actual dynamic types, the result type is not clearly defined.
 Called feature: 'case4.e.me'
-Original result type: 'option case4.this.e.this'
-Type depending on target: 'case4.this.e.this'
-Target type: 'case4.this.p.this'
-To solve this, you could try to use a value type as the target type of the call, e,g., 'case4.e', or change the result type of 'case4.e.me' to no longer depend on 'case4.this.e.this'.
+Original result type: 'option case4.e.this'
+Type depending on target: 'case4.e.this'
+Target type: 'case4.p.this'
+To solve this, you could try to use a value type as the target type of the call, e,g., 'case4.e', or change the result type of 'case4.e.me' to no longer depend on 'case4.e.this'.
 
 
 --CURDIR--/reg_issue4273.fz:84:17: error 4: Call has an ambiguous result type since target of the call is a 'ref' type.
@@ -37,9 +37,9 @@ To solve this, you could try to use a value type as the target type of the call,
 ----------------^^^^^^^^^^^^^
 The result type of this call depends on the target type.  Since the target type is a 'ref' type that may represent a number of different actual dynamic types, the result type is not clearly defined.
 Called feature: 'option'
-Original result type: 'option case4.this.e.this'
-Type depending on target: 'case4.this.e.this'
-Target type: 'case4.this.p.this'
-To solve this, you could try to use a value type as the target type of the call, e,g., 'universe', or change the result type of 'option' to no longer depend on 'case4.this.e.this'.
+Original result type: 'option case4.e.this'
+Type depending on target: 'case4.e.this'
+Target type: 'case4.p.this'
+To solve this, you could try to use a value type as the target type of the call, e,g., 'universe', or change the result type of 'option' to no longer depend on 'case4.e.this'.
 
 4 errors.

--- a/tests/reg_issue776/reg_issue776.fz.expected_err
+++ b/tests/reg_issue776/reg_issue776.fz.expected_err
@@ -6,7 +6,7 @@ The result type of this call depends on the target type.  Since the target type 
 Called feature: 'String.mysubstring.anonymous'
 Original result type: 'String.this.mysubstring.anonymous'
 Type depending on target: 'String.this'
-Target type: 'String.this.mysubstring.this.anonymous'
+Target type: 'String.mysubstring.this.anonymous'
 To solve this, you could try to use a value type as the target type of the call, e,g., 'String.this.mysubstring', or change the result type of 'String.mysubstring.anonymous' to no longer depend on 'String.this'.
 
 one error.

--- a/tests/reg_issues4992_5001_negative/reg_issues4992_5001_negative.fz.expected_err
+++ b/tests/reg_issues4992_5001_negative/reg_issues4992_5001_negative.fz.expected_err
@@ -23,8 +23,8 @@ actual type parameter 'tuple i32 i32 i32'
 --CURDIR--/reg_issues4992_5001_negative.fz:162:13: error 4: Incompatible type parameter
     (x f32).i (box i32)  # 5. should flag an error: wrong type parameter `box i32` instead of `box f32`
 ------------^
-formal type parameter 'U' with constraint 'reg_issues4992_5000.this.case7.this.box reg_issues4992_5000.case7.x.type.A'
-actual type parameter 'reg_issues4992_5000.this.case7.this.box i32'
+formal type parameter 'U' with constraint 'reg_issues4992_5000.case7.this.box reg_issues4992_5000.case7.x.type.A'
+actual type parameter 'reg_issues4992_5000.case7.this.box i32'
 
 
 --CURDIR--/reg_issues4992_5001_negative.fz:64:14: error 5: Constraint for type parameter must not be a type parameter

--- a/tests/this_type_negative/test_this_type_negative.fz.expected_err
+++ b/tests/this_type_negative/test_this_type_negative.fz.expected_err
@@ -61,12 +61,12 @@ To solve this you could:
 ----^
 assignment to field : 'test_this_type_negative.a._'
 expected formal type: 'test_this_type_negative.this.a'
-actual type found   : 'test_this_type_negative.this.a.this'
+actual type found   : 'test_this_type_negative.a.this'
 assignable to       : 'test_this_type_negative.this.ref a'
 for value assigned  : 'a.this'
 To solve this you could:
   • make  'test_this_type_negative.this.a' a reference by adding the 'ref' keyword, so all its heirs can be used in place of it,
-  • change the type of the target 'test_this_type_negative.a._' to 'test_this_type_negative.this.a.this', or
+  • change the type of the target 'test_this_type_negative.a._' to 'test_this_type_negative.a.this', or
   • convert the type of the assigned value to 'test_this_type_negative.this.a'.
 
 
@@ -75,12 +75,12 @@ To solve this you could:
 ------^
 assignment to field : 'test_this_type_negative.a.x._'
 expected formal type: 'test_this_type_negative.this.a'
-actual type found   : 'test_this_type_negative.this.a.this'
+actual type found   : 'test_this_type_negative.a.this'
 assignable to       : 'test_this_type_negative.this.ref a'
 for value assigned  : 'a.this'
 To solve this you could:
   • make  'test_this_type_negative.this.a' a reference by adding the 'ref' keyword, so all its heirs can be used in place of it,
-  • change the type of the target 'test_this_type_negative.a.x._' to 'test_this_type_negative.this.a.this', or
+  • change the type of the target 'test_this_type_negative.a.x._' to 'test_this_type_negative.a.this', or
   • convert the type of the assigned value to 'test_this_type_negative.this.a'.
 
 6 errors.

--- a/tests/typecheck_negative/typecheck_negative.fz.expected_err
+++ b/tests/typecheck_negative/typecheck_negative.fz.expected_err
@@ -3,181 +3,181 @@
     set q := p # 1. should flag an error, illegal assignment
 ----------^
 assignment to field : 'typecheck_negative.assign.q'
-expected formal type: '((typecheck_negative.this.assign.this.A i64).B u64).C bool'
-actual type found   : '((typecheck_negative.this.assign.this.A i32).B u64).C bool'
-assignable to       : '((typecheck_negative.this.assign.this.A i32).B u64).C bool'
+expected formal type: '((typecheck_negative.assign.this.A i64).B u64).C bool'
+actual type found   : '((typecheck_negative.assign.this.A i32).B u64).C bool'
+assignable to       : '((typecheck_negative.assign.this.A i32).B u64).C bool'
 for value assigned  : 'p'
 To solve this you could:
-  • make  '((typecheck_negative.this.assign.this.A i64).B u64).C bool' a reference by adding the 'ref' keyword, so all its heirs can be used in place of it,
-  • change the type of the target 'typecheck_negative.assign.q' to '((typecheck_negative.this.assign.this.A i32).B u64).C bool', or
-  • convert the type of the assigned value to '((typecheck_negative.this.assign.this.A i64).B u64).C bool'.
+  • make  '((typecheck_negative.assign.this.A i64).B u64).C bool' a reference by adding the 'ref' keyword, so all its heirs can be used in place of it,
+  • change the type of the target 'typecheck_negative.assign.q' to '((typecheck_negative.assign.this.A i32).B u64).C bool', or
+  • convert the type of the assigned value to '((typecheck_negative.assign.this.A i64).B u64).C bool'.
 
 
 --CURDIR--/typecheck_negative.fz:40:11: error 2: Incompatible types in assignment
     set r := p # 2. should flag an error, illegal assignment
 ----------^
 assignment to field : 'typecheck_negative.assign.r'
-expected formal type: '((typecheck_negative.this.assign.this.A i32).B bool).C bool'
-actual type found   : '((typecheck_negative.this.assign.this.A i32).B u64).C bool'
-assignable to       : '((typecheck_negative.this.assign.this.A i32).B u64).C bool'
+expected formal type: '((typecheck_negative.assign.this.A i32).B bool).C bool'
+actual type found   : '((typecheck_negative.assign.this.A i32).B u64).C bool'
+assignable to       : '((typecheck_negative.assign.this.A i32).B u64).C bool'
 for value assigned  : 'p'
 To solve this you could:
-  • make  '((typecheck_negative.this.assign.this.A i32).B bool).C bool' a reference by adding the 'ref' keyword, so all its heirs can be used in place of it,
-  • change the type of the target 'typecheck_negative.assign.r' to '((typecheck_negative.this.assign.this.A i32).B u64).C bool', or
-  • convert the type of the assigned value to '((typecheck_negative.this.assign.this.A i32).B bool).C bool'.
+  • make  '((typecheck_negative.assign.this.A i32).B bool).C bool' a reference by adding the 'ref' keyword, so all its heirs can be used in place of it,
+  • change the type of the target 'typecheck_negative.assign.r' to '((typecheck_negative.assign.this.A i32).B u64).C bool', or
+  • convert the type of the assigned value to '((typecheck_negative.assign.this.A i32).B bool).C bool'.
 
 
 --CURDIR--/typecheck_negative.fz:41:11: error 3: Incompatible types in assignment
     set q := r # 3. should flag an error, illegal assignment
 ----------^
 assignment to field : 'typecheck_negative.assign.q'
-expected formal type: '((typecheck_negative.this.assign.this.A i64).B u64).C bool'
-actual type found   : '((typecheck_negative.this.assign.this.A i32).B bool).C bool'
-assignable to       : '((typecheck_negative.this.assign.this.A i32).B bool).C bool'
+expected formal type: '((typecheck_negative.assign.this.A i64).B u64).C bool'
+actual type found   : '((typecheck_negative.assign.this.A i32).B bool).C bool'
+assignable to       : '((typecheck_negative.assign.this.A i32).B bool).C bool'
 for value assigned  : 'r'
 To solve this you could:
-  • make  '((typecheck_negative.this.assign.this.A i64).B u64).C bool' a reference by adding the 'ref' keyword, so all its heirs can be used in place of it,
-  • change the type of the target 'typecheck_negative.assign.q' to '((typecheck_negative.this.assign.this.A i32).B bool).C bool', or
-  • convert the type of the assigned value to '((typecheck_negative.this.assign.this.A i64).B u64).C bool'.
+  • make  '((typecheck_negative.assign.this.A i64).B u64).C bool' a reference by adding the 'ref' keyword, so all its heirs can be used in place of it,
+  • change the type of the target 'typecheck_negative.assign.q' to '((typecheck_negative.assign.this.A i32).B bool).C bool', or
+  • convert the type of the assigned value to '((typecheck_negative.assign.this.A i64).B u64).C bool'.
 
 
 --CURDIR--/typecheck_negative.fz:42:11: error 4: Incompatible types in assignment
     set r := q # 4. should flag an error, illegal assignment
 ----------^
 assignment to field : 'typecheck_negative.assign.r'
-expected formal type: '((typecheck_negative.this.assign.this.A i32).B bool).C bool'
-actual type found   : '((typecheck_negative.this.assign.this.A i64).B u64).C bool'
-assignable to       : '((typecheck_negative.this.assign.this.A i64).B u64).C bool'
+expected formal type: '((typecheck_negative.assign.this.A i32).B bool).C bool'
+actual type found   : '((typecheck_negative.assign.this.A i64).B u64).C bool'
+assignable to       : '((typecheck_negative.assign.this.A i64).B u64).C bool'
 for value assigned  : 'q'
 To solve this you could:
-  • make  '((typecheck_negative.this.assign.this.A i32).B bool).C bool' a reference by adding the 'ref' keyword, so all its heirs can be used in place of it,
-  • change the type of the target 'typecheck_negative.assign.r' to '((typecheck_negative.this.assign.this.A i64).B u64).C bool', or
-  • convert the type of the assigned value to '((typecheck_negative.this.assign.this.A i32).B bool).C bool'.
+  • make  '((typecheck_negative.assign.this.A i32).B bool).C bool' a reference by adding the 'ref' keyword, so all its heirs can be used in place of it,
+  • change the type of the target 'typecheck_negative.assign.r' to '((typecheck_negative.assign.this.A i64).B u64).C bool', or
+  • convert the type of the assigned value to '((typecheck_negative.assign.this.A i32).B bool).C bool'.
 
 
 --CURDIR--/typecheck_negative.fz:43:11: error 5: Incompatible types in assignment
     set s := p # 5. should flag an error, illegal assignment
 ----------^
 assignment to field : 'typecheck_negative.assign.s'
-expected formal type: '((typecheck_negative.this.assign.this.A i32).B u64).C u32'
-actual type found   : '((typecheck_negative.this.assign.this.A i32).B u64).C bool'
-assignable to       : '((typecheck_negative.this.assign.this.A i32).B u64).C bool'
+expected formal type: '((typecheck_negative.assign.this.A i32).B u64).C u32'
+actual type found   : '((typecheck_negative.assign.this.A i32).B u64).C bool'
+assignable to       : '((typecheck_negative.assign.this.A i32).B u64).C bool'
 for value assigned  : 'p'
 To solve this you could:
-  • make  '((typecheck_negative.this.assign.this.A i32).B u64).C u32' a reference by adding the 'ref' keyword, so all its heirs can be used in place of it,
-  • change the type of the target 'typecheck_negative.assign.s' to '((typecheck_negative.this.assign.this.A i32).B u64).C bool', or
-  • convert the type of the assigned value to '((typecheck_negative.this.assign.this.A i32).B u64).C u32'.
+  • make  '((typecheck_negative.assign.this.A i32).B u64).C u32' a reference by adding the 'ref' keyword, so all its heirs can be used in place of it,
+  • change the type of the target 'typecheck_negative.assign.s' to '((typecheck_negative.assign.this.A i32).B u64).C bool', or
+  • convert the type of the assigned value to '((typecheck_negative.assign.this.A i32).B u64).C u32'.
 
 
 --CURDIR--/typecheck_negative.fz:44:11: error 6: Incompatible types in assignment
     set s := q # 6. should flag an error, illegal assignment
 ----------^
 assignment to field : 'typecheck_negative.assign.s'
-expected formal type: '((typecheck_negative.this.assign.this.A i32).B u64).C u32'
-actual type found   : '((typecheck_negative.this.assign.this.A i64).B u64).C bool'
-assignable to       : '((typecheck_negative.this.assign.this.A i64).B u64).C bool'
+expected formal type: '((typecheck_negative.assign.this.A i32).B u64).C u32'
+actual type found   : '((typecheck_negative.assign.this.A i64).B u64).C bool'
+assignable to       : '((typecheck_negative.assign.this.A i64).B u64).C bool'
 for value assigned  : 'q'
 To solve this you could:
-  • make  '((typecheck_negative.this.assign.this.A i32).B u64).C u32' a reference by adding the 'ref' keyword, so all its heirs can be used in place of it,
-  • change the type of the target 'typecheck_negative.assign.s' to '((typecheck_negative.this.assign.this.A i64).B u64).C bool', or
-  • convert the type of the assigned value to '((typecheck_negative.this.assign.this.A i32).B u64).C u32'.
+  • make  '((typecheck_negative.assign.this.A i32).B u64).C u32' a reference by adding the 'ref' keyword, so all its heirs can be used in place of it,
+  • change the type of the target 'typecheck_negative.assign.s' to '((typecheck_negative.assign.this.A i64).B u64).C bool', or
+  • convert the type of the assigned value to '((typecheck_negative.assign.this.A i32).B u64).C u32'.
 
 
 --CURDIR--/typecheck_negative.fz:45:11: error 7: Incompatible types in assignment
     set s := r # 7. should flag an error, illegal assignment
 ----------^
 assignment to field : 'typecheck_negative.assign.s'
-expected formal type: '((typecheck_negative.this.assign.this.A i32).B u64).C u32'
-actual type found   : '((typecheck_negative.this.assign.this.A i32).B bool).C bool'
-assignable to       : '((typecheck_negative.this.assign.this.A i32).B bool).C bool'
+expected formal type: '((typecheck_negative.assign.this.A i32).B u64).C u32'
+actual type found   : '((typecheck_negative.assign.this.A i32).B bool).C bool'
+assignable to       : '((typecheck_negative.assign.this.A i32).B bool).C bool'
 for value assigned  : 'r'
 To solve this you could:
-  • make  '((typecheck_negative.this.assign.this.A i32).B u64).C u32' a reference by adding the 'ref' keyword, so all its heirs can be used in place of it,
-  • change the type of the target 'typecheck_negative.assign.s' to '((typecheck_negative.this.assign.this.A i32).B bool).C bool', or
-  • convert the type of the assigned value to '((typecheck_negative.this.assign.this.A i32).B u64).C u32'.
+  • make  '((typecheck_negative.assign.this.A i32).B u64).C u32' a reference by adding the 'ref' keyword, so all its heirs can be used in place of it,
+  • change the type of the target 'typecheck_negative.assign.s' to '((typecheck_negative.assign.this.A i32).B bool).C bool', or
+  • convert the type of the assigned value to '((typecheck_negative.assign.this.A i32).B u64).C u32'.
 
 
 --CURDIR--/typecheck_negative.fz:57:11: error 8: Incompatible types in assignment
     set v := u # 8. should flag an error, illegal assignment
 ----------^
 assignment to field : 'typecheck_negative.assign.v'
-expected formal type: '((typecheck_negative.this.assign.this.D i64).E u64).F bool'
-actual type found   : '((typecheck_negative.this.assign.this.D i32).E u64).F bool'
-assignable to       : '((typecheck_negative.this.assign.this.D i32).E u64).F bool',
+expected formal type: '((typecheck_negative.assign.this.D i64).E u64).F bool'
+actual type found   : '((typecheck_negative.assign.this.D i32).E u64).F bool'
+assignable to       : '((typecheck_negative.assign.this.D i32).E u64).F bool',
                       'Any'
 for value assigned  : 'u'
-To solve this, you could change the type of the target 'typecheck_negative.assign.v' to '((typecheck_negative.this.assign.this.D i32).E u64).F bool' or convert the type of the assigned value to '((typecheck_negative.this.assign.this.D i64).E u64).F bool'.
+To solve this, you could change the type of the target 'typecheck_negative.assign.v' to '((typecheck_negative.assign.this.D i32).E u64).F bool' or convert the type of the assigned value to '((typecheck_negative.assign.this.D i64).E u64).F bool'.
 
 
 --CURDIR--/typecheck_negative.fz:58:11: error 9: Incompatible types in assignment
     set w := u # 9. should flag an error, illegal assignment
 ----------^
 assignment to field : 'typecheck_negative.assign.w'
-expected formal type: '((typecheck_negative.this.assign.this.D i32).E bool).F bool'
-actual type found   : '((typecheck_negative.this.assign.this.D i32).E u64).F bool'
-assignable to       : '((typecheck_negative.this.assign.this.D i32).E u64).F bool',
+expected formal type: '((typecheck_negative.assign.this.D i32).E bool).F bool'
+actual type found   : '((typecheck_negative.assign.this.D i32).E u64).F bool'
+assignable to       : '((typecheck_negative.assign.this.D i32).E u64).F bool',
                       'Any'
 for value assigned  : 'u'
-To solve this, you could change the type of the target 'typecheck_negative.assign.w' to '((typecheck_negative.this.assign.this.D i32).E u64).F bool' or convert the type of the assigned value to '((typecheck_negative.this.assign.this.D i32).E bool).F bool'.
+To solve this, you could change the type of the target 'typecheck_negative.assign.w' to '((typecheck_negative.assign.this.D i32).E u64).F bool' or convert the type of the assigned value to '((typecheck_negative.assign.this.D i32).E bool).F bool'.
 
 
 --CURDIR--/typecheck_negative.fz:59:11: error 10: Incompatible types in assignment
     set v := w # 10. should flag an error, illegal assignment
 ----------^
 assignment to field : 'typecheck_negative.assign.v'
-expected formal type: '((typecheck_negative.this.assign.this.D i64).E u64).F bool'
-actual type found   : '((typecheck_negative.this.assign.this.D i32).E bool).F bool'
-assignable to       : '((typecheck_negative.this.assign.this.D i32).E bool).F bool',
+expected formal type: '((typecheck_negative.assign.this.D i64).E u64).F bool'
+actual type found   : '((typecheck_negative.assign.this.D i32).E bool).F bool'
+assignable to       : '((typecheck_negative.assign.this.D i32).E bool).F bool',
                       'Any'
 for value assigned  : 'w'
-To solve this, you could change the type of the target 'typecheck_negative.assign.v' to '((typecheck_negative.this.assign.this.D i32).E bool).F bool' or convert the type of the assigned value to '((typecheck_negative.this.assign.this.D i64).E u64).F bool'.
+To solve this, you could change the type of the target 'typecheck_negative.assign.v' to '((typecheck_negative.assign.this.D i32).E bool).F bool' or convert the type of the assigned value to '((typecheck_negative.assign.this.D i64).E u64).F bool'.
 
 
 --CURDIR--/typecheck_negative.fz:60:11: error 11: Incompatible types in assignment
     set w := v # 11. should flag an error, illegal assignment
 ----------^
 assignment to field : 'typecheck_negative.assign.w'
-expected formal type: '((typecheck_negative.this.assign.this.D i32).E bool).F bool'
-actual type found   : '((typecheck_negative.this.assign.this.D i64).E u64).F bool'
-assignable to       : '((typecheck_negative.this.assign.this.D i64).E u64).F bool',
+expected formal type: '((typecheck_negative.assign.this.D i32).E bool).F bool'
+actual type found   : '((typecheck_negative.assign.this.D i64).E u64).F bool'
+assignable to       : '((typecheck_negative.assign.this.D i64).E u64).F bool',
                       'Any'
 for value assigned  : 'v'
-To solve this, you could change the type of the target 'typecheck_negative.assign.w' to '((typecheck_negative.this.assign.this.D i64).E u64).F bool' or convert the type of the assigned value to '((typecheck_negative.this.assign.this.D i32).E bool).F bool'.
+To solve this, you could change the type of the target 'typecheck_negative.assign.w' to '((typecheck_negative.assign.this.D i64).E u64).F bool' or convert the type of the assigned value to '((typecheck_negative.assign.this.D i32).E bool).F bool'.
 
 
 --CURDIR--/typecheck_negative.fz:61:11: error 12: Incompatible types in assignment
     set x := u # 12. should flag an error, illegal assignment
 ----------^
 assignment to field : 'typecheck_negative.assign.x'
-expected formal type: '((typecheck_negative.this.assign.this.D i32).E u64).F u32'
-actual type found   : '((typecheck_negative.this.assign.this.D i32).E u64).F bool'
-assignable to       : '((typecheck_negative.this.assign.this.D i32).E u64).F bool',
+expected formal type: '((typecheck_negative.assign.this.D i32).E u64).F u32'
+actual type found   : '((typecheck_negative.assign.this.D i32).E u64).F bool'
+assignable to       : '((typecheck_negative.assign.this.D i32).E u64).F bool',
                       'Any'
 for value assigned  : 'u'
-To solve this, you could change the type of the target 'typecheck_negative.assign.x' to '((typecheck_negative.this.assign.this.D i32).E u64).F bool' or convert the type of the assigned value to '((typecheck_negative.this.assign.this.D i32).E u64).F u32'.
+To solve this, you could change the type of the target 'typecheck_negative.assign.x' to '((typecheck_negative.assign.this.D i32).E u64).F bool' or convert the type of the assigned value to '((typecheck_negative.assign.this.D i32).E u64).F u32'.
 
 
 --CURDIR--/typecheck_negative.fz:62:11: error 13: Incompatible types in assignment
     set x := v # 13. should flag an error, illegal assignment
 ----------^
 assignment to field : 'typecheck_negative.assign.x'
-expected formal type: '((typecheck_negative.this.assign.this.D i32).E u64).F u32'
-actual type found   : '((typecheck_negative.this.assign.this.D i64).E u64).F bool'
-assignable to       : '((typecheck_negative.this.assign.this.D i64).E u64).F bool',
+expected formal type: '((typecheck_negative.assign.this.D i32).E u64).F u32'
+actual type found   : '((typecheck_negative.assign.this.D i64).E u64).F bool'
+assignable to       : '((typecheck_negative.assign.this.D i64).E u64).F bool',
                       'Any'
 for value assigned  : 'v'
-To solve this, you could change the type of the target 'typecheck_negative.assign.x' to '((typecheck_negative.this.assign.this.D i64).E u64).F bool' or convert the type of the assigned value to '((typecheck_negative.this.assign.this.D i32).E u64).F u32'.
+To solve this, you could change the type of the target 'typecheck_negative.assign.x' to '((typecheck_negative.assign.this.D i64).E u64).F bool' or convert the type of the assigned value to '((typecheck_negative.assign.this.D i32).E u64).F u32'.
 
 
 --CURDIR--/typecheck_negative.fz:63:11: error 14: Incompatible types in assignment
     set x := w # 14. should flag an error, illegal assignment
 ----------^
 assignment to field : 'typecheck_negative.assign.x'
-expected formal type: '((typecheck_negative.this.assign.this.D i32).E u64).F u32'
-actual type found   : '((typecheck_negative.this.assign.this.D i32).E bool).F bool'
-assignable to       : '((typecheck_negative.this.assign.this.D i32).E bool).F bool',
+expected formal type: '((typecheck_negative.assign.this.D i32).E u64).F u32'
+actual type found   : '((typecheck_negative.assign.this.D i32).E bool).F bool'
+assignable to       : '((typecheck_negative.assign.this.D i32).E bool).F bool',
                       'Any'
 for value assigned  : 'w'
-To solve this, you could change the type of the target 'typecheck_negative.assign.x' to '((typecheck_negative.this.assign.this.D i32).E bool).F bool' or convert the type of the assigned value to '((typecheck_negative.this.assign.this.D i32).E u64).F u32'.
+To solve this, you could change the type of the target 'typecheck_negative.assign.x' to '((typecheck_negative.assign.this.D i32).E bool).F bool' or convert the type of the assigned value to '((typecheck_negative.assign.this.D i32).E u64).F u32'.
 
 14 errors.

--- a/tests/typeinference_negative/typeinference_negative.fz.expected_err
+++ b/tests/typeinference_negative/typeinference_negative.fz.expected_err
@@ -388,7 +388,7 @@ block returns value of type 'String' at --CURDIR--/typeinference_negative.fz:252
 block returns value of type 'bool' at --CURDIR--/typeinference_negative.fz:253:16:
         D   => false
 ---------------^^^^^
-block returns value of type 'typeinference_negative.this.typeInferencingFromMatch1.this.E' at --CURDIR--/typeinference_negative.fz:254:16:
+block returns value of type 'typeinference_negative.typeInferencingFromMatch1.this.E' at --CURDIR--/typeinference_negative.fz:254:16:
         e E => e
 ---------------^
 
@@ -414,7 +414,7 @@ block returns value of type 'String' at --CURDIR--/typeinference_negative.fz:268
 block returns value of type 'bool' at --CURDIR--/typeinference_negative.fz:269:18:
           D   => false
 -----------------^^^^^
-block returns value of type 'typeinference_negative.this.typeInferencingFromMatch2.this.E' at --CURDIR--/typeinference_negative.fz:270:18:
+block returns value of type 'typeinference_negative.typeInferencingFromMatch2.this.E' at --CURDIR--/typeinference_negative.fz:270:18:
           e E => e
 -----------------^
 


### PR DESCRIPTION
now `a.this.b.this` is just `a.b.this`
