### PR TITLE
ast: hasOuterRef add !isTypeParameter

### DIFF
--- a/src/dev/flang/ast/AbstractFeature.java
+++ b/src/dev/flang/ast/AbstractFeature.java
@@ -1310,7 +1310,8 @@ public abstract class AbstractFeature extends Expr implements Comparable<Abstrac
       !isField() &&
       !isChoice() &&
       !isUniverse() &&
-      !outer().isUniverse();
+      !outer().isUniverse() &&
+      !isTypeParameter();
   }
 
 


### PR DESCRIPTION
Found that outer refs are created for type parameters which seems weird and unnecessary.
Especially for `THIS#TYPE`  (this type in cotype)