### PR TITLE
parser: move parsing of `...` after type to `formArgs` to match EBNF

### DIFF
--- a/src/dev/flang/parser/Parser.java
+++ b/src/dev/flang/parser/Parser.java
@@ -871,7 +871,12 @@ argType     : type
                                     else if (isTypePrefix())
                                       {
                                         i = Impl.FIELD;
-                                        t = type();
+                                        var ut = type();
+                                        if (skip("..."))
+                                          {
+                                            ut.setFollowedByDots();
+                                          }
+                                        t = ut;
                                       }
                                     else
                                       {
@@ -3454,10 +3459,6 @@ freeType    : name ":" type
         skipColon())
       {
         result = new FreeType(result.pos(), result.freeTypeName(), type());
-      }
-    if (skip("..."))
-      {
-        result.setFollowedByDots();
       }
     return result;
   }


### PR DESCRIPTION
This matches the EBNF grammar that allows `...` only in `formArgs`, so we should not permit them anywhere a `type` occurs.