### PR TITLE
fix reading uninitialized field

### DIFF
--- a/src/dev/flang/fuir/analysis/dfa/Instance.java
+++ b/src/dev/flang/fuir/analysis/dfa/Instance.java
@@ -194,7 +194,7 @@ public class Instance extends Value
     Val res = v;
     if (v == null)
       {
-        if (dfa._reportResults && !Errors.any())
+        if (!Errors.any())
           {
             DfaErrors.readingUninitializedField(site == -1 ? dev.flang.util.SourcePosition.notAvailable : // NYI: REMOVE
                                                 site == IR.NO_SITE ? null : dfa._fuir.sitePos(site),

--- a/tests/reg_issue5085/Makefile
+++ b/tests/reg_issue5085/Makefile
@@ -1,0 +1,25 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test Makefile
+#
+# -----------------------------------------------------------------------
+
+override NAME = reg_issue5085
+include ../simple.mk

--- a/tests/reg_issue5085/reg_issue5085.fz
+++ b/tests/reg_issue5085/reg_issue5085.fz
@@ -1,0 +1,26 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test reg_issue5085
+#
+# -----------------------------------------------------------------------
+
+x i32 := [1,2].fold1 a,b->x
+say x
+

--- a/tests/reg_issue5085/reg_issue5085.fz.expected_err
+++ b/tests/reg_issue5085/reg_issue5085.fz.expected_err
@@ -1,0 +1,30 @@
+
+--CURDIR--/reg_issue5085.fz:24:27: error 1: reading uninitialized field 'x' from instance of 'universe'
+x i32 := [1,2].fold1 a,b->x
+--------------------------^
+Callchain that lead to this point:
+
+call 'λ.call#2' at {base.fum}/list.fz:239:41:
+              | c Cons => c.tail.foldf (f e c.head) f
+----------------------------------------^
+call '(list i32).foldf#3 i32' at {base.fum}/list.fz:230:27:
+              | c Cons => c.tail.foldf c.head f
+--------------------------^^^^^^^^^^^^^^^^^^^^^
+call '(list i32).fold1#1' at {base.fum}/list.fz:228:16:
+  public redef fold1 (f (A,A)->A) A =>
+---------------^^^^^
+call '(list i32).precall fold1' at {base.fum}/Sequence.fz:433:5:
+    as_list.fold1 f
+----^^^^^^^^^^^^^^^
+call '(array i32).fold1#1' at {base.fum}/Sequence.fz:430:3:
+  pre
+--^^^
+    debug: !is_empty
+----^^^^^^^^^^^^^^^^
+call '(array i32).precall fold1' at --CURDIR--/reg_issue5085.fz:24:10:
+x i32 := [1,2].fold1 a,b->x
+---------^^^^^^^^^^^^^^^^^^
+call 'universe'
+program entry point
+
+one error.


### PR DESCRIPTION
fixes #5085 
In the second pass of the DFA, fields are already written, so it can not be detected anymore that they are uninitialized.