### PR TITLE
ast: In `AstErrors.declarationsInLazy` do not use `Expr.toString()`

### DIFF
--- a/src/dev/flang/ast/AstErrors.java
+++ b/src/dev/flang/ast/AstErrors.java
@@ -2171,7 +2171,7 @@ public class AstErrors extends ANY
               "\n"+
               "To solve this, create a helper feature " + sqn("lazy_value") + " that calculates the value as follows:\n" +
               "\n" +
-              "  lazy_value => " + lazy + "\n" +
+              "  lazy_value => " + s(lazy) + "\n" +
               "\n" +
               "and then use " + expr("lazy_value") + " as instead of the original expression.\n");
       }

--- a/tests/reg_issue1666/reg_issue1666.fz.expected_err
+++ b/tests/reg_issue1666/reg_issue1666.fz.expected_err
@@ -10,10 +10,7 @@ This is an implementation restriction that should be removed in a future version
 
 To solve this, create a helper feature 'lazy_value' that calculates the value as follows:
 
-  lazy_value => {
-  private loop ***not yet known*** : Any is routine
-  f.this.loop
-}
+  lazy_value => '(do)'
 
 and then use 'lazy_value' as instead of the original expression.
 


### PR DESCRIPTION
For error output, there is `AstErrors.s(Expr)` which is much nicer.
