### PR TITLE
base: fix visibility and add comments to `state.fz`

### DIFF
--- a/modules/base/src/state.fz
+++ b/modules/base/src/state.fz
@@ -52,7 +52,7 @@
 # NYI: BUG: #5634: use `infix !` in this example once #5634 is fixed
 #
 # note that access to the state value is possible in any code executed while the state
-# is instated, also, e.g., in lambdas that that are passed to a call and then called
+# is instated, also, e.g., in lambdas that are passed to a call and then called
 # further down the call chain.
 #
 # The wrapper type, `demo` in the example, is not strictly required, we could use

--- a/modules/base/src/state.fz
+++ b/modules/base/src/state.fz
@@ -30,7 +30,7 @@
 #
 # use as follows to store data of type `u8` for purpose `demo`:
 #
-#      # first, declare a type that holds a value pf `u8` that describes the purpose
+#      # first, declare a type that holds a value of `u8` that describes the purpose
 #      #
 #      demo(contents u8) is
 #

--- a/modules/base/src/state.fz
+++ b/modules/base/src/state.fz
@@ -59,7 +59,7 @@
 # just `u8` instead.  However, this would permit unrelated code to read and modify
 # the value using `state_get u8`, while the wrapper type `demo` restricts this to
 # code for which `demo` is visible.  To avoid accidental and intentional (malicious)
-# acceses to state effects, we need our own local type!
+# accesses to state effects, we need our own local type!
 #
 public state(
 

--- a/modules/base/src/state.fz
+++ b/modules/base/src/state.fz
@@ -28,17 +28,49 @@
 # this can be used both as plain or as a oneway monad to store a state
 # in a way orthogonal to the actual computation.
 #
+# use as follows to store data of type `u8` for purpose `demo`:
+#
+#      # first, declare a type that holds a value pf `u8` that describes the purpose
+#      #
+#      demo(contents u8) is
+#
+#      # then, create an instate an instance of `state` with initial value `23`
+#      #
+#      state demo unit (demo 23) ()->
+#
+#        # now, we can access the value using `state_get demo`
+#        # or, to unwrap it `state_get demo .contents`
+#        #
+#        say "state value is {state_get demo .contents}"
+#
+#        # we can now modify the value, e.g, doubling it via
+#        #
+#        new_demo := state_modify demo (x -> demo x.contents*2)
+#        say "state value is {new_demo.get.contents}"
+#        say "state value is {state_get demo .contents}"
+#
+# NYI: BUG: #5634: use `infix !` in this example once #5634 is fixed
+#
+# note that access to the state value is possible in any code executed while the state
+# is instated, also, e.g., in lambdas that that are passed to a call and then called
+# further down the call chain.
+#
+# The wrapper type, `demo` in the example, is not strictly required, we could use
+# just `u8` instead.  However, this would permit unrelated code to read and modify
+# the value using `state_get u8`, while the wrapper type `demo` restricts this to
+# code for which `demo` is visible.  To avoid accidental and intentional (malicious)
+# acceses to state effects, we need our own local type!
 #
 public state(
 
   # types of contained and the state value
-  T, S type,
+  public T, S type,
 
   # the contained value
-  val T,
+  public val T,
 
   # the current state
-  get S,
+  public get S,
 
   # `plain` monad or effect to be `inst`alled or `repl`aced by new value?
   mode oneway_monad_mode.val


### PR DESCRIPTION
I had difficulties writing code using a state effect, so I added example code.

This example currently does not use `infix !` to instate the effect due to #5634.

