### PR TITLE
fe: fix explicit specification of a return type

### DIFF
--- a/modules/base/src/container/abstract_array.fz
+++ b/modules/base/src/container/abstract_array.fz
@@ -255,7 +255,7 @@ public abstract_array
 
   # returns a copy of this array as a mutable array
   #
-  public as_mutable(LM type : mutate) /* NYI: BUG: LM.array T*/ =>
+  public as_mutable(LM type : mutate) LM.array T =>
     data := fuzion.sys.internal_array_init T length
 
     # NYI: PERFORMANCE: copy complete array at once

--- a/modules/base/src/container/ordered_map.fz
+++ b/modules/base/src/container/ordered_map.fz
@@ -63,7 +63,7 @@ is
 
   # a sorted array of entries of this map
   #
-  public sorted_entries :=
+  public sorted_entries container.sorted_array entry :=
     ks.indices.map (i -> entry i)
       .sort
 

--- a/src/dev/flang/ast/Feature.java
+++ b/src/dev/flang/ast/Feature.java
@@ -842,6 +842,8 @@ public class Feature extends AbstractFeature
                         (p._kind != Impl.Kind.FieldDef   ) &&
                         (p._kind != Impl.Kind.FieldInit  ) &&
                         (p._kind != Impl.Kind.Field      ) &&
+                        (p._kind != Impl.Kind.TypeParameter ) &&
+                        (p._kind != Impl.Kind.TypeParameterOpen ) &&
                         (qname.size() != 1 || (!qname.getFirst().equals(FuzionConstants.ANY_NAME  ) &&
                                                !qname.getFirst().equals(FuzionConstants.UNIVERSE_NAME))))
       ? new List<>(new Call(_pos, FuzionConstants.ANY_NAME))


### PR DESCRIPTION
fixes #5261

Excluding type parameters from inheriting `Any` is necessary for this patch to work. Otherwise there are errors when resolving the unresolved result type `LM.array`.
