### PR TITLE
ast: formalgenerics, transparently use type args of feature

### DIFF
--- a/src/dev/flang/ast/AbstractFeature.java
+++ b/src/dev/flang/ast/AbstractFeature.java
@@ -150,12 +150,6 @@ public abstract class AbstractFeature extends Expr implements Comparable<Abstrac
 
 
   /**
-   * cached result of typeArguments();
-   */
-  private List<AbstractFeature> _typeArguments = null;
-
-
-  /**
    * cached result of cotype()
    */
   protected AbstractFeature _cotype = null;
@@ -164,7 +158,7 @@ public abstract class AbstractFeature extends Expr implements Comparable<Abstrac
   /**
    * The formal generic arguments of this feature, cached result of generics()
    */
-  protected FormalGenerics _generics;
+  private FormalGenerics _generics;
 
 
   /**
@@ -477,7 +471,7 @@ public abstract class AbstractFeature extends Expr implements Comparable<Abstrac
     var result = featureName();
     if (hasOpenGenericsArgList(res))
       {
-        var argCount = arguments().size() + actualGenerics.size() - outer().generics().list.size();
+        var argCount = arguments().size() + actualGenerics.size() - outer().typeArguments().size();
         if (CHECKS) check
           (Errors.any() || argCount >= 0);
         if (argCount < 0)
@@ -610,7 +604,7 @@ public abstract class AbstractFeature extends Expr implements Comparable<Abstrac
     AbstractFeature o = this;
     while (o != null && !result)
       {
-        for (var g : o.generics().list)
+        for (var g : o.typeArguments())
           {
             if (g.isOpenTypeParameter())
               {
@@ -1482,24 +1476,12 @@ public abstract class AbstractFeature extends Expr implements Comparable<Abstrac
    */
   public List<AbstractFeature> typeArguments()
   {
-    if (_typeArguments == null)
-      {
-        var args = arguments();
-        if (args.stream().anyMatch(a -> a.isTypeParameter()))
-          {
-            _typeArguments = new List<>();
-            _typeArguments.addAll(args.stream().filter(a -> a.isTypeParameter()).toList());
-          }
-        else if (args.stream().anyMatch(a -> !a.isTypeParameter()))
-          {
-            _typeArguments = new List<>();
-          }
-        else
-          {
-            _typeArguments = args;
-          }
-      }
-    return _typeArguments;
+    var ta = arguments()
+      .stream()
+      .filter(a -> a.isTypeParameter())
+      .collect(List.collector());
+    ta.freeze();
+    return ta;
   }
 
 
@@ -1529,17 +1511,7 @@ public abstract class AbstractFeature extends Expr implements Comparable<Abstrac
   {
     if (_generics == null)
       {
-        // Recreate FormalGenerics from typeParameters
-        // NYI: Remove, FormalGenerics should use AbstractFeature.typeArguments() instead of its own list of Generics.
-        if (typeArguments().isEmpty())
-          {
-            _generics = FormalGenerics.NONE;
-          }
-        else
-          {
-            // NYI: use this
-            _generics = new FormalGenerics(typeArguments());
-          }
+        _generics = new FormalGenerics(this);
       }
     return _generics;
   }
@@ -1810,10 +1782,10 @@ public abstract class AbstractFeature extends Expr implements Comparable<Abstrac
        outer().generics().sizeMatches(actuals));
 
     if (CHECKS) check
-      (outer().generics().list.getLast() == this);
+      (outer().typeArguments().getLast() == this);
 
     return outer().generics().sizeMatches(actuals)
-      ? new List<>(actuals.subList(outer().generics().list.size()-1, actuals.size()).iterator())
+      ? new List<>(actuals.subList(outer().typeArguments().size()-1, actuals.size()).iterator())
       : new List<AbstractType>(Types.t_ERROR);
   }
 
@@ -1841,7 +1813,7 @@ public abstract class AbstractFeature extends Expr implements Comparable<Abstrac
     var o = outer();
     if (!isThisTypeInCotype() && o.isCotype())
       {
-        result = o.cotypeOrigin().generics().list.get(typeParameterIndex()-1);
+        result = o.cotypeOrigin().typeArguments().get(typeParameterIndex()-1);
       }
     return result;
   }

--- a/src/dev/flang/ast/AbstractType.java
+++ b/src/dev/flang/ast/AbstractType.java
@@ -2112,7 +2112,7 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
       {
         if (genericArgument().outer() == outerCotype.cotypeOrigin())
           {
-            result = outerCotype.generics().list.get(genericArgument().typeParameterIndex() + 1).asGenericType();
+            result = outerCotype.typeArguments().get(genericArgument().typeParameterIndex() + 1).asGenericType();
           }
         else
           {
@@ -2376,7 +2376,7 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
   static boolean checkActualTypePars(Context context, AbstractFeature called, List<AbstractType> actuals, List<AbstractType> unresolvedActuals, Call call)
   {
     var result = true;
-    var fi = called.generics().list.iterator();
+    var fi = called.typeArguments().iterator();
     var ai = actuals.iterator();
     var ui = unresolvedActuals.iterator();
     while (fi.hasNext() &&

--- a/src/dev/flang/ast/AstErrors.java
+++ b/src/dev/flang/ast/AstErrors.java
@@ -631,7 +631,7 @@ public class AstErrors extends ANY
           "Wrong number of type parameters",
           "Wrong number of actual type parameters in " + detail1 + ":\n" +
           detail2 +
-          "expected " + fg.sizeText() + (fg == FormalGenerics.NONE ? "" : " for " + s(fg) + "") + "\n" +
+          "expected " + fg.sizeText() + (fg.list().isEmpty() ? "" : " for " + s(fg) + "") + "\n" +
           "found " + (actualGenerics.size() == 0 ? "none" : "" + actualGenerics.size() + ": " + s(actualGenerics) + "" ) + ".\n");
   }
 
@@ -751,7 +751,7 @@ public class AstErrors extends ANY
     error(redefinedFeature.pos(),
           "Wrong number of type parameters in redefined feature",
           "In " + s(redefinedFeature) + " that redefines " + s(originalFeature) + " " +
-          "type parameter count is " + redefinedFeature.generics().list.size() + " while it should be " + originalFeature.generics().list.size() + ".\n" +
+          "type parameter count is " + redefinedFeature.typeArguments().size() + " while it should be " + originalFeature.typeArguments().size() + ".\n" +
           "Original type parameters: "  + s(originalFeature .generics()) + "\n" +
           "redefined type parameters: " + s(redefinedFeature.generics()) + "\n" +
           "Original feature declared at " + originalFeature.pos().show());

--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -96,7 +96,7 @@ public class Call extends AbstractCall
     if (_generics == NO_GENERICS && needsToInferTypeParametersFromArgs())
       {
         res = new List<>();
-        for (var g : _calledFeature.generics().list)
+        for (var g : _calledFeature.typeArguments())
           {
             if (!g.isOpenTypeParameter())
               {
@@ -1582,7 +1582,7 @@ public class Call extends AbstractCall
    */
   private void inferGenericsFromArgs(Resolution res, Context context)
   {
-    int sz = _calledFeature.generics().list.size();
+    int sz = _calledFeature.typeArguments().size();
     boolean[] conflict = new boolean[sz]; // The generics that had conflicting types
     var foundAt  = new List<List<Pair<SourcePosition, AbstractType>>>(); // generics that were found will get the type and pos found stored here, null while not found
     for (var i = 0; i<sz ; i++)
@@ -1665,7 +1665,7 @@ public class Call extends AbstractCall
   {
     // replace any missing type parameters or conflicting ones with t_ERROR,
     // report errors for conflicts
-    for (var g : _calledFeature.generics().list)
+    for (var g : _calledFeature.typeArguments())
       {
         int i = g.typeParameterIndex();
         if (!g.isOpenTypeParameter() && (_generics.size() <= i || _generics.get(i) == Types.t_UNDEFINED) || conflict[i])
@@ -1693,7 +1693,7 @@ public class Call extends AbstractCall
   private List<AbstractFeature> missingGenerics()
   {
     List<AbstractFeature> missing = new List<>();
-    for (var g : _calledFeature.generics().list)
+    for (var g : _calledFeature.typeArguments())
       {
         int i = g.typeParameterIndex();
         if (!g.isOpenTypeParameter() && _generics.get(i) == Types.t_UNDEFINED)
@@ -2114,7 +2114,7 @@ public class Call extends AbstractCall
                   }
               }
           }
-        else if (actualArgIndex != -1 && aft != null && !aft.inheritsFrom(fft) && !fft.generics().list.isEmpty())
+        else if (actualArgIndex != -1 && aft != null && !aft.inheritsFrom(fft) && !fft.typeArguments().isEmpty())
           {
             AstErrors.incompatibleArgumentTypeInCall(_calledFeature, actualArgIndex, formalType, _actuals.get(actualArgIndex), Context.NONE);
             setToErrorState();
@@ -2297,7 +2297,7 @@ public class Call extends AbstractCall
    */
   boolean needsToInferTypeParametersFromArgs()
   {
-    return _calledFeature != null && (_generics == NO_GENERICS || _generics.stream().anyMatch(g -> g.containsUndefined(false))) && _calledFeature.generics() != FormalGenerics.NONE;
+    return _calledFeature != null && (_generics == NO_GENERICS || _generics.stream().anyMatch(g -> g.containsUndefined(false))) && !_calledFeature.typeArguments().isEmpty();
   }
 
 

--- a/src/dev/flang/ast/Case.java
+++ b/src/dev/flang/ast/Case.java
@@ -306,7 +306,7 @@ public class Case extends AbstractCase
     List<AbstractType> matches = new List<>();
     int i = 0;
     t = t.resolve(res, context);
-    var inferGenerics = !t.isGenericArgument() && (t.isThisType() || t.generics().isEmpty()) && t.feature().generics() != FormalGenerics.NONE;
+    var inferGenerics = !t.isGenericArgument() && (t.isThisType() || t.generics().isEmpty()) && !t.feature().typeArguments().isEmpty();
     var hasErrors = t.containsError();
     check
       (!hasErrors || Errors.any());

--- a/src/dev/flang/ast/Context.java
+++ b/src/dev/flang/ast/Context.java
@@ -139,8 +139,7 @@ abstract class Context extends ANY
                         .applyToGenericsAndOuter(x ->
                           x instanceof ResolvedParametricType rpt
                             ? f
-                              .generics()
-                              .list
+                              .typeArguments()
                               .stream()
                               .filter(y ->
                                   y.outer().origin() == rpt.genericArgument().outer().origin() &&

--- a/src/dev/flang/ast/Feature.java
+++ b/src/dev/flang/ast/Feature.java
@@ -2267,22 +2267,20 @@ A ((Choice)) declaration must not contain a result type.
       (ta.isFreeType());
 
     // A call to generics() has the side effects of setting _generics,
-    // _arguments and _typeArguments
+    // _arguments
     var ignore = generics();
 
-    // Now we patch the new type parameter ta into _arguments, _typeArguments
+    // Now we patch the new type parameter ta into _arguments,
     // and _generics:
     var a = _arguments;
     _arguments = new List<>(a);
     var tas = typeArguments();
     _arguments.add(tas.size(), ta);
-    tas.add(ta);
 
     checkDuplicateFeature(res);
 
     res._module.findDeclarations(ta, this);
 
-    _generics = _generics.addTypeParameter(ta);
     res._module.addTypeParameter(this, ta);
     this.whenResolvedTypes(()->res.resolveTypes(ta));
 

--- a/src/dev/flang/ast/FormalGenerics.java
+++ b/src/dev/flang/ast/FormalGenerics.java
@@ -74,7 +74,7 @@ public class FormalGenerics extends ANY
   /**
    * Constructor for a FormalGenerics instance
    *
-   * @param l the list of formal generics. May not be empty.
+   * @param af the features for which this is the generics.
    */
   public FormalGenerics(AbstractFeature af)
   {

--- a/src/dev/flang/fe/FeErrors.java
+++ b/src/dev/flang/fe/FeErrors.java
@@ -64,7 +64,7 @@ public class FeErrors extends AstErrors
     var g = m.generics();
     error(m.pos(),
           "Main feature must not have type arguments",
-          "Main feature has " + StringHelpers.singularOrPlural(g.list.size(),"type argument") + " " + g + ", but should have no arguments to be used as main feature in an application\n" +
+          "Main feature has " + StringHelpers.singularOrPlural(m.typeArguments().size(),"type argument") + " " + g + ", but should have no arguments to be used as main feature in an application\n" +
           "To solve this, remove the arguments from feature " + s(m) + "\n");
   }
 

--- a/src/dev/flang/fe/LibraryModule.java
+++ b/src/dev/flang/fe/LibraryModule.java
@@ -462,7 +462,7 @@ public class LibraryModule extends Module implements MirModule
   {
     var tp = feature(offset);
     var o = tp.outer();
-    for (var g : o.generics().list)
+    for (var g : o.typeArguments())
       {
         if (g == tp)
           {

--- a/src/dev/flang/fe/LibraryOut.java
+++ b/src/dev/flang/fe/LibraryOut.java
@@ -458,7 +458,7 @@ class LibraryOut extends ANY
                                 : FuzionConstants.MIR_FILE_KIND_CONSTRUCTOR_VALUE);
     if (CHECKS) check
       (k >= 0,
-       Errors.any() || f.isRoutine() || f.isChoice() || f.isIntrinsic() || f.isAbstract() || f.isNative() || f.generics() == FormalGenerics.NONE);
+       Errors.any() || f.isRoutine() || f.isChoice() || f.isIntrinsic() || f.isAbstract() || f.isNative() || f.typeArguments().isEmpty());
     if (f.hasCotype())
       {
         k = k | FuzionConstants.MIR_FILE_KIND_HAS_COTYPE;
@@ -824,7 +824,7 @@ class LibraryOut extends ANY
           }
         else
           {
-            n = cf.generics().list.size();
+            n = cf.typeArguments().size();
             if (CHECKS) check
               (c.actualTypeParameters().size() == n);
           }

--- a/src/dev/flang/fe/SourceModule.java
+++ b/src/dev/flang/fe/SourceModule.java
@@ -327,7 +327,7 @@ public class SourceModule extends Module implements SrcModule
               case Intrinsic: FeErrors.mainFeatureMustNotBeIntrinsic(main); break;
               case Choice   : FeErrors.mainFeatureMustNotBeChoice   (main); break;
               case Routine  :
-                if (!main.generics().list.isEmpty())
+                if (!main.typeArguments().isEmpty())
                   {
                     FeErrors.mainFeatureMustNotHaveTypeArguments(main);
                   }
@@ -1640,7 +1640,7 @@ A redefined feature must have the same total number of formal arguments (type pa
             */
             AstErrors.argumentLengthsMismatch(o, ta.length, f, ra.length);
           }
-        else if (o.generics().list.size() != f.generics().list.size())
+        else if (o.typeArguments().size() != f.typeArguments().size())
           {
             /*
     // tag::fuzion_rule_REDEF_TYPE_PAR_COUNT[]

--- a/src/dev/flang/lsp/shared/TypeTool.java
+++ b/src/dev/flang/lsp/shared/TypeTool.java
@@ -73,11 +73,11 @@ public class TypeTool extends ANY
    */
   public static String label(FormalGenerics generics, boolean brief)
   {
-    if (!generics.isOpen() && generics.list.isEmpty() || brief)
+    if (!generics.isOpen() && generics.list().isEmpty() || brief)
       {
         return "";
       }
-    return " " + generics.list + (generics.isOpen() ? "... ": "");
+    return " " + generics.list() + (generics.isOpen() ? "... ": "");
   }
 
   private static String labelNoErrorOrUndefined(AbstractType type)


### PR DESCRIPTION
no need to patch FormalGenerics anymore when adding typePar (freetype).

This will hopefully enable fixing all those open free-type bugs...

