### PR TITLE
ast: fix #5467 by resetting pending error when Call must be resolved again

### DIFF
--- a/src/dev/flang/ast/ParsedOperatorCall.java
+++ b/src/dev/flang/ast/ParsedOperatorCall.java
@@ -226,6 +226,9 @@ public class ParsedOperatorCall extends ParsedCall
     _actualsResolvedFor = null;
     _calledFeature = null;
     _type = null;
+    _pendingError = null; // original attempt to resolve might have caused an
+                          // error that might be fixed in new attempt, see #5467
+                          // or tests/reg_issue5467
   }
 
 }

--- a/tests/reg_issue5467/Makefile
+++ b/tests/reg_issue5467/Makefile
@@ -1,0 +1,25 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test Makefile
+#
+# -----------------------------------------------------------------------
+
+override NAME = reg_issue5467
+include ../simple.mk

--- a/tests/reg_issue5467/reg_issue5467.fz
+++ b/tests/reg_issue5467/reg_issue5467.fz
@@ -1,0 +1,45 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test reg_issue5467
+#
+# -----------------------------------------------------------------------
+
+# The problem here is that a feature `Any.infix +` is originally not found
+# as a right-associative operator, but when turning operators into left-associative
+# ones, it is. However, the pending error is not reset and gets reported.
+#
+reg_issue5467 =>
+
+  # the original code from #5467
+  greet(who Any) => say ("Hi " + who + "! π is " + 3.142 + ".")
+
+  # the workaround from #5467
+  greet_fixed1(who Any) => say (("Hi " + who) + "! π is " + 3.142 + ".")
+  greet_fixed2(who Any) => say ("Hi " + $who + "! π is " + 3.142 + ".")
+
+  greet "Alice"
+  greet_fixed1 "Bob"
+  greet_fixed2 "Charlie"
+
+  # the simpler test from #5467 that works
+  x := ">"+Any+"<"; say x
+
+  # the simpler test from #5467 that does not work
+  say ">"+Any+"<"

--- a/tests/reg_issue5467/reg_issue5467.fz.expected_out
+++ b/tests/reg_issue5467/reg_issue5467.fz.expected_out
@@ -1,0 +1,5 @@
+Hi Alice! π is 3.142.
+Hi Bob! π is 3.142.
+Hi Charlie! π is 3.142.
+>instance[Any]<
+>instance[Any]<


### PR DESCRIPTION
An early, failed attempt to resolve `Any+"<"` for target `Any` was still recorded as pending error and reported falsely even after the target ´had been changed to `(">"+Any)`.

