### PR TITLE
ast: fix handling of open type parameters when resolving types

### DIFF
--- a/src/dev/flang/ast/AbstractType.java
+++ b/src/dev/flang/ast/AbstractType.java
@@ -671,7 +671,10 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
       }
     else
       {
-        result = genericsToReplace.map(t -> t.applyTypePars(f, actualGenerics));
+        result = genericsToReplace.flatMap
+          (t -> t.isOpenGeneric() && t.genericArgument().outer().generics() == f.generics()
+                ? t.genericArgument().replaceOpen(actualGenerics)
+                : new List<>(t.applyTypePars(f, actualGenerics)));
       }
     return result;
   }
@@ -1093,7 +1096,7 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
               }
           }
       }
-    else
+    else if (!result.isThisType())
       {
         var generics = result.generics();
         var g2 = generics instanceof FormalGenerics.AsActuals aa && aa.actualsOf(f)

--- a/src/dev/flang/util/List.java
+++ b/src/dev/flang/util/List.java
@@ -569,10 +569,20 @@ public class List<T>
    */
   public List<T> flatMap(Function<T,List<T>> f)
   {
-    var result = new List<T>();
+    var result = this;
     for (var i = 0; i < size(); i++)
       {
-        result.addAll(f.apply(get(i)));
+        var e = get(i);
+        var l = f.apply(e);
+        if (result != this)
+          {
+            result.addAll(l);
+          }
+        else if (l.size() != 1 || e != l.getFirst())
+          {
+            result = take(i);
+            result.addAll(l);
+          }
       }
     return result;
   }
@@ -594,13 +604,30 @@ public class List<T>
   }
 
 
+  /**
+   * Create a new list of the first n elements
+   *
+   * @param n the number of elements to put into new list
+   *
+   * @return new list of the length max(n, this.length()), containing get(0) .. get(n-1).
+   */
+  public List<T> take(int n)
+  {
+    var result = new List<T>();
+    for (var i = 0; i < n; i++)
+      {
+        result.add(get(i));
+      }
+    return result;
+  }
+
 
   /**
    * Create a new list without the first n elements
    *
    * @param n the number of elements to drop
    *
-   * @return new list of the length max(0, this.length()-1), containing get(n) .. get(length()-1).
+   * @return new list of the length max(0, this.length()-n), containing get(n) .. get(length()-1).
    */
   public List<T> drop(int n)
   {

--- a/tests/reg_issue5436/Makefile
+++ b/tests/reg_issue5436/Makefile
@@ -1,0 +1,25 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test Makefile
+#
+# -----------------------------------------------------------------------
+
+override NAME = reg_issue5436
+include ../simple.mk

--- a/tests/reg_issue5436/reg_issue5436.fz
+++ b/tests/reg_issue5436/reg_issue5436.fz
@@ -1,0 +1,80 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test reg_issue5436
+#
+# -----------------------------------------------------------------------
+
+# this contains tests using open type parameters in a ways that used to
+# result in IndexOutOfBounds, ClassCast or precondition failures during fz
+# compilation since handling of open type parameters was missing.
+#
+# To avoid errors, the tests from #5436 where changed to not contain abstract
+# features
+
+# the first test from #5436 which uses an empty list of actual generics
+
+test1.q
+test1(A type...) is
+  q => g r
+  g (B type) unit => say "in {type_of g.this}"
+  r is
+
+
+# the first test from #5436, but using a non empty list of actual generics
+
+(test1a unit).q
+test1a(A type...) is
+  q => g r
+  g (B type) unit => say "in {type_of g.this}"
+  r is
+
+
+# the first test from #5436, but using a long list of actual generics
+
+(test1b unit nil false_ Any String bool).q
+test1b(A type...) is
+  q => g r
+  g (B type) unit => say "in {type_of g.this}"
+  r is
+
+
+# the second test from #5436 which uses an empty list of actual generics
+
+test2
+test2(A type...) =>
+  f q
+  f(X type) unit => say "in {type_of f.this}"
+  q is
+
+# the second test from #5436, but using a non empty list of actual generics
+
+test2a unit
+test2a(A type...) =>
+  f q
+  f(X type) unit => say "in {type_of f.this}"
+  q is
+
+# the second test from #5436, but using a long list of actual generics
+
+test2b (Sequence (option (array u8))) bool String (Lazy i32->(num.complex f32))
+test2b(A type...) =>
+  f q
+  f(X type) unit => say "in {type_of f.this}"
+  q is

--- a/tests/reg_issue5436/reg_issue5436.fz.expected_out
+++ b/tests/reg_issue5436/reg_issue5436.fz.expected_out
@@ -1,0 +1,6 @@
+in Type of 'test1.g test1.r'
+in Type of '(test1a unit).g (test1a unit).r'
+in Type of '(test1b unit nil false_ Any String bool).g (test1b unit nil false_ Any String bool).r'
+in Type of 'test2.f test2.q'
+in Type of '(test2a unit).f (test2a unit).q'
+in Type of '(test2b (Sequence (option (array u8))) bool String (Lazy (Unary (num.complex f32) i32))).f (test2b (Sequence (option (array u8))) bool String (Lazy (Unary (num.complex f32) i32))).q'


### PR DESCRIPTION
This fixes #5436 by adding support for replacing open type parameters by a list of actual types.

Since this requires the use of `flatMap` instead of `map` since the numer of type parameters may change, and `List.flatMap` always allocated a new array even if nothing changed this first failed since the code relies on list of generics to stay equal if there is no change.  For this reason, and for the probable performance improvement, `List.flatMap` was changed to create a new `List` on demand only.

A new helper `List.take(n)` was added to implement `List.flatMap()`.

`AbstractType.applyTypeParsLocally` no longer applies actual generics to a this type, which was the cause of the third failure in #5436.

Added a test with variants of the examples from #5436.
