### PR TITLE
ast: move argument type adjustment from genericsAssignable

### DIFF
--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -1974,9 +1974,7 @@ public class Call extends AbstractCall
             actualType = Types.resolved.f_Type.selfType();
           }
       }
-    return actualType == null
-      ? actualType
-      : targetTypeOrConstraint(res, context).actualType(actualType, context);
+    return actualType;
   }
 
 
@@ -2830,7 +2828,13 @@ public class Call extends AbstractCall
         if (!errorInActuals())
           {
             // Check that generics match formal generic constraints
-            AbstractType.checkActualTypePars(context, _calledFeature, _generics, _originalGenerics, pos());
+            AbstractType.checkActualTypePars(
+              context,
+              _calledFeature,
+              _generics,
+              _originalGenerics,
+              pos(),
+              constraint -> adjustResultType(res, context, targetType(context), constraint, null, false));
           }
       }
   }

--- a/tests/reg_issues4992_5001_negative/reg_issues4992_5001_negative.fz.expected_err
+++ b/tests/reg_issues4992_5001_negative/reg_issues4992_5001_negative.fz.expected_err
@@ -9,21 +9,21 @@ actual type parameter 'tuple i32 bool'
 --CURDIR--/reg_issues4992_5001_negative.fz:97:9: error 2: Incompatible type parameter
       X.i (tuple unit true_) # 3. should flag an error: wrong type parameter `true_` instead of `X`
 --------^
-formal type parameter 'U' with constraint 'tuple unit reg_issues4992_5000.case5.x.this.type'
+formal type parameter 'U' with constraint 'tuple unit reg_issues4992_5000.case5.y.X'
 actual type parameter 'tuple unit true_'
 
 
 --CURDIR--/reg_issues4992_5001_negative.fz:150:9: error 3: Incompatible type parameter
       X.i (tuple i32 i32 i32) (42,43,44)  # 4. should flag an error: wrong type parameter `tuple i32 i32 i32` instead of `tuple Any unit f32`
 --------^
-formal type parameter 'U' with constraint 'tuple reg_issues4992_5000.case6.x.type.A reg_issues4992_5000.case6.x.type.B reg_issues4992_5000.case6.x.type.C'
+formal type parameter 'U' with constraint 'tuple Any unit f32'
 actual type parameter 'tuple i32 i32 i32'
 
 
 --CURDIR--/reg_issues4992_5001_negative.fz:162:13: error 4: Incompatible type parameter
     (x f32).i (box i32)  # 5. should flag an error: wrong type parameter `box i32` instead of `box f32`
 ------------^
-formal type parameter 'U' with constraint 'reg_issues4992_5000.case7.this.box reg_issues4992_5000.case7.x.type.A'
+formal type parameter 'U' with constraint 'reg_issues4992_5000.case7.this.box f32'
 actual type parameter 'reg_issues4992_5000.case7.this.box i32'
 
 


### PR DESCRIPTION
Benefit of this cleanup/refactoring is that the error messages improved.