### PR TITLE
base/String: rename `fields_func` as `split_if`

### DIFF
--- a/modules/base/src/String.fz
+++ b/modules/base/src/String.fz
@@ -722,19 +722,19 @@ public String ref : property.equatable, property.hashable, property.orderable is
   # evaluated to be true by p, this does not cause empty strings to be added to
   # the result list, rather this case is being treated as being one big separator.
   #
-  public fields_func(p codepoint -> bool) Sequence String =>
-    i := ff_state (Sequence String).empty false 0 0
-    last_state := as_codepoints.reduce ff_state i (r,c)->
+  public split_if(p codepoint -> bool) Sequence String =>
+    i := split_if_state (Sequence String).empty false 0 0
+    last_state := as_codepoints.reduce split_if_state i (r,c)->
       if p c
         if r.in_run
-          ff_state r.l true r.current_pos (r.current_pos + 1)
+          split_if_state r.l true r.current_pos (r.current_pos + 1)
         else
-          ff_state (r.l ++ [(substring_codepoint r.start_pos (r.current_pos))]) true r.current_pos (r.current_pos + 1)
+          split_if_state (r.l ++ [(substring_codepoint r.start_pos (r.current_pos))]) true r.current_pos (r.current_pos + 1)
       else
         if r.in_run
-          ff_state r.l false r.current_pos (r.current_pos + 1)
+          split_if_state r.l false r.current_pos (r.current_pos + 1)
         else
-          ff_state r.l false r.start_pos (r.current_pos + 1)
+          split_if_state r.l false r.start_pos (r.current_pos + 1)
 
     if last_state.in_run
       last_state.l
@@ -894,10 +894,10 @@ public String ref : property.equatable, property.hashable, property.orderable is
   public type.cap_z_char  u8 => "Z".utf8.first.get
 
 
-# state used by `String.fields_func`.
+# state used by `String.split_if`.
 #
-# Due to #4619, this currently cannot be declared local to `String.fields_func`
+# Due to #4619, this currently cannot be declared local to `String.split_if`
 # since it would then define a type whose outer type is `String.this` which is
 # a ref type that currently cannot be used a result type.
 #
-private ff_state(l Sequence String, in_run bool, start_pos, current_pos i32) is
+private split_if_state(l Sequence String, in_run bool, start_pos, current_pos i32) is

--- a/tests/check_simple_example.fz
+++ b/tests/check_simple_example.fz
@@ -140,7 +140,7 @@ String.excecute(
   # feed .stdin file to executed process?
   feed_stdin bool
 ) =>
-  ((fields_func (=" ")).map (.replace protected_space " ")).excecute feed_stdin
+  ((split_if (=" ")).map (.replace protected_space " ")).excecute feed_stdin
 
 # execute this string by splitting at all whitespaces
 #


### PR DESCRIPTION
This name is more intuitive and highlights the fact that the feature takes a predicate as an argument.