### PR TITLE
ast: enable precondition for matching generic sizes

### DIFF
--- a/src/dev/flang/ast/ResolvedNormalType.java
+++ b/src/dev/flang/ast/ResolvedNormalType.java
@@ -145,8 +145,7 @@ public class ResolvedNormalType extends ResolvedType
                             TypeKind typeKind)
   {
     if (PRECONDITIONS) require
-      (true // disabled for now since generics may be empty when resolving a type in a match case, actual generics will be inferred later.
-       || Errors.any() || f == null || f.generics().sizeMatches(g == null ? UnresolvedType.NONE : g),
+      (Errors.any() || f == null || f.generics().sizeMatches(g == null ? UnresolvedType.NONE : g),
        typeKind == TypeKind.ValueType || typeKind == TypeKind.RefType
        /* NYI: Types.resolved == null
          || f.compareTo(Types.resolved.f_void) != 0*/);
@@ -429,9 +428,10 @@ public class ResolvedNormalType extends ResolvedType
         {
           return originalOuterFeature;
         }
-        ResolvedType _resolved = null;
+        AbstractType _resolved = null;
 
         /**
+         * NYI: CLEANUP:
          * This is a bit ugly, even though this type is a ResolvedType, the generics are not.
          */
         @Override

--- a/src/dev/flang/ast/UnresolvedType.java
+++ b/src/dev/flang/ast/UnresolvedType.java
@@ -29,6 +29,7 @@ package dev.flang.ast;
 import java.util.Optional;
 import java.util.Set;
 
+import dev.flang.util.Errors;
 import dev.flang.util.FuzionConstants;
 import dev.flang.util.HasSourcePosition;
 import dev.flang.util.List;
@@ -700,7 +701,7 @@ public abstract class UnresolvedType extends AbstractType implements HasSourcePo
         new AbstractType() {
           @Override protected AbstractFeature backingFeature() { return f0; }
           @Override public List<AbstractType> generics() { return AbstractCall.NO_GENERICS; }
-          @Override public AbstractType outer() { check(false); return null; }
+          @Override public AbstractType outer() { if (CHECKS) check(Errors.any()); return null; }
           @Override public TypeKind kind() { return typeKind; }
         }
       : !f.generics().sizeMatches(generics)


### PR DESCRIPTION
This change guarantees that ResolvedNormalTypes are valid in the sense the generics size match the backing feature. Generics in a ResolvedNormalType may still be unresolved though...