### PR TITLE
ast: Make error nicer by using singular in case list has only one element

### DIFF
--- a/src/dev/flang/ast/AstErrors.java
+++ b/src/dev/flang/ast/AstErrors.java
@@ -874,9 +874,11 @@ public class AstErrors extends ANY
       }
     else
       {
+        var n = missingMatches.size();
         error(pos,
               "" + skw("match") + " expression does not cover all of the subject's types",
-              "Missing cases for types: " + typeListConjunction(missingMatches) + "\n" +
+              "Missing " + StringHelpers.plural(n,"case") +
+              " for "    + StringHelpers.plural(n,"type") + ": " + typeListConjunction(missingMatches) + "\n" +
               subjectTypes(choiceGenerics));
       }
   }


### PR DESCRIPTION
This turns

    Missing cases for types: i32

and

    Missing cases for types: i32, bool

into

    Missing case for type: i32

and

    Missing cases for types: i32, bool

Which is somewhat nicer.
