### PR TITLE
ast: supress `failed to infer actual type parameters` for call to `f_ERROR`

### DIFF
--- a/src/dev/flang/ast/AstErrors.java
+++ b/src/dev/flang/ast/AstErrors.java
@@ -1845,7 +1845,7 @@ public class AstErrors extends ANY
 
   static void failedToInferActualGeneric(SourcePosition pos, AbstractFeature cf, List<AbstractFeature> missing)
   {
-    if (!any() || cf != Types.f_ERROR)
+    if (!any() || (cf != Types.f_ERROR && !missing.isEmpty()))
       {
         error(pos,
               "Failed to infer actual type parameters",

--- a/src/dev/flang/ast/AstErrors.java
+++ b/src/dev/flang/ast/AstErrors.java
@@ -1845,11 +1845,14 @@ public class AstErrors extends ANY
 
   static void failedToInferActualGeneric(SourcePosition pos, AbstractFeature cf, List<AbstractFeature> missing)
   {
-    error(pos,
-          "Failed to infer actual type parameters",
-          "In call to " + s(cf) + ", no actual type parameters are given and inference of the type parameters failed.\n" +
-          "Expected type parameters: " + s(cf.generics()) + "\n"+
-          "Type inference failed for " + StringHelpers.singularOrPlural(missing.size(), "type parameter") + " " + slg(missing) + "\n");
+    if (!any() || cf != Types.f_ERROR)
+      {
+        error(pos,
+              "Failed to infer actual type parameters",
+              "In call to " + s(cf) + ", no actual type parameters are given and inference of the type parameters failed.\n" +
+              "Expected type parameters: " + s(cf.generics()) + "\n"+
+              "Type inference failed for " + StringHelpers.singularOrPlural(missing.size(), "type parameter") + " " + slg(missing) + "\n");
+      }
   }
 
   static void cannotCallChoice(SourcePosition pos, AbstractFeature cf)


### PR DESCRIPTION
This is one of the additional errors currently produced by fuzion-lang.dev's man_or_boy2.fz example.
