### PR TITLE
tests: fix sed-expression in negative.mk

### DIFF
--- a/tests/negative.mk
+++ b/tests/negative.mk
@@ -30,7 +30,7 @@
 
 FUZION_OPTIONS ?=
 FUZION = FUZION_DISABLE_ANSI_ESCAPES=true ../../bin/fz -XmaxErrors=-1 $(FUZION_OPTIONS)
-EXPECTED_ERRORS = `cat *.fz | grep "should.flag.an.error"  | sed "s ^.*\#  g"| sort -n | uniq | wc -l | tr -d ' '`
+EXPECTED_ERRORS = `cat *.fz | grep "should.flag.an.error"  | sed "s-^.*\# \(.*\)-\1-g" | sort -n | uniq | wc -l | tr -d ' '`
 
 all: jvm c int
 
@@ -38,25 +38,25 @@ int:
 	$(FUZION) -interpreter $(NAME) 2>err.txt || true
 # check if for every unique comment containing "should flag an error" an error is reported for a line with that comment
 	@printf "RUN negative test $(NAME).fz using interpreter backend "; \
-	cat err.txt  | grep "should.flag.an.error" | sed "s ^.*\#  g" | sort -n | uniq | wc -l | tr -d ' ' | grep ^$(EXPECTED_ERRORS)$$ > /dev/null && \
+	cat err.txt  | grep "should.flag.an.error" | sed "s-^.*\# \(.*\)-\1-g" | sort -n | uniq | wc -l | tr -d ' ' | grep ^$(EXPECTED_ERRORS)$$ > /dev/null && \
 		printf "\033[32;1mPASSED\033[0m.\n" || (printf "\033[31;1m*** FAILED ***\033[0m\n" && exit 1)
 
 jvm:
 	$(FUZION) -jvm $(NAME) 2>err.txt || true
 # check if for every unique comment containing "should flag an error" an error is reported for a line with that comment
 	@printf "RUN negative test $(NAME).fz using jvm backend "; \
-	cat err.txt  | grep "should.flag.an.error" | sed "s ^.*\#  g" | sort -n | uniq | wc -l | tr -d ' ' | grep ^$(EXPECTED_ERRORS)$$ > /dev/null && \
+	cat err.txt  | grep "should.flag.an.error" | sed "s-^.*\# \(.*\)-\1-g" | sort -n | uniq | wc -l | tr -d ' ' | grep ^$(EXPECTED_ERRORS)$$ > /dev/null && \
 		printf "\033[32;1mPASSED\033[0m.\n" || (printf "\033[31;1m*** FAILED ***\033[0m\n" && exit 1)
 
 c:
 	($(FUZION) -c -o=testbin $(NAME) && ./testbin) 2>err.txt || true
 # check if for every unique comment containing "should flag an error" an error is reported for a line with that comment
 	@printf "RUN negative test $(NAME).fz using c backend "; \
-	cat err.txt  | grep "should.flag.an.error" | sed "s ^.*\#  g" | sort -n | uniq | wc -l | tr -d ' ' | grep ^$(EXPECTED_ERRORS)$$ > /dev/null && \
+	cat err.txt  | grep "should.flag.an.error" | sed "s-^.*\# \(.*\)-\1-g" | sort -n | uniq | wc -l | tr -d ' ' | grep ^$(EXPECTED_ERRORS)$$ > /dev/null && \
 		printf "\033[32;1mPASSED\033[0m.\n" || (printf "\033[31;1m*** FAILED ***\033[0m\n" && exit 1)
 
 show:
-	printf "Expected $(EXPECTED_ERRORS) errors, found " && cat err.txt  | grep "should.flag.an.error" | sed "s ^.*\#  g"| sort -n | uniq | wc -l | tr -d ' '
-	cat err.txt  | grep "should.flag.an.error" | sed "s ^.*\#  g"| sort -n | uniq
+	@printf "Expected $(EXPECTED_ERRORS) errors, found " && cat err.txt  | grep "should.flag.an.error" | sed "s-^.*\# \(.*\)-\1-g" | sort -n | uniq | wc -l | tr -d ' '
+	cat err.txt  | grep "should.flag.an.error" | sed "s-^.*\# \(.*\)-\1-g" | sort -n | uniq
 
 effect:


### PR DESCRIPTION
The old expression failed for comments like

    # 47. should flag an error: incompatible argument #1

that contain another `#`. This appeared in tests/generics_negative and results in `make show` reducing this line to just

    1

instead of

    47. should flag an error: incompatible argument #1

Also, the error count was wrong since other comments also were reduce to the same single letters.
