### PR TITLE
dfa: implement comparison of `SysArray`

### DIFF
--- a/src/dev/flang/fuir/analysis/dfa/SysArray.java
+++ b/src/dev/flang/fuir/analysis/dfa/SysArray.java
@@ -26,6 +26,8 @@ Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
 
 package dev.flang.fuir.analysis.dfa;
 
+import java.util.Comparator;
+
 import dev.flang.fuir.FUIR;
 
 /**
@@ -153,6 +155,24 @@ public class SysArray extends Value
       {
         throw new Error("DFA: trying to join SysArray with " + v.getClass());
       }
+  }
+
+
+  /**
+   * Compare this SysArray another SysArray.
+   *
+   * @param other the other SysArray
+   *
+   * @return -1, 0, or +1 depending on whether this &lt; other, this == other or
+   * this &gt; other by some order.
+   */
+  public int compareTo(Comparator<Value> comp, SysArray other)
+  {
+    return _elementClazz < other._elementClazz
+      ? -1
+      : _elementClazz > other._elementClazz
+      ? 1
+      : comp.compare(_elements, other._elements);
   }
 
 

--- a/src/dev/flang/fuir/analysis/dfa/Value.java
+++ b/src/dev/flang/fuir/analysis/dfa/Value.java
@@ -70,8 +70,10 @@ public class Value extends Val
         else if (a == UNIT                    || b == UNIT                   ) { return a == UNIT  ? +1 : -1; }
         else if (a instanceof TaggedValue  at && b instanceof TaggedValue  bt) { return at.compareTo(bt);     }
         else if (a instanceof ValueSet     as && b instanceof ValueSet     bs) { return as.compareTo(bs);     }
+        else if (a instanceof SysArray     sa && b instanceof SysArray     sb) { return sa.compareTo(this, sb);     }
         else if (a instanceof TaggedValue ) { return +1; } else if (b instanceof TaggedValue    ) { return -1; }
         else if (a instanceof ValueSet    ) { return +1; } else if (b instanceof ValueSet       ) { return -1; }
+        else if (a instanceof SysArray    ) { return +1; } else if (b instanceof SysArray       ) { return -1; }
         else if (a._id >= 0 && b._id >= 0 ) { return Integer.compare(a._id, b._id); }
         else
           {


### PR DESCRIPTION
Ran into this bug when moving tagging/boxing to IR.

Can also be triggered in main in process/test_process.fz when replacing this code:
```
  private boolean isConst(Object o)
  {
    return o instanceof InlineArray iai && isConst(iai)
        || o instanceof Constant
        || o instanceof AbstractCall ac && isConst(ac)
        || o instanceof AbstractBlock ab && ab._expressions.size() == 1 && isConst(ab.resultExpression());
  }
```
by
```
  private boolean isConst(Object o)
  {
    return false;
  }
```