### PR TITLE
ast: use schedule for resolution instead of  `whenResolvedTypes`

### DIFF
--- a/src/dev/flang/ast/Feature.java
+++ b/src/dev/flang/ast/Feature.java
@@ -2283,7 +2283,6 @@ A ((Choice)) declaration must not contain a result type.
     res._module.findDeclarations(ta, this);
 
     res._module.addTypeParameter(this, ta);
-    this.whenResolvedTypes(()->res.resolveTypes(ta));
 
     return ta;
   }

--- a/src/dev/flang/ast/UnresolvedType.java
+++ b/src/dev/flang/ast/UnresolvedType.java
@@ -876,6 +876,7 @@ public abstract class UnresolvedType extends AbstractType implements HasSourcePo
         public boolean isFreeType() { return true; }
       };
     var g = outer.outer().addTypeParameter(res, tp);
+    tp.scheduleForResolution(res);
     return g.asGenericType();
   }
 


### PR DESCRIPTION
I find this expresses the intent more cleanly.

