### PR TITLE
make: enhance java version detection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@
 
 JAVA = java --enable-preview --enable-native-access=ALL-UNNAMED
 MIN_JAVA_VERSION = 21 # NYI: when updating to Java version 22 or higher: remove this hack (revert #4264) and remove option '--enable-preview'
-JAVA_VERSION = $(shell v=$$(java -version 2>&1 | grep 'version' | cut -d '"' -f2 | cut -d. -f1); [ $$v -lt $(MIN_JAVA_VERSION) ] && echo $(MIN_JAVA_VERSION) || echo $$v)
+JAVA_VERSION = $(shell v=$$(java -version 2>&1 | grep 'version' | cut -d '"' -f2 | cut -d. -f1 | grep -o '[[:digit:]]*'); [ $$v -lt $(MIN_JAVA_VERSION) ] && echo $(MIN_JAVA_VERSION) || echo $$v)
 # NYI: CLEANUP: remove some/all of the exclusions
 LINT = -Xlint:all,-preview,-this-escape,-rawtypes,-serial,-static,-cast,-unchecked,-fallthrough
 JAVAC = javac $(LINT) -encoding UTF8 --release $(JAVA_VERSION) --enable-preview


### PR DESCRIPTION
had this problem with java 25
```
~/openvscode-server-fuzion/vscode-fuzion/fuzion-lsp-server/fuzion (main)$ make syntaxcheck
/bin/sh: 1: [: Illegal number: 25-ea
error: release version 25-ea not supported
Usage: javac <options> <source files>
use --help for a list of possible options
make: *** [Makefile:527: build/classes/dev/flang/ast/__marker_for_make__] Error 2
~
```