### PR TITLE
ast: Suppress type inference errors if actuals of call had errors

### DIFF
--- a/src/dev/flang/ast/AstErrors.java
+++ b/src/dev/flang/ast/AstErrors.java
@@ -1328,7 +1328,7 @@ public class AstErrors extends ANY
                                     List<FeatureAndOuter> candidatesArgCountMismatch,
                                     List<FeatureAndOuter> candidatesHidden)
   {
-    if (!any() || !errorInOuterFeatures(targetFeature) && noErrorInArguments(call))
+    if (!any() || !errorInOuterFeatures(targetFeature) && !call.errorInActuals())
       {
         var msg = !candidatesHidden.isEmpty()
           ? StringHelpers.plural(candidatesHidden.size(), "Feature") + " not visible at call site"
@@ -1353,11 +1353,6 @@ public class AstErrors extends ANY
                solution4 != "" ? solution4 :
                solution5 != "" ? solution5 : ""));
       }
-  }
-
-  private static boolean noErrorInArguments(Call call)
-  {
-    return call.actuals().stream().allMatch(x -> x != Call.ERROR);
   }
 
   private static String solutionLambda(Call call)

--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -1149,7 +1149,8 @@ public class Call extends AbstractCall
     var result = typeForInferencing();
     if (result == null)
       {
-        if (hasPendingError || errorInActuals())
+        // NYI: CLEANUP: Why can't we use `errorInActuals()` in the following condition?
+        if (hasPendingError || _actuals.stream().anyMatch(a -> a.type() == Types.t_ERROR))
           {
             result = Types.t_ERROR;
           }
@@ -1633,8 +1634,9 @@ public class Call extends AbstractCall
   {
     return (rt == null ||
         !rt.isGenericArgument() ||
-         rt.genericArgument().outer().outer() != _calledFeature.outer()) &&
-      !errorInActuals();
+         rt.genericArgument().outer().outer() != _calledFeature.outer()) ||
+         // NYI: CLEANUP: why true, i.e., must report errors, in case of previous errors in the actuals?
+         _actuals.stream().anyMatch(a -> a.typeForInferencing() == Types.t_ERROR);
   }
 
 

--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -1149,7 +1149,7 @@ public class Call extends AbstractCall
     var result = typeForInferencing();
     if (result == null)
       {
-        if (hasPendingError || _actuals.stream().anyMatch(a -> a.type() == Types.t_ERROR))
+        if (hasPendingError || errorInActuals())
           {
             result = Types.t_ERROR;
           }
@@ -1633,8 +1633,8 @@ public class Call extends AbstractCall
   {
     return (rt == null ||
         !rt.isGenericArgument() ||
-         rt.genericArgument().outer().outer() != _calledFeature.outer()) ||
-         _actuals.stream().anyMatch(a -> a.typeForInferencing() == Types.t_ERROR);
+         rt.genericArgument().outer().outer() != _calledFeature.outer()) &&
+      !errorInActuals();
   }
 
 
@@ -1706,6 +1706,18 @@ public class Call extends AbstractCall
 
 
   /**
+   * Was there an error in any of the actual arguments and was this (or some
+   * other) error reported already?
+   */
+  boolean errorInActuals()
+  {
+    return
+      Errors.any() &&
+      _actuals.stream().anyMatch(x -> x.typeForInferencing() == Types.t_ERROR);
+  }
+
+
+  /**
    * report that generics in missing could not be inferred.
    *
    * @param missing the list of generics that could not be inferred
@@ -1717,8 +1729,7 @@ public class Call extends AbstractCall
     if (!missing.isEmpty() &&
         !_calledFeature.isCotype() &&
         _calledFeature != Types.f_ERROR &&
-        (!Errors.any() ||
-         _actuals.stream().allMatch(x -> x.type() != Types.t_ERROR)))
+        !errorInActuals())
       {
         AstErrors.failedToInferActualGeneric(pos(), _calledFeature, missing);
         setToErrorState();
@@ -2782,7 +2793,7 @@ public class Call extends AbstractCall
             AstErrors.mustNotCallOpenTypeParameter(this);
           }
 
-        if ( !(Errors.any() && _actuals.stream().anyMatch(a->a.typeForInferencing() == Types.t_ERROR)) )
+        if (!errorInActuals())
           {
             // Check that generics match formal generic constraints
             AbstractType.checkActualTypePars(context, _calledFeature, _generics, _originalGenerics, this);

--- a/tests/free_types_negative/test_free_types_negative.fz.expected_err
+++ b/tests/free_types_negative/test_free_types_negative.fz.expected_err
@@ -56,22 +56,20 @@ To solve this, you might replace the free type 'test_free_type_negative.neg.i33'
 --------^^^
 
 
---CURDIR--/test_free_types_negative.fz:142:28: error 6: No type information can be inferred from a lambda expression
+--CURDIR--/test_free_types_negative.fz:142:9: error 6: Failed to infer actual type parameters
   say ((apply2             a,b->"$a $b").call true 3.14)   # 10. should flag an error, unable to infer actual type parameters
----------------------------^^^^^^^^^^^^
-A lambda expression can only be used if assigned to a field or argument of type 'Function'
-with argument count of the lambda expression equal to the number of type parameters of the type.  The type of the
-assigned field must be given explicitly.
-To solve this, declare an explicit type for the target field, e.g., 'f (i32, i32) -> bool := x, y -> x > y'.
+--------^^^^^^
+In call to 'test_free_type_negative.apply2', no actual type parameters are given and inference of the type parameters failed.
+Expected type parameters: 'A, B'
+Type inference failed for 2 type parameters 'A', 'B'
 
 
---CURDIR--/test_free_types_negative.fz:150:25: error 7: No type information can be inferred from a lambda expression
+--CURDIR--/test_free_types_negative.fz:150:9: error 7: Failed to infer actual type parameters
   say ((apply3a         a,b->"$a $b").call true (u8 127))  # 11. should flag an error, unable to infer actual type parameters
-------------------------^^^^^^^^^^^^
-A lambda expression can only be used if assigned to a field or argument of type 'Function'
-with argument count of the lambda expression equal to the number of type parameters of the type.  The type of the
-assigned field must be given explicitly.
-To solve this, declare an explicit type for the target field, e.g., 'f (i32, i32) -> bool := x, y -> x > y'.
+--------^^^^^^^
+In call to 'test_free_type_negative.apply3a', no actual type parameters are given and inference of the type parameters failed.
+Expected type parameters: 'A, B'
+Type inference failed for 2 type parameters 'A', 'B'
 
 
 --CURDIR--/test_free_types_negative.fz:35:3: error 8: Incompatible type parameter

--- a/tests/reg_issue5556/Makefile
+++ b/tests/reg_issue5556/Makefile
@@ -1,0 +1,25 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test Makefile
+#
+# -----------------------------------------------------------------------
+
+override NAME = reg_issue5556
+include ../simple.mk

--- a/tests/reg_issue5556/reg_issue5556.fz
+++ b/tests/reg_issue5556/reg_issue5556.fz
@@ -1,0 +1,30 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test reg_issue5556
+#
+# -----------------------------------------------------------------------
+
+# using an undefined feature `bla` in `say <| bla` results in one reasonable
+# error `Could not find called feature` followed by a bizarre one
+# `No type information can be inferred...`:
+#
+reg_issue5556 =>
+
+  say <| bla    # this should produce only a single error about `bla`

--- a/tests/reg_issue5556/reg_issue5556.fz.expected_err
+++ b/tests/reg_issue5556/reg_issue5556.fz.expected_err
@@ -1,0 +1,9 @@
+
+--CURDIR--/reg_issue5556.fz:30:10: error 1: Could not find called feature
+  say <| bla    # this should produce only a single error about `bla`
+---------^^^
+Feature not found: 'bla' (no arguments)
+Target feature: 'reg_issue5556'
+In call: 'bla'
+
+one error.


### PR DESCRIPTION
This suppresses subsequent errors in code like `say <| bla` if `bla` does not exist.

fix #5556.

This also adds comment to confusing logic in `Call.mustReportMissingImmediately()` and to `Call.type` where `errorsInActuals()` cannot be used for some reason that is unclear to me. 