### PR TITLE
be/c: `match` on `void` results in C compiler failure in C backend

### DIFF
--- a/src/dev/flang/be/c/CIdent.java
+++ b/src/dev/flang/be/c/CIdent.java
@@ -126,6 +126,20 @@ class CIdent extends CExpr
     };
   }
 
+
+  /**
+   * create identifier for choice entry.
+   *
+   * @param tagNum The tag number 0..
+   */
+  public static CIdent choiceEntry(int tagNum)
+  {
+    if (PRECONDITIONS) require
+      (tagNum >= 0);
+
+    return new CIdent(CNames.CHOICE_ENTRY_NAME + tagNum);
+  }
+
 }
 
 /* end of file */

--- a/src/dev/flang/be/c/CTypes.java
+++ b/src/dev/flang/be/c/CTypes.java
@@ -313,7 +313,7 @@ public class CTypes extends ANY
                 var cc = _fuir.clazzChoice(cl, i);
                 if (!_fuir.clazzIsVoidType(cc) && !_fuir.clazzIsRef(cc))
                   {
-                    uls.add(CStmnt.decl(clazz(cc), new CIdent(_names.CHOICE_ENTRY_NAME + i)));
+                    uls.add(CStmnt.decl(clazz(cc), CIdent.choiceEntry(i)));
                   }
               }
             if (_fuir.clazzIsChoiceWithRefs(cl))

--- a/src/dev/flang/be/c/Intrinsics.java
+++ b/src/dev/flang/be/c/Intrinsics.java
@@ -1160,7 +1160,7 @@ public class Intrinsics extends ANY
       }
     else if (c._fuir.clazzIsUnitType(rt))
       { // unit-type values are always equal:
-        result = tmp.assign(new CIdent("true"));
+        result = tmp.assign(CIdent.TRUE);
       }
     else if (isIntegerOrRef(c, rt))
       {
@@ -1192,7 +1192,7 @@ public class Intrinsics extends ANY
           {
             var tc = c._fuir.clazzChoice(rt, i);
             var fld = c._fuir.clazzIsRef(tc) ? CNames.CHOICE_REF_ENTRY_NAME
-                                             : new CIdent(CNames.CHOICE_ENTRY_NAME + i);
+                                             : CIdent.choiceEntry(i);
             var entry1  = union1.field(fld);
             var entry2  = union2.field(fld);
             var cmp = compareValues(c, entry1, entry2, tc, tmp);
@@ -1204,11 +1204,11 @@ public class Intrinsics extends ANY
                             CStmnt.suitch(value1.field(CNames.TAG_NAME),
                                           cazes,
                                           null),
-                            tmp.assign(new CIdent("false")));
+                            tmp.assign(CIdent.FALSE));
       }
     else // not a choice, so a 'normal' product type
       {
-        result = tmp.assign(new CIdent("true"));
+        result = tmp.assign(CIdent.TRUE);
         for (var i = 0; i < c._fuir.clazzFieldCount(rt); i++)
           {
             var fi = c._fuir.clazzField(rt, i);

--- a/tests/reg_issue5636/Makefile
+++ b/tests/reg_issue5636/Makefile
@@ -1,0 +1,25 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test Makefile
+#
+# -----------------------------------------------------------------------
+
+override NAME = reg_issue5636
+include ../simple.mk

--- a/tests/reg_issue5636/reg_issue5636.fz
+++ b/tests/reg_issue5636/reg_issue5636.fz
@@ -1,0 +1,28 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test reg_issue5636
+#
+# -----------------------------------------------------------------------
+
+test is
+match exception test .on ()->
+    (exception test).env.cause (error "bla")
+  e error => say $e
+  void    => # will not happen

--- a/tests/reg_issue5636/reg_issue5636.fz.expected_out
+++ b/tests/reg_issue5636/reg_issue5636.fz.expected_out
@@ -1,0 +1,1 @@
+error: bla


### PR DESCRIPTION
fixes #5636

