### PR TITLE
ast: Support for types that depend on outer type of type parameter constraint

### DIFF
--- a/src/dev/flang/ast/AbstractType.java
+++ b/src/dev/flang/ast/AbstractType.java
@@ -1805,7 +1805,7 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
         ||
         isThisType() && (!tt.isGenericArgument() && tt.feature().inheritsFrom(feature())  // we have abc.this.type with tt inheriting from abc, so use tt
                          ||
-                         // we have a,b,c.this.type ann tt is type parameter with constraing x.y.z: So replace it if
+                         // we have a,b,c.this.type and tt is type parameter with constraing x.y.z: So replace it if
                          // any of `a.b.c`, `a.b`, or `a` inherits from this. During monomorphization, when the type
                          // parameter will be replaced, we will find that actual outer type that fits here.
                          //

--- a/src/dev/flang/ast/Resolution.java
+++ b/src/dev/flang/ast/Resolution.java
@@ -612,7 +612,8 @@ public class Resolution extends ANY
               {
                 var i = t.isOpenTypeParameter() ? Impl.TYPE_PARAMETER_OPEN
                                                 : Impl.TYPE_PARAMETER;
-                var constraint0 = t instanceof Feature tf ? tf.returnType().functionReturnType() : t.resultType();
+                var constraint0 = (t instanceof Feature tf ? tf.returnType().functionReturnType() : t.resultType())
+                  .resolve(this, af.context());
                 var constraint = af.rebaseTypeForCotype(constraint0);
                 var ta = new Feature(p, t.visibility(), t.modifiers() & FuzionConstants.MODIFIER_REDEFINE, constraint, t.featureName().baseName(),
                                      Contract.EMPTY_CONTRACT,

--- a/src/dev/flang/ast/UnresolvedType.java
+++ b/src/dev/flang/ast/UnresolvedType.java
@@ -934,11 +934,6 @@ public abstract class UnresolvedType extends AbstractType implements HasSourcePo
       .orElse(TypeKind.ValueType);
   }
 
-  public AbstractType applyTypeParsLocally(AbstractFeature f, List<AbstractType> actualGenerics, int select)
-  {
-    return this;
-  }
-
 }
 
 /* end of file */

--- a/src/dev/flang/ast/UnresolvedType.java
+++ b/src/dev/flang/ast/UnresolvedType.java
@@ -934,6 +934,10 @@ public abstract class UnresolvedType extends AbstractType implements HasSourcePo
       .orElse(TypeKind.ValueType);
   }
 
+  public AbstractType applyTypeParsLocally(AbstractFeature f, List<AbstractType> actualGenerics, int select)
+  {
+    return this;
+  }
 
 }
 

--- a/src/dev/flang/fuir/Clazz.java
+++ b/src/dev/flang/fuir/Clazz.java
@@ -2032,11 +2032,6 @@ class Clazz extends ANY implements Comparable<Clazz>
     AbstractFeature parent = feature();
     while (child != null)
       {
-        while (!child.feature().inheritsFrom(parent))
-          {
-            child = child.outerRef() != null ? child.outerRef().resultClazz()
-                                             : child._outer;
-          }
         var childf = child.feature();
         // find outer that inherits this clazz, e.g.
         //

--- a/src/dev/flang/fuir/Clazz.java
+++ b/src/dev/flang/fuir/Clazz.java
@@ -2032,6 +2032,11 @@ class Clazz extends ANY implements Comparable<Clazz>
     AbstractFeature parent = feature();
     while (child != null)
       {
+        while (!child.feature().inheritsFrom(parent))
+          {
+            child = child.outerRef() != null ? child.outerRef().resultClazz()
+                                             : child._outer;
+          }
         var childf = child.feature();
         // find outer that inherits this clazz, e.g.
         //

--- a/tests/reg_issue5569/Makefile
+++ b/tests/reg_issue5569/Makefile
@@ -1,0 +1,25 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test Makefile
+#
+# -----------------------------------------------------------------------
+
+override NAME = reg_issue5569
+include ../simple.mk

--- a/tests/reg_issue5569/reg_issue5569.fz
+++ b/tests/reg_issue5569/reg_issue5569.fz
@@ -1,0 +1,71 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test reg_issue5569
+#
+# -----------------------------------------------------------------------
+
+# This issue creates a situation where an type parameter with a constraint is
+# used to produce a type that depends on the outer type of the actual type
+# parameter.
+#
+reg_issue5569 =>
+
+  # the orginal example from #5569:
+  #
+  #   - the result type of t.e.r is `t.this.i`
+  #   - so the result type of `E.c.r` for `E`=`t.e` must be `t.i`
+  #
+  t is
+    e : effect is
+      r => i
+      type.c => e.this.env
+    i is
+  u(E type : t.e) => _ := E.c.r
+  t.e ! (u t.e)
+
+  # the original example change to output the type
+  v(E type : t.e) =>
+    E.c.r |> type_of |> say
+
+  yak "expecting t.i : "; t.e ! (v t.e)
+
+  # using a different outer type `t2`
+  t2 : t is
+  yak "expecting t2.i: "; t2.e ! v t2.e
+
+  # using a different inner type `e2`
+  t.e2 : t.e is
+  yak "expecting t.i : "; t.e2 ! v t.e2
+
+  # using a different outer and inner type `t2.e2`
+  yak "expecting t2.i: "; t2.e2 ! v t2.e2
+
+  t.e.j is
+  t.e.q => j
+
+  w(E type : t.e) =>
+    x := E.c.r
+    y := E.c.q
+    say "{type_of x} {type_of y}"
+
+  yak "expecting t.i /t.e.j  : "; t.e   ! w t.e
+  yak "expecting t2.i/t2.e.j : "; t2.e  ! w t2.e
+  yak "expecting t.i /t.e2.j : "; t.e2  ! w t.e2
+  yak "expecting t2.i/t2.e2.j: "; t2.e2 ! w t2.e2

--- a/tests/reg_issue5569/reg_issue5569.fz
+++ b/tests/reg_issue5569/reg_issue5569.fz
@@ -69,3 +69,17 @@ reg_issue5569 =>
   yak "expecting t2.i/t2.e.j : "; t2.e  ! w t2.e
   yak "expecting t.i /t.e2.j : "; t.e2  ! w t.e2
   yak "expecting t2.i/t2.e2.j: "; t2.e2 ! w t2.e2
+
+  # check if this still works for types that are generic arguments
+  t.e.r2() option (array i) => option [i]
+  t.e.q2() option (array j) => option [j]
+
+  w2(E type : t.e) =>
+    x := E.c.r2
+    y := E.c.q2
+    say "{type_of x} {type_of y}"
+
+  yak "expecting option (array t.i /t.e.j  ): "; t.e   ! w2 t.e
+  yak "expecting option (array t2.i/t2.e.j ): "; t2.e  ! w2 t2.e
+  yak "expecting option (array t.i /t.e2.j ): "; t.e2  ! w2 t.e2
+  yak "expecting option (array t2.i/t2.e2.j): "; t2.e2 ! w2 t2.e2

--- a/tests/reg_issue5569/reg_issue5569.fz
+++ b/tests/reg_issue5569/reg_issue5569.fz
@@ -83,3 +83,37 @@ reg_issue5569 =>
   yak "expecting option (array t2.i/t2.e.j ): "; t2.e  ! w2 t2.e
   yak "expecting option (array t.i /t.e2.j ): "; t.e2  ! w2 t.e2
   yak "expecting option (array t2.i/t2.e2.j): "; t2.e2 ! w2 t2.e2
+
+  # check if this still works for types that are generic arguments
+  t.e.ee() e.this => e.this
+  t.e.tt() t.this => t.this
+
+/* NYI: BUG: The following does not work yet, the type of `y` is `t.e.this` and not `t.this`:
+
+  w3(E type : t.e) =>
+    x := E.c.ee
+    y := E.c.tt
+    _ := x.j
+    _ := y.i
+    say "{type_of x} {type_of y}"
+
+  yak "expecting t.e /t  : "; t.e   ! w3 t.e
+  yak "expecting t2.e/t2 : "; t2.e  ! w3 t2.e
+  yak "expecting t.e2/t  : "; t.e2  ! w3 t.e2
+  yak "expecting t2.e2/t2: "; t2.e2 ! w3 t2.e2
+
+*/
+
+/* NYI: BUG: The following results in a crash of `fz` during momnorphization:
+
+  e3 : t.e is
+
+  w4(E type : t.e) =>
+    y := E.c.tt
+    say (type_of y)
+    say y
+
+  t.e ! w4 t.e
+  e3 ! w4 e3
+
+*/

--- a/tests/reg_issue5569/reg_issue5569.fz.expected_out
+++ b/tests/reg_issue5569/reg_issue5569.fz.expected_out
@@ -6,3 +6,7 @@ expecting t.i /t.e.j  : Type of 'reg_issue5569.t.i' Type of 'reg_issue5569.t.e.j
 expecting t2.i/t2.e.j : Type of 'reg_issue5569.t2.i' Type of 'reg_issue5569.t2.e.j'
 expecting t.i /t.e2.j : Type of 'reg_issue5569.t.i' Type of 'reg_issue5569.t.e2.j'
 expecting t2.i/t2.e2.j: Type of 'reg_issue5569.t2.i' Type of 'reg_issue5569.t2.e2.j'
+expecting option (array t.i /t.e.j  ): Type of 'option (array reg_issue5569.t.i)' Type of 'option (array reg_issue5569.t.e.j)'
+expecting option (array t2.i/t2.e.j ): Type of 'option (array reg_issue5569.t2.i)' Type of 'option (array reg_issue5569.t2.e.j)'
+expecting option (array t.i /t.e2.j ): Type of 'option (array reg_issue5569.t.i)' Type of 'option (array reg_issue5569.t.e2.j)'
+expecting option (array t2.i/t2.e2.j): Type of 'option (array reg_issue5569.t2.i)' Type of 'option (array reg_issue5569.t2.e2.j)'

--- a/tests/reg_issue5569/reg_issue5569.fz.expected_out
+++ b/tests/reg_issue5569/reg_issue5569.fz.expected_out
@@ -1,0 +1,8 @@
+expecting t.i : Type of 'reg_issue5569.t.i'
+expecting t2.i: Type of 'reg_issue5569.t2.i'
+expecting t.i : Type of 'reg_issue5569.t.i'
+expecting t2.i: Type of 'reg_issue5569.t2.i'
+expecting t.i /t.e.j  : Type of 'reg_issue5569.t.i' Type of 'reg_issue5569.t.e.j'
+expecting t2.i/t2.e.j : Type of 'reg_issue5569.t2.i' Type of 'reg_issue5569.t2.e.j'
+expecting t.i /t.e2.j : Type of 'reg_issue5569.t.i' Type of 'reg_issue5569.t.e2.j'
+expecting t2.i/t2.e2.j: Type of 'reg_issue5569.t2.i' Type of 'reg_issue5569.t2.e2.j'


### PR DESCRIPTION
A feature `f` with a type parameter `T` and a constraint `a.b.c` as follows

    f(T type : a.b.c) =>

may be used to produce types that depend on the actual types corresponding to `a.b` or just `a` as passed to `f`.  This was not supported so far resulting in `fz` crashing.

In case we have

    a is
      b is
        c is
          j is
          get_i => i
          get_j => j
        i is

Before this commit, the result type of `get_i`/`get_j` was `a.b.this.i` and `a.b.c.this.j`. When called within `f`, only the one for `get_j` was replaced by `T.j`, while the one for `get_i` remained `a.b.this.i`, which did not get replaced during monomorphization resulting an an `fz` crash.

Now, the types used in `f` will be `T.i` and `T.j`, respectively, and monomorphization will replace them with the actual clazz used for `T` or the corresponding outer clazz.

fix #5569.
