### PR TITLE
fix windows sockets test

### DIFF
--- a/include/win.c
+++ b/include/win.c
@@ -246,6 +246,7 @@ int fzE_close(int sockfd)
 // family, socket_type, protocol
 int fzE_socket(int family, int type, int protocol){
   WSADATA wsaData;
+  // NYI: CLEANUP: call only once
   return WSAStartup(MAKEWORD(2,2), &wsaData) != 0
     ? -1
     : socket(fzE_get_family(family), fzE_get_socket_type(type), fzE_get_protocol(protocol));
@@ -274,7 +275,7 @@ int fzE_bind(int family, int socktype, int protocol, char * host, char * port, i
   result[0] = fzE_socket(family, socktype, protocol);
   if (result[0] == -1)
   {
-    result[0] = fzE_net_error();
+    last_error = fzE_net_error();
     return -1;
   }
   struct addrinfo *addr_info = NULL;
@@ -289,8 +290,8 @@ int fzE_bind(int family, int socktype, int protocol, char * host, char * port, i
 
   if(bind_res == -1)
   {
+    last_error = fzE_net_error();
     fzE_close(result[0]);
-    result[0] = fzE_net_error();
     return -1;
   }
   freeaddrinfo(addr_info);

--- a/tests/check_simple_example.fz
+++ b/tests/check_simple_example.fz
@@ -65,7 +65,10 @@ envir_var_kv := [
   "DYLD_FALLBACK_LIBRARY_PATH",
   "C_INCLUDE_PATH",
   "LANGUAGE",
-  "dev_flang_fuir_analysis_dfa_TRACE_ALL_EFFECT_ENVS"
+  "dev_flang_fuir_analysis_dfa_TRACE_ALL_EFFECT_ENVS",
+  # without this test/socket fails on windows,
+  # winsock2 seems to need this to properly load the dlls
+  "SYSTEMROOT"
 ].map k->
   if k="DYLD_FALLBACK_LIBRARY_PATH"||k="PATH"||k="LD_LIBRARY_PATH"
     (envir.vars.get k)


### PR DESCRIPTION
[ci skip]
winsock2 depends on environment variable SYSTEMROOT to load dlls

