### PR TITLE
Base time add histogram

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1373,11 +1373,11 @@ spellcheck:
 	bin/spell_check_java.sh
 
 # target to do a syntax check of fz files.
-# currently only examples/ are checked.
+# currently only code in bin/ and examples/ are checked.
 .PHONY: syntaxcheck
 syntaxcheck: min-java
-	find ./examples/ -name '*.fz' -print0 | xargs -0L1 $(FZ) -modules=clang,java.base,java.datatransfer,java.xml,java.desktop -noBackend
-	find ./bin/ -name '*.fz' -print0 | xargs -0L1 $(FZ) -modules=clang,java.base,java.datatransfer,java.xml,java.desktop -noBackend
+	find ./examples/ -name '*.fz' -print0 | xargs -0L1 $(FZ) -modules=terminal,clang,java.base,java.datatransfer,java.xml,java.desktop -noBackend
+	find ./bin/ -name '*.fz' -print0 | xargs -0L1 $(FZ) -modules=terminal,clang,java.base,java.datatransfer,java.xml,java.desktop -noBackend
 
 .PHONY: add_simple_test
 add_simple_test: no-java

--- a/examples/jitter/Makefile
+++ b/examples/jitter/Makefile
@@ -1,0 +1,35 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion pythagorean_triple example Makefile
+#
+#  Author: Fridtjof Siebert (siebert@tokiwa.software)
+#
+# -----------------------------------------------------------------------
+
+all: jvm
+
+jvm:
+	../../bin/fz -modules=terminal jitter.fz
+
+c: jitter
+	./$^
+
+jitter:
+	../../bin/fz -modules=terminal -c -o=$@ jitter.fz

--- a/examples/jitter/jitter.fz
+++ b/examples/jitter/jitter.fz
@@ -1,0 +1,154 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion example jitter
+#
+#  Author: Fridtjof Siebert (siebert@tokiwa.software)
+#
+# -----------------------------------------------------------------------
+
+# jitter -- demo measuring periodic task jitter using time.histogram
+#
+# See Makefile for how to start fuzion to run this example.
+#
+# NYI: UNDER DEVELOPMENT: Currently, this supports only one single test using
+# `time.nano.run_periodic`.  Once we have support for periodic tasks run by dedicated
+# threads, we should add jitter tests for those.
+#
+jitter =>
+
+  # the period to start with
+  #
+  period_default => time.duration.ms  500
+
+
+  # the time to spend with each period
+  #
+  test_duration  => time.duration.ms 2100
+
+
+  # the time to wait before first release
+  #
+  start_delay    => time.duration.ms  500
+
+
+  # should the linear histogram be output?
+  #
+  show_lin_histogram => true
+
+
+  # should the log histogram be output?
+  #
+  show_log_histogram => true
+
+
+  # should the linear csv be output?
+  #
+  show_lin_csv => false
+
+
+  # should the log csv be output?
+  #
+  show_log_csv => false
+
+
+
+  # run jitter test using C.clock.run_periodic
+  #
+  test_jitter(# the clock used to schedule the releases
+              C type : time.Clock,
+
+              # the clock used to measure the times
+              TIMER type : time.Clock)
+  =>
+
+    # type used to identify exception to stop in case jitter is too high
+    #
+    jitter_too_high is
+
+    # test payload, just some dummy code requiring a moderate amount of calculation
+    #
+    payload =>
+      for
+        i := 0, i+1
+        s := i, s +° i
+      while i < 1000
+      else
+        if s = s +° 1   # make sure the compiler does not optimize this aways
+          say "$s (never called)"
+
+    # perform jitter test for given period
+    #
+    run_for_period(period time.duration)
+    =>
+
+      # time for next release used by state effect
+      next_release(t time.instant) is
+
+      # NYI: BUG: #5634: use `infix !` in this example once #5634 is fixed
+      state next_release unit (next_release TIMER.clock.read+start_delay) ()->
+
+        start := C.clock.read + start_delay
+        end := start + test_duration
+        yak "testing period $period for $test_duration..."
+
+        # record jitter using linear and log histograms
+        h  := time.histogram.new "period $period, log count / linear time" period period*2 1 0
+        h2 := time.histogram.new "period $period, log count / log time"    nil nil 1 0
+
+        # run test
+        _ := C.clock.run_periodic start period end run_one_release
+
+        # output results
+        say terminal.clear_line
+        if show_lin_histogram then say h
+        if show_log_histogram then say h2
+        if show_lin_csv       then say h.csv
+        if show_log_csv       then say h2.csv
+        say ""
+
+        # run one single release: record the actual release and run the payload
+        #
+        # in case of a late release or a overrun into the next release time, cause `exception jitter_too_high`
+        #
+        run_one_release ! exception jitter_too_high =>
+          actual_release := TIMER.clock.read
+          h .add_instant actual_release
+          h2.add_instant actual_release
+          expected_rel := state_get next_release .t
+          next_rel     := state_modify next_release (x -> next_release x.t+period) .get.t
+          if actual_release >= next_rel
+            (exception jitter_too_high).env.cause <| error "release time jitter exceeded period"
+          else
+            payload
+            actual_finish := TIMER.clock.read
+            if actual_finish >= next_rel
+              e := error "*** overrun: run started at {actual_release-expected_rel}  and took {actual_finish-actual_release}, which is larger than period $period"
+              (exception jitter_too_high).env.cause e
+
+    match exception jitter_too_high .on unit /* NYI: CLEANUP: remove `unit` when #5636 is fixed */ ()->
+
+         for p := period_default, p.times 0.5 do
+           run_for_period p
+
+      e error => say $e
+      unit    => # will not happen
+
+  time.nano ! ()->
+    test_jitter time.nano time.nano

--- a/modules/base/src/state.fz
+++ b/modules/base/src/state.fz
@@ -52,7 +52,7 @@
 # NYI: BUG: #5634: use `infix !` in this example once #5634 is fixed
 #
 # note that access to the state value is possible in any code executed while the state
-# is instated, also, e.g., in lambdas that that are passed to a call and then called
+# is instated, also, e.g., in lambdas that are passed to a call and then called
 # further down the call chain.
 #
 # The wrapper type, `demo` in the example, is not strictly required, we could use

--- a/modules/base/src/state.fz
+++ b/modules/base/src/state.fz
@@ -30,7 +30,7 @@
 #
 # use as follows to store data of type `u8` for purpose `demo`:
 #
-#      # first, declare a type that holds a value pf `u8` that describes the purpose
+#      # first, declare a type that holds a value of `u8` that describes the purpose
 #      #
 #      demo(contents u8) is
 #

--- a/modules/base/src/state.fz
+++ b/modules/base/src/state.fz
@@ -59,7 +59,7 @@
 # just `u8` instead.  However, this would permit unrelated code to read and modify
 # the value using `state_get u8`, while the wrapper type `demo` restricts this to
 # code for which `demo` is visible.  To avoid accidental and intentional (malicious)
-# acceses to state effects, we need our own local type!
+# accesses to state effects, we need our own local type!
 #
 public state(
 

--- a/modules/base/src/state.fz
+++ b/modules/base/src/state.fz
@@ -28,17 +28,49 @@
 # this can be used both as plain or as a oneway monad to store a state
 # in a way orthogonal to the actual computation.
 #
+# use as follows to store data of type `u8` for purpose `demo`:
+#
+#      # first, declare a type that holds a value pf `u8` that describes the purpose
+#      #
+#      demo(contents u8) is
+#
+#      # then, create an instate an instance of `state` with initial value `23`
+#      #
+#      state demo unit (demo 23) ()->
+#
+#        # now, we can access the value using `state_get demo`
+#        # or, to unwrap it `state_get demo .contents`
+#        #
+#        say "state value is {state_get demo .contents}"
+#
+#        # we can now modify the value, e.g, doubling it via
+#        #
+#        new_demo := state_modify demo (x -> demo x.contents*2)
+#        say "state value is {new_demo.get.contents}"
+#        say "state value is {state_get demo .contents}"
+#
+# NYI: BUG: #5634: use `infix !` in this example once #5634 is fixed
+#
+# note that access to the state value is possible in any code executed while the state
+# is instated, also, e.g., in lambdas that that are passed to a call and then called
+# further down the call chain.
+#
+# The wrapper type, `demo` in the example, is not strictly required, we could use
+# just `u8` instead.  However, this would permit unrelated code to read and modify
+# the value using `state_get u8`, while the wrapper type `demo` restricts this to
+# code for which `demo` is visible.  To avoid accidental and intentional (malicious)
+# acceses to state effects, we need our own local type!
 #
 public state(
 
   # types of contained and the state value
-  T, S type,
+  public T, S type,
 
   # the contained value
-  val T,
+  public val T,
 
   # the current state
-  get S,
+  public get S,
 
   # `plain` monad or effect to be `inst`alled or `repl`aced by new value?
   mode oneway_monad_mode.val

--- a/modules/base/src/time/Clock.fz
+++ b/modules/base/src/time/Clock.fz
@@ -34,7 +34,7 @@ public Clock ref : effect is
 
   # read the time of this clock
   #
-  public read instant => abstract
+  public read time.instant => abstract
 
 
   # halt the current thread during the given period of time
@@ -78,9 +78,9 @@ public Clock ref : effect is
   #
   # return the number of times the code was run
   #
-  public run_periodic(first instant,
+  public run_periodic(first time.instant,
                       period time.duration,
-                      last instant,
+                      last time.instant,
                       code ()->unit) u64
   pre
     debug: period > time.duration.ns 0
@@ -92,10 +92,11 @@ public Clock ref : effect is
       cnt := u64 0, cnt + 1
       ima := read
       next1 := first, next + period
-      skip := if ima > next1 then (ima - next1) / period else 0
+      skip := if ima > next1 then (ima - next1 + period - time.duration.ns 1) / period else 0
       next := next1 + period * skip
     while next <= last
-      sleep next-ima
+      if ima < next
+        sleep next-ima
       code()
     else
       cnt

--- a/modules/base/src/time/duration.fz
+++ b/modules/base/src/time/duration.fz
@@ -298,7 +298,7 @@ is
   => a n
 
 
-  # the empty duration
+  # the zero duration, representing a time span of zero
   #
   public type.zero => time.duration 0
 

--- a/modules/base/src/time/duration.fz
+++ b/modules/base/src/time/duration.fz
@@ -87,17 +87,22 @@ is
   #
   public fixed infix - (other duration) duration
   pre
-    safety: duration.this > other
+    safety: duration.this >= other
   =>
     duration (nanos - other.nanos)
 
 
-  # this duration multiplied by n
+  # this duration multiplied by factor n
   #
-  public infix * (n u64) duration => (duration nanos*n)
+  public infix *(n u64) duration => duration nanos*n
 
 
-  # this duration multiplied by duration d, rounding down
+  # this duration multiplied by factor f
+  #
+  public times(f f64) duration => duration (nanos.as_f64 * f).as_i64.as_u64
+
+
+  # this duration divided by duration d, rounding down
   #
   public infix / (other duration) u64 => nanos / other.nanos
 
@@ -107,12 +112,7 @@ is
   # and at most 4 decimal digits followed by a time unit string.
   #
   public redef as_string String =>
-    for
-      x := time_unit.ns, nx.get
-      nx := x.larger
-    while nx >>? (u -> nanos / u.in_ns >= 10)
-    else
-      as_string x
+    as_string unit_for_as_string
 
 
   # create a string representation of this duration using the given unit.
@@ -120,6 +120,18 @@ is
   public as_string(u time.time_unit) String =>
     n := $(nanos / u.in_ns)
     " "*(max 0 4-n.byte_length) + n + u.short_name
+
+
+  # create a string representation of this duration. The string
+  # representation is not accurate, it consists of at least two
+  # and at most 4 decimal digits followed by a time unit string.
+  #
+  public unit_for_as_string time.time_unit =>
+    for
+      x := time.time_unit.ns, nx.get
+      nx := x.larger
+    while nx >>? (u -> nanos / u.in_ns >= 10) else
+      x
 
 
   # total order
@@ -284,3 +296,13 @@ is
   pre
     debug: n ≤ max_duration_years
   => a n
+
+
+  # the empty duration
+  #
+  public type.zero => time.duration 0
+
+
+  # the maximum duration
+  #
+  public type.max => time.duration.ns time.duration.max_duration_nanos

--- a/modules/base/src/time/histogram.fz
+++ b/modules/base/src/time/histogram.fz
@@ -23,10 +23,10 @@
 #
 # -----------------------------------------------------------------------
 
-# time.histogram -- feature to collect and output timeing data
+# time.histogram -- feature to collect and output timing data
 #
 # This is particularly useful to analyse variations in release or
-# execution times of tasks or events
+# execution times of repeatedly executed tasks or events.
 #
 # For this, it distributes time.duration values into a list of
 # buckets that correspond to different ranges of durations.  These

--- a/modules/base/src/time/histogram.fz
+++ b/modules/base/src/time/histogram.fz
@@ -56,23 +56,23 @@ public histogram(# title to be printed for this histogram
                  # the maximum duration that will be recorded in this histogram
                  #
                  # if specified, the histogram will use a linear time scale from
-                 # 0 up to maxRecorded
+                 # 0 up to max_recorded
                  #
                  # if `nil`, the histogram will use a generic logarithmic time scale
                  # from 1ns up to about 1day.
                  #
-                 public maxRecorded option time.duration,
+                 public max_recorded option time.duration,
 
                  # number of initial recordings that should be ignored (i.e.,
                  # that are considered to be part of a _warm up_ phase).
                  #
-                 public ignoreFirst u64,
+                 public ignore_first u64,
 
                  # number of final recordings that should be ignored. This permits
                  # errors introduces by starting of the shutdown process to be
                  # ignored.
                  #
-                 public ignoreLast u64
+                 public ignore_last u64
                  )
 is
 
@@ -94,22 +94,22 @@ is
 
   # total number of measurements, including ignored ones.
   #
-  totalNumber := lm.new (u64 0)
+  total_number := lm.new (u64 0)
 
 
   # buffer of measurements at the end that should be ignored.
   #
-  ignoreLastBuffer := lm.new_array ignoreLast.as_i64 (option time.duration nil)
+  ignore_last_buffer := lm.new_array ignore_last.as_i64 (option time.duration nil)
 
 
-  # current index to add new data to ignoreLastBuffer
+  # current index to add new data to ignore_last_buffer
   #
-  ignoreLastBufferIndex := lm.new (i64 0)
+  ignore_last_buffer_index := lm.new (i64 0)
 
 
   # Number of distinct buckets that are recorded
   #
-  N => i64 66
+  num_buckets => i64 66
 
 
   # Total number of samples recorded.  The values are not stored, only
@@ -137,7 +137,7 @@ is
 
   # time of first sample
   #
-  startTime := lm.new (option time.instant) nil
+  start_time := lm.new (option time.instant) nil
 
 
   # table of durations in each bucket, each entry gives the maximum duration for that index
@@ -145,26 +145,28 @@ is
   # the last entry is always time.duration.max
   #
   table array time.duration :=
-           match maxRecorded
-             mr time.duration => array N.as_i32 (i -> if i<N.as_i32-1 then mr.times ((i+1).as_f64 / (N.as_f64-1))
-                                                                      else time.duration.max                     )
-             nil              => logTable
+    match max_recorded
+      mr time.duration => n := num_buckets.as_i32
+                          array n i->
+                            if i<n-1 then mr.times ((i+1).as_f64 / (num_buckets.as_f64-1))
+                                     else time.duration.max
+      nil              => log_table
 
   check
-    debug: table.length = N.as_i32
-    debug: table[N.as_i32-1] = time.duration.max
+    debug: table.length = num_buckets.as_i32
+    debug: table[num_buckets.as_i32-1] = time.duration.max
 
 
   # table of durations for logarithmic histogram
   #
-  logTable
+  log_table
   post
-    debug: result.length = N.as_i32
+    debug: result.length = num_buckets.as_i32
   =>
     step := 1.65  # step factor determined via trial and error
     (1.0 :: *step).map f->(time.duration.ns 1 .times f)
                   .dedup     # some lower values might be duplicates like 1ns*1.65=1ns
-                  .take N.as_i32-1
+                  .take num_buckets.as_i32-1
                   .concat [time.duration.max]
                   .as_array
 
@@ -177,10 +179,10 @@ is
   # create an empty histogram
   #
   public type.new(title String,
-           maxRecorded option time.duration,
-           ignoreFirst, ignoreLast u64)
+                  max_recorded option time.duration,
+                  ignore_first, ignore_last u64)
   =>
-    time.histogram title nil maxRecorded ignoreFirst ignoreLast
+    time.histogram title nil max_recorded ignore_first ignore_last
 
 
 
@@ -188,18 +190,18 @@ is
   #
   public type.new(title String,
                   period option time.duration,
-                  maxRecorded option time.duration,
-                  ignoreFirst, ignoreLast u64)
+                  max_recorded option time.duration,
+                  ignore_first, ignore_last u64)
   =>
-    time.histogram title period maxRecorded ignoreFirst ignoreLast
+    time.histogram title period max_recorded ignore_first ignore_last
 
 
   # Construct a new empty histogram for jitter
   #
   public type.new(title String,
-                  maxRecorded option time.duration)
+                  max_recorded option time.duration)
   =>
-    time.histogram title nil maxRecorded 0 0
+    time.histogram title nil max_recorded 0 0
 
 
   u64.log2
@@ -212,33 +214,28 @@ is
 
   # search for index in table, i.e., the smallest index for which l <= table[result].
   #
-  searchIndex(l time.duration)
+  indx(l time.duration)
+  post
+    debug: result.as_i32 ∈ table.indices
+    debug: l <= table[result.as_i32]
+    debug: result = 0 || table[result.as_i32-1] < l
   =>
     # binary search in range s..e:
     for
       m := i64 0, (s+e)/2
       v := l, table[m.as_i32]
-      s := i64 0, l >  v ? m+1 : s
-      e := N    , l <= v ? m   : e
+      s := i64 0      , l >  v ? m+1 : s
+      e := num_buckets, l <= v ? m   : e
     while s < e
     else
       l <= v ? m : m+1
-
-
-  # index of time l in buckets array, i.e., in the range 0..N
-  #
-  indx(l time.duration)
-  =>
-    match maxRecorded
-      _ time.duration => searchIndex l # min (l.nanos.as_f64 * N.as_f64 / mr.nanos.as_f64).as_i64 N
-      nil              => searchIndex l
 
 
   # for given index, what is the smallest duration
   #
   smallest(i i64) time.duration
   pre
-    debug: i64 0 <= i < N
+    debug: i64 0 <= i < num_buckets
   post
     debug: indx result = i
     debug: i = 0 || indx (result - time.duration.ns 1) = i-1
@@ -253,7 +250,7 @@ is
   #
   largest(i i64) time.duration
   pre
-    debug: i64 0 <= i < N
+    debug: i64 0 <= i < num_buckets
   post
     debug: indx result = i
     debug: indx (result + time.duration.ns 1) = i+1
@@ -266,38 +263,38 @@ is
   #
   public add_instant(t time.instant)
   =>
-    totalNumber <- totalNumber + 1
-    if totalNumber.get > ignoreFirst
-      match startTime.get
-        nil             => startTime <- t
+    total_number <- total_number + 1
+    if total_number.get > ignore_first
+      match start_time.get
+        nil             => start_time <- t
         st time.instant =>
           match period
             p time.duration => add (t - st - p*size)
-            nil             => startTime <- t
+            nil             => start_time <- t
                                add t-st
 
 
   # record the given duration
   #
-  # if `ignoreFirst` or `ignoreLast` are non-zero, this will ignore the
+  # if `ignore_first` or `ignore_last` are non-zero, this will ignore the
   # first or last records accordingly
   #
   public add(d time.duration)
   =>
-    totalNumber <- totalNumber + 1
-    if totalNumber.get > ignoreFirst
-      if ignoreLast > 0
-        ld := ignoreLastBuffer[ignoreLastBufferIndex]
-        ignoreLastBuffer[ignoreLastBufferIndex] := d
-        ignoreLastBufferIndex <- (ignoreLastBufferIndex.get = 0 ? ignoreLastBuffer.length
-                                                                : ignoreLastBufferIndex.get)- 1
+    total_number <- total_number + 1
+    if total_number.get > ignore_first
+      if ignore_last > 0
+        ld := ignore_last_buffer[ignore_last_buffer_index]
+        ignore_last_buffer[ignore_last_buffer_index] := d
+        ignore_last_buffer_index <- (ignore_last_buffer_index.get = 0 ? ignore_last_buffer.length
+                                                                      : ignore_last_buffer_index.get)- 1
         ld.bind add0 |> ignore
       else
         add0 d
 
   # internal feature to record the given duration in its bucket
   #
-  # this is called by `add` after handing `ignoreFirst` and `ignoreLast`
+  # this is called by `add` after handing `ignore_first` and `ignore_last`
   #
   private add0(d time.duration)
   =>
@@ -398,27 +395,11 @@ is
         str := for
                  str1 := "{($cnt).pad_left 3}{units.substring unit0 unit0+1} ", str1 + str2 + str3
                  i in buckets.indices
-                 str2 := i = N ? "       " : ""
+                 str2 := i = num_buckets ? "       " : ""
                  str3 := buckets[i].log2 < c ? " " : "*"
                else
                  str1 + "\n"
       else
-      /*
-        bot := match maxRecorded
-                 mr time.duration =>
-                   t := (0..4).map (i -> i.as_f64/4)
-                              .map (f -> (if f=0 then time.duration.zero.as_string (mr.times 0.25 .unit_for_as_string)
-                                                 else mr.times f        .as_string
-                                         ).pad_center 9)
-                   ("     |       |       |       |       |       |       |       |       |       |\n" +
-                    " "+t[0] +"       "+t[1] +"       "+t[2] +"       "+t[3] +"       "+t[4] +"   >\n")
-                 nil =>
-                   t := (i64 0 .. 64 : 8).map i->"{((largest i).as_string.trim.pad_center 8)}"
-                                      .as_string ""
-                   ("     |       |       |       |       |       |       |       |       |       |\n" +
-                    "  "+t+"   >\n")
-        ignore bot
-        */
         t2 := (i64 0 .. 64 : 8).map (i-> largest i .as_string.trim.pad_center 8)
                                .as_string ""
         bot :=    ("     |       |       |       |       |       |       |       |       |       |\n" +

--- a/modules/base/src/time/histogram.fz
+++ b/modules/base/src/time/histogram.fz
@@ -180,7 +180,8 @@ is
   #
   public type.new(title String,
                   max_recorded option time.duration,
-                  ignore_first, ignore_last u64)
+                  ignore_first, ignore_last u64
+                  ) time.histogram
   =>
     time.histogram title nil max_recorded ignore_first ignore_last
 
@@ -191,7 +192,8 @@ is
   public type.new(title String,
                   period option time.duration,
                   max_recorded option time.duration,
-                  ignore_first, ignore_last u64)
+                  ignore_first, ignore_last u64
+                  ) time.histogram
   =>
     time.histogram title period max_recorded ignore_first ignore_last
 
@@ -199,7 +201,8 @@ is
   # Construct a new empty histogram for jitter
   #
   public type.new(title String,
-                  max_recorded option time.duration)
+                  max_recorded option time.duration
+                  ) time.histogram
   =>
     time.histogram title nil max_recorded 0 0
 
@@ -261,7 +264,7 @@ is
   # record the given time instant, i.e., create the difference to the previous instant
   # and record that
   #
-  public add_instant(t time.instant)
+  public add_instant(t time.instant) unit
   =>
     total_number <- total_number + 1
     if total_number.get > ignore_first
@@ -279,7 +282,7 @@ is
   # if `ignore_first` or `ignore_last` are non-zero, this will ignore the
   # first or last records accordingly
   #
-  public add(d time.duration)
+  public add(d time.duration) unit
   =>
     total_number <- total_number + 1
     if total_number.get > ignore_first
@@ -310,17 +313,17 @@ is
 
   # number of measurements in this histogram.
   #
-  public count => size.get
+  public count u64 => size.get
 
 
   # Determine the minimum value in this histogram.
   #
-  public min => min_.get
+  public min option time.duration => min_.get
 
 
   # Determine the maximum value in this histogram.
   #
-  public max => max_.get
+  public max option time.duration => max_.get
 
 
   # Determine the average value in this histogram or 0 in case there are

--- a/modules/base/src/time/histogram.fz
+++ b/modules/base/src/time/histogram.fz
@@ -1,0 +1,455 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion standard library feature time.nano
+#
+#  Author: Fridtjof Siebert (siebert@tokiwa.software)
+#
+# -----------------------------------------------------------------------
+
+# time.histogram -- feature to collect and output timeing data
+#
+# This is particularly useful to analyse variations in release or
+# execution times of tasks or events
+#
+# For this, it distributes time.duration values into a list of
+# buckets that correspond to different ranges of durations.  These
+# buckets may be equally spaced (linear) or growing by an equal
+# factor (logarithmic).
+#
+# The use of buckets permits the collection of large numbers of
+# sampe durations since only the counts per bucket are recorded
+#
+public histogram(# title to be printed for this histogram
+                 public title String,
+
+                 # For measuring a periodic jitter, this gives the period.
+                 #
+                 # If the period is given it becomes possible to detect drift,
+                 # i.e, the actual times are measured relative to the expected
+                 # times for given `period`. A cumulative drift, i.e., an actual
+                 # period that is slightly longer or shorter in average, will add
+                 # up to a significant jitter.
+                 #
+                 # Note that periods like `1/60` cannot be traced accurately, the
+                 # rounding error in 16666666ns (or 16666667ns) will add up over
+                 # time!
+                 #
+                 public period option time.duration,
+
+                 # the maximum duration that will be recorded in this histogram
+                 #
+                 # if specified, the histogram will use a linear time scale from
+                 # 0 up to maxRecorded
+                 #
+                 # if `nil`, the histogram will use a generic logarithmic time scale
+                 # from 1ns up to about 1day.
+                 #
+                 public maxRecorded option time.duration,
+
+                 # number of initial recordings that should be ignored (i.e.,
+                 # that are considered to be part of a _warm up_ phase).
+                 #
+                 public ignoreFirst u64,
+
+                 # number of final recordings that should be ignored. This permits
+                 # errors introduces by starting of the shutdown process to be
+                 # ignored.
+                 #
+                 public ignoreLast u64
+                 )
+is
+
+
+  # a local mutate instance we are using to modify our state
+  #
+  private local_mutate : mutate is
+
+
+  # get local mutate instance from env, install it if necessary
+  #
+  lm =>
+    # NYI: should be done via effect configuration file, see `effect.type.default`.
+    #
+    if !local_mutate.is_instated
+      local_mutate.default
+    local_mutate.env
+
+
+  # total number of measurements, including ignored ones.
+  #
+  totalNumber := lm.new (u64 0)
+
+
+  # buffer of measurements at the end that should be ignored.
+  #
+  ignoreLastBuffer := lm.new_array ignoreLast.as_i64 (option time.duration nil)
+
+
+  # current index to add new data to ignoreLastBuffer
+  #
+  ignoreLastBufferIndex := lm.new (i64 0)
+
+
+  # Number of distinct buckets that are recorded
+  #
+  N => i64 66
+
+
+  # Total number of samples recorded.  The values are not stored, only
+  # the counts for different value ranges corresponding to buckets are
+  # stored in buckets.
+  #
+  size := lm.new (u64 0)
+
+
+  # min and max recorded durations
+  #
+  min_ := lm.new (option time.duration) nil
+  max_ := lm.new (option time.duration) nil
+
+
+  # sum of recorded durations
+  #
+  sum := lm.new time.duration.zero
+
+
+  # sum of squares of recorded ns values
+  #
+  squares := lm.new 0.0
+
+
+  # time of first sample
+  #
+  startTime := lm.new (option time.instant) nil
+
+
+  # table of durations in each bucket, each entry gives the maximum duration for that index
+  #
+  # the last entry is always time.duration.max
+  #
+  table array time.duration :=
+           match maxRecorded
+             mr time.duration => array N.as_i32 (i -> if i<N.as_i32-1 then mr.times ((i+1).as_f64 / (N.as_f64-1))
+                                                                      else time.duration.max                     )
+             nil              => logTable
+
+  check
+    debug: table.length = N.as_i32
+    debug: table[N.as_i32-1] = time.duration.max
+
+
+  # table of durations for logarithmic histogram
+  #
+  logTable
+  post
+    debug: result.length = N.as_i32
+  =>
+    step := 1.65  # step factor determined via trial and error
+    (1.0 :: *step).map f->(time.duration.ns 1 .times f)
+                  .dedup     # some lower values might be duplicates like 1ns*1.65=1ns
+                  .take N.as_i32-1
+                  .concat [time.duration.max]
+                  .as_array
+
+
+  # The frequency counts for each bucket
+  #
+  buckets := lm.new_array (indx time.duration.max)+1 (u64 0)
+
+
+  # create an empty histogram
+  #
+  public type.new(title String,
+           maxRecorded option time.duration,
+           ignoreFirst, ignoreLast u64)
+  =>
+    time.histogram title nil maxRecorded ignoreFirst ignoreLast
+
+
+
+  # Construct a new empty histogram for jitter on a known period using
+  #
+  public type.new(title String,
+                  period option time.duration,
+                  maxRecorded option time.duration,
+                  ignoreFirst, ignoreLast u64)
+  =>
+    time.histogram title period maxRecorded ignoreFirst ignoreLast
+
+
+  # Construct a new empty histogram for jitter
+  #
+  public type.new(title String,
+                  maxRecorded option time.duration)
+  =>
+    time.histogram title nil maxRecorded 0 0
+
+
+  u64.log2
+  post
+    debug: true || (val != 0: (u64 1 << result.as_u64) >= val > (u64 1 << result.as_u64-1)) # NYI: incorrect for val=1 / result=0
+    debug: (val =  0: result = -1)
+  =>
+    (val = 0) ? -1 : (val.highest_one_bit-1).ones_count
+
+
+  # search for index in table, i.e., the smallest index for which l <= table[result].
+  #
+  searchIndex(l time.duration)
+  =>
+    # binary search in range s..e:
+    for
+      m := i64 0, (s+e)/2
+      v := l, table[m.as_i32]
+      s := i64 0, l >  v ? m+1 : s
+      e := N    , l <= v ? m   : e
+    while s < e
+    else
+      l <= v ? m : m+1
+
+
+  # index of time l in buckets array, i.e., in the range 0..N
+  #
+  indx(l time.duration)
+  =>
+    match maxRecorded
+      _ time.duration => searchIndex l # min (l.nanos.as_f64 * N.as_f64 / mr.nanos.as_f64).as_i64 N
+      nil              => searchIndex l
+
+
+  # for given index, what is the smallest duration
+  #
+  smallest(i i64) time.duration
+  pre
+    debug: i64 0 <= i < N
+  post
+    debug: indx result = i
+    debug: i = 0 || indx (result - time.duration.ns 1) = i-1
+  =>
+    if i=0 then
+      time.duration.zero
+    else
+      largest i-1 + time.duration.ns 1
+
+
+  # for given index, what is the largest duration
+  #
+  largest(i i64) time.duration
+  pre
+    debug: i64 0 <= i < N
+  post
+    debug: indx result = i
+    debug: indx (result + time.duration.ns 1) = i+1
+  =>
+    table[i.as_i32]
+
+
+  # record the given time instant, i.e., create the difference to the previous instant
+  # and record that
+  #
+  public add_instant(t time.instant)
+  =>
+    totalNumber <- totalNumber + 1
+    if totalNumber.get > ignoreFirst
+      match startTime.get
+        nil             => startTime <- t
+        st time.instant =>
+          match period
+            p time.duration => add (t - st - p*size)
+            nil             => startTime <- t
+                               add t-st
+
+
+  # record the given duration
+  #
+  # if `ignoreFirst` or `ignoreLast` are non-zero, this will ignore the
+  # first or last records accordingly
+  #
+  public add(d time.duration)
+  =>
+    totalNumber <- totalNumber + 1
+    if totalNumber.get > ignoreFirst
+      if ignoreLast > 0
+        ld := ignoreLastBuffer[ignoreLastBufferIndex]
+        ignoreLastBuffer[ignoreLastBufferIndex] := d
+        ignoreLastBufferIndex <- (ignoreLastBufferIndex.get = 0 ? ignoreLastBuffer.length
+                                                                : ignoreLastBufferIndex.get)- 1
+        ld.bind add0 |> ignore
+      else
+        add0 d
+
+  # internal feature to record the given duration in its bucket
+  #
+  # this is called by `add` after handing `ignoreFirst` and `ignoreLast`
+  #
+  private add0(d time.duration)
+  =>
+    i := indx d
+    buckets[i] := buckets[i] + 1
+    size <- size.get + 1
+    min_ <- min d (min_.or_else d)
+    max_ <- max d (max_.or_else d)
+    sum  <- sum.get + d
+    ns := d.nanos.as_f64
+    squares <- squares.get + ns * ns
+
+
+  # number of measurements in this histogram.
+  #
+  public count => size.get
+
+
+  # Determine the minimum value in this histogram.
+  #
+  public min => min_.get
+
+
+  # Determine the maximum value in this histogram.
+  #
+  public max => max_.get
+
+
+  # Determine the average value in this histogram or 0 in case there are
+  # no recorded values.
+  #
+  public average time.duration
+  =>
+    if size.get > 0
+      sum.get.times 1.0/size.get.as_f64
+    else
+      time.duration.zero
+
+
+  # Determine the standard deviation of the difference of the recorded values
+  # in this histogram to a given value m, result is 0 in case there are no
+  # recorded values.
+  #
+  # result is `time.duration.zero` if no measurements were made yet
+  #
+  public sigma(# the expected value
+               m time.duration) time.duration
+  =>
+    n := size.get
+    if size.get > 0
+      #   sum((ti - m)^2)
+      # = sum(ti^2  - 2 * ti      * m +     m^2)
+      # = sum(ti^2) - 2 * sum(ti) * m + n * m^2
+      # = squares   - 2 * sum     * m + n * m^2
+      #
+      mf := m.nanos.as_f64
+      sumf := sum.nanos.as_f64
+      nf := n.as_f64
+      sqs := squares.get - 2.0 * sumf * mf + nf * mf * mf
+      ns := (sqs / nf).square_root.as_i64.as_u64
+      time.duration.ns ns
+    else
+      time.duration.zero
+
+
+  # Determine the standard deviation from the average of the
+  # difference of the values in this histogram to a given value m.
+  #
+  public sigma time.duration
+  =>
+    sigma average
+
+
+  # Find the highest count recorded for this histogram, or 0 if no times were recorded.
+  #
+  public highest u64
+  =>
+    buckets.indices.map i->buckets[i] .max.or_else 0
+
+
+  # Create a string with a graphical representation of this histogram.
+  #
+  public redef as_string String
+  =>
+    h := highest
+    if h > 0
+      titl := """
+              {"---  $title  ---".pad_center 78}
+              count
+              """
+      for
+        res := titl, res + str
+        c := h.log2, c-1
+      while c >= 0 do
+        units := " KMGTPEZY"; /* Kilo, Mega, Giga, Tera, etc. */
+        unit0 := min units.byte_length-1 c/10  # 2^10 is times 1024
+        cnt := u64 1 << (c - unit0 * 10).as_u64
+        str := for
+                 str1 := "{($cnt).pad_left 3}{units.substring unit0 unit0+1} ", str1 + str2 + str3
+                 i in buckets.indices
+                 str2 := i = N ? "       " : ""
+                 str3 := buckets[i].log2 < c ? " " : "*"
+               else
+                 str1 + "\n"
+      else
+      /*
+        bot := match maxRecorded
+                 mr time.duration =>
+                   t := (0..4).map (i -> i.as_f64/4)
+                              .map (f -> (if f=0 then time.duration.zero.as_string (mr.times 0.25 .unit_for_as_string)
+                                                 else mr.times f        .as_string
+                                         ).pad_center 9)
+                   ("     |       |       |       |       |       |       |       |       |       |\n" +
+                    " "+t[0] +"       "+t[1] +"       "+t[2] +"       "+t[3] +"       "+t[4] +"   >\n")
+                 nil =>
+                   t := (i64 0 .. 64 : 8).map i->"{((largest i).as_string.trim.pad_center 8)}"
+                                      .as_string ""
+                   ("     |       |       |       |       |       |       |       |       |       |\n" +
+                    "  "+t+"   >\n")
+        ignore bot
+        */
+        t2 := (i64 0 .. 64 : 8).map (i-> largest i .as_string.trim.pad_center 8)
+                               .as_string ""
+        bot :=    ("     |       |       |       |       |       |       |       |       |       |\n" +
+                    "  "+t2+"   >\n")
+        res + bot + "\n" + (" average |" +
+                            "   min   |" +
+                            "   max   |" +
+                            "  sigma  |" +
+                            "  count  |\n"+
+                            ($average()).pad_center 9 + "|" +
+                            ($min_     ).pad_center 9 + "|" +
+                            ($max_     ).pad_center 9 + "|" +
+                            ($sigma()  ).pad_center 9 + "|" +
+                            ($size     ).pad_center 9 + "|\n")
+    else
+      "not data"
+
+
+  # Create semicolon-separated CSV data for these measurments to import into Excel or
+  # OpenOffice. First lines will be descriptions.
+  #
+  public csv String
+  =>
+    h := highest
+    if h > 0
+      non_zero_buckets := buckets.indices.filter i->buckets[i]!=0
+      first := non_zero_buckets.first.get
+      last  := non_zero_buckets.last .get
+      ("from/ns;to/ns;count\n" +
+        (first..last).map i->"{smallest i .nanos};{largest i .nanos};{buckets[i]}"
+                     .as_string "\n"
+      )
+    else
+      ""

--- a/modules/base/src/time/nano.fz
+++ b/modules/base/src/time/nano.fz
@@ -38,10 +38,10 @@ public nano (p Nano_Time_Handler) : Clock is
 
   # no guarantee can be given for precision nor resolution
   #
-  public redef read instant =>
+  public redef read time.instant =>
     res := p.read
     replace
-    instant res
+    time.instant res
 
 
   # no guarantee can be given for precision nor resolution


### PR DESCRIPTION
Add infrastructure to record and output timing histograms to analyze jitter in release or execution times. Added `examples/jitter` to measure the jitter in periodic code run via `time.nano.run_periodic` while decreasing the period until we the release time latency exceeds the period or we get an overrun into the next release. 

This measures the actual release times relative to the expected release times of one earlier iteration, i.e., ideally, this time is equal to the period, but we see jitter. 

The output are graphs like this:


                   ---  period  976µs, log count / linear time  ---               
    count
      1K                                 *                                 
    512                                  *                                 
    256                                  *                                 
    128                                  **                                
     64                                  ***                               
     32                                 ****                               
     16                                 ****                               
      8                                 ****                               
      4                                *****                               
      2                                *****                               
      1                                ******                              
         |       |       |       |       |       |       |       |       |       |
        30µs   270µs   510µs   751µs   991µs   1231µs  1472µs  1712µs  1953µs    >
    
     average |   min   |   max   |  sigma  |  count  |
      979µs  |  928µs  | 1055µs  |   14µs  |  2149   |

For this histogram, the actual times measured are divided into buckets for time ranges and the total number per bucket is counted and then shown. Also, the _average_, _min_-imum, _max_-imum times are shown as well as the standard deviation _sigma_ and the total _count_ of releases. 

This graphs shows that the desired period is met relatively often, but there were frequent outliers of about 100µs in both directions. 

This PR requires PRs #5637 and #5638 to be merged first. 
