### PR TITLE
lib: fix some types

### DIFF
--- a/modules/base/src/io/dir/read.fz
+++ b/modules/base/src/io/dir/read.fz
@@ -59,9 +59,9 @@ public read(ro Dir_Read_Handler) : effect is
 
 # short-hand for accessing read effect in current environment
 #
-public read read =>
+public read io.dir.read =>
   read.type.install_default
-  read.env
+  io.dir.read.env
 
 
 # reference to the reading operations that could take place

--- a/modules/base/src/mutate.fz
+++ b/modules/base/src/mutate.fz
@@ -189,7 +189,7 @@ public mutate : linear_effect is
 
     # unwrap this mutable value
     #
-    public redef unwrap T ! mutate => get
+    public redef unwrap T ! mutate.this => get
 
 
     # returns `as_string` of the current value

--- a/modules/base/src/time/nano.fz
+++ b/modules/base/src/time/nano.fz
@@ -73,10 +73,10 @@ public nano (p Nano_Time_Handler) : effect is
 
 # short-hand for accessing time.nano effect in current environment
 #
-public nano nano =>
+public nano time.nano =>
   if !nano.is_instated
     nano.install_default
-  nano.env
+  time.nano.env
 
 
 # abstract handler that can deliver a nano time


### PR DESCRIPTION
Found this while working on detecting used effects of features.

e.g. here:
```
public read outcome String ! io.dir.read =>
```
would have correctly been:
```
public read outcome String ! dir.this.read =>
```

so I changed the implementations of the short-hands
