### PR TITLE
parser: unify handling of `()` and `{}` with respect to indentation, fix #4425

### DIFF
--- a/src/dev/flang/parser/Parser.java
+++ b/src/dev/flang/parser/Parser.java
@@ -59,6 +59,20 @@ public class Parser extends Lexer
   }
 
 
+  /**
+   * Exception used for control flow to exit a call.
+   */
+  static class GiveUp extends RuntimeException
+  {
+
+    /**
+     * Pre-allocated instance of `GiveUp`
+     */
+    static GiveUp _INSTANCE_ = new GiveUp();
+
+  };
+
+
   /*----------------------------  constants  ----------------------------*/
 
 
@@ -1343,7 +1357,7 @@ indexTail   : ":=" exprInLine
     do
       {
         SourcePosition pos = tokenSourcePos();
-        var l = bracketTermWithNLs(BRACKETS, "indexCall", () -> actualCommas());
+        var l = bracketTermWithNLs(BRACKETS, "indexCall", () -> actualCommas(true));
         String n = FuzionConstants.FEATURE_NAME_INDEX;
         if (skip(":="))
           {
@@ -1556,7 +1570,7 @@ actualArgs  : actualSpaces
   {
     return (ignoredTokenBefore() || current() != Token.t_lparen)
       ? actualSpaces()
-      : bracketTermWithNLs(PARENS, "actualArgs", () -> actualCommas());
+      : bracketTermWithNLs(PARENS, "actualArgs", () -> actualCommas(true));
   }
 
 
@@ -1652,6 +1666,12 @@ actualArgs  : actualSpaces
   /**
    * Parse actualCommas
    *
+   * @param endAtComma true to treat `x, v->2*v` as two actuals `x` and `v->2*v`
+   * instead of one `(x,v)->2*v`.
+   *
+   * NYI: CLEANUP: It might be better to omit the case endAtComma==true and to always
+   * parse the case `x, v->2*v` as one actual.
+   *
 actualCommas: actualSome
             |
             ;
@@ -1662,7 +1682,7 @@ actualMore  : COMMA actualSome
             |
             ;
    */
-  List<Expr> actualCommas()
+  List<Expr> actualCommas(boolean endAtComma)
   {
     var result = new List<Expr>();
     if (current() != Token.t_rparen   &&
@@ -1670,7 +1690,7 @@ actualMore  : COMMA actualSome
       {
         do
           {
-            var oldEAc = endAtComma(true);   /* see #3798 for an example where this is necessary: a call `f(x, v->2*v)` */
+            var oldEAc = endAtComma(endAtComma);   /* see #3798 for an example where this is necessary: a call `f(x, v->2*v)` */
             result.add(operatorExpr());
             endAtComma(oldEAc);
           }
@@ -1893,52 +1913,86 @@ opsTerms    : ops
   /**
    * Parse klammer is either a single parenthesized expression or a tuple
    *
-klammer     : klammerExpr
+klammer     : LPAREN block RPAREN
             | tuple
-            | klammerLambd
-            ;
-klammerExpr : LPAREN expr RPAREN
-            ;
-tuple       : LPAREN RPAREN
-            | LPAREN operatorExpr (COMMA operatorExpr)+ RPAREN
-            ;
-klammerLambd: tuple lambda
+            | tuple lambda
             ;
    */
   Expr klammer()
   {
-    SourcePosition pos = tokenSourcePos();
-    var tupleElements = new List<Expr>();
-    bracketTermWithNLs(PARENS, "klammer",
-                       () -> {
-                         do
-                           {
-                             tupleElements.add(operatorExpr());
-                           }
-                         while (skipComma());
-                         return Void.TYPE;
-                       },
-                       () -> Void.TYPE);
-
-
-    if (isLambdaPrefix())                  // a lambda expression
+    Expr res;
+    var f = fork();
+    var t = f.tuple();
+    if (t != null && f.isLambdaPrefix())                  // a lambda expression
       {
-        return lambda(tupleElements);
+        // a little overkill: we first permit an arbitrary tuple, just to later
+        // extract either the argument names or types.
+        res = lambda(tuple());
       }
-    else if (tupleElements.size() == 1)    // an expr wrapped in parentheses, not a tuple
+    else if (t != null && t.size() != 1)
       {
-        var e = tupleElements.get(0);
-        if (e instanceof ParsedOperatorCall oc)
+        res = new ParsedCall(null, new ParsedName(tokenSourcePos(), "tuple"), tuple());
+      }
+    else if (t != null)
+      {
+        // NYI: UNDER DEVELOPMENT: This case of a single operatorExpr in parentheses is parsed slightly different than
+        // a block.  Would be good to avoid the special handling here and always use the `else` case below.
+        //
+        // in particular:
+        //
+        //   _ := l.zip m (a,b -> unit)         # as block, would be parsed as declaration of `a` and `b` and not lambda
+        //   _ := ("bla"
+        //          + "blub")                   # as block, causes indentation error
+        //   _ := (a).this                      # as block, causes qualifier expected for '.this' expression.
+        //
+        // I suggest the cases `(a,b -> unit)` and `(a).this` should be
+        // supported when parsing a block in parentheses, while the indentation
+        // problem is maybe acceptable to cause an error.
+        //
+        res = tuple().get(0);
+        if (res instanceof ParsedOperatorCall oc)
           { // disable chained boolean optimization:
             oc.putInParentheses();
           }
-        return e;
       }
-    else                                   // a tuple
+    else                                                    // a block
       {
-        return new ParsedCall(null, new ParsedName(pos, "tuple"), tupleElements);
+        res = bracketTermWithNLs(PARENS, "klammer",
+                                 () -> block(),
+                                 () -> emptyBlock());
       }
+    return res;
   }
+
+
+  /**
+   * Parse tuple, return null in case this is not a tuple, but a block (leaving
+   * the Parser instance in an undefined state).
+   *
+tuple       : LPAREN actualCommas RPAREN
+            ;
+   */
+  List<Expr> tuple()
+  {
+    try
+      {
+        return bracketTermWithNLs(PARENS, "klammer",
+                                  () -> {
+                                    var l = actualCommas(false);
+                                    if (currentAtMinIndent() != Token.t_rparen ) // there is more, so this might be a block
+                                      {
+                                        throw GiveUp._INSTANCE_;
+                                      }
+                                    return l;
+                                  },
+                                  () -> new List<Expr>() // default for `()` is an empty tuple
+                                  );
+      }
+    catch (GiveUp _)
+      {
+        return null;
+      }
+  };
 
 
   /**

--- a/tests/choice_negative/choice_negative.fz.expected_err
+++ b/tests/choice_negative/choice_negative.fz.expected_err
@@ -17,32 +17,32 @@ While parsing: implRout, parse stack: implRout, routOrField, feature, expr, expr
 While parsing: implRout, parse stack: implRout, routOrField, feature, expr, exprs, block (twice), implRout, implFldOrRout, routOrField, feature, expr, exprs, block (twice), implRout, implFldOrRout, routOrField, feature, expr, exprs, block (twice), unit
 
 
---CURDIR--/choice_negative.fz:61:26: error 4: Repeated inheritance of choice is not permitted
-    A : choice i32 bool, choice String f64 is # 9. should flag an error: choice type must inherit exactly once from choice
--------------------------^^^^^^
-A choice feature must inherit directly from choice exactly once.
-Previous inheritance from choice at --CURDIR--/choice_negative.fz:61:9:
-
-
---CURDIR--/choice_negative.fz:66:12: error 5: Repeated inheritance of choice is not permitted
+--CURDIR--/choice_negative.fz:66:12: error 4: Repeated inheritance of choice is not permitted
     C : A, B is # 10. should flag an error: choice type must inherit exactly once from choice
 -----------^
 A choice feature must inherit directly from choice exactly once.
 Previous inheritance from choice at --CURDIR--/choice_negative.fz:66:9:
 
 
---CURDIR--/choice_negative.fz:70:12: error 6: Repeated inheritance of choice is not permitted
+--CURDIR--/choice_negative.fz:70:12: error 5: Repeated inheritance of choice is not permitted
     B : A, choice String f64 is # 11. should flag an error: choice type must inherit exactly once from choice
 -----------^^^^^^
 A choice feature must inherit directly from choice exactly once.
 Previous inheritance from choice at --CURDIR--/choice_negative.fz:70:9:
 
 
---CURDIR--/choice_negative.fz:74:28: error 7: Repeated inheritance of choice is not permitted
+--CURDIR--/choice_negative.fz:74:28: error 6: Repeated inheritance of choice is not permitted
     B : choice String f64, A is # 12. should flag an error: choice type must inherit exactly once from choice
 ---------------------------^
 A choice feature must inherit directly from choice exactly once.
 Previous inheritance from choice at --CURDIR--/choice_negative.fz:74:9:
+
+
+--CURDIR--/choice_negative.fz:61:26: error 7: Repeated inheritance of choice is not permitted
+    A : choice i32 bool, choice String f64 is # 9. should flag an error: choice type must inherit exactly once from choice
+-------------------------^^^^^^
+A choice feature must inherit directly from choice exactly once.
+Previous inheritance from choice at --CURDIR--/choice_negative.fz:61:9:
 
 
 --CURDIR--/choice_negative.fz:54:10: error 8: Could not find called feature

--- a/tests/reg_issue3406/reg_issue3406.fz.expected_err
+++ b/tests/reg_issue3406/reg_issue3406.fz.expected_err
@@ -2,6 +2,6 @@
 --CURDIR--/reg_issue3406.fz:25:3: error 1: Syntax error: expected term (lbrace, lparen, lbracket, fun, string, integer, old, match, or name), found end-of-file
 (#
 --^
-While parsing: term, parse stack: term, opExpr, operatorExpr, klammer, bracketTerm, term, opExpr, operatorExpr, expr, exprs, block (twice), unit
+While parsing: term, parse stack: term, opExpr, operatorExpr, actualCommas, tuple, klammer, bracketTerm, term, opExpr, operatorExpr, expr, exprs, block (twice), unit
 
 one error.

--- a/tests/reg_issue4348/reg_issue4348.fz.expected_err
+++ b/tests/reg_issue4348/reg_issue4348.fz.expected_err
@@ -2,12 +2,12 @@
 --CURDIR--/reg_issue4348.fz:31:46: error 1: Syntax error: expected identifier name, infix/prefix/postfix operator, 'ternary ? :', 'index' or 'set' name, found left parenthesis '('
   say ((T : property.orderable): res.zip res.(drop 1)  (<=) |> .reduce true (&&))
 ---------------------------------------------^
-While parsing: name, parse stack: name (twice), call, dotCall, callTail, call, call0, callOrFeatOrThis, term, opExpr, operatorExpr, actualSpace, actualSpaces, actualArgs, call, dotCall, callTail, call, call0, callOrFeatOrThis, term, opsTail, opExpr, operatorExpr, klammer, bracketTerm, term, opExpr, operatorExpr, actualSpace, actualSpaces, actualArgs, call, call0, callOrFeatOrThis, term, opExpr, operatorExpr, expr, exprs, block (twice), implRout, implFldOrRout, routOrField, feature, expr, exprs, block (twice), unit
+While parsing: name, parse stack: name (twice), call, dotCall, callTail, call, call0, callOrFeatOrThis, term, opExpr, operatorExpr, actualSpace, actualSpaces, actualArgs, call, dotCall, callTail, call, call0, callOrFeatOrThis, term, opsTail, opExpr, operatorExpr, actualCommas, tuple, klammer, bracketTerm, term, opExpr, operatorExpr, actualSpace, actualSpaces, actualArgs, call, call0, callOrFeatOrThis, term, opExpr, operatorExpr, expr, exprs, block (twice), implRout, implFldOrRout, routOrField, feature, expr, exprs, block (twice), unit
 
 
 --CURDIR--/reg_issue4348.fz:32:46: error 2: Syntax error: expected identifier name, infix/prefix/postfix operator, 'ternary ? :', 'index' or 'set' name, found left parenthesis '('
   say ((T : property.orderable): res.zip res.(drop 1)  (a,b -> { say "$a $b {a <= b}"; a<=b }) |> .reduce true (&&))
 ---------------------------------------------^
-While parsing: name, parse stack: name (twice), call, dotCall, callTail, call, call0, callOrFeatOrThis, term, opExpr, operatorExpr, actualSpace, actualSpaces, actualArgs, call, dotCall, callTail, call, call0, callOrFeatOrThis, term, opsTail, opExpr, operatorExpr, klammer, bracketTerm, term, opExpr, operatorExpr, actualSpace, actualSpaces, actualArgs, call, call0, callOrFeatOrThis, term, opExpr, operatorExpr, expr, exprs, block (twice), implRout, implFldOrRout, routOrField, feature, expr, exprs, block (twice), unit
+While parsing: name, parse stack: name (twice), call, dotCall, callTail, call, call0, callOrFeatOrThis, term, opExpr, operatorExpr, actualSpace, actualSpaces, actualArgs, call, dotCall, callTail, call, call0, callOrFeatOrThis, term, opsTail, opExpr, operatorExpr, actualCommas, tuple, klammer, bracketTerm, term, opExpr, operatorExpr, actualSpace, actualSpaces, actualArgs, call, call0, callOrFeatOrThis, term, opExpr, operatorExpr, expr, exprs, block (twice), implRout, implFldOrRout, routOrField, feature, expr, exprs, block (twice), unit
 
 2 errors.

--- a/tests/reg_issue4425/Makefile
+++ b/tests/reg_issue4425/Makefile
@@ -1,0 +1,25 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test Makefile
+#
+# -----------------------------------------------------------------------
+
+override NAME = reg_issue4425
+include ../simple.mk

--- a/tests/reg_issue4425/reg_issue4425.fz
+++ b/tests/reg_issue4425/reg_issue4425.fz
@@ -1,0 +1,68 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test reg_issue4425
+#
+# -----------------------------------------------------------------------
+
+# parentheses ( ) around a block should behave the same as braces around
+# that block
+#
+reg_issue4425 =>
+
+  # original positive example from #4425
+  #
+  ignore i32->bool p->{if p = 3 then
+                          say "hi"
+                       false}
+
+
+  # original negative example from #4425 that used to cause an indentation
+  # error while parsing
+  #
+  ignore i32->bool p->(if p = 3 then
+                         say "hi"
+                       false)
+
+  # same tests, but producing some output:
+  (id i32->bool p->{if p = 3 then
+                      say "hi using \{\}"
+                    false}).call 3 |> say
+  (id i32->bool p->(if p = 3 then
+                      say "hi using ()"
+                    false)).call 3 |> say
+
+  type_of ()                           |> x -> say "should be empty tuple: $x"
+  type_of ("a",42)                     |> x -> say "should be tuple String 42: $x"
+  type_of (id i32,i32->i32 (a,b)->a*b) |> x -> say "should be Binary i32 i32 i32: $x"
+  type_of (if 3 = 4 then
+             say "strange"
+           else
+             say "*** should not run ***"
+           say "done code block")      |> x -> say "should be unit: $x"
+  (if 3 = 4 then
+     say "strange"
+   else
+     say "this should run 1"
+   "result from code block 1")         |> x -> say "should be result form code block 1: $x"
+  {if 3 = 4 then
+     say "strange"
+   else
+     say "this should run 2"
+   "result from code block 2"}         |> x -> say "should be result form code block 2: $x"

--- a/tests/reg_issue4425/reg_issue4425.fz.expected_out
+++ b/tests/reg_issue4425/reg_issue4425.fz.expected_out
@@ -1,0 +1,12 @@
+hi using {}
+false
+hi using ()
+false
+should be empty tuple: Type of 'tuple'
+should be tuple String 42: Type of 'tuple codepoint i32'
+should be Binary i32 i32 i32: Type of 'Binary i32 i32 i32'
+should be unit: Type of 'unit'
+this should run 1
+should be result form code block 1: result from code block 1
+this should run 2
+should be result form code block 2: result from code block 2

--- a/tests/reg_issue4426/reg_issue4426.fz.expected_err
+++ b/tests/reg_issue4426/reg_issue4426.fz.expected_err
@@ -1,16 +1,22 @@
 
---CURDIR--/reg_issue4426.fz:24:16: error 1: Inconsistent indentation
+--CURDIR--/reg_issue4426.fz:24:16: error 1: Syntax error: expected semicolon ';', found keyword 'do'
   while (b = 1 do
 ---------------^
+While parsing: semicolon or flat line break, parse stack: semiOrFlatLF, exprs, block (twice), klammer, bracketTerm, term, opExpr, operatorExpr, exprInLine, loop, term, opExpr, operatorExpr, expr, exprs, block (twice), unit
+
+
+--CURDIR--/reg_issue4426.fz:25:1: error 2: Inconsistent indentation
+do
+^
 Indentation reference point is --CURDIR--/reg_issue4426.fz:24:10:
   while (b = 1 do
 ---------^
 While parsing: klammer, parse stack: klammer, bracketTerm, term, opExpr, operatorExpr, exprInLine, loop, term, opExpr, operatorExpr, expr, exprs, block (twice), unit
 
 
---CURDIR--/reg_issue4426.fz:24:12: error 2: Wrong syntax in '.type' expression.
+--CURDIR--/reg_issue4426.fz:24:10: error 3: Wrong syntax in '.type' expression.
   while (b = 1 do
------------^
+---------^^^^^^^^
 To solve this, make sure the expression to the left of '.type' denotes a type.
 
-2 errors.
+3 errors.

--- a/tests/select_clause_negative/select_clause_negative.fz.expected_err
+++ b/tests/select_clause_negative/select_clause_negative.fz.expected_err
@@ -2,13 +2,13 @@
 --CURDIR--/select_clause_negative.fz:30:11: error 1: Syntax error: expected identifier name, infix/prefix/postfix operator, 'ternary ? :', 'index' or 'set' name, found operator '-'
   say (a. -1)   # should flag an error:
 ----------^
-While parsing: name, parse stack: name (twice), call, dotCall, callTail, call, call0, callOrFeatOrThis, term, opExpr, operatorExpr, klammer, bracketTerm, term, opExpr, operatorExpr, actualSpace, actualSpaces, actualArgs, call, call0, callOrFeatOrThis, term, opExpr, operatorExpr, expr, exprs, block (twice), implRout, implFldOrRout, routOrField, feature, expr, exprs, block (twice), unit
+While parsing: name, parse stack: name (twice), call, dotCall, callTail, call, call0, callOrFeatOrThis, term, opExpr, operatorExpr, actualCommas, tuple, klammer, bracketTerm, term, opExpr, operatorExpr, actualSpace, actualSpaces, actualArgs, call, call0, callOrFeatOrThis, term, opExpr, operatorExpr, expr, exprs, block (twice), implRout, implFldOrRout, routOrField, feature, expr, exprs, block (twice), unit
 
 
 --CURDIR--/select_clause_negative.fz:32:12: error 2: Syntax error: expected identifier name, infix/prefix/postfix operator, 'ternary ? :', 'index' or 'set' name, found operator '-'
   say (a . -1)  # should flag an error:
 -----------^
-While parsing: name, parse stack: name (twice), call, dotCall, callTail, call, call0, callOrFeatOrThis, term, opExpr, operatorExpr, klammer, bracketTerm, term, opExpr, operatorExpr, actualSpace, actualSpaces, actualArgs, call, call0, callOrFeatOrThis, term, opExpr, operatorExpr, expr, exprs, block (twice), implRout, implFldOrRout, routOrField, feature, expr, exprs, block (twice), unit
+While parsing: name, parse stack: name (twice), call, dotCall, callTail, call, call0, callOrFeatOrThis, term, opExpr, operatorExpr, actualCommas, tuple, klammer, bracketTerm, term, opExpr, operatorExpr, actualSpace, actualSpaces, actualArgs, call, call0, callOrFeatOrThis, term, opExpr, operatorExpr, expr, exprs, block (twice), implRout, implFldOrRout, routOrField, feature, expr, exprs, block (twice), unit
 
 
 --CURDIR--/select_clause_negative.fz:34:9: error 3: Selector must be in the range of 0..1 for 2 actual type parameters given for the open type parameter type


### PR DESCRIPTION
Now, `{`  and `(` can be used largely interchangably around code block, e.g., we can create a block as follows

    say (if 3 = 4 then
           say "strange"
         else
           say "this should run 1"
         "result from code block 1")

which is equivalent to the same code using `{`/`}`:

    say {if 3 = 4 then
           say "strange"
         else
           say "this should run 2"
         "result from code block 2"}

Simplified the grammar rules for `klammer`, `tuple` and `lambda`.

There are still some minor syntactical differences if one a single `operatorExpr` is put in `(`/`)` vs. `{`/`}`, in particular

    _ := l.zip m (a,b -> unit)  # with {}, would be parsed as declaration of `a` and `b` and not lambda
    _ := ("bla"
           + "blub")            # with {}, causes indentation error
    _ := (a).this               # with {}, causes qualifier expected for '.this' expression.

I will leave these for later to be fixed.

Also, there are still differences when parsing actual arguments in parentheses vs. a tuple with respect to the handling of commas: `(x,y->unit,z)` would be parsed as three actual arguments (`x`, `y->unit` and `z`), but as a two-tuple (cosisting of `x, y->unit` and `z`).

Add a regression test for #4425.
