### PR TITLE
ast: attempt to set `generics` to empty list for `this`-type

### DIFF
--- a/src/dev/flang/ast/AbstractType.java
+++ b/src/dev/flang/ast/AbstractType.java
@@ -671,7 +671,10 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
       }
     else
       {
-        result = genericsToReplace.map(t -> t.applyTypePars(f, actualGenerics));
+        result = genericsToReplace.flatMap
+          (t -> t.isOpenGeneric() && t.genericArgument().outer().generics() == f.generics()
+                ? t.genericArgument().replaceOpen(actualGenerics)
+                : new List<>(t.applyTypePars(f, actualGenerics)));
       }
     return result;
   }
@@ -1093,7 +1096,7 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
               }
           }
       }
-    else
+    else if (!result.isThisType())
       {
         var generics = result.generics();
         var g2 = generics instanceof FormalGenerics.AsActuals aa && aa.actualsOf(f)

--- a/src/dev/flang/ast/ResolvedNormalType.java
+++ b/src/dev/flang/ast/ResolvedNormalType.java
@@ -186,7 +186,7 @@ public class ResolvedNormalType extends ResolvedType
        /* NYI: Types.resolved == null
          || f.compareTo(Types.resolved.f_void) != 0*/);
 
-    this._generics = ((g == null) || g.isEmpty()) ? UnresolvedType.NONE : g;
+    this._generics = ((typeMode == TypeMode.ThisType || g == null) || g.isEmpty()) ? UnresolvedType.NONE : g;
     this._generics.freeze();
     this._unresolvedGenerics = ((ug == null) || ug.isEmpty()) ? UnresolvedType.NONE : ug;
 
@@ -213,8 +213,10 @@ public class ResolvedNormalType extends ResolvedType
 
     if (POSTCONDITIONS) ensure
       (_feature == null /* artificial built in type */
+       || isThisType()
        || feature().generics().sizeMatches(generics())
-       || generics().isEmpty() /* e.g. an incomplete type in a match case */);
+       || generics().isEmpty() /* e.g. an incomplete type in a match case */,
+       !isThisType() || generics().isEmpty());
   }
 
   /**
@@ -249,13 +251,15 @@ public class ResolvedNormalType extends ResolvedType
       );
 
     this._typeMode           = typeMode;
-    this._generics           = original._generics;
+    this._generics           =          isThisType() ? UnresolvedType.NONE :
+                               original.isThisType() ? original.feature().generics().asActuals()
+                                                     : original._generics;
     this._unresolvedGenerics = original._unresolvedGenerics;
     this._outer              = original._outer;
     this._feature            = original._feature;
 
     if (POSTCONDITIONS) ensure
-      (feature().generics().sizeMatches(generics()));
+      (isThisType() || feature().generics().sizeMatches(generics()));
   }
 
 
@@ -303,7 +307,7 @@ public class ResolvedNormalType extends ResolvedType
     this._feature            = original._feature;
 
     if (POSTCONDITIONS) ensure
-      (feature().generics().sizeMatches(generics()));
+      (isThisType() || feature().generics().sizeMatches(generics()));
   }
 
 

--- a/src/dev/flang/fe/NormalType.java
+++ b/src/dev/flang/fe/NormalType.java
@@ -93,6 +93,8 @@ public class NormalType extends LibraryType
              AbstractType outer)
   {
     super(mod, at);
+    if (PRECONDITIONS) require
+      (typeMode != TypeMode.ThisType || generics.isEmpty());
 
     this._feature = feature;
     this._typeMode = typeMode;

--- a/src/dev/flang/util/List.java
+++ b/src/dev/flang/util/List.java
@@ -569,10 +569,20 @@ public class List<T>
    */
   public List<T> flatMap(Function<T,List<T>> f)
   {
-    var result = new List<T>();
+    var result = this;
     for (var i = 0; i < size(); i++)
       {
-        result.addAll(f.apply(get(i)));
+        var e = get(i);
+        var l = f.apply(e);
+        if (result != this)
+          {
+            result.addAll(l);
+          }
+        else if (l.size() != 1 || e != l.getFirst())
+          {
+            result = take(i);
+            result.addAll(l);
+          }
       }
     return result;
   }
@@ -594,13 +604,30 @@ public class List<T>
   }
 
 
+  /**
+   * Create a new list of the first n elements
+   *
+   * @param n the number of elements to put into new list
+   *
+   * @return new list of the length max(n, this.length()), containing get(0) .. get(n-1).
+   */
+  public List<T> take(int n)
+  {
+    var result = new List<T>();
+    for (var i = 0; i < n; i++)
+      {
+        result.add(get(i));
+      }
+    return result;
+  }
+
 
   /**
    * Create a new list without the first n elements
    *
    * @param n the number of elements to drop
    *
-   * @return new list of the length max(0, this.length()-1), containing get(n) .. get(length()-1).
+   * @return new list of the length max(0, this.length()-n), containing get(n) .. get(length()-1).
    */
   public List<T> drop(int n)
   {

--- a/tests/reg_issue5436/Makefile
+++ b/tests/reg_issue5436/Makefile
@@ -1,0 +1,25 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test Makefile
+#
+# -----------------------------------------------------------------------
+
+override NAME = reg_issue5436
+include ../simple.mk

--- a/tests/reg_issue5436/reg_issue5436.fz
+++ b/tests/reg_issue5436/reg_issue5436.fz
@@ -1,0 +1,80 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test reg_issue5436
+#
+# -----------------------------------------------------------------------
+
+# this contains tests using open type parameters in a ways that used to
+# result in IndexOutOfBounds, ClassCast or precondition failures during fz
+# compilation since handling of open type parameters was missing.
+#
+# To avoid errors, the tests from #5436 where changed to not contain abstract
+# features
+
+# the first test from #5436 which uses an empty list of actual generics
+
+test1.q
+test1(A type...) is
+  q => g r
+  g (B type) unit => say "in {type_of g.this}"
+  r is
+
+
+# the first test from #5436, but using a non empty list of actual generics
+
+(test1a unit).q
+test1a(A type...) is
+  q => g r
+  g (B type) unit => say "in {type_of g.this}"
+  r is
+
+
+# the first test from #5436, but using a long list of actual generics
+
+(test1b unit nil false_ Any String bool).q
+test1b(A type...) is
+  q => g r
+  g (B type) unit => say "in {type_of g.this}"
+  r is
+
+
+# the second test from #5436 which uses an empty list of actual generics
+
+test2
+test2(A type...) =>
+  f q
+  f(X type) unit => say "in {type_of f.this}"
+  q is
+
+# the second test from #5436, but using a non empty list of actual generics
+
+test2a unit
+test2a(A type...) =>
+  f q
+  f(X type) unit => say "in {type_of f.this}"
+  q is
+
+# the second test from #5436, but using a long list of actual generics
+
+test2b (Sequence (option (array u8))) bool String (Lazy i32->(num.complex f32))
+test2b(A type...) =>
+  f q
+  f(X type) unit => say "in {type_of f.this}"
+  q is

--- a/tests/reg_issue5436/reg_issue5436.fz.expected_out
+++ b/tests/reg_issue5436/reg_issue5436.fz.expected_out
@@ -1,0 +1,6 @@
+in Type of 'test1.g test1.r'
+in Type of '(test1a unit).g (test1a unit).r'
+in Type of '(test1b unit nil false_ Any String bool).g (test1b unit nil false_ Any String bool).r'
+in Type of 'test2.f test2.q'
+in Type of '(test2a unit).f (test2a unit).q'
+in Type of '(test2b (Sequence (option (array u8))) bool String (Lazy (Unary (num.complex f32) i32))).f (test2b (Sequence (option (array u8))) bool String (Lazy (Unary (num.complex f32) i32))).q'


### PR DESCRIPTION
This is a try to improve #5440, but does not work yet.

This patch is based on PR #5439, only the second commit is relevant. 

@michaellilltokiwa, I assign this to you and stop working on it since this might overlap with your work on this-types. 