### PR TITLE
net/connection: treat zero read from socket as EOF unless requested

### DIFF
--- a/modules/base/src/net/connection.fz
+++ b/modules/base/src/net/connection.fz
@@ -43,7 +43,11 @@ module:public connection(desc i32) is
       read_handler : io.Read_Handler is
         public redef read(count i32) choice (array u8) io.end_of_file error =>
           match fuzion.sys.net.read desc count.as_i64
-            a array => a
+            a array =>
+              if a.is_empty && count != 0
+                io.end_of_file
+              else
+                a
             e error => e
       (io.buffered LM)
         .reader read_handler 1024


### PR DESCRIPTION
According to the `recv(2)` manual, reading from a socket returns zero if the socket has been closed or if zero bytes have been requested to read.

In the former situation, return `io.end_of_file` for easier handling in more high-level code.