### PR TITLE
ast: resultTypeIfPresentUrgent, resolve outer on incomplete type

### DIFF
--- a/src/dev/flang/ast/AbstractType.java
+++ b/src/dev/flang/ast/AbstractType.java
@@ -2562,6 +2562,16 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
 
   }
 
+
+  /**
+   * Is this is an incomplete type,
+   * a resolve type where generics sizes do not match, yet.
+   */
+  public boolean isIncompleteType()
+  {
+    return this instanceof IncompleteType;
+  }
+
 }
 
 /* end of file */

--- a/src/dev/flang/ast/Case.java
+++ b/src/dev/flang/ast/Case.java
@@ -232,7 +232,7 @@ public class Case extends AbstractCase
     boolean result = true;
     if (_field != null)  // matching 'x type'
       {
-        var t = _field.returnType().functionReturnType();
+        var t = _field.returnType().functionReturnType(true);
         var rt = resolveType(res, t, cgs, context, matched);
         _field._returnType = new FunctionReturnType(rt);
         result &= rt != Types.t_ERROR;

--- a/src/dev/flang/ast/Feature.java
+++ b/src/dev/flang/ast/Feature.java
@@ -2366,6 +2366,13 @@ A ((Choice)) declaration must not contain a result type.
       }
     else
       {
+        result = _returnType.functionReturnType(true);
+        if (result != null && result.isIncompleteType())
+          {
+            // we need to resolve _outer which contains
+            // this case field before having a usable functionReturnType
+            res.resolveTypes(_outer);
+          }
         result = _returnType.functionReturnType();
         result = urgent && result == null ? Types.t_ERROR : result;
       }
@@ -2384,7 +2391,8 @@ A ((Choice)) declaration must not contain a result type.
     if (POSTCONDITIONS) ensure
       (!urgent || result != null,
        result != Types.t_UNDEFINED,
-       Errors.any() || result != Types.t_ERROR);
+       Errors.any() || result != Types.t_ERROR,
+       result == null || result instanceof ResolvedType);
 
     return result;
   }

--- a/src/dev/flang/ast/FunctionReturnType.java
+++ b/src/dev/flang/ast/FunctionReturnType.java
@@ -87,9 +87,10 @@ public class FunctionReturnType extends ReturnType
    *
    * @return the function return type.
    */
-  public AbstractType functionReturnType()
+  @Override
+  public AbstractType functionReturnType(boolean allowIncomplete)
   {
-    return _type == Types.t_UNDEFINED
+    return _type == Types.t_UNDEFINED || _type.isIncompleteType() && !allowIncomplete
       ? null
       : _type;
   }

--- a/src/dev/flang/ast/IncompleteType.java
+++ b/src/dev/flang/ast/IncompleteType.java
@@ -1,0 +1,49 @@
+/*
+
+This file is part of the Fuzion language implementation.
+
+The Fuzion language implementation is free software: you can redistribute it
+and/or modify it under the terms of the GNU General Public License as published
+by the Free Software Foundation, version 3 of the License.
+
+The Fuzion language implementation is distributed in the hope that it will be
+useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+License for more details.
+
+You should have received a copy of the GNU General Public License along with The
+Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+*/
+
+/*-----------------------------------------------------------------------
+ *
+ * Tokiwa Software GmbH, Germany
+ *
+ * Source of class IncompleteType
+ *
+ *---------------------------------------------------------------------*/
+
+
+package dev.flang.ast;
+
+import dev.flang.util.Errors;
+import dev.flang.util.List;
+
+/**
+ * An incomplete type is a type whose generics are missing.
+ * I.e. a type from a case field where it is allowed to omit the generics.
+ */
+public class IncompleteType extends ResolvedType {
+  private final AbstractFeature _feature;
+  private final TypeKind _typeKind;
+  public IncompleteType(AbstractFeature f, TypeKind typeKind)
+  {
+    _feature = f;
+    _typeKind = typeKind;
+  }
+  @Override protected AbstractFeature backingFeature() { return _feature; }
+  @Override public List<AbstractType> generics() { return AbstractCall.NO_GENERICS; }
+  @Override public AbstractType outer() { if (CHECKS) check(Errors.any()); return null; }
+  @Override public TypeKind kind() { return _typeKind; }
+}

--- a/src/dev/flang/ast/ReturnType.java
+++ b/src/dev/flang/ast/ReturnType.java
@@ -81,6 +81,20 @@ public abstract class ReturnType extends ANY
    */
   public AbstractType functionReturnType()
   {
+    return functionReturnType(false);
+  }
+
+
+  /**
+   * For a function, the result type.
+   *
+   * @param allowIncomplete allow returning types where generics are missing,
+   * i.e. an incomplete type from a case field
+   *
+   * @return the function result type.
+   */
+  public AbstractType functionReturnType(boolean allowIncomplete)
+  {
     if (PRECONDITIONS) require
       (!isConstructorType());
 

--- a/src/dev/flang/ast/UnresolvedType.java
+++ b/src/dev/flang/ast/UnresolvedType.java
@@ -693,17 +693,10 @@ public abstract class UnresolvedType extends AbstractType implements HasSourcePo
         generics.freeze();
       }
 
-    var f0 = f;
     return typeKind == TypeKind.ThisType
       ? new ThisType(f)
       : !f.generics().sizeMatches(generics) && ignoreActualTypePars
-      ? // incomplete type, will be replaced in Case.resolveType
-        new AbstractType() {
-          @Override protected AbstractFeature backingFeature() { return f0; }
-          @Override public List<AbstractType> generics() { return AbstractCall.NO_GENERICS; }
-          @Override public AbstractType outer() { if (CHECKS) check(Errors.any()); return null; }
-          @Override public TypeKind kind() { return typeKind; }
-        }
+      ? new IncompleteType(f, typeKind)
       : !f.generics().sizeMatches(generics)
       ? (tolerant ? null : Types.t_ERROR)
       : ResolvedNormalType.create(generics,


### PR DESCRIPTION
partially solves #5585

Before this patch, resultTypeIfPresentUrgent happily returned an incomplete type. This patch solves this by resolving _outer before asking for the functionReturnType.

I successfully ran HelloWorld with patch in #5585 applied with the caveat that I had to comment two features in base.fum. This means there is at least one more bug to solve before solving #5585

