### PR TITLE
docs: limit annotation `[Contains abstract features]` to current module and its dependencies

### DIFF
--- a/src/dev/flang/fe/LibraryModule.java
+++ b/src/dev/flang/fe/LibraryModule.java
@@ -2470,6 +2470,18 @@ SourceFile
     throw new UnsupportedOperationException("Unimplemented method 'data'");
   }
 
+
+  /**
+   * Is this module the same as the provided one or does this module depend on the provided one?
+   *
+   * @param lm the LibraryModule against which this module should be checked
+   * @return true iff they are the same or this module depends on the provided one
+   */
+  public boolean sameOrDependent(LibraryModule lm)
+  {
+    return lm == this || Arrays.asList(_modules).stream().map(r->r._module).anyMatch(x->x==lm);
+  }
+
 }
 
 /* end of file */

--- a/src/dev/flang/fe/ModuleRef.java
+++ b/src/dev/flang/fe/ModuleRef.java
@@ -66,7 +66,7 @@ public class ModuleRef extends ANY
   /**
    * this module as loaded.
    */
-  final LibraryModule _module;
+  public final LibraryModule _module;
 
 
   /*--------------------------  constructors  ---------------------------*/

--- a/src/dev/flang/tools/docs/Html.java
+++ b/src/dev/flang/tools/docs/Html.java
@@ -332,9 +332,12 @@ public class Html extends ANY
     var allInner = new List<AbstractFeature>();
     lm.forEachDeclaredOrInheritedFeature(af, f -> allInner.add(f));
 
-    return allInner.stream().filter(f->isVisible(f)).anyMatch(f->f.isAbstract())
+    return allInner.stream()
+        .filter(f->isVisible(f))
+        .filter(f->f instanceof LibraryFeature lf && lm.sameOrDependent(lf._libModule))
+        .anyMatch(f->f.isAbstract())
              ? "<div class='fd-parent ml-10' title='This feature contains inner or inherited features " +
-               "which are abstract.'>[Contains abstract features]</div>"
+               "which are abstract.'>[Contains abstract features]</div>" // NYI: replace title attribute with proper tooltip
              : "";
   }
 
@@ -354,9 +357,7 @@ public class Html extends ANY
 
   private boolean isVisible(AbstractFeature af)
   {
-    var vis = af.visibility();
-    return vis.typeVisibility() == Visi.PUB;
-
+    return af.visibility().typeVisibility() == Visi.PUB;
   }
 
 


### PR DESCRIPTION
Currently, every feature in the docs has the annotation because 0e9b57cdd9fc61488a7df03abc2e7cfd6d539a92 in module `json_encode` introduced an abstract feature in `Any`.

This will only show the annotation `[Contains abstract features]` if the abstract feature is in the same module (for which the docs are displayed) or in any of the modules it depends on (in most cases only base).

This way, [`String` in module `terminal`](https://fuzion-lang.dev/docs/terminal#String_0) will still have the annotation (because `String` contains abstract features in the base module).

supersedes #5402
