### PR TITLE
ast/fe/fuir: cleanup: resolved types are not a concept for the middle end

### DIFF
--- a/src/dev/flang/ast/AbstractType.java
+++ b/src/dev/flang/ast/AbstractType.java
@@ -1249,15 +1249,7 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
        this instanceof ResolvedType,
        feature().generics().sizeMatches(g));
 
-    var g2 = new List<>(g);
-    g2.freeze();
-
-    return new ResolvedType() {
-      @Override protected AbstractFeature backingFeature() { return AbstractType.this.backingFeature(); }
-      @Override public List<AbstractType> generics() { return g2; }
-      @Override public AbstractType outer() { return o == null ? feature().outer().selfType() : o; }
-      @Override public TypeKind kind() { return AbstractType.this.kind(); }
-    };
+    throw new Error("replaceGenericsAndOuter not supported for "+getClass());
   }
 
 

--- a/src/dev/flang/ast/AbstractType.java
+++ b/src/dev/flang/ast/AbstractType.java
@@ -135,6 +135,20 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
 
 
   /**
+   * `this` as a value.
+   *
+   * Requires that at isNormalType().
+   */
+  public AbstractType asValue()
+  {
+    if (PRECONDITIONS) require
+      (isNormalType());
+
+    throw new Error("asValue() not supported for "+getClass());
+  }
+
+
+  /**
    * This type as a reference.
    *
    * Requires that this is resolved, !isGenericArgument().

--- a/src/dev/flang/ast/ResolvedNormalType.java
+++ b/src/dev/flang/ast/ResolvedNormalType.java
@@ -391,7 +391,6 @@ public class ResolvedNormalType extends ResolvedType
    * @return a new type with same feature(), but using g2/o2 as generics
    * and outer type.
    */
-  // NYI: CLEANUP: remove, why does this behave differently from super.replaceGenericsAndOuter?
   @Override
   public AbstractType replaceGenericsAndOuter(List<AbstractType> g2, AbstractType o2)
   {

--- a/src/dev/flang/ast/ResolvedNormalType.java
+++ b/src/dev/flang/ast/ResolvedNormalType.java
@@ -380,6 +380,26 @@ public class ResolvedNormalType extends ResolvedType
 
 
   /**
+   * `this` as a value.
+   *
+   * Requires that at isNormalType().
+   */
+  @Override
+  public AbstractType asValue()
+  {
+    if (PRECONDITIONS) require
+      (isNormalType());
+
+    return switch (kind())
+      {
+      case ValueType -> this;
+      case RefType   -> create(generics(), Call.NO_GENERICS, outer(), feature(), TypeKind.ValueType);
+      default        -> throw new Error("unexpected kind "+kind()+" for ResolvedNormalType");
+    };
+  }
+
+
+  /**
    * For a type that is not a type parameter, create a new variant using given
    * actual generics and outer type.
    *

--- a/src/dev/flang/fe/NormalType.java
+++ b/src/dev/flang/fe/NormalType.java
@@ -110,7 +110,6 @@ class NormalType extends LibraryType
    * @return a new type with same feature(), but using g2/o2 as generics
    * and outer type.
    */
-  // NYI: CLEANUP: remove, why does this behave differently from super.replaceGenericsAndOuter?
   @Override
   public AbstractType replaceGenericsAndOuter(List<AbstractType> g2, AbstractType o2)
   {

--- a/src/dev/flang/fe/NormalType.java
+++ b/src/dev/flang/fe/NormalType.java
@@ -99,6 +99,24 @@ class NormalType extends LibraryType
 
 
   /**
+   * `this` as a value.
+   *
+   * Requires that at isNormalType().
+   */
+  @Override
+  public AbstractType asValue()
+  {
+    return switch (kind())
+      {
+      case ValueType -> this;
+      case RefType   -> new NormalType(_libModule, _at, _feature, TypeKind.ValueType, generics(), outer());
+      default        -> throw new Error("unexpected kind "+kind()+" for NormalType");
+      };
+  }
+
+
+
+  /**
    * For a type that is not a type parameter, create a new variant using given
    * actual generics and outer type.
    *


### PR DESCRIPTION
Resolving of features and types happens during he front end phase only, so anything related to resolution should no longer be touched in the middle end. 

Replace dummy implementation of `AbstractType.replaceGenericsAndOuter` since this is redefined in `ast.ResolvedNormalType` and `fe.NormalType`

Moved `Clazz.asValue` to `AbstractType.asValue` to avoid the imports for `ResolvedType` in `Clazz`, the resolution is a front-end thing that should be unknown to the middle-end.
