### PR TITLE
base: remove constraint for `option.infix >>?`

### DIFF
--- a/modules/base/src/option.fz
+++ b/modules/base/src/option.fz
@@ -59,8 +59,6 @@ is
   # monadic operator for bool result, false for nil
   #
   public infix >>? (f T -> bool) bool
-  pre
-    T : numeric
   =>
     option.this ? v T => f v
                 | nil => false


### PR DESCRIPTION
This constraint is not needed, this function works for any option.
