### PR TITLE
ast: set inferred argument field types before checking argument types in call

### DIFF
--- a/modules/lock_free/src/lock_free/Sieve_Cache.fz
+++ b/modules/lock_free/src/lock_free/Sieve_Cache.fz
@@ -115,7 +115,7 @@ public Sieve_Cache(K type : property.hashable, V type, public capacity i32) ref 
 
   public redef as_string String =>
     for res := "", res + "{n.val} (Visited: {n.val.visited.read})" + (if n.val.next.read?? then " -> " else "")
-        n := head.read, n.val.next
+        n := head.read, n.val.next.read
     while n??
     else
       res

--- a/src/dev/flang/ast/AbstractFeature.java
+++ b/src/dev/flang/ast/AbstractFeature.java
@@ -1185,7 +1185,7 @@ public abstract class AbstractFeature extends Expr implements Comparable<Abstrac
     if (PRECONDITIONS) require
       (!t.isOpenGeneric(),
        heir != null,
-       res == null || res.state(heir).atLeast(State.CHECKING_TYPES));
+       res == null || res.state(heir).atLeast(State.RESOLVED_SUGAR2));
 
     var a = handDown(res, new AbstractType[] { t }, heir);
 

--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -2712,6 +2712,11 @@ public class Call extends AbstractCall
     if (CHECKS) check
       (res._options.isLanguageServer() || Errors.any() || _type != null);
 
+    if (_calledFeature instanceof Feature cf && !cf.state().atLeast(State.CHECKING_TYPES))
+      { // make sure argument types, if inferred from actual calls, are all known
+        cf.checkTypes(res);
+      }
+
     if (_calledFeature != null &&
         context.outerFeature() != Types.resolved.f_effect_static_finally &&
         (_calledFeature == Types.resolved.f_effect_finally ||

--- a/src/dev/flang/ast/Impl.java
+++ b/src/dev/flang/ast/Impl.java
@@ -577,6 +577,10 @@ public class Impl extends ANY
             AstErrors.incompatibleTypesOfActualArguments(formalArg, types, positions);
           }
       }
+    else if (result == Types.t_ERROR)
+      {
+        result = null; // not urgent, we will report an error during CHECKING_TYPES phase.
+      }
     if (POSTCONDITIONS) ensure
       (!urgent || result != null);
 

--- a/tests/reg_issue5560/Makefile
+++ b/tests/reg_issue5560/Makefile
@@ -1,0 +1,25 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test Makefile
+#
+# -----------------------------------------------------------------------
+
+override NAME = reg_issue5560
+include ../simple.mk

--- a/tests/reg_issue5560/reg_issue5560.fz
+++ b/tests/reg_issue5560/reg_issue5560.fz
@@ -1,0 +1,51 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test reg_issue5560
+#
+# -----------------------------------------------------------------------
+
+# Failure to infer arguments types from call site results in too many errors
+#
+reg_issue5560 =>
+
+  # Original example from #5560: This should produce onle one error
+  #
+  # This is supposed to infer the type of argument v from the calls to f.
+  #
+  #
+  # This should fail since the argument types in both calls are different
+  # (String vs i32), but before #5560 was fixed, it first reports an error
+  # in call `f 1` that is actually correct for itself, only the second
+  # error clarifies why there is a problem:
+  #
+  f(v) => say v
+  f "a"
+  f 1
+
+  # a second example with more call sites. This should currently produce one error.
+  #
+  # NYI: UNDER DEVELOPMENT: once #5561 is fixed, this might actually work and not
+  # produce any error
+  #
+  g(v) => say v
+  g "aa"
+  g nil
+  g (option "")
+  g Any

--- a/tests/reg_issue5560/reg_issue5560.fz.expected_err
+++ b/tests/reg_issue5560/reg_issue5560.fz.expected_err
@@ -1,0 +1,31 @@
+
+--CURDIR--/reg_issue5560.fz:38:5: error 1: Type inference from actual arguments failed due to incompatible types of actual arguments
+  f(v) => say v
+----^
+For the formal argument 'reg_issue5560.f.v' the following incompatible actual arguments where found for type inference:
+actual is value of type 'codepoint' at --CURDIR--/reg_issue5560.fz:39:5:
+  f "a"
+----^^^
+actual is value of type 'i32' at --CURDIR--/reg_issue5560.fz:40:5:
+  f 1
+----^
+
+
+--CURDIR--/reg_issue5560.fz:47:5: error 2: Type inference from actual arguments failed due to incompatible types of actual arguments
+  g(v) => say v
+----^
+For the formal argument 'reg_issue5560.g.v' the following incompatible actual arguments where found for type inference:
+actual is value of type 'String' at --CURDIR--/reg_issue5560.fz:48:5:
+  g "aa"
+----^^^^
+actual is value of type 'nil' at --CURDIR--/reg_issue5560.fz:49:5:
+  g nil
+----^^^
+actual is value of type 'option String' at --CURDIR--/reg_issue5560.fz:50:6:
+  g (option "")
+-----^^^^^^
+actual is value of type 'Any' at --CURDIR--/reg_issue5560.fz:51:5:
+  g Any
+----^^^
+
+2 errors.


### PR DESCRIPTION
This ensures that failure to infer the argument type due to incompatible actual arguments as in the exampe from #5560

    f(v) => say v
    f "a"
    f 1

will be reported first and the type of the argument will be set to t_ERROR such that no subsequent error will be shown for the actual arguments passed to the call.

This required explicitly checking the called feature's types first and making Feature.checkTypes() re-entrant.

The stricter checking required a minor change in a loop in `Sieve_Cache` that can no longer use auto-unwrap.

fix #5560.
