### PR TITLE
ast: Fix `IndexOutOfBoundsException` in redefinition with open type parameter

### DIFF
--- a/src/dev/flang/fe/SourceModule.java
+++ b/src/dev/flang/fe/SourceModule.java
@@ -1647,10 +1647,11 @@ A post-condition of a feature that does not redefine an inherited feature must s
                       (Errors.any() ||
                        i < args.size() ||
                        args.get(args.size()-1).resultType().isOpenGeneric());
-                    int ai = Math.min(args.size() - 1, i);
 
-                    var originalArg = o.arguments().get(i);
-                    var actualArg   =   args       .get(ai);
+                    var oargs = o.arguments();
+                    int oi    = Math.min(oargs.size() - 1, i);
+                    var originalArg = oargs.get(oi);
+                    var actualArg   =  args.get(i);
                     AstErrors.argumentTypeMismatchInRedefinition(o, originalArg, t1,
                                                                  f, actualArg,
                                                                  isLegalCovariantThisType(o, f, t1, t2, true));

--- a/tests/reg_issue5501/Makefile
+++ b/tests/reg_issue5501/Makefile
@@ -1,0 +1,25 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test Makefile
+#
+# -----------------------------------------------------------------------
+
+override NAME = reg_issue5501
+include ../simple.mk

--- a/tests/reg_issue5501/reg_issue5501.fz
+++ b/tests/reg_issue5501/reg_issue5501.fz
@@ -1,0 +1,48 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test reg_issue5501
+#
+# -----------------------------------------------------------------------
+
+# test that should produce an error due to wrong argument type in
+# redefined feature where the original argument type is an open type
+# parameter that was replaced by an actual argument list during inheritance.
+#
+reg_issue5501 =>
+
+  # the original test from #5501
+  #
+  f : Function unit unit unit is
+    public redef call(x unit,
+                      y u8  # wrong type, should cause error
+                     )
+    => unit
+
+
+  # another test using way more arguments
+  #
+  g : Function i32 String bool (option u8) (Sequence i64) f32 is
+    public redef call(v String,
+                      w bool,
+                      x option u8,
+                      y Sequence i64,
+                      z f64   # wrong type, should cause error
+                      )
+    => 42

--- a/tests/reg_issue5501/reg_issue5501.fz.expected_err
+++ b/tests/reg_issue5501/reg_issue5501.fz.expected_err
@@ -1,0 +1,31 @@
+
+--CURDIR--/reg_issue5501.fz:34:23: error 1: Wrong argument type in redefined feature
+                      y u8  # wrong type, should cause error
+----------------------^
+In 'reg_issue5501.f.call' that redefines 'Function.call'
+argument type is       : 'u8'
+argument type should be: 'unit' (from 'Function.A')
+
+Original argument declared at {base.fum}/Function.fz:35:15:
+  public call(a A...) R => abstract
+--------------^
+To solve this, change type of argument to 'unit' at --CURDIR--/reg_issue5501.fz:34:23:
+                      y u8  # wrong type, should cause error
+----------------------^
+
+
+--CURDIR--/reg_issue5501.fz:46:23: error 2: Wrong argument type in redefined feature
+                      z f64   # wrong type, should cause error
+----------------------^
+In 'reg_issue5501.g.call' that redefines 'Function.call'
+argument type is       : 'f64'
+argument type should be: 'f32' (from 'Function.A')
+
+Original argument declared at {base.fum}/Function.fz:35:15:
+  public call(a A...) R => abstract
+--------------^
+To solve this, change type of argument to 'f32' at --CURDIR--/reg_issue5501.fz:46:23:
+                      z f64   # wrong type, should cause error
+----------------------^
+
+2 errors.


### PR DESCRIPTION
Instead of an error reporting about a wrong type in the redefinition, the original code resulted in a crash. fix #5501.

