### PR TITLE
ast: fix resultTypeIfPresentUrgent for outer ref

### DIFF
--- a/src/dev/flang/ast/Feature.java
+++ b/src/dev/flang/ast/Feature.java
@@ -2403,14 +2403,14 @@ A ((Choice)) declaration must not contain a result type.
           }
         result = urgent ? Types.t_ERROR : null;
       }
+    else if (isOuterRef())
+      {
+        result = outer().outer().thisType(outer().isFixed());
+      }
     else
       {
         result = _returnType.functionReturnType();
         result = urgent && result == null ? Types.t_ERROR : result;
-      }
-    if (isOuterRef() && !outer().isFixed())
-      {
-        result = result.asThis();
       }
     if (res != null && result != null && outer() != null)
       {


### PR DESCRIPTION
previous code was incorrect since result was sometimes Types.t_ADDRESS and Types.t_ADDRESS.asThis() results in `Any.this`. Does not result in error currently because other errors in isLegalCovariantThisType to be fixed in another PR.
