### PR TITLE
ast: Fix `NullPointerException` in `Universe.typeforInferencing`

### DIFF
--- a/src/dev/flang/ast/Universe.java
+++ b/src/dev/flang/ast/Universe.java
@@ -72,7 +72,7 @@ public class Universe extends ExprWithPos
   @Override
   AbstractType typeForInferencing()
   {
-    return Types.resolved.universe.selfType();
+    return Types.resolved == null ? null : Types.resolved.universe.selfType();
   }
 
 


### PR DESCRIPTION
This was triggered when this is called early during compilation of `base.fum` with my changes from #5568, but I did not bother trying to create a test case.
