### PR TITLE
revert cfe45d7, since this does not work on windows

### DIFF
--- a/tests/modules/b.make
+++ b/tests/modules/b.make
@@ -23,8 +23,6 @@
 #
 # -----------------------------------------------------------------------
 
-override MAKEFILE_DIR = $(patsubst %/,%,$(dir $(lastword $(MAKEFILE_LIST))))
-override TEST_DIR = $(realpath $(MAKEFILE_DIR)/modules)
-override NAME = $(TEST_DIR)/src/test_modules
-override FUZION_OPTIONS = -sourceDirs=$(TEST_DIR)/src -modules=b -moduleDirs=$(TEST_DIR)/modules
+override NAME = src/test_modules
+override FUZION_OPTIONS = -sourceDirs=src -modules=b -moduleDirs=modules
 include ../simple.mk


### PR DESCRIPTION
Comment was, does it still apply?:
```
When doing a 'run_tests', the paths in the error output contained
'--CURDIR__/../modules', where '/../modules' was redundant and caused an error.
```