### PR TITLE
tests: add source dir option to generics_negative tests

### DIFF
--- a/tests/generics_negative/Makefile
+++ b/tests/generics_negative/Makefile
@@ -24,5 +24,5 @@
 # -----------------------------------------------------------------------
 
 override NAME = generics_negative
-FUZION_OPTIONS = -XenableSetKeyword
+FUZION_OPTIONS = -XenableSetKeyword -sourceDirs=.
 include ../simple_and_negative.mk

--- a/tests/generics_negative/generics_negative.fz.expected_err
+++ b/tests/generics_negative/generics_negative.fz.expected_err
@@ -92,52 +92,7 @@ expected 3 generic arguments for 'A, B, C'
 found 4: 'i32, i32, i32, i32'.
 
 
---CURDIR--/generics_negative.fz:140:11: error 12: Type not found
-    hjkl (qwerty i32).uiop.asdfg.hjkl := (qwerty i32).uiop.asdfg.hjkl 42
-----------^^^^^^
-Type 'qwerty' was not found, no corresponding feature nor formal type parameter exists
-Type that was not found: 'qwerty'
-in feature: 'generics_negative.features_from_separate_source_file.hjkl'
-To solve this, check the spelling of the type you have used.
-
-
---CURDIR--/generics_negative.fz:142:13: error 13: Type not found
-    asdfg1 (qwerty i32).uiop.asdfg := qwerty.uiop.asdfg      # 43. should flag an error: missing generic argument to qwerty
-------------^^^^^^
-Type 'qwerty' was not found, no corresponding feature nor formal type parameter exists
-Type that was not found: 'qwerty'
-in feature: 'generics_negative.features_from_separate_source_file.asdfg1'
-To solve this, check the spelling of the type you have used.
-
-
---CURDIR--/generics_negative.fz:143:13: error 14: Type not found
-    asdfg2 (qwerty i32).uiop.asdfg := (qwerty i32).uiop.asdfg
-------------^^^^^^
-Type 'qwerty' was not found, no corresponding feature nor formal type parameter exists
-Type that was not found: 'qwerty'
-in feature: 'generics_negative.features_from_separate_source_file.asdfg2'
-To solve this, check the spelling of the type you have used.
-
-
---CURDIR--/generics_negative.fz:144:11: error 15: Type not found
-    uiop (qwerty i32).uiop := (qwerty i32).uiop
-----------^^^^^^
-Type 'qwerty' was not found, no corresponding feature nor formal type parameter exists
-Type that was not found: 'qwerty'
-in feature: 'generics_negative.features_from_separate_source_file.uiop'
-To solve this, check the spelling of the type you have used.
-
-
---CURDIR--/generics_negative.fz:145:11: error 16: Type not found
-    qwert qwerty i32 := qwerty i32
-----------^^^^^^
-Type 'qwerty' was not found, no corresponding feature nor formal type parameter exists
-Type that was not found: 'qwerty'
-in feature: 'generics_negative.features_from_separate_source_file.qwert'
-To solve this, check the spelling of the type you have used.
-
-
---CURDIR--/generics_negative.fz:206:15: error 17: Type not found
+--CURDIR--/generics_negative.fz:206:15: error 12: Type not found
       g1      PARENT_TYPE_PARAMETER => v       # 54. should flag an error: PARENT_TYPE_PARAMETER not visible
 --------------^^^^^^^^^^^^^^^^^^^^^
 Type 'PARENT_TYPE_PARAMETER' was not found, no corresponding feature nor formal type parameter exists
@@ -146,7 +101,7 @@ in feature: 'generics_negative.inheriting_type_parameter.child.g1'
 To solve this, check the spelling of the type you have used.
 
 
---CURDIR--/generics_negative.fz:207:15: error 18: Type not found
+--CURDIR--/generics_negative.fz:207:15: error 13: Type not found
       g2 list PARENT_TYPE_PARAMETER => v : g2  # 55. should flag an error: PARENT_TYPE_PARAMETER not visible
 --------------^^^^^^^^^^^^^^^^^^^^^
 Type 'PARENT_TYPE_PARAMETER' was not found, no corresponding feature nor formal type parameter exists
@@ -155,47 +110,23 @@ in feature: 'generics_negative.inheriting_type_parameter.child.g2'
 To solve this, check the spelling of the type you have used.
 
 
---CURDIR--/generics_negative.fz:140:43: error 19: Could not find called feature
-    hjkl (qwerty i32).uiop.asdfg.hjkl := (qwerty i32).uiop.asdfg.hjkl 42
-------------------------------------------^^^^^^
-Feature not found: 'qwerty' (one argument)
-Target feature: 'generics_negative.features_from_separate_source_file'
-In call: 'qwerty i32'
-
-
---CURDIR--/generics_negative.fz:141:5: error 20: Could not find called feature
+--CURDIR--/generics_negative.fz:141:5: error 14: Failed to infer actual type parameters
     qwerty.uiop.asdfg                                       # 42. should flag an error: missing generic argument to qwerty
 ----^^^^^^
-Feature not found: 'qwerty' (no arguments)
-Target feature: 'generics_negative.features_from_separate_source_file'
-In call: 'qwerty'
+In call to 'qwerty', no actual type parameters are given and inference of the type parameters failed.
+Expected type parameters: 'T'
+Type inference failed for one type parameter 'T'
 
 
---CURDIR--/generics_negative.fz:142:39: error 21: Could not find called feature
+--CURDIR--/generics_negative.fz:142:39: error 15: Failed to infer actual type parameters
     asdfg1 (qwerty i32).uiop.asdfg := qwerty.uiop.asdfg      # 43. should flag an error: missing generic argument to qwerty
 --------------------------------------^^^^^^
-Feature not found: 'qwerty' (no arguments)
-Target feature: 'generics_negative.features_from_separate_source_file'
-In call: 'qwerty'
+In call to 'qwerty', no actual type parameters are given and inference of the type parameters failed.
+Expected type parameters: 'T'
+Type inference failed for one type parameter 'T'
 
 
---CURDIR--/generics_negative.fz:143:40: error 22: Could not find called feature
-    asdfg2 (qwerty i32).uiop.asdfg := (qwerty i32).uiop.asdfg
----------------------------------------^^^^^^
-Feature not found: 'qwerty' (one argument)
-Target feature: 'generics_negative.features_from_separate_source_file'
-In call: 'qwerty i32'
-
-
---CURDIR--/generics_negative.fz:144:32: error 23: Could not find called feature
-    uiop (qwerty i32).uiop := (qwerty i32).uiop
--------------------------------^^^^^^
-Feature not found: 'qwerty' (one argument)
-Target feature: 'generics_negative.features_from_separate_source_file'
-In call: 'qwerty i32'
-
-
---CURDIR--/generics_negative.fz:190:22: error 24: Ambiguous type
+--CURDIR--/generics_negative.fz:190:22: error 16: Ambiguous type
         _  := option X  nil      # 52. should flag an error: ambiguous type parameter
 ---------------------^
 For a type used in a declaration, overloading results in an ambiguity that cannot be resolved by the compiler.
@@ -211,7 +142,7 @@ and 'generics_negative.ambiguousTypeParameterName.outer.X' defined at --CURDIR--
 To solve this, rename these features such that each one has a unique name.
 
 
---CURDIR--/generics_negative.fz:193:22: error 25: Ambiguous type
+--CURDIR--/generics_negative.fz:193:22: error 17: Ambiguous type
         _  := option Z  nil      # 53. should flag an error: ambiguous type parameter
 ---------------------^
 For a type used in a declaration, overloading results in an ambiguity that cannot be resolved by the compiler.
@@ -227,7 +158,7 @@ and 'generics_negative.ambiguousTypeParameterName.outer.Z' defined at --CURDIR--
 To solve this, rename these features such that each one has a unique name.
 
 
---CURDIR--/generics_negative.fz:208:20: error 26: Type not found
+--CURDIR--/generics_negative.fz:208:20: error 18: Type not found
       g3 => option PARENT_TYPE_PARAMETER nil   # 56. should flag an error: PARENT_TYPE_PARAMETER not visible
 -------------------^^^^^^^^^^^^^^^^^^^^^
 Type 'PARENT_TYPE_PARAMETER' was not found, no corresponding feature nor formal type parameter exists
@@ -236,15 +167,20 @@ in feature: 'generics_negative.inheriting_type_parameter.child.g3'
 To solve this, check the spelling of the type you have used.
 
 
---CURDIR--/generics_negative.fz:145:25: error 27: Could not find called feature
-    qwert qwerty i32 := qwerty i32
-------------------------^^^^^^
-Feature not found: 'qwerty' (one argument)
-Target feature: 'generics_negative.features_from_separate_source_file'
-In call: 'qwerty i32'
+--CURDIR--/generics_negative.fz:146:34: error 19: Different count of arguments needed when calling feature
+    set hjkl := qwert.uiop.asdfg.hjkl                       # 44. should flag an error: missing actual argument to hjkl
+---------------------------------^^^^
+Feature not found: 'hjkl' (no arguments)
+Target feature: 'qwerty.uiop.asdfg'
+In call: 'qwert.uiop.asdfg.hjkl'
+To solve this, you might change the actual number of arguments to match the feature 'hjkl' (one value argument) at ./qwerty.fz:36:14:
+      module hjkl(x T) is
+-------------^^^^
+To call 'hjkl' you must provide one argument.
 
 
---CURDIR--/generics_negative.fz:76:11: error 28: Wrong number of actual arguments in call
+
+--CURDIR--/generics_negative.fz:76:11: error 20: Wrong number of actual arguments in call
   _ := f1.call 7              #  9. should flag an error, wrong number of arguments
 ----------^^^^
 Number of actual arguments is 1, while call expects no arguments.
@@ -255,7 +191,7 @@ Declared at {base.fum}/Function.fz:35:10:
 ---------^^^^
 
 
---CURDIR--/generics_negative.fz:78:8: error 29: Wrong number of actual arguments in call
+--CURDIR--/generics_negative.fz:78:8: error 21: Wrong number of actual arguments in call
   _ := f1 7                   # 10. should flag an error, wrong number of arguments
 -------^^
 Number of actual arguments is 1, while call expects no arguments.
@@ -266,7 +202,7 @@ Declared at {base.fum}/Function.fz:35:10:
 ---------^^^^
 
 
---CURDIR--/generics_negative.fz:81:11: error 30: Wrong number of actual arguments in call
+--CURDIR--/generics_negative.fz:81:11: error 22: Wrong number of actual arguments in call
   _ := f2.call()              # 11. should flag an error, wrong number of arguments
 ----------^^^^
 Number of actual arguments is 0, while call expects one argument.
@@ -277,7 +213,7 @@ Declared at {base.fum}/Function.fz:35:10:
 ---------^^^^
 
 
---CURDIR--/generics_negative.fz:83:11: error 31: Wrong number of actual arguments in call
+--CURDIR--/generics_negative.fz:83:11: error 23: Wrong number of actual arguments in call
   _ := f2.call true false     # 12. should flag an error, wrong number of arguments
 ----------^^^^
 Number of actual arguments is 2, while call expects one argument.
@@ -288,7 +224,7 @@ Declared at {base.fum}/Function.fz:35:10:
 ---------^^^^
 
 
---CURDIR--/generics_negative.fz:84:8: error 32: Wrong number of actual arguments in call
+--CURDIR--/generics_negative.fz:84:8: error 24: Wrong number of actual arguments in call
   _ := f2()                   # 13. should flag an error, wrong number of arguments
 -------^^
 Number of actual arguments is 0, while call expects one argument.
@@ -299,7 +235,7 @@ Declared at {base.fum}/Function.fz:35:10:
 ---------^^^^
 
 
---CURDIR--/generics_negative.fz:86:8: error 33: Wrong number of actual arguments in call
+--CURDIR--/generics_negative.fz:86:8: error 25: Wrong number of actual arguments in call
   _ := f2 true false          # 14. should flag an error, wrong number of arguments
 -------^^
 Number of actual arguments is 2, while call expects one argument.
@@ -310,7 +246,7 @@ Declared at {base.fum}/Function.fz:35:10:
 ---------^^^^
 
 
---CURDIR--/generics_negative.fz:90:11: error 34: Wrong number of actual arguments in call
+--CURDIR--/generics_negative.fz:90:11: error 26: Wrong number of actual arguments in call
   _ := r1.call 7              # 15. should flag an error, wrong number of arguments
 ----------^^^^
 Number of actual arguments is 1, while call expects no arguments.
@@ -321,7 +257,7 @@ Declared at {base.fum}/Function.fz:35:10:
 ---------^^^^
 
 
---CURDIR--/generics_negative.fz:92:8: error 35: Wrong number of actual arguments in call
+--CURDIR--/generics_negative.fz:92:8: error 27: Wrong number of actual arguments in call
   _ := r1 7                   # 16. should flag an error, wrong number of arguments
 -------^^
 Number of actual arguments is 1, while call expects no arguments.
@@ -332,7 +268,7 @@ Declared at {base.fum}/Function.fz:35:10:
 ---------^^^^
 
 
---CURDIR--/generics_negative.fz:95:11: error 36: Wrong number of actual arguments in call
+--CURDIR--/generics_negative.fz:95:11: error 28: Wrong number of actual arguments in call
   _ := r2.call()              # 17. should flag an error, wrong number of arguments
 ----------^^^^
 Number of actual arguments is 0, while call expects 2 arguments.
@@ -343,7 +279,7 @@ Declared at {base.fum}/Function.fz:35:10:
 ---------^^^^
 
 
---CURDIR--/generics_negative.fz:96:11: error 37: Wrong number of actual arguments in call
+--CURDIR--/generics_negative.fz:96:11: error 29: Wrong number of actual arguments in call
   _ := r2.call 3              # 18. should flag an error, wrong number of arguments
 ----------^^^^
 Number of actual arguments is 1, while call expects 2 arguments.
@@ -354,7 +290,7 @@ Declared at {base.fum}/Function.fz:35:10:
 ---------^^^^
 
 
---CURDIR--/generics_negative.fz:98:11: error 38: Wrong number of actual arguments in call
+--CURDIR--/generics_negative.fz:98:11: error 30: Wrong number of actual arguments in call
   _ := r2.call 3 false 7      # 19. should flag an error, wrong number of arguments
 ----------^^^^
 Number of actual arguments is 3, while call expects 2 arguments.
@@ -365,7 +301,7 @@ Declared at {base.fum}/Function.fz:35:10:
 ---------^^^^
 
 
---CURDIR--/generics_negative.fz:99:8: error 39: Wrong number of actual arguments in call
+--CURDIR--/generics_negative.fz:99:8: error 31: Wrong number of actual arguments in call
   _ := r2()                   # 20. should flag an error, wrong number of arguments
 -------^^
 Number of actual arguments is 0, while call expects 2 arguments.
@@ -376,7 +312,7 @@ Declared at {base.fum}/Function.fz:35:10:
 ---------^^^^
 
 
---CURDIR--/generics_negative.fz:100:8: error 40: Wrong number of actual arguments in call
+--CURDIR--/generics_negative.fz:100:8: error 32: Wrong number of actual arguments in call
   _ := r2 3                   # 21. should flag an error, wrong number of arguments
 -------^^
 Number of actual arguments is 1, while call expects 2 arguments.
@@ -387,7 +323,7 @@ Declared at {base.fum}/Function.fz:35:10:
 ---------^^^^
 
 
---CURDIR--/generics_negative.fz:102:8: error 41: Wrong number of actual arguments in call
+--CURDIR--/generics_negative.fz:102:8: error 33: Wrong number of actual arguments in call
   _ := r2 3 false 7           # 22. should flag an error, wrong number of arguments
 -------^^
 Number of actual arguments is 3, while call expects 2 arguments.
@@ -398,7 +334,7 @@ Declared at {base.fum}/Function.fz:35:10:
 ---------^^^^
 
 
---CURDIR--/generics_negative.fz:159:5: error 42: Incompatible types in assignment
+--CURDIR--/generics_negative.fz:159:5: error 34: Incompatible types in assignment
     x2 (A i32 i32   ).B String bool := (A i64 bool).B String bool true  # 45. should flag an error: incompatible types
 ----^^
 assignment to field : 'generics_negative.outerGenerics.x2'
@@ -412,7 +348,7 @@ To solve this you could:
   • convert the type of the assigned value to '(generics_negative.outerGenerics.this.A i32 i32).B String bool'.
 
 
---CURDIR--/generics_negative.fz:160:5: error 43: Incompatible types in assignment
+--CURDIR--/generics_negative.fz:160:5: error 35: Incompatible types in assignment
     x3 (A i32 String).B String bool := x1                               # 46. should flag an error: incompatible types
 ----^^
 assignment to field : 'generics_negative.outerGenerics.x3'
@@ -426,7 +362,7 @@ To solve this you could:
   • convert the type of the assigned value to '(generics_negative.outerGenerics.this.A i32 String).B String bool'.
 
 
---CURDIR--/generics_negative.fz:176:9: error 44: Incompatible types when passing argument in a call
+--CURDIR--/generics_negative.fz:176:9: error 36: Incompatible types when passing argument in a call
     x.f "String" false 7  # 47. should flag an error: incompatible argument #1
 --------^^^^^^^^
 Actual type for argument #1 'a0' does not match expected type.
@@ -438,7 +374,7 @@ for value assigned  : '"String"'
 To solve this, you could change the type of the target 'a0' to 'String' or convert the type of the assigned value to 'i32'.
 
 
---CURDIR--/generics_negative.fz:177:11: error 45: Incompatible types when passing argument in a call
+--CURDIR--/generics_negative.fz:177:11: error 37: Incompatible types when passing argument in a call
     x.f 4 3 7             # 48. should flag an error: incompatible argument #2
 ----------^
 Actual type for argument #2 'a1' does not match expected type.
@@ -450,7 +386,7 @@ for value assigned  : '3'
 To solve this, you could change the type of the target 'a1' to 'i32' or convert the type of the assigned value to 'bool'.
 
 
---CURDIR--/generics_negative.fz:178:17: error 46: Incompatible types when passing argument in a call
+--CURDIR--/generics_negative.fz:178:17: error 38: Incompatible types when passing argument in a call
     x.f 4 false "false"   # 49.a should flag an error: incompatible argument #3
 ----------------^^^^^^^
 Actual type for argument #3 'a2' does not match expected type.
@@ -462,7 +398,7 @@ for value assigned  : '"false"'
 To solve this, you could change the type of the target 'a2' to 'String' or convert the type of the assigned value to 'i32'.
 
 
---CURDIR--/generics_negative.fz:181:9: error 47: Incompatible types when passing argument in a call
+--CURDIR--/generics_negative.fz:181:9: error 39: Incompatible types when passing argument in a call
     y.f "String" false 8  # 49.b should flag an error: incompatible argument #1
 --------^^^^^^^^
 Actual type for argument #1 'a' does not match expected type.
@@ -474,7 +410,7 @@ for value assigned  : '"String"'
 To solve this, you could change the type of the target 'a' to 'String' or convert the type of the assigned value to 'i32'.
 
 
---CURDIR--/generics_negative.fz:182:11: error 48: Incompatible types when passing argument in a call
+--CURDIR--/generics_negative.fz:182:11: error 40: Incompatible types when passing argument in a call
     y.f 9 10 8            # 50. should flag an error: incompatible argument #2
 ----------^^
 Actual type for argument #2 does not match expected type.
@@ -486,7 +422,7 @@ for value assigned  : '10'
 To solve this, you could change the type of the target 'argument #2' to 'i32' or convert the type of the assigned value to 'bool'.
 
 
---CURDIR--/generics_negative.fz:183:17: error 49: Incompatible types when passing argument in a call
+--CURDIR--/generics_negative.fz:183:17: error 41: Incompatible types when passing argument in a call
     y.f 9 false "8"       # 51. should flag an error: incompatible argument #3
 ----------------^^^
 Actual type for argument #3 does not match expected type.
@@ -498,7 +434,7 @@ for value assigned  : '"8"'
 To solve this, you could change the type of the target 'argument #3' to 'codepoint' or convert the type of the assigned value to 'i32'.
 
 
---CURDIR--/generics_negative.fz:114:23: error 50: Incompatible types when passing argument in a call
+--CURDIR--/generics_negative.fz:114:23: error 42: Incompatible types when passing argument in a call
     _ i32  := x2.call 3         # 26. should flag an error: wrong argument type
 ----------------------^
 Actual type for argument #1 'a' does not match expected type.
@@ -510,7 +446,7 @@ for value assigned  : '3'
 To solve this, you could change the type of the target 'a' to 'i32' or convert the type of the assigned value to 'bool'.
 
 
---CURDIR--/generics_negative.fz:115:5: error 51: Incompatible types in assignment
+--CURDIR--/generics_negative.fz:115:5: error 43: Incompatible types in assignment
     _ bool := x2.call true      # 27. should flag an error: wrong type in assignment
 ----^
 assignment to field : 'generics_negative.opengenerics24._'
@@ -521,7 +457,7 @@ for value assigned  : 'x2.call true'
 To solve this, you could change the type of the target 'generics_negative.opengenerics24._' to 'i32' or convert the type of the assigned value to 'bool'.
 
 
---CURDIR--/generics_negative.fz:117:18: error 52: Incompatible types when passing argument in a call
+--CURDIR--/generics_negative.fz:117:18: error 44: Incompatible types when passing argument in a call
     _ i32  := x2 3              # 28. should flag an error: wrong argument type
 -----------------^
 Actual type for argument #1 'a' does not match expected type.
@@ -533,7 +469,7 @@ for value assigned  : '3'
 To solve this, you could change the type of the target 'a' to 'i32' or convert the type of the assigned value to 'bool'.
 
 
---CURDIR--/generics_negative.fz:118:5: error 53: Incompatible types in assignment
+--CURDIR--/generics_negative.fz:118:5: error 45: Incompatible types in assignment
     _ bool := x2 true           # 29. should flag an error: wrong type in assignment
 ----^
 assignment to field : 'generics_negative.opengenerics24._'
@@ -544,7 +480,7 @@ for value assigned  : 'x2'
 To solve this, you could change the type of the target 'generics_negative.opengenerics24._' to 'i32' or convert the type of the assigned value to 'bool'.
 
 
---CURDIR--/generics_negative.fz:121:13: error 54: Incompatible types when passing argument in a call
+--CURDIR--/generics_negative.fz:121:13: error 46: Incompatible types when passing argument in a call
     x3.call false false          # 30. should flag an error: wrong argument type
 ------------^^^^^
 Actual type for argument #1 'a' does not match expected type.
@@ -556,7 +492,7 @@ for value assigned  : 'false'
 To solve this, you could change the type of the target 'a' to 'bool' or convert the type of the assigned value to 'i32'.
 
 
---CURDIR--/generics_negative.fz:122:15: error 55: Incompatible types when passing argument in a call
+--CURDIR--/generics_negative.fz:122:15: error 47: Incompatible types when passing argument in a call
     x3.call 3 3                  # 31. should flag an error: wrong argument type
 --------------^
 Actual type for argument #2 does not match expected type.
@@ -568,7 +504,7 @@ for value assigned  : '3'
 To solve this, you could change the type of the target 'argument #2' to 'i32' or convert the type of the assigned value to 'bool'.
 
 
---CURDIR--/generics_negative.fz:123:8: error 56: Wrong number of actual arguments in call
+--CURDIR--/generics_negative.fz:123:8: error 48: Wrong number of actual arguments in call
     x3.call 3 true 3             # 32. should flag an error: wrong argument count
 -------^^^^
 Number of actual arguments is 3, while call expects 2 arguments.
@@ -579,7 +515,7 @@ Declared at {base.fum}/Function.fz:35:10:
 ---------^^^^
 
 
---CURDIR--/generics_negative.fz:124:8: error 57: Wrong number of actual arguments in call
+--CURDIR--/generics_negative.fz:124:8: error 49: Wrong number of actual arguments in call
     x3.call 3                    # 33. should flag an error: wrong argument count
 -------^^^^
 Number of actual arguments is 1, while call expects 2 arguments.
@@ -590,7 +526,7 @@ Declared at {base.fum}/Function.fz:35:10:
 ---------^^^^
 
 
---CURDIR--/generics_negative.fz:126:8: error 58: Incompatible types when passing argument in a call
+--CURDIR--/generics_negative.fz:126:8: error 50: Incompatible types when passing argument in a call
     x3 false false               # 34. should flag an error: wrong argument type
 -------^^^^^
 Actual type for argument #1 'a' does not match expected type.
@@ -602,7 +538,7 @@ for value assigned  : 'false'
 To solve this, you could change the type of the target 'a' to 'bool' or convert the type of the assigned value to 'i32'.
 
 
---CURDIR--/generics_negative.fz:127:10: error 59: Incompatible types when passing argument in a call
+--CURDIR--/generics_negative.fz:127:10: error 51: Incompatible types when passing argument in a call
     x3 3 3                       # 35. should flag an error: wrong argument type
 ---------^
 Actual type for argument #2 does not match expected type.
@@ -614,7 +550,7 @@ for value assigned  : '3'
 To solve this, you could change the type of the target 'argument #2' to 'i32' or convert the type of the assigned value to 'bool'.
 
 
---CURDIR--/generics_negative.fz:128:5: error 60: Wrong number of actual arguments in call
+--CURDIR--/generics_negative.fz:128:5: error 52: Wrong number of actual arguments in call
     x3 3 true 3                  # 36. should flag an error: wrong argument count
 ----^^
 Number of actual arguments is 3, while call expects 2 arguments.
@@ -625,7 +561,7 @@ Declared at {base.fum}/Function.fz:35:10:
 ---------^^^^
 
 
---CURDIR--/generics_negative.fz:129:5: error 61: Wrong number of actual arguments in call
+--CURDIR--/generics_negative.fz:129:5: error 53: Wrong number of actual arguments in call
     x3 3                         # 37. should flag an error: wrong argument count
 ----^^
 Number of actual arguments is 1, while call expects 2 arguments.
@@ -635,4 +571,4 @@ Declared at {base.fum}/Function.fz:35:10:
   public call(a A...) R => abstract
 ---------^^^^
 
-61 errors.
+53 errors.


### PR DESCRIPTION
Missing this option results in additional errors when running this as a simple test.

