### PR TITLE
ast: Fix require condition failure when redefining with wrong # of type pars

### DIFF
--- a/src/dev/flang/ast/AstErrors.java
+++ b/src/dev/flang/ast/AstErrors.java
@@ -719,6 +719,18 @@ public class AstErrors extends ANY
           "Original feature declared at " + originalFeature.pos().show());
   }
 
+  public static void formalTypeParametersLengthsMismatch(AbstractFeature originalFeature,
+                                                         AbstractFeature redefinedFeature)
+  {
+    error(redefinedFeature.pos(),
+          "Wrong number of type parameters in redefined feature",
+          "In " + s(redefinedFeature) + " that redefines " + s(originalFeature) + " " +
+          "type parameter count is " + redefinedFeature.generics().list.size() + " while it should be " + originalFeature.generics().list.size() + ".\n" +
+          "Original type parameters: "  + s(originalFeature .generics()) + "\n" +
+          "redefined type parameters: " + s(redefinedFeature.generics()) + "\n" +
+          "Original feature declared at " + originalFeature.pos().show());
+  }
+
   /* NYI: currently unused, need to check if a "while (23)" produces a useful error message
   static void whileConditionMustBeBool(SourcePosition pos, Type type)
   {

--- a/src/dev/flang/fe/SourceModule.java
+++ b/src/dev/flang/fe/SourceModule.java
@@ -1634,6 +1634,10 @@ A post-condition of a feature that does not redefine an inherited feature must s
           {
             AstErrors.argumentLengthsMismatch(o, ta.length, f, ra.length);
           }
+        else if (o.generics().list.size() != f.generics().list.size())
+          {
+            AstErrors.formalTypeParametersLengthsMismatch(o, f);
+          }
         else
           {
             for (int i = 0; i < ta.length; i++)

--- a/tests/reg_issue5503/Makefile
+++ b/tests/reg_issue5503/Makefile
@@ -22,4 +22,4 @@
 # -----------------------------------------------------------------------
 
 override NAME = reg_issue5503
-include ../simple.mk
+include ../simple_and_negative.mk

--- a/tests/reg_issue5503/Makefile
+++ b/tests/reg_issue5503/Makefile
@@ -1,0 +1,25 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test Makefile
+#
+# -----------------------------------------------------------------------
+
+override NAME = reg_issue5503
+include ../simple.mk

--- a/tests/reg_issue5503/reg_issue5503.fz
+++ b/tests/reg_issue5503/reg_issue5503.fz
@@ -1,0 +1,63 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test reg_issue5503
+#
+# -----------------------------------------------------------------------
+
+# test that the number of type parameters in a redefinition is not changed
+# compared to the original feature
+#
+reg_issue5503 =>
+
+  a is
+    f(X type) =>
+
+  # the orginal example from #5503
+  #
+  b : a is
+    redef f(x Any) =>   # 1. should cause an error: no type parameters, expecting 1
+
+  # cross-check with a correct redefinition:
+  #
+  c : a is
+    redef f(Y type) =>  # ok
+
+  # a more complex example with 3 type parameters and 2 value arguments
+  #
+  d is
+    f(X, Y, Z type, v, w i32) =>
+
+  e : d is
+    redef f(                    x, y, z Any, v, w i32) =>  # 2. should cause an error: no type parameters, expecting 3
+
+  f : d is
+    redef f(X             type, y, z    Any, v, w i32) =>  # 3. should cause an error: 1 type parameter, expecting 3
+
+  g : d is
+    redef f(X, Y          type, z       Any, v, w i32) =>  # 4. should cause an error: 2 type parameters, expecting 3
+
+  h : d is
+    redef f(X, Y, Z       type,              v, w i32) =>  # ok
+
+  i : d is
+    redef f(X, Y, Z, V    type,                 w i32) =>  # 5. should cause an error: 4 type parameters, expecting 3
+
+  j : d is
+    redef f(X, Y, Z, V, W type                       ) =>  # 6. should cause an error: 5 type parameters, expecting 3

--- a/tests/reg_issue5503/reg_issue5503.fz
+++ b/tests/reg_issue5503/reg_issue5503.fz
@@ -32,7 +32,7 @@ reg_issue5503 =>
   # the orginal example from #5503
   #
   b : a is
-    redef f(x Any) =>   # 1. should cause an error: no type parameters, expecting 1
+    redef f(x Any) =>   # 1. should flag an error: no type parameters, expecting 1
 
   # cross-check with a correct redefinition:
   #
@@ -45,19 +45,19 @@ reg_issue5503 =>
     f(X, Y, Z type, v, w i32) =>
 
   e : d is
-    redef f(                    x, y, z Any, v, w i32) =>  # 2. should cause an error: no type parameters, expecting 3
+    redef f(                    x, y, z Any, v, w i32) =>  # 2. should flag an error: no type parameters, expecting 3
 
   f : d is
-    redef f(X             type, y, z    Any, v, w i32) =>  # 3. should cause an error: 1 type parameter, expecting 3
+    redef f(X             type, y, z    Any, v, w i32) =>  # 3. should flag an error: 1 type parameter, expecting 3
 
   g : d is
-    redef f(X, Y          type, z       Any, v, w i32) =>  # 4. should cause an error: 2 type parameters, expecting 3
+    redef f(X, Y          type, z       Any, v, w i32) =>  # 4. should flag an error: 2 type parameters, expecting 3
 
   h : d is
     redef f(X, Y, Z       type,              v, w i32) =>  # ok
 
   i : d is
-    redef f(X, Y, Z, V    type,                 w i32) =>  # 5. should cause an error: 4 type parameters, expecting 3
+    redef f(X, Y, Z, V    type,                 w i32) =>  # 5. should flag an error: 4 type parameters, expecting 3
 
   j : d is
-    redef f(X, Y, Z, V, W type                       ) =>  # 6. should cause an error: 5 type parameters, expecting 3
+    redef f(X, Y, Z, V, W type                       ) =>  # 6. should flag an error: 5 type parameters, expecting 3

--- a/tests/reg_issue5503/reg_issue5503.fz.expected_err
+++ b/tests/reg_issue5503/reg_issue5503.fz.expected_err
@@ -1,6 +1,6 @@
 
 --CURDIR--/reg_issue5503.fz:51:11: error 1: Wrong number of type parameters in redefined feature
-    redef f(X             type, y, z    Any, v, w i32) =>  # 3. should cause an error: 1 type parameter, expecting 3
+    redef f(X             type, y, z    Any, v, w i32) =>  # 3. should flag an error: 1 type parameter, expecting 3
 ----------^
 In 'reg_issue5503.f.f' that redefines 'reg_issue5503.d.f' type parameter count is 1 while it should be 3.
 Original type parameters: 'X, Y, Z'
@@ -11,7 +11,7 @@ Original feature declared at --CURDIR--/reg_issue5503.fz:45:5:
 
 
 --CURDIR--/reg_issue5503.fz:35:11: error 2: Wrong number of type parameters in redefined feature
-    redef f(x Any) =>   # 1. should cause an error: no type parameters, expecting 1
+    redef f(x Any) =>   # 1. should flag an error: no type parameters, expecting 1
 ----------^
 In 'reg_issue5503.b.f' that redefines 'reg_issue5503.a.f' type parameter count is 0 while it should be 1.
 Original type parameters: 'X'
@@ -22,7 +22,7 @@ Original feature declared at --CURDIR--/reg_issue5503.fz:30:5:
 
 
 --CURDIR--/reg_issue5503.fz:48:11: error 3: Wrong number of type parameters in redefined feature
-    redef f(                    x, y, z Any, v, w i32) =>  # 2. should cause an error: no type parameters, expecting 3
+    redef f(                    x, y, z Any, v, w i32) =>  # 2. should flag an error: no type parameters, expecting 3
 ----------^
 In 'reg_issue5503.e.f' that redefines 'reg_issue5503.d.f' type parameter count is 0 while it should be 3.
 Original type parameters: 'X, Y, Z'
@@ -33,7 +33,7 @@ Original feature declared at --CURDIR--/reg_issue5503.fz:45:5:
 
 
 --CURDIR--/reg_issue5503.fz:54:11: error 4: Wrong number of type parameters in redefined feature
-    redef f(X, Y          type, z       Any, v, w i32) =>  # 4. should cause an error: 2 type parameters, expecting 3
+    redef f(X, Y          type, z       Any, v, w i32) =>  # 4. should flag an error: 2 type parameters, expecting 3
 ----------^
 In 'reg_issue5503.g.f' that redefines 'reg_issue5503.d.f' type parameter count is 2 while it should be 3.
 Original type parameters: 'X, Y, Z'
@@ -44,7 +44,7 @@ Original feature declared at --CURDIR--/reg_issue5503.fz:45:5:
 
 
 --CURDIR--/reg_issue5503.fz:60:11: error 5: Wrong number of type parameters in redefined feature
-    redef f(X, Y, Z, V    type,                 w i32) =>  # 5. should cause an error: 4 type parameters, expecting 3
+    redef f(X, Y, Z, V    type,                 w i32) =>  # 5. should flag an error: 4 type parameters, expecting 3
 ----------^
 In 'reg_issue5503.i.f' that redefines 'reg_issue5503.d.f' type parameter count is 4 while it should be 3.
 Original type parameters: 'X, Y, Z'
@@ -55,7 +55,7 @@ Original feature declared at --CURDIR--/reg_issue5503.fz:45:5:
 
 
 --CURDIR--/reg_issue5503.fz:63:11: error 6: Wrong number of type parameters in redefined feature
-    redef f(X, Y, Z, V, W type                       ) =>  # 6. should cause an error: 5 type parameters, expecting 3
+    redef f(X, Y, Z, V, W type                       ) =>  # 6. should flag an error: 5 type parameters, expecting 3
 ----------^
 In 'reg_issue5503.j.f' that redefines 'reg_issue5503.d.f' type parameter count is 5 while it should be 3.
 Original type parameters: 'X, Y, Z'

--- a/tests/reg_issue5503/reg_issue5503.fz.expected_err
+++ b/tests/reg_issue5503/reg_issue5503.fz.expected_err
@@ -1,0 +1,67 @@
+
+--CURDIR--/reg_issue5503.fz:51:11: error 1: Wrong number of type parameters in redefined feature
+    redef f(X             type, y, z    Any, v, w i32) =>  # 3. should cause an error: 1 type parameter, expecting 3
+----------^
+In 'reg_issue5503.f.f' that redefines 'reg_issue5503.d.f' type parameter count is 1 while it should be 3.
+Original type parameters: 'X, Y, Z'
+redefined type parameters: 'X'
+Original feature declared at --CURDIR--/reg_issue5503.fz:45:5:
+    f(X, Y, Z type, v, w i32) =>
+----^
+
+
+--CURDIR--/reg_issue5503.fz:35:11: error 2: Wrong number of type parameters in redefined feature
+    redef f(x Any) =>   # 1. should cause an error: no type parameters, expecting 1
+----------^
+In 'reg_issue5503.b.f' that redefines 'reg_issue5503.a.f' type parameter count is 0 while it should be 1.
+Original type parameters: 'X'
+redefined type parameters: ''
+Original feature declared at --CURDIR--/reg_issue5503.fz:30:5:
+    f(X type) =>
+----^
+
+
+--CURDIR--/reg_issue5503.fz:48:11: error 3: Wrong number of type parameters in redefined feature
+    redef f(                    x, y, z Any, v, w i32) =>  # 2. should cause an error: no type parameters, expecting 3
+----------^
+In 'reg_issue5503.e.f' that redefines 'reg_issue5503.d.f' type parameter count is 0 while it should be 3.
+Original type parameters: 'X, Y, Z'
+redefined type parameters: ''
+Original feature declared at --CURDIR--/reg_issue5503.fz:45:5:
+    f(X, Y, Z type, v, w i32) =>
+----^
+
+
+--CURDIR--/reg_issue5503.fz:54:11: error 4: Wrong number of type parameters in redefined feature
+    redef f(X, Y          type, z       Any, v, w i32) =>  # 4. should cause an error: 2 type parameters, expecting 3
+----------^
+In 'reg_issue5503.g.f' that redefines 'reg_issue5503.d.f' type parameter count is 2 while it should be 3.
+Original type parameters: 'X, Y, Z'
+redefined type parameters: 'X, Y'
+Original feature declared at --CURDIR--/reg_issue5503.fz:45:5:
+    f(X, Y, Z type, v, w i32) =>
+----^
+
+
+--CURDIR--/reg_issue5503.fz:60:11: error 5: Wrong number of type parameters in redefined feature
+    redef f(X, Y, Z, V    type,                 w i32) =>  # 5. should cause an error: 4 type parameters, expecting 3
+----------^
+In 'reg_issue5503.i.f' that redefines 'reg_issue5503.d.f' type parameter count is 4 while it should be 3.
+Original type parameters: 'X, Y, Z'
+redefined type parameters: 'X, Y, Z, V'
+Original feature declared at --CURDIR--/reg_issue5503.fz:45:5:
+    f(X, Y, Z type, v, w i32) =>
+----^
+
+
+--CURDIR--/reg_issue5503.fz:63:11: error 6: Wrong number of type parameters in redefined feature
+    redef f(X, Y, Z, V, W type                       ) =>  # 6. should cause an error: 5 type parameters, expecting 3
+----------^
+In 'reg_issue5503.j.f' that redefines 'reg_issue5503.d.f' type parameter count is 5 while it should be 3.
+Original type parameters: 'X, Y, Z'
+redefined type parameters: 'X, Y, Z, V, W'
+Original feature declared at --CURDIR--/reg_issue5503.fz:45:5:
+    f(X, Y, Z type, v, w i32) =>
+----^
+
+6 errors.


### PR DESCRIPTION
The checks for redefinitions only checked that the total numer of arguments
match without checking that the number of type parameters might still be
different.

This patch adds a check for a different number of type parameters and adds
corresponding errors.  A regression tests checks that this works.

Fix #5503.
