### PR TITLE
tests: make `tests/free_types_negative` _simple_and_negative_

### DIFF
--- a/tests/free_types_negative/Makefile
+++ b/tests/free_types_negative/Makefile
@@ -24,4 +24,4 @@
 # -----------------------------------------------------------------------
 
 override NAME = test_free_types_negative
-include ../simple.mk
+include ../simple_and_negative.mk


### PR DESCRIPTION
This still reports one error too many (12 instead of 11), but it is good to check that the expected errors are all there.
