### PR TITLE
ast: cleanup misuse of result type propagation

### DIFF
--- a/src/dev/flang/ast/AbstractMatch.java
+++ b/src/dev/flang/ast/AbstractMatch.java
@@ -102,12 +102,17 @@ public abstract class AbstractMatch extends ExprWithPos
     if (CHECKS) check
       (Errors.any() || subject() == ns);
 
-    v.action(this);
+    var result = v.action(this);
+
+    if (CHECKS) check
+      // replacing, currently only used for Match
+      (result == this);
+
     for (var c: cases())
       {
         c.visit(v, this, outer);
       }
-    return this;
+    return result;
   }
 
 

--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -2658,25 +2658,6 @@ public class Call extends AbstractCall
                                                             context,
                                                             formalType,
                                                             () -> "formal argument type in call to " + AstErrors.s(_calledFeature)));
-
-    if (_target != null)
-      {
-        // This informs target that it is used which may
-        // - e.g. for if- and match-expressions -
-        // lead to these expressions adding a result field via
-        // `addFieldForResult`.
-        // This result field is then the target of the call.
-        //
-        // NYI: CLEANUP: there should be another mechanism, for
-        // adding missing result fields instead of misusing
-        // `propagateExpectedType`.
-        //
-        var t = _target.typeForInferencing();
-        if (t != null)
-          {
-            _target = _target.propagateExpectedType(res, context, t, null);
-          }
-      }
   }
 
 

--- a/src/dev/flang/ast/Feature.java
+++ b/src/dev/flang/ast/Feature.java
@@ -2153,16 +2153,7 @@ A ((Choice)) declaration must not contain a result type.
         // get the corrected nesting of Lazy features created during this
         // phase
         public boolean visitActualsLate() { return true; }
-        @Override public void  action(AbstractAssign a) { a.wrapValueInLazy  (res, _context); a.unwrapValue  (res, _context); }
         @Override public Expr  action(Call           c) { c.wrapActualsInLazy(res, _context); c.unwrapActuals(res, _context); return c; }
-        @Override public Expr action(AbstractMatch am){
-          Expr result = am;
-          if (am instanceof Match m)
-            {
-              result = m.addResultField(res, _context);
-            }
-          return result;
-        }
       });
 
 
@@ -2171,6 +2162,16 @@ A ((Choice)) declaration must not contain a result type.
         @Override public Expr action(InlineArray i) { return i.resolveSyntacticSugar2(res, _context); }
         @Override public void action(Impl        i) {        i.resolveSyntacticSugar2(res, _context); }
         @Override public Expr action(Constant    c) { return c.resolveSyntacticSugar2(res, _context); }
+        @Override public Expr action(AbstractMatch am){
+          Expr result = am;
+          if (am instanceof Match m)
+            {
+              result = m.addResultField(res, _context);
+            }
+          return result;
+        }
+        // Match.addResultField may add Assigns that need wrapping/unwrapping
+        @Override public void  action(AbstractAssign a) { a.wrapValueInLazy  (res, _context); a.unwrapValue  (res, _context); }
       });
 
 

--- a/src/dev/flang/ast/FeatureVisitor.java
+++ b/src/dev/flang/ast/FeatureVisitor.java
@@ -68,7 +68,7 @@ public abstract class FeatureVisitor extends ANY
   public Expr         action      (Function         f                       ) { return f; }
   public void         action      (Impl             i                       ) { }
   public Expr         action      (InlineArray      i                       ) { return i; }
-  public void         action      (AbstractMatch    m                       ) { }
+  public Expr         action      (AbstractMatch    m                       ) { return m; }
   public Expr         action      (This             t                       ) { return t; }
   public AbstractType action      (AbstractType     t                       ) { return t; }
 

--- a/src/dev/flang/ast/Match.java
+++ b/src/dev/flang/ast/Match.java
@@ -241,6 +241,8 @@ public class Match extends AbstractMatch
   @Override
   Expr propagateExpectedType(Resolution res, Context context, AbstractType t, Supplier<String> from)
   {
+    if (CHECKS) check
+      (_type == null || t.isAssignableFrom(_type, context).yes());
     _type = t;
     return this;
   }
@@ -257,22 +259,24 @@ public class Match extends AbstractMatch
   Expr addResultField(Resolution res, Context context)
   {
     Expr result = this;
+    // we have not received type via type propagation
+    if (_type == null)
+      {
+        _type = typeFromCases(true);
+      }
     if (!_assignedToField)
       {
         var t = _type;
-        if (t != null && !t.isVoid())
-          {
-            var pos = pos();
-            Feature r = new Feature(res,
-                                    pos,
-                                    Visi.PRIV,
-                                    t,
-                                    FuzionConstants.EXPRESSION_RESULT_PREFIX + (_id_++),
-                                    context.outerFeature());
-            res.resolveTypes(r);
-            result = new Block(new List<>(assignToField(res, context, r),
-                                          new Call(pos, new Current(pos, context.outerFeature()), r).resolveTypes(res, context)));
-          }
+        var pos = pos();
+        Feature r = new Feature(res,
+                                pos,
+                                Visi.PRIV,
+                                t,
+                                FuzionConstants.EXPRESSION_RESULT_PREFIX + (_id_++),
+                                context.outerFeature());
+        res.resolveTypes(r);
+        result = new Block(new List<>(assignToField(res, context, r),
+                                      new Call(pos, new Current(pos, context.outerFeature()), r).resolveTypes(res, context)));
       }
     return result;
   }

--- a/src/dev/flang/ast/Match.java
+++ b/src/dev/flang/ast/Match.java
@@ -121,7 +121,7 @@ public class Match extends AbstractMatch
    *
    * @return this.
    */
-  public Match visit(FeatureVisitor v, AbstractFeature outer)
+  public Expr visit(FeatureVisitor v, AbstractFeature outer)
   {
     var os = _subject;
     var ns = _subject.visit(v, outer);
@@ -130,12 +130,12 @@ public class Match extends AbstractMatch
       // while okay for it to change after a visit
       (os == _subject);
     _subject = ns;
-    v.action(this);
+    var result = v.action(this);
     for (var c: cases())
       {
         c.visit(v, this, outer);
       }
-    return this;
+    return result;
   }
 
 
@@ -241,11 +241,8 @@ public class Match extends AbstractMatch
   @Override
   Expr propagateExpectedType(Resolution res, Context context, AbstractType t, Supplier<String> from)
   {
-    // NYI: CLEANUP: there should be another mechanism, for
-    // adding missing result fields instead of misusing
-    // `propagateExpectedType`.
-    //
-    return addFieldForResult(res, context, t);
+    _type = t;
+    return this;
   }
 
 
@@ -256,41 +253,28 @@ public class Match extends AbstractMatch
    * @param res the resolution instance.
    *
    * @param context the source code context where this assignment is used
-   *
-   * @param t the type to use for the result field
    */
-  private Expr addFieldForResult(Resolution res, Context context, AbstractType t)
+  Expr addResultField(Resolution res, Context context)
   {
     Expr result = this;
-    if (!t.isVoid())
+    if (!_assignedToField)
       {
-        var pos = pos();
-        Feature r = new Feature(res,
-                                pos,
-                                Visi.PRIV,
-                                t,
-                                FuzionConstants.EXPRESSION_RESULT_PREFIX + (_id_++),
-                                context.outerFeature());
-        res.resolveTypes(r);
-        result = new Block(new List<>(assignToField(res, context, r),
-                                      new Call(pos, new Current(pos, context.outerFeature()), r).resolveTypes(res, context)));
+        var t = _type;
+        if (t != null && !t.isVoid())
+          {
+            var pos = pos();
+            Feature r = new Feature(res,
+                                    pos,
+                                    Visi.PRIV,
+                                    t,
+                                    FuzionConstants.EXPRESSION_RESULT_PREFIX + (_id_++),
+                                    context.outerFeature());
+            res.resolveTypes(r);
+            result = new Block(new List<>(assignToField(res, context, r),
+                                          new Call(pos, new Current(pos, context.outerFeature()), r).resolveTypes(res, context)));
+          }
       }
     return result;
-  }
-
-
-  /**
-   * This will trigger addFieldForResult in some cases, e.g.:
-   * `match (if true then true else true) * =>`
-   *
-   * @param res this is called during type inference, res gives the resolution
-   * instance.
-   *
-   * @param context the source code context where this Expr is used
-   */
-  void addFieldsForSubject(Resolution res, Context context)
-  {
-    _subject = subject().propagateExpectedType(res, context, subject().type(), null);
   }
 
 

--- a/src/dev/flang/lsp/shared/ParserTool.java
+++ b/src/dev/flang/lsp/shared/ParserTool.java
@@ -258,7 +258,7 @@ public class ParserTool extends ANY
         @Override public Expr         action      (Function       f) { FoundPos(f.pos()); return f; }
         @Override public void         action      (Impl           i) { FoundPos(i.pos); }
         @Override public Expr         action      (InlineArray    i) { FoundPos(i.pos()); return i; }
-        @Override public void         action      (AbstractMatch  m) { FoundPos(m.pos()); }
+        @Override public Expr         action      (AbstractMatch  m) { FoundPos(m.pos()); return super.action(m); }
         @Override public Expr         action      (This           t) { FoundPos(t.pos()); return t; }
         @Override public AbstractType action      (AbstractType   t) { FoundPos(t.declarationPos()); return t; }
       };

--- a/tests/reg_issue2775/reg_issue2775.fz.expected_err
+++ b/tests/reg_issue2775/reg_issue2775.fz.expected_err
@@ -1,13 +1,12 @@
 
---CURDIR--/reg_issue2775.fz:28:3: error 1: Incompatible types when passing argument in a call
+--CURDIR--/reg_issue2775.fz:28:22: error 1: Incompatible types in assignment
 a (match (v) unit => 4711)
---^^^^^^^^^^^^^^^^^^^^^^^^
-Actual type for argument #1 'v' does not match expected type.
-In call to          : 'a'
+---------------------^^^^
+assignment to field : 'result'
 expected formal type: 'void'
 actual type found   : 'i32'
 assignable to       : 'i32'
-for value assigned  : '(match (v) unit => 4711)'
-To solve this, you could change the type of the target 'v' to 'i32' or convert the type of the assigned value to 'void'.
+for value assigned  : '4711'
+To solve this, you could change the type of the target 'result' to 'i32' or convert the type of the assigned value to 'void'.
 
 one error.

--- a/tests/visibility_negative/visibility_negative.fz.expected_err
+++ b/tests/visibility_negative/visibility_negative.fz.expected_err
@@ -863,919 +863,7 @@ Target feature: 'visibility_negative.visi9'
 In call: 'ix3'
 
 
---CURDIR--/visibility_negative.fz:120:11: error 109: Could not find called feature
-      use f2   # 33. should flag an error: feature not found / not visible
-----------^^
-Feature not found: 'f2' (no arguments)
-Target feature: 'visibility_negative.visi2.a1'
-In call: 'f2'
-
-
---CURDIR--/visibility_negative.fz:121:11: error 110: Could not find called feature
-      use f3   # 34. should flag an error: feature not found / not visible
-----------^^
-Feature not found: 'f3' (no arguments)
-Target feature: 'visibility_negative.visi2.a1'
-In call: 'f3'
-
-
---CURDIR--/visibility_negative.fz:122:11: error 111: Could not find called feature
-      use f4   # 35. should flag an error: feature not found / not visible
-----------^^
-Feature not found: 'f4' (no arguments)
-Target feature: 'visibility_negative.visi2.a1'
-In call: 'f4'
-
-
---CURDIR--/visibility_negative.fz:123:11: error 112: Could not find called feature
-      use f5   # 36. should flag an error: feature not found / not visible
-----------^^
-Feature not found: 'f5' (no arguments)
-Target feature: 'visibility_negative.visi2.a1'
-In call: 'f5'
-
-
---CURDIR--/visibility_negative.fz:124:11: error 113: Could not find called feature
-      use f6   # 37. should flag an error: feature not found / not visible
-----------^^
-Feature not found: 'f6' (no arguments)
-Target feature: 'visibility_negative.visi2.a1'
-In call: 'f6'
-
-
---CURDIR--/visibility_negative.fz:125:11: error 114: Could not find called feature
-      use f7   # 38. should flag an error: feature not found / not visible
-----------^^
-Feature not found: 'f7' (no arguments)
-Target feature: 'visibility_negative.visi2.a1'
-In call: 'f7'
-
-
---CURDIR--/visibility_negative.fz:126:11: error 115: Could not find called feature
-      use f8   # 39. should flag an error: feature not found / not visible
-----------^^
-Feature not found: 'f8' (no arguments)
-Target feature: 'visibility_negative.visi2.a1'
-In call: 'f8'
-
-
---CURDIR--/visibility_negative.fz:127:11: error 116: Could not find called feature
-      use f9   # 40. should flag an error: feature not found / not visible
-----------^^
-Feature not found: 'f9' (no arguments)
-Target feature: 'visibility_negative.visi2.a1'
-In call: 'f9'
-
-
---CURDIR--/visibility_negative.fz:238:11: error 117: Could not find called feature
-      use f2   # 112. should flag an error: feature not found / not visible
-----------^^
-Feature not found: 'f2' (no arguments)
-Target feature: 'visibility_negative.visi2.a1'
-In call: 'f2'
-
-
---CURDIR--/visibility_negative.fz:239:11: error 118: Could not find called feature
-      use f3   # 113. should flag an error: feature not found / not visible
-----------^^
-Feature not found: 'f3' (no arguments)
-Target feature: 'visibility_negative.visi2.a1'
-In call: 'f3'
-
-
---CURDIR--/visibility_negative.fz:240:11: error 119: Could not find called feature
-      use f4   # 114. should flag an error: feature not found / not visible
-----------^^
-Feature not found: 'f4' (no arguments)
-Target feature: 'visibility_negative.visi2.a1'
-In call: 'f4'
-
-
---CURDIR--/visibility_negative.fz:241:11: error 120: Could not find called feature
-      use f5   # 115. should flag an error: feature not found / not visible
-----------^^
-Feature not found: 'f5' (no arguments)
-Target feature: 'visibility_negative.visi2.a1'
-In call: 'f5'
-
-
---CURDIR--/visibility_negative.fz:242:11: error 121: Could not find called feature
-      use f6   # 116. should flag an error: feature not found / not visible
-----------^^
-Feature not found: 'f6' (no arguments)
-Target feature: 'visibility_negative.visi2.a1'
-In call: 'f6'
-
-
---CURDIR--/visibility_negative.fz:243:11: error 122: Could not find called feature
-      use f7   # 117. should flag an error: feature not found / not visible
-----------^^
-Feature not found: 'f7' (no arguments)
-Target feature: 'visibility_negative.visi2.a1'
-In call: 'f7'
-
-
---CURDIR--/visibility_negative.fz:244:11: error 123: Could not find called feature
-      use f8   # 118. should flag an error: feature not found / not visible
-----------^^
-Feature not found: 'f8' (no arguments)
-Target feature: 'visibility_negative.visi2.a1'
-In call: 'f8'
-
-
---CURDIR--/visibility_negative.fz:245:11: error 124: Could not find called feature
-      use f9   # 119. should flag an error: feature not found / not visible
-----------^^
-Feature not found: 'f9' (no arguments)
-Target feature: 'visibility_negative.visi2.a1'
-In call: 'f9'
-
-
---CURDIR--/visibility_negative.fz:248:11: error 125: Could not find called feature
-      use f2   # 120. should flag an error: feature not found / not visible
-----------^^
-Feature not found: 'f2' (no arguments)
-Target feature: 'visibility_negative.visi2.a1'
-In call: 'f2'
-
-
---CURDIR--/visibility_negative.fz:249:11: error 126: Could not find called feature
-      use f3   # 121. should flag an error: feature not found / not visible
-----------^^
-Feature not found: 'f3' (no arguments)
-Target feature: 'visibility_negative.visi2.a1'
-In call: 'f3'
-
-
---CURDIR--/visibility_negative.fz:250:11: error 127: Could not find called feature
-      use f4   # 122. should flag an error: feature not found / not visible
-----------^^
-Feature not found: 'f4' (no arguments)
-Target feature: 'visibility_negative.visi2.a1'
-In call: 'f4'
-
-
---CURDIR--/visibility_negative.fz:251:11: error 128: Could not find called feature
-      use f5   # 123. should flag an error: feature not found / not visible
-----------^^
-Feature not found: 'f5' (no arguments)
-Target feature: 'visibility_negative.visi2.a1'
-In call: 'f5'
-
-
---CURDIR--/visibility_negative.fz:252:11: error 129: Could not find called feature
-      use f6   # 124. should flag an error: feature not found / not visible
-----------^^
-Feature not found: 'f6' (no arguments)
-Target feature: 'visibility_negative.visi2.a1'
-In call: 'f6'
-
-
---CURDIR--/visibility_negative.fz:253:11: error 130: Could not find called feature
-      use f7   # 125. should flag an error: feature not found / not visible
-----------^^
-Feature not found: 'f7' (no arguments)
-Target feature: 'visibility_negative.visi2.a1'
-In call: 'f7'
-
-
---CURDIR--/visibility_negative.fz:255:11: error 131: Could not find called feature
-      use f9   # 126. should flag an error: feature not found / not visible
-----------^^
-Feature not found: 'f9' (no arguments)
-Target feature: 'visibility_negative.visi2.a1'
-In call: 'f9'
-
-
---CURDIR--/visibility_negative.fz:278:11: error 132: Could not find called feature
-      use f2   # 140. should flag an error: feature not found / not visible
-----------^^
-Feature not found: 'f2' (no arguments)
-Target feature: 'visibility_negative.visi2.a1'
-In call: 'f2'
-
-
---CURDIR--/visibility_negative.fz:279:11: error 133: Could not find called feature
-      use f3   # 141. should flag an error: feature not found / not visible
-----------^^
-Feature not found: 'f3' (no arguments)
-Target feature: 'visibility_negative.visi2.a1'
-In call: 'f3'
-
-
---CURDIR--/visibility_negative.fz:280:11: error 134: Could not find called feature
-      use f4   # 142. should flag an error: feature not found / not visible
-----------^^
-Feature not found: 'f4' (no arguments)
-Target feature: 'visibility_negative.visi2.a1'
-In call: 'f4'
-
-
---CURDIR--/visibility_negative.fz:281:11: error 135: Could not find called feature
-      use f5   # 143. should flag an error: feature not found / not visible
-----------^^
-Feature not found: 'f5' (no arguments)
-Target feature: 'visibility_negative.visi2.a1'
-In call: 'f5'
-
-
---CURDIR--/visibility_negative.fz:282:11: error 136: Could not find called feature
-      use f6   # 144. should flag an error: feature not found / not visible
-----------^^
-Feature not found: 'f6' (no arguments)
-Target feature: 'visibility_negative.visi2.a1'
-In call: 'f6'
-
-
---CURDIR--/visibility_negative.fz:283:11: error 137: Could not find called feature
-      use f7   # 145. should flag an error: feature not found / not visible
-----------^^
-Feature not found: 'f7' (no arguments)
-Target feature: 'visibility_negative.visi2.a1'
-In call: 'f7'
-
-
---CURDIR--/visibility_negative.fz:285:11: error 138: Could not find called feature
-      use f9   # 146. should flag an error: feature not found / not visible
-----------^^
-Feature not found: 'f9' (no arguments)
-Target feature: 'visibility_negative.visi2.a1'
-In call: 'f9'
-
-
---CURDIR--/visibility_negative.fz:130:13: error 139: Could not find called feature
-        use f2   # 41. should flag an error: feature not found / not visible
-------------^^
-Feature not found: 'f2' (no arguments)
-Target feature: 'visibility_negative.visi2.a1.b1'
-In call: 'f2'
-
-
---CURDIR--/visibility_negative.fz:131:13: error 140: Could not find called feature
-        use f3   # 42. should flag an error: feature not found / not visible
-------------^^
-Feature not found: 'f3' (no arguments)
-Target feature: 'visibility_negative.visi2.a1.b1'
-In call: 'f3'
-
-
---CURDIR--/visibility_negative.fz:132:13: error 141: Could not find called feature
-        use f4   # 43. should flag an error: feature not found / not visible
-------------^^
-Feature not found: 'f4' (no arguments)
-Target feature: 'visibility_negative.visi2.a1.b1'
-In call: 'f4'
-
-
---CURDIR--/visibility_negative.fz:133:13: error 142: Could not find called feature
-        use f5   # 44. should flag an error: feature not found / not visible
-------------^^
-Feature not found: 'f5' (no arguments)
-Target feature: 'visibility_negative.visi2.a1.b1'
-In call: 'f5'
-
-
---CURDIR--/visibility_negative.fz:134:13: error 143: Could not find called feature
-        use f6   # 45. should flag an error: feature not found / not visible
-------------^^
-Feature not found: 'f6' (no arguments)
-Target feature: 'visibility_negative.visi2.a1.b1'
-In call: 'f6'
-
-
---CURDIR--/visibility_negative.fz:135:13: error 144: Could not find called feature
-        use f7   # 46. should flag an error: feature not found / not visible
-------------^^
-Feature not found: 'f7' (no arguments)
-Target feature: 'visibility_negative.visi2.a1.b1'
-In call: 'f7'
-
-
---CURDIR--/visibility_negative.fz:137:13: error 145: Could not find called feature
-        use f9   # 48. should flag an error: feature not found / not visible
-------------^^
-Feature not found: 'f9' (no arguments)
-Target feature: 'visibility_negative.visi2.a1.b1'
-In call: 'f9'
-
-
---CURDIR--/visibility_negative.fz:141:13: error 146: Could not find called feature
-        use f3   # 49. should flag an error: feature not found / not visible
-------------^^
-Feature not found: 'f3' (no arguments)
-Target feature: 'visibility_negative.visi2.a1.b1'
-In call: 'f3'
-
-
---CURDIR--/visibility_negative.fz:142:13: error 147: Could not find called feature
-        use f4   # 50. should flag an error: feature not found / not visible
-------------^^
-Feature not found: 'f4' (no arguments)
-Target feature: 'visibility_negative.visi2.a1.b1'
-In call: 'f4'
-
-
---CURDIR--/visibility_negative.fz:143:13: error 148: Could not find called feature
-        use f5   # 51. should flag an error: feature not found / not visible
-------------^^
-Feature not found: 'f5' (no arguments)
-Target feature: 'visibility_negative.visi2.a1.b1'
-In call: 'f5'
-
-
---CURDIR--/visibility_negative.fz:144:13: error 149: Could not find called feature
-        use f6   # 52. should flag an error: feature not found / not visible
-------------^^
-Feature not found: 'f6' (no arguments)
-Target feature: 'visibility_negative.visi2.a1.b1'
-In call: 'f6'
-
-
---CURDIR--/visibility_negative.fz:145:13: error 150: Could not find called feature
-        use f7   # 53. should flag an error: feature not found / not visible
-------------^^
-Feature not found: 'f7' (no arguments)
-Target feature: 'visibility_negative.visi2.a1.b1'
-In call: 'f7'
-
-
---CURDIR--/visibility_negative.fz:147:13: error 151: Could not find called feature
-        use f9   # 55. should flag an error: feature not found / not visible
-------------^^
-Feature not found: 'f9' (no arguments)
-Target feature: 'visibility_negative.visi2.a1.b1'
-In call: 'f9'
-
-
---CURDIR--/visibility_negative.fz:180:13: error 152: Could not find called feature
-        use f3   # 74. should flag an error: feature not found / not visible
-------------^^
-Feature not found: 'f3' (no arguments)
-Target feature: 'visibility_negative.visi2.a1.b1'
-In call: 'f3'
-
-
---CURDIR--/visibility_negative.fz:181:13: error 153: Could not find called feature
-        use f4   # 75. should flag an error: feature not found / not visible
-------------^^
-Feature not found: 'f4' (no arguments)
-Target feature: 'visibility_negative.visi2.a1.b1'
-In call: 'f4'
-
-
---CURDIR--/visibility_negative.fz:182:13: error 154: Could not find called feature
-        use f5   # 76. should flag an error: feature not found / not visible
-------------^^
-Feature not found: 'f5' (no arguments)
-Target feature: 'visibility_negative.visi2.a1.b1'
-In call: 'f5'
-
-
---CURDIR--/visibility_negative.fz:183:13: error 155: Could not find called feature
-        use f6   # 77. should flag an error: feature not found / not visible
-------------^^
-Feature not found: 'f6' (no arguments)
-Target feature: 'visibility_negative.visi2.a1.b1'
-In call: 'f6'
-
-
---CURDIR--/visibility_negative.fz:184:13: error 156: Could not find called feature
-        use f7   # 78. should flag an error: feature not found / not visible
-------------^^
-Feature not found: 'f7' (no arguments)
-Target feature: 'visibility_negative.visi2.a1.b1'
-In call: 'f7'
-
-
---CURDIR--/visibility_negative.fz:186:13: error 157: Could not find called feature
-        use f9   # 80. should flag an error: feature not found / not visible
-------------^^
-Feature not found: 'f9' (no arguments)
-Target feature: 'visibility_negative.visi2.a1.b1'
-In call: 'f9'
-
-
---CURDIR--/visibility_negative.fz:220:13: error 158: Could not find called feature
-        use f3   # 99. should flag an error: feature not found / not visible
-------------^^
-Feature not found: 'f3' (no arguments)
-Target feature: 'visibility_negative.visi2.a1.b1'
-In call: 'f3'
-
-
---CURDIR--/visibility_negative.fz:221:13: error 159: Could not find called feature
-        use f4   # 100. should flag an error: feature not found / not visible
-------------^^
-Feature not found: 'f4' (no arguments)
-Target feature: 'visibility_negative.visi2.a1.b1'
-In call: 'f4'
-
-
---CURDIR--/visibility_negative.fz:222:13: error 160: Could not find called feature
-        use f5   # 101. should flag an error: feature not found / not visible
-------------^^
-Feature not found: 'f5' (no arguments)
-Target feature: 'visibility_negative.visi2.a1.b1'
-In call: 'f5'
-
-
---CURDIR--/visibility_negative.fz:223:13: error 161: Could not find called feature
-        use f6   # 102. should flag an error: feature not found / not visible
-------------^^
-Feature not found: 'f6' (no arguments)
-Target feature: 'visibility_negative.visi2.a1.b1'
-In call: 'f6'
-
-
---CURDIR--/visibility_negative.fz:224:13: error 162: Could not find called feature
-        use f7   # 103. should flag an error: feature not found / not visible
-------------^^
-Feature not found: 'f7' (no arguments)
-Target feature: 'visibility_negative.visi2.a1.b1'
-In call: 'f7'
-
-
---CURDIR--/visibility_negative.fz:226:13: error 163: Could not find called feature
-        use f9   # 105. should flag an error: feature not found / not visible
-------------^^
-Feature not found: 'f9' (no arguments)
-Target feature: 'visibility_negative.visi2.a1.b1'
-In call: 'f9'
-
-
---CURDIR--/visibility_negative.fz:230:13: error 164: Could not find called feature
-        use f3   # 106. should flag an error: feature not found / not visible
-------------^^
-Feature not found: 'f3' (no arguments)
-Target feature: 'visibility_negative.visi2.a1.b1'
-In call: 'f3'
-
-
---CURDIR--/visibility_negative.fz:231:13: error 165: Could not find called feature
-        use f4   # 107. should flag an error: feature not found / not visible
-------------^^
-Feature not found: 'f4' (no arguments)
-Target feature: 'visibility_negative.visi2.a1.b1'
-In call: 'f4'
-
-
---CURDIR--/visibility_negative.fz:232:13: error 166: Could not find called feature
-        use f5   # 108. should flag an error: feature not found / not visible
-------------^^
-Feature not found: 'f5' (no arguments)
-Target feature: 'visibility_negative.visi2.a1.b1'
-In call: 'f5'
-
-
---CURDIR--/visibility_negative.fz:233:13: error 167: Could not find called feature
-        use f6   # 109. should flag an error: feature not found / not visible
-------------^^
-Feature not found: 'f6' (no arguments)
-Target feature: 'visibility_negative.visi2.a1.b1'
-In call: 'f6'
-
-
---CURDIR--/visibility_negative.fz:236:13: error 168: Could not find called feature
-        use f9   # 111. should flag an error: feature not found / not visible
-------------^^
-Feature not found: 'f9' (no arguments)
-Target feature: 'visibility_negative.visi2.a1.b1'
-In call: 'f9'
-
-
---CURDIR--/visibility_negative.fz:151:15: error 169: Could not find called feature
-          use f3   # 56. should flag an error: feature not found / not visible
---------------^^
-Feature not found: 'f3' (no arguments)
-Target feature: 'visibility_negative.visi2.a1.b1.c1'
-In call: 'f3'
-
-
---CURDIR--/visibility_negative.fz:152:15: error 170: Could not find called feature
-          use f4   # 57. should flag an error: feature not found / not visible
---------------^^
-Feature not found: 'f4' (no arguments)
-Target feature: 'visibility_negative.visi2.a1.b1.c1'
-In call: 'f4'
-
-
---CURDIR--/visibility_negative.fz:153:15: error 171: Could not find called feature
-          use f5   # 58. should flag an error: feature not found / not visible
---------------^^
-Feature not found: 'f5' (no arguments)
-Target feature: 'visibility_negative.visi2.a1.b1.c1'
-In call: 'f5'
-
-
---CURDIR--/visibility_negative.fz:154:15: error 172: Could not find called feature
-          use f6   # 59. should flag an error: feature not found / not visible
---------------^^
-Feature not found: 'f6' (no arguments)
-Target feature: 'visibility_negative.visi2.a1.b1.c1'
-In call: 'f6'
-
-
---CURDIR--/visibility_negative.fz:157:15: error 173: Could not find called feature
-          use f9   # 62. should flag an error: feature not found / not visible
---------------^^
-Feature not found: 'f9' (no arguments)
-Target feature: 'visibility_negative.visi2.a1.b1.c1'
-In call: 'f9'
-
-
---CURDIR--/visibility_negative.fz:162:15: error 174: Could not find called feature
-          use f4   # 63. should flag an error: feature not found / not visible
---------------^^
-Feature not found: 'f4' (no arguments)
-Target feature: 'visibility_negative.visi2.a1.b1.c1'
-In call: 'f4'
-
-
---CURDIR--/visibility_negative.fz:163:15: error 175: Could not find called feature
-          use f5   # 64. should flag an error: feature not found / not visible
---------------^^
-Feature not found: 'f5' (no arguments)
-Target feature: 'visibility_negative.visi2.a1.b1.c1'
-In call: 'f5'
-
-
---CURDIR--/visibility_negative.fz:164:15: error 176: Could not find called feature
-          use f6   # 65. should flag an error: feature not found / not visible
---------------^^
-Feature not found: 'f6' (no arguments)
-Target feature: 'visibility_negative.visi2.a1.b1.c1'
-In call: 'f6'
-
-
---CURDIR--/visibility_negative.fz:167:15: error 177: Could not find called feature
-          use f9   # 68. should flag an error: feature not found / not visible
---------------^^
-Feature not found: 'f9' (no arguments)
-Target feature: 'visibility_negative.visi2.a1.b1.c1'
-In call: 'f9'
-
-
---CURDIR--/visibility_negative.fz:173:15: error 178: Could not find called feature
-          use f5   # 69. should flag an error: feature not found / not visible
---------------^^
-Feature not found: 'f5' (no arguments)
-Target feature: 'visibility_negative.visi2.a1.b1.c1'
-In call: 'f5'
-
-
---CURDIR--/visibility_negative.fz:174:15: error 179: Could not find called feature
-          use f6   # 70. should flag an error: feature not found / not visible
---------------^^
-Feature not found: 'f6' (no arguments)
-Target feature: 'visibility_negative.visi2.a1.b1.c1'
-In call: 'f6'
-
-
---CURDIR--/visibility_negative.fz:177:15: error 180: Could not find called feature
-          use f9   # 73. should flag an error: feature not found / not visible
---------------^^
-Feature not found: 'f9' (no arguments)
-Target feature: 'visibility_negative.visi2.a1.b1.c1'
-In call: 'f9'
-
-
---CURDIR--/visibility_negative.fz:191:15: error 181: Could not find called feature
-          use f3   # 81. should flag an error: feature not found / not visible
---------------^^
-Feature not found: 'f3' (no arguments)
-Target feature: 'visibility_negative.visi2.a1.b1.c2'
-In call: 'f3'
-
-
---CURDIR--/visibility_negative.fz:192:15: error 182: Could not find called feature
-          use f4   # 82. should flag an error: feature not found / not visible
---------------^^
-Feature not found: 'f4' (no arguments)
-Target feature: 'visibility_negative.visi2.a1.b1.c2'
-In call: 'f4'
-
-
---CURDIR--/visibility_negative.fz:193:15: error 183: Could not find called feature
-          use f5   # 83. should flag an error: feature not found / not visible
---------------^^
-Feature not found: 'f5' (no arguments)
-Target feature: 'visibility_negative.visi2.a1.b1.c2'
-In call: 'f5'
-
-
---CURDIR--/visibility_negative.fz:194:15: error 184: Could not find called feature
-          use f6   # 84. should flag an error: feature not found / not visible
---------------^^
-Feature not found: 'f6' (no arguments)
-Target feature: 'visibility_negative.visi2.a1.b1.c2'
-In call: 'f6'
-
-
---CURDIR--/visibility_negative.fz:197:15: error 185: Could not find called feature
-          use f9   # 87. should flag an error: feature not found / not visible
---------------^^
-Feature not found: 'f9' (no arguments)
-Target feature: 'visibility_negative.visi2.a1.b1.c2'
-In call: 'f9'
-
-
---CURDIR--/visibility_negative.fz:201:15: error 186: Could not find called feature
-          use f3   # 88. should flag an error: feature not found / not visible
---------------^^
-Feature not found: 'f3' (no arguments)
-Target feature: 'visibility_negative.visi2.a1.b1.c2'
-In call: 'f3'
-
-
---CURDIR--/visibility_negative.fz:202:15: error 187: Could not find called feature
-          use f4   # 89. should flag an error: feature not found / not visible
---------------^^
-Feature not found: 'f4' (no arguments)
-Target feature: 'visibility_negative.visi2.a1.b1.c2'
-In call: 'f4'
-
-
---CURDIR--/visibility_negative.fz:204:15: error 188: Could not find called feature
-          use f6   # 90. should flag an error: feature not found / not visible
---------------^^
-Feature not found: 'f6' (no arguments)
-Target feature: 'visibility_negative.visi2.a1.b1.c2'
-In call: 'f6'
-
-
---CURDIR--/visibility_negative.fz:207:15: error 189: Could not find called feature
-          use f9   # 93. should flag an error: feature not found / not visible
---------------^^
-Feature not found: 'f9' (no arguments)
-Target feature: 'visibility_negative.visi2.a1.b1.c2'
-In call: 'f9'
-
-
---CURDIR--/visibility_negative.fz:211:15: error 190: Could not find called feature
-          use f3   # 94. should flag an error: feature not found / not visible
---------------^^
-Feature not found: 'f3' (no arguments)
-Target feature: 'visibility_negative.visi2.a1.b1.c2'
-In call: 'f3'
-
-
---CURDIR--/visibility_negative.fz:212:15: error 191: Could not find called feature
-          use f4   # 95. should flag an error: feature not found / not visible
---------------^^
-Feature not found: 'f4' (no arguments)
-Target feature: 'visibility_negative.visi2.a1.b1.c2'
-In call: 'f4'
-
-
---CURDIR--/visibility_negative.fz:217:15: error 192: Could not find called feature
-          use f9   # 98. should flag an error: feature not found / not visible
---------------^^
-Feature not found: 'f9' (no arguments)
-Target feature: 'visibility_negative.visi2.a1.b1.c2'
-In call: 'f9'
-
-
---CURDIR--/visibility_negative.fz:259:13: error 193: Could not find called feature
-        use f2   # 127. should flag an error: feature not found / not visible
-------------^^
-Feature not found: 'f2' (no arguments)
-Target feature: 'visibility_negative.visi2.a1.b2'
-In call: 'f2'
-
-
---CURDIR--/visibility_negative.fz:260:13: error 194: Could not find called feature
-        use f3   # 128. should flag an error: feature not found / not visible
-------------^^
-Feature not found: 'f3' (no arguments)
-Target feature: 'visibility_negative.visi2.a1.b2'
-In call: 'f3'
-
-
---CURDIR--/visibility_negative.fz:261:13: error 195: Could not find called feature
-        use f4   # 129. should flag an error: feature not found / not visible
-------------^^
-Feature not found: 'f4' (no arguments)
-Target feature: 'visibility_negative.visi2.a1.b2'
-In call: 'f4'
-
-
---CURDIR--/visibility_negative.fz:262:13: error 196: Could not find called feature
-        use f5   # 130. should flag an error: feature not found / not visible
-------------^^
-Feature not found: 'f5' (no arguments)
-Target feature: 'visibility_negative.visi2.a1.b2'
-In call: 'f5'
-
-
---CURDIR--/visibility_negative.fz:263:13: error 197: Could not find called feature
-        use f6   # 131. should flag an error: feature not found / not visible
-------------^^
-Feature not found: 'f6' (no arguments)
-Target feature: 'visibility_negative.visi2.a1.b2'
-In call: 'f6'
-
-
---CURDIR--/visibility_negative.fz:264:13: error 198: Could not find called feature
-        use f7   # 132. should flag an error: feature not found / not visible
-------------^^
-Feature not found: 'f7' (no arguments)
-Target feature: 'visibility_negative.visi2.a1.b2'
-In call: 'f7'
-
-
---CURDIR--/visibility_negative.fz:266:13: error 199: Could not find called feature
-        use f9   # 133. should flag an error: feature not found / not visible
-------------^^
-Feature not found: 'f9' (no arguments)
-Target feature: 'visibility_negative.visi2.a1.b2'
-In call: 'f9'
-
-
---CURDIR--/visibility_negative.fz:269:13: error 200: Could not find called feature
-        use f2   # 134. should flag an error: feature not found / not visible
-------------^^
-Feature not found: 'f2' (no arguments)
-Target feature: 'visibility_negative.visi2.a1.b2'
-In call: 'f2'
-
-
---CURDIR--/visibility_negative.fz:270:13: error 201: Could not find called feature
-        use f3   # 135. should flag an error: feature not found / not visible
-------------^^
-Feature not found: 'f3' (no arguments)
-Target feature: 'visibility_negative.visi2.a1.b2'
-In call: 'f3'
-
-
---CURDIR--/visibility_negative.fz:271:13: error 202: Could not find called feature
-        use f4   # 136. should flag an error: feature not found / not visible
-------------^^
-Feature not found: 'f4' (no arguments)
-Target feature: 'visibility_negative.visi2.a1.b2'
-In call: 'f4'
-
-
---CURDIR--/visibility_negative.fz:272:13: error 203: Could not find called feature
-        use f5   # 137. should flag an error: feature not found / not visible
-------------^^
-Feature not found: 'f5' (no arguments)
-Target feature: 'visibility_negative.visi2.a1.b2'
-In call: 'f5'
-
-
---CURDIR--/visibility_negative.fz:273:13: error 204: Could not find called feature
-        use f6   # 138. should flag an error: feature not found / not visible
-------------^^
-Feature not found: 'f6' (no arguments)
-Target feature: 'visibility_negative.visi2.a1.b2'
-In call: 'f6'
-
-
---CURDIR--/visibility_negative.fz:274:13: error 205: Could not find called feature
-        use f7   # 139. should flag an error: feature not found / not visible
-------------^^
-Feature not found: 'f7' (no arguments)
-Target feature: 'visibility_negative.visi2.a1.b2'
-In call: 'f7'
-
-
---CURDIR--/visibility_negative.fz:471:13: error 206: Could not find called feature
-      chck (x = "Outer!") "outer x"               # 261. should flag an error: field used before it is declared
-------------^
-Feature not found: 'x' (no arguments)
-Target feature: 'visibility_negative.visi5.a'
-In call: 'x'
-
-
---CURDIR--/visibility_negative.fz:472:20: error 207: Could not find called feature
-      chck (a.this.x = "Outer!") "a.this.x"       # 262. should flag an error: field used before it is declared
--------------------^
-Feature not found: 'x' (no arguments)
-Target feature: 'visibility_negative.visi5.a'
-In call: 'a.this.x'
-
-
---CURDIR--/visibility_negative.fz:483:22: error 208: Could not find called feature
-        chck (b.this.x = "Inner!") "b.this.x"       # 267. should flag an error: feature used before it is declared
----------------------^
-Feature not found: 'x' (no arguments)
-Target feature: 'visibility_negative.visi5.a.b'
-In call: 'b.this.x'
-
-
---CURDIR--/visibility_negative.fz:495:24: error 209: Could not find called feature
-          chck (c.this.x = "Inner Inner!") "c.this.x" # 270. should flag an error: feature used before it is declared
------------------------^
-Feature not found: 'x' (no arguments)
-Target feature: 'visibility_negative.visi5.a.b.c'
-In call: 'c.this.x'
-
-
---CURDIR--/visibility_negative.fz:505:16: error 210: Could not find called feature
-    say "x is $x"   # 271. should flag an error: feature used before it is declared
----------------^
-Feature not found: 'x' (no arguments)
-Target feature: 'visibility_negative.visi6'
-In call: 'x'
-
-
---CURDIR--/visibility_negative.fz:562:12: error 211: Could not find called feature
-           b = 3 && # 285. should flag an error: feature not visible
------------^
-Feature not found: 'b' (no arguments)
-Target feature: 'visibility_negative.visi9.loop'
-In call: 'b'
-
-
---CURDIR--/visibility_negative.fz:563:12: error 212: Could not find called feature
-           q = 3 && # 286. should flag an error: feature not visible
------------^
-Feature not found: 'q' (no arguments)
-Target feature: 'visibility_negative.visi9.loop'
-In call: 'q'
-
-
---CURDIR--/visibility_negative.fz:564:12: error 213: Could not find called feature
-           r = 3 && # 287. should flag an error: feature not visible
------------^
-Feature not found: 'r' (no arguments)
-Target feature: 'visibility_negative.visi9.loop'
-In call: 'r'
-
-
---CURDIR--/visibility_negative.fz:565:12: error 214: Could not find called feature
-           s = 3  ) # 288. should flag an error: feature not visible
------------^
-Feature not found: 's' (no arguments)
-Target feature: 'visibility_negative.visi9.loop'
-In call: 's'
-
-
---CURDIR--/visibility_negative.fz:572:12: error 215: Could not find called feature
-           r = 3 &&  # 292. should flag an error: feature not visible
------------^
-Feature not found: 'r' (no arguments)
-Target feature: 'visibility_negative.visi9.loop'
-In call: 'r'
-
-
---CURDIR--/visibility_negative.fz:573:12: error 216: Could not find called feature
-           s = 3 )   # 293. should flag an error: feature not visible
------------^
-Feature not found: 's' (no arguments)
-Target feature: 'visibility_negative.visi9.loop'
-In call: 's'
-
-
---CURDIR--/visibility_negative.fz:607:12: error 217: Could not find called feature
-    while (r = 3 &&     # 315a. should flag an error: feature not visible
------------^
-Feature not found: 'r' (no arguments)
-Target feature: 'visibility_negative.visi10.loop'
-In call: 'r'
-
-
---CURDIR--/visibility_negative.fz:608:12: error 218: Could not find called feature
-           q = 4)       # 315b. should flag an error: feature not visible
------------^
-Feature not found: 'q' (no arguments)
-Target feature: 'visibility_negative.visi10.loop'
-In call: 'q'
-
-
---CURDIR--/visibility_negative.fz:627:12: error 219: Could not find called feature
-    while (q = 3 &&     # 321a. should flag an error: feature not visible
------------^
-Feature not found: 'q' (no arguments)
-Target feature: 'visibility_negative.visi11.loop'
-In call: 'q'
-
-
---CURDIR--/visibility_negative.fz:628:12: error 220: Could not find called feature
-           r = 4)       # 321b. should flag an error: feature not visible
------------^
-Feature not found: 'r' (no arguments)
-Target feature: 'visibility_negative.visi11.loop'
-In call: 'r'
-
-
---CURDIR--/visibility_negative.fz:646:8: error 221: Could not find called feature
-   say b  # 327. should flag an error: feature not visible
--------^
-Feature not found: 'b' (no arguments)
-Target feature: 'visibility_negative.visiA'
-In call: 'b'
-
-
---CURDIR--/visibility_negative.fz:647:8: error 222: Could not find called feature
-   say c  # 328. should flag an error: feature not visible
--------^
-Feature not found: 'c' (no arguments)
-Target feature: 'visibility_negative.visiA'
-In call: 'c'
-
-
---CURDIR--/visibility_negative.fz:590:10: error 223: Could not find called feature
+--CURDIR--/visibility_negative.fz:590:10: error 109: Could not find called feature
     _ := ix1    # 307. should flag an error: feature not visible
 ---------^^^
 Feature not found: 'ix1' (no arguments)
@@ -1783,7 +871,7 @@ Target feature: 'visibility_negative.visi9'
 In call: 'ix1'
 
 
---CURDIR--/visibility_negative.fz:591:10: error 224: Could not find called feature
+--CURDIR--/visibility_negative.fz:591:10: error 110: Could not find called feature
     _ := ix2    # 308. should flag an error: feature not visible
 ---------^^^
 Feature not found: 'ix2' (no arguments)
@@ -1791,7 +879,7 @@ Target feature: 'visibility_negative.visi9'
 In call: 'ix2'
 
 
---CURDIR--/visibility_negative.fz:592:10: error 225: Could not find called feature
+--CURDIR--/visibility_negative.fz:592:10: error 111: Could not find called feature
     _ := it1    # 309. should flag an error: feature not visible
 ---------^^^
 Feature not found: 'it1' (no arguments)
@@ -1799,7 +887,7 @@ Target feature: 'visibility_negative.visi9'
 In call: 'it1'
 
 
---CURDIR--/visibility_negative.fz:593:10: error 226: Could not find called feature
+--CURDIR--/visibility_negative.fz:593:10: error 112: Could not find called feature
     _ := it2    # 310. should flag an error: feature not visible
 ---------^^^
 Feature not found: 'it2' (no arguments)
@@ -1807,7 +895,7 @@ Target feature: 'visibility_negative.visi9'
 In call: 'it2'
 
 
---CURDIR--/visibility_negative.fz:594:10: error 227: Could not find called feature
+--CURDIR--/visibility_negative.fz:594:10: error 113: Could not find called feature
     _ := ix3    # 311. should flag an error: feature not visible
 ---------^^^
 Feature not found: 'ix3' (no arguments)
@@ -1815,7 +903,7 @@ Target feature: 'visibility_negative.visi9'
 In call: 'ix3'
 
 
---CURDIR--/visibility_negative.fz:595:10: error 228: Could not find called feature
+--CURDIR--/visibility_negative.fz:595:10: error 114: Could not find called feature
     _ := b      # 312. should flag an error: feature not visible
 ---------^
 Feature not found: 'b' (no arguments)
@@ -1823,7 +911,7 @@ Target feature: 'visibility_negative.visi9'
 In call: 'b'
 
 
---CURDIR--/visibility_negative.fz:596:10: error 229: Could not find called feature
+--CURDIR--/visibility_negative.fz:596:10: error 115: Could not find called feature
     _ := q      # 313. should flag an error: feature not visible
 ---------^
 Feature not found: 'q' (no arguments)
@@ -1831,7 +919,7 @@ Target feature: 'visibility_negative.visi9'
 In call: 'q'
 
 
---CURDIR--/visibility_negative.fz:597:10: error 230: Could not find called feature
+--CURDIR--/visibility_negative.fz:597:10: error 116: Could not find called feature
     _ := r      # 314. should flag an error: feature not visible
 ---------^
 Feature not found: 'r' (no arguments)
@@ -1839,7 +927,7 @@ Target feature: 'visibility_negative.visi9'
 In call: 'r'
 
 
---CURDIR--/visibility_negative.fz:579:15: error 231: Could not find called feature
+--CURDIR--/visibility_negative.fz:579:15: error 117: Could not find called feature
         t6 := it1 # 297. should flag an error: feature not visible
 --------------^^^
 Feature not found: 'it1' (no arguments)
@@ -1847,7 +935,7 @@ Target feature: 'visibility_negative.visi9.else'
 In call: 'it1'
 
 
---CURDIR--/visibility_negative.fz:580:15: error 232: Could not find called feature
+--CURDIR--/visibility_negative.fz:580:15: error 118: Could not find called feature
         t7 := it2 # 298. should flag an error: feature not visible
 --------------^^^
 Feature not found: 'it2' (no arguments)
@@ -1855,7 +943,7 @@ Target feature: 'visibility_negative.visi9.else'
 In call: 'it2'
 
 
---CURDIR--/visibility_negative.fz:581:15: error 233: Could not find called feature
+--CURDIR--/visibility_negative.fz:581:15: error 119: Could not find called feature
         t8 := ix3 # 299. should flag an error: feature not visible
 --------------^^^
 Feature not found: 'ix3' (no arguments)
@@ -1863,7 +951,7 @@ Target feature: 'visibility_negative.visi9.else'
 In call: 'ix3'
 
 
---CURDIR--/visibility_negative.fz:582:15: error 234: Could not find called feature
+--CURDIR--/visibility_negative.fz:582:15: error 120: Could not find called feature
         t9 := b   # 300. should flag an error: feature not visible
 --------------^
 Feature not found: 'b' (no arguments)
@@ -1871,7 +959,7 @@ Target feature: 'visibility_negative.visi9.else'
 In call: 'b'
 
 
---CURDIR--/visibility_negative.fz:583:16: error 235: Could not find called feature
+--CURDIR--/visibility_negative.fz:583:16: error 121: Could not find called feature
         t10 := q  # 301. should flag an error: feature not visible
 ---------------^
 Feature not found: 'q' (no arguments)
@@ -1879,7 +967,7 @@ Target feature: 'visibility_negative.visi9.else'
 In call: 'q'
 
 
---CURDIR--/visibility_negative.fz:584:16: error 236: Could not find called feature
+--CURDIR--/visibility_negative.fz:584:16: error 122: Could not find called feature
         t11 := r  # 302. should flag an error: feature not visible
 ---------------^
 Feature not found: 'r' (no arguments)
@@ -1887,7 +975,7 @@ Target feature: 'visibility_negative.visi9.else'
 In call: 'r'
 
 
---CURDIR--/visibility_negative.fz:585:16: error 237: Could not find called feature
+--CURDIR--/visibility_negative.fz:585:16: error 123: Could not find called feature
         t12 := s  # 303. should flag an error: feature not visible
 ---------------^
 Feature not found: 's' (no arguments)
@@ -1895,7 +983,7 @@ Target feature: 'visibility_negative.visi9.else'
 In call: 's'
 
 
---CURDIR--/visibility_negative.fz:587:16: error 238: Could not find called feature
+--CURDIR--/visibility_negative.fz:587:16: error 124: Could not find called feature
         t13 := b  # 304. should flag an error: feature not visible
 ---------------^
 Feature not found: 'b' (no arguments)
@@ -1903,7 +991,7 @@ Target feature: 'visibility_negative.visi9.else'
 In call: 'b'
 
 
---CURDIR--/visibility_negative.fz:588:16: error 239: Could not find called feature
+--CURDIR--/visibility_negative.fz:588:16: error 125: Could not find called feature
         t14 := q  # 305. should flag an error: feature not visible
 ---------------^
 Feature not found: 'q' (no arguments)
@@ -1911,7 +999,7 @@ Target feature: 'visibility_negative.visi9.else'
 In call: 'q'
 
 
---CURDIR--/visibility_negative.fz:589:16: error 240: Could not find called feature
+--CURDIR--/visibility_negative.fz:589:16: error 126: Could not find called feature
         t15 := r  # 306. should flag an error: feature not visible
 ---------------^
 Feature not found: 'r' (no arguments)
@@ -1919,7 +1007,7 @@ Target feature: 'visibility_negative.visi9.else'
 In call: 'r'
 
 
---CURDIR--/visibility_negative.fz:613:15: error 241: Could not find called feature
+--CURDIR--/visibility_negative.fz:613:15: error 127: Could not find called feature
         t6 := it1 # 316. should flag an error: feature not visible
 --------------^^^
 Feature not found: 'it1' (no arguments)
@@ -1927,7 +1015,7 @@ Target feature: 'visibility_negative.visi10.else'
 In call: 'it1'
 
 
---CURDIR--/visibility_negative.fz:614:15: error 242: Could not find called feature
+--CURDIR--/visibility_negative.fz:614:15: error 128: Could not find called feature
         t7 := it2 # 317. should flag an error: feature not visible
 --------------^^^
 Feature not found: 'it2' (no arguments)
@@ -1935,7 +1023,7 @@ Target feature: 'visibility_negative.visi10.else'
 In call: 'it2'
 
 
---CURDIR--/visibility_negative.fz:615:15: error 243: Could not find called feature
+--CURDIR--/visibility_negative.fz:615:15: error 129: Could not find called feature
         t8 := ix3 # 318. should flag an error: feature not visible
 --------------^^^
 Feature not found: 'ix3' (no arguments)
@@ -1943,7 +1031,7 @@ Target feature: 'visibility_negative.visi10.else'
 In call: 'ix3'
 
 
---CURDIR--/visibility_negative.fz:616:15: error 244: Could not find called feature
+--CURDIR--/visibility_negative.fz:616:15: error 130: Could not find called feature
         t9 := q   # 319. should flag an error: feature not visible
 --------------^
 Feature not found: 'q' (no arguments)
@@ -1951,7 +1039,7 @@ Target feature: 'visibility_negative.visi10.else'
 In call: 'q'
 
 
---CURDIR--/visibility_negative.fz:617:16: error 245: Could not find called feature
+--CURDIR--/visibility_negative.fz:617:16: error 131: Could not find called feature
         t10 := r  # 320. should flag an error: feature not visible
 ---------------^
 Feature not found: 'r' (no arguments)
@@ -1959,7 +1047,7 @@ Target feature: 'visibility_negative.visi10.else'
 In call: 'r'
 
 
---CURDIR--/visibility_negative.fz:633:15: error 246: Could not find called feature
+--CURDIR--/visibility_negative.fz:633:15: error 132: Could not find called feature
         t6 := it1 # 322. should flag an error: feature not visible
 --------------^^^
 Feature not found: 'it1' (no arguments)
@@ -1967,7 +1055,7 @@ Target feature: 'visibility_negative.visi11.else'
 In call: 'it1'
 
 
---CURDIR--/visibility_negative.fz:634:15: error 247: Could not find called feature
+--CURDIR--/visibility_negative.fz:634:15: error 133: Could not find called feature
         t7 := it2 # 323. should flag an error: feature not visible
 --------------^^^
 Feature not found: 'it2' (no arguments)
@@ -1975,7 +1063,7 @@ Target feature: 'visibility_negative.visi11.else'
 In call: 'it2'
 
 
---CURDIR--/visibility_negative.fz:635:15: error 248: Could not find called feature
+--CURDIR--/visibility_negative.fz:635:15: error 134: Could not find called feature
         t8 := ix3 # 324. should flag an error: feature not visible
 --------------^^^
 Feature not found: 'ix3' (no arguments)
@@ -1983,7 +1071,7 @@ Target feature: 'visibility_negative.visi11.else'
 In call: 'ix3'
 
 
---CURDIR--/visibility_negative.fz:636:15: error 249: Could not find called feature
+--CURDIR--/visibility_negative.fz:636:15: error 135: Could not find called feature
         t9 := q   # 325. should flag an error: feature not visible
 --------------^
 Feature not found: 'q' (no arguments)
@@ -1991,7 +1079,7 @@ Target feature: 'visibility_negative.visi11.else'
 In call: 'q'
 
 
---CURDIR--/visibility_negative.fz:637:16: error 250: Could not find called feature
+--CURDIR--/visibility_negative.fz:637:16: error 136: Could not find called feature
         t10 := r  # 326. should flag an error: feature not visible
 ---------------^
 Feature not found: 'r' (no arguments)
@@ -1999,7 +1087,7 @@ Target feature: 'visibility_negative.visi11.else'
 In call: 'r'
 
 
---CURDIR--/visibility_negative.fz:567:14: error 251: Could not find called feature
+--CURDIR--/visibility_negative.fz:567:14: error 137: Could not find called feature
         t0:= q     # 289. should flag an error: feature not visible
 -------------^
 Feature not found: 'q' (no arguments)
@@ -2007,7 +1095,7 @@ Target feature: 'visibility_negative.visi9.loop'
 In call: 'q'
 
 
---CURDIR--/visibility_negative.fz:569:15: error 252: Could not find called feature
+--CURDIR--/visibility_negative.fz:569:15: error 138: Could not find called feature
         t1 := r    # 290. should flag an error: feature not visible
 --------------^
 Feature not found: 'r' (no arguments)
@@ -2015,7 +1103,7 @@ Target feature: 'visibility_negative.visi9.loop'
 In call: 'r'
 
 
---CURDIR--/visibility_negative.fz:570:15: error 253: Could not find called feature
+--CURDIR--/visibility_negative.fz:570:15: error 139: Could not find called feature
         t2 := s    # 291. should flag an error: feature not visible
 --------------^
 Feature not found: 's' (no arguments)
@@ -2023,7 +1111,7 @@ Target feature: 'visibility_negative.visi9.loop'
 In call: 's'
 
 
---CURDIR--/visibility_negative.fz:574:15: error 254: Could not find called feature
+--CURDIR--/visibility_negative.fz:574:15: error 140: Could not find called feature
         t3 := r    # 294. should flag an error: feature not visible
 --------------^
 Feature not found: 'r' (no arguments)
@@ -2031,7 +1119,7 @@ Target feature: 'visibility_negative.visi9.loop'
 In call: 'r'
 
 
---CURDIR--/visibility_negative.fz:575:15: error 255: Could not find called feature
+--CURDIR--/visibility_negative.fz:575:15: error 141: Could not find called feature
         t4 := s    # 295. should flag an error: feature not visible
 --------------^
 Feature not found: 's' (no arguments)
@@ -2039,7 +1127,7 @@ Target feature: 'visibility_negative.visi9.loop'
 In call: 's'
 
 
---CURDIR--/visibility_negative.fz:577:15: error 256: Could not find called feature
+--CURDIR--/visibility_negative.fz:577:15: error 142: Could not find called feature
         t5 := s    # 296. should flag an error: feature not visible
 --------------^
 Feature not found: 's' (no arguments)
@@ -2047,279 +1135,823 @@ Target feature: 'visibility_negative.visi9.loop'
 In call: 's'
 
 
---CURDIR--/visibility_negative.fz:48:11: error 257: Could not find called feature
-          c3 #  1. should flag an error: feature not found / not visible
+--CURDIR--/visibility_negative.fz:120:11: error 143: Could not find called feature
+      use f2   # 33. should flag an error: feature not found / not visible
 ----------^^
-Feature not found: 'c3' (no arguments)
-Target feature: 'visibility_negative.visi1.a1.b1.c1'
-In call: 'c3'
+Feature not found: 'f2' (no arguments)
+Target feature: 'visibility_negative.visi2.a1'
+In call: 'f2'
 
 
---CURDIR--/visibility_negative.fz:49:11: error 258: Could not find called feature
-          c4 #  2. should flag an error: feature not found / not visible
+--CURDIR--/visibility_negative.fz:121:11: error 144: Could not find called feature
+      use f3   # 34. should flag an error: feature not found / not visible
 ----------^^
-Feature not found: 'c4' (no arguments)
-Target feature: 'visibility_negative.visi1.a1.b1.c1'
-In call: 'c4'
+Feature not found: 'f3' (no arguments)
+Target feature: 'visibility_negative.visi2.a1'
+In call: 'f3'
 
 
---CURDIR--/visibility_negative.fz:50:11: error 259: Could not find called feature
-          b3 #  3. should flag an error: feature not found / not visible
+--CURDIR--/visibility_negative.fz:122:11: error 145: Could not find called feature
+      use f4   # 35. should flag an error: feature not found / not visible
 ----------^^
-Feature not found: 'b3' (no arguments)
-Target feature: 'visibility_negative.visi1.a1.b1.c1'
-In call: 'b3'
+Feature not found: 'f4' (no arguments)
+Target feature: 'visibility_negative.visi2.a1'
+In call: 'f4'
 
 
---CURDIR--/visibility_negative.fz:51:11: error 260: Could not find called feature
-          c5 #  4. should flag an error: feature not found / not visible
+--CURDIR--/visibility_negative.fz:123:11: error 146: Could not find called feature
+      use f5   # 36. should flag an error: feature not found / not visible
 ----------^^
-Feature not found: 'c5' (no arguments)
-Target feature: 'visibility_negative.visi1.a1.b1.c1'
-In call: 'c5'
+Feature not found: 'f5' (no arguments)
+Target feature: 'visibility_negative.visi2.a1'
+In call: 'f5'
 
 
---CURDIR--/visibility_negative.fz:52:11: error 261: Could not find called feature
-          c6 #  5. should flag an error: feature not found / not visible
+--CURDIR--/visibility_negative.fz:124:11: error 147: Could not find called feature
+      use f6   # 37. should flag an error: feature not found / not visible
 ----------^^
-Feature not found: 'c6' (no arguments)
-Target feature: 'visibility_negative.visi1.a1.b1.c1'
-In call: 'c6'
+Feature not found: 'f6' (no arguments)
+Target feature: 'visibility_negative.visi2.a1'
+In call: 'f6'
 
 
---CURDIR--/visibility_negative.fz:57:11: error 262: Could not find called feature
-          c3 #  6. should flag an error: feature not found / not visible
+--CURDIR--/visibility_negative.fz:125:11: error 148: Could not find called feature
+      use f7   # 38. should flag an error: feature not found / not visible
 ----------^^
-Feature not found: 'c3' (no arguments)
-Target feature: 'visibility_negative.visi1.a1.b1.c2'
-In call: 'c3'
+Feature not found: 'f7' (no arguments)
+Target feature: 'visibility_negative.visi2.a1'
+In call: 'f7'
 
 
---CURDIR--/visibility_negative.fz:58:11: error 263: Could not find called feature
-          c4 #  7. should flag an error: feature not found / not visible
+--CURDIR--/visibility_negative.fz:126:11: error 149: Could not find called feature
+      use f8   # 39. should flag an error: feature not found / not visible
 ----------^^
-Feature not found: 'c4' (no arguments)
-Target feature: 'visibility_negative.visi1.a1.b1.c2'
-In call: 'c4'
+Feature not found: 'f8' (no arguments)
+Target feature: 'visibility_negative.visi2.a1'
+In call: 'f8'
 
 
---CURDIR--/visibility_negative.fz:59:11: error 264: Could not find called feature
-          b3 #  8. should flag an error: feature not found / not visible
+--CURDIR--/visibility_negative.fz:127:11: error 150: Could not find called feature
+      use f9   # 40. should flag an error: feature not found / not visible
 ----------^^
-Feature not found: 'b3' (no arguments)
-Target feature: 'visibility_negative.visi1.a1.b1.c2'
-In call: 'b3'
+Feature not found: 'f9' (no arguments)
+Target feature: 'visibility_negative.visi2.a1'
+In call: 'f9'
 
 
---CURDIR--/visibility_negative.fz:60:11: error 265: Could not find called feature
-          c5 #  9. should flag an error: feature not found / not visible
+--CURDIR--/visibility_negative.fz:238:11: error 151: Could not find called feature
+      use f2   # 112. should flag an error: feature not found / not visible
 ----------^^
-Feature not found: 'c5' (no arguments)
-Target feature: 'visibility_negative.visi1.a1.b1.c2'
-In call: 'c5'
+Feature not found: 'f2' (no arguments)
+Target feature: 'visibility_negative.visi2.a1'
+In call: 'f2'
 
 
---CURDIR--/visibility_negative.fz:61:11: error 266: Could not find called feature
-          c6 # 10. should flag an error: feature not found / not visible
+--CURDIR--/visibility_negative.fz:239:11: error 152: Could not find called feature
+      use f3   # 113. should flag an error: feature not found / not visible
 ----------^^
-Feature not found: 'c6' (no arguments)
-Target feature: 'visibility_negative.visi1.a1.b1.c2'
-In call: 'c6'
+Feature not found: 'f3' (no arguments)
+Target feature: 'visibility_negative.visi2.a1'
+In call: 'f3'
 
 
---CURDIR--/visibility_negative.fz:67:11: error 267: Could not find called feature
-          c1 # 11. should flag an error: feature not found / not visible
+--CURDIR--/visibility_negative.fz:240:11: error 153: Could not find called feature
+      use f4   # 114. should flag an error: feature not found / not visible
 ----------^^
-Feature not found: 'c1' (no arguments)
-Target feature: 'visibility_negative.visi1.a1.b2.c3'
-In call: 'c1'
+Feature not found: 'f4' (no arguments)
+Target feature: 'visibility_negative.visi2.a1'
+In call: 'f4'
 
 
---CURDIR--/visibility_negative.fz:68:11: error 268: Could not find called feature
-          c2 # 12. should flag an error: feature not found / not visible
+--CURDIR--/visibility_negative.fz:241:11: error 154: Could not find called feature
+      use f5   # 115. should flag an error: feature not found / not visible
 ----------^^
-Feature not found: 'c2' (no arguments)
-Target feature: 'visibility_negative.visi1.a1.b2.c3'
-In call: 'c2'
+Feature not found: 'f5' (no arguments)
+Target feature: 'visibility_negative.visi2.a1'
+In call: 'f5'
 
 
---CURDIR--/visibility_negative.fz:69:11: error 269: Could not find called feature
-          b3 # 13. should flag an error: feature not found / not visible
+--CURDIR--/visibility_negative.fz:242:11: error 155: Could not find called feature
+      use f6   # 116. should flag an error: feature not found / not visible
 ----------^^
-Feature not found: 'b3' (no arguments)
-Target feature: 'visibility_negative.visi1.a1.b2.c3'
-In call: 'b3'
+Feature not found: 'f6' (no arguments)
+Target feature: 'visibility_negative.visi2.a1'
+In call: 'f6'
 
 
---CURDIR--/visibility_negative.fz:70:11: error 270: Could not find called feature
-          c5 # 14. should flag an error: feature not found / not visible
+--CURDIR--/visibility_negative.fz:243:11: error 156: Could not find called feature
+      use f7   # 117. should flag an error: feature not found / not visible
 ----------^^
-Feature not found: 'c5' (no arguments)
-Target feature: 'visibility_negative.visi1.a1.b2.c3'
-In call: 'c5'
+Feature not found: 'f7' (no arguments)
+Target feature: 'visibility_negative.visi2.a1'
+In call: 'f7'
 
 
---CURDIR--/visibility_negative.fz:71:11: error 271: Could not find called feature
-          c6 # 15. should flag an error: feature not found / not visible
+--CURDIR--/visibility_negative.fz:244:11: error 157: Could not find called feature
+      use f8   # 118. should flag an error: feature not found / not visible
 ----------^^
-Feature not found: 'c6' (no arguments)
-Target feature: 'visibility_negative.visi1.a1.b2.c3'
-In call: 'c6'
+Feature not found: 'f8' (no arguments)
+Target feature: 'visibility_negative.visi2.a1'
+In call: 'f8'
 
 
---CURDIR--/visibility_negative.fz:76:11: error 272: Could not find called feature
-          c1 # 16. should flag an error: feature not found / not visible
+--CURDIR--/visibility_negative.fz:245:11: error 158: Could not find called feature
+      use f9   # 119. should flag an error: feature not found / not visible
 ----------^^
-Feature not found: 'c1' (no arguments)
-Target feature: 'visibility_negative.visi1.a1.b2.c4'
-In call: 'c1'
+Feature not found: 'f9' (no arguments)
+Target feature: 'visibility_negative.visi2.a1'
+In call: 'f9'
 
 
---CURDIR--/visibility_negative.fz:77:11: error 273: Could not find called feature
-          c2 # 17. should flag an error: feature not found / not visible
+--CURDIR--/visibility_negative.fz:248:11: error 159: Could not find called feature
+      use f2   # 120. should flag an error: feature not found / not visible
 ----------^^
-Feature not found: 'c2' (no arguments)
-Target feature: 'visibility_negative.visi1.a1.b2.c4'
-In call: 'c2'
+Feature not found: 'f2' (no arguments)
+Target feature: 'visibility_negative.visi2.a1'
+In call: 'f2'
 
 
---CURDIR--/visibility_negative.fz:78:11: error 274: Could not find called feature
-          b3 # 18. should flag an error: feature not found / not visible
+--CURDIR--/visibility_negative.fz:249:11: error 160: Could not find called feature
+      use f3   # 121. should flag an error: feature not found / not visible
 ----------^^
-Feature not found: 'b3' (no arguments)
-Target feature: 'visibility_negative.visi1.a1.b2.c4'
-In call: 'b3'
+Feature not found: 'f3' (no arguments)
+Target feature: 'visibility_negative.visi2.a1'
+In call: 'f3'
 
 
---CURDIR--/visibility_negative.fz:79:11: error 275: Could not find called feature
-          c5 # 19. should flag an error: feature not found / not visible
+--CURDIR--/visibility_negative.fz:250:11: error 161: Could not find called feature
+      use f4   # 122. should flag an error: feature not found / not visible
 ----------^^
-Feature not found: 'c5' (no arguments)
-Target feature: 'visibility_negative.visi1.a1.b2.c4'
-In call: 'c5'
+Feature not found: 'f4' (no arguments)
+Target feature: 'visibility_negative.visi2.a1'
+In call: 'f4'
 
 
---CURDIR--/visibility_negative.fz:80:11: error 276: Could not find called feature
-          c6 # 20. should flag an error: feature not found / not visible
+--CURDIR--/visibility_negative.fz:251:11: error 162: Could not find called feature
+      use f5   # 123. should flag an error: feature not found / not visible
 ----------^^
-Feature not found: 'c6' (no arguments)
-Target feature: 'visibility_negative.visi1.a1.b2.c4'
-In call: 'c6'
+Feature not found: 'f5' (no arguments)
+Target feature: 'visibility_negative.visi2.a1'
+In call: 'f5'
 
 
---CURDIR--/visibility_negative.fz:87:11: error 277: Could not find called feature
-          c1 # 21. should flag an error: feature not found / not visible
+--CURDIR--/visibility_negative.fz:252:11: error 163: Could not find called feature
+      use f6   # 124. should flag an error: feature not found / not visible
 ----------^^
-Feature not found: 'c1' (no arguments)
-Target feature: 'visibility_negative.visi1.a2.b3.c5'
-In call: 'c1'
+Feature not found: 'f6' (no arguments)
+Target feature: 'visibility_negative.visi2.a1'
+In call: 'f6'
 
 
---CURDIR--/visibility_negative.fz:88:11: error 278: Could not find called feature
-          c2 # 22. should flag an error: feature not found / not visible
+--CURDIR--/visibility_negative.fz:253:11: error 164: Could not find called feature
+      use f7   # 125. should flag an error: feature not found / not visible
 ----------^^
-Feature not found: 'c2' (no arguments)
-Target feature: 'visibility_negative.visi1.a2.b3.c5'
-In call: 'c2'
+Feature not found: 'f7' (no arguments)
+Target feature: 'visibility_negative.visi2.a1'
+In call: 'f7'
 
 
---CURDIR--/visibility_negative.fz:89:11: error 279: Could not find called feature
-          c3 # 23. should flag an error: feature not found / not visible
+--CURDIR--/visibility_negative.fz:255:11: error 165: Could not find called feature
+      use f9   # 126. should flag an error: feature not found / not visible
 ----------^^
-Feature not found: 'c3' (no arguments)
-Target feature: 'visibility_negative.visi1.a2.b3.c5'
-In call: 'c3'
+Feature not found: 'f9' (no arguments)
+Target feature: 'visibility_negative.visi2.a1'
+In call: 'f9'
 
 
---CURDIR--/visibility_negative.fz:90:11: error 280: Could not find called feature
-          c4 # 24. should flag an error: feature not found / not visible
+--CURDIR--/visibility_negative.fz:278:11: error 166: Could not find called feature
+      use f2   # 140. should flag an error: feature not found / not visible
 ----------^^
-Feature not found: 'c4' (no arguments)
-Target feature: 'visibility_negative.visi1.a2.b3.c5'
-In call: 'c4'
+Feature not found: 'f2' (no arguments)
+Target feature: 'visibility_negative.visi2.a1'
+In call: 'f2'
 
 
---CURDIR--/visibility_negative.fz:91:11: error 281: Could not find called feature
-          b1 # 25. should flag an error: feature not found / not visible
+--CURDIR--/visibility_negative.fz:279:11: error 167: Could not find called feature
+      use f3   # 141. should flag an error: feature not found / not visible
 ----------^^
-Feature not found: 'b1' (no arguments)
-Target feature: 'visibility_negative.visi1.a2.b3.c5'
-In call: 'b1'
+Feature not found: 'f3' (no arguments)
+Target feature: 'visibility_negative.visi2.a1'
+In call: 'f3'
 
 
---CURDIR--/visibility_negative.fz:92:11: error 282: Could not find called feature
-          b2 # 26. should flag an error: feature not found / not visible
+--CURDIR--/visibility_negative.fz:280:11: error 168: Could not find called feature
+      use f4   # 142. should flag an error: feature not found / not visible
 ----------^^
-Feature not found: 'b2' (no arguments)
-Target feature: 'visibility_negative.visi1.a2.b3.c5'
-In call: 'b2'
+Feature not found: 'f4' (no arguments)
+Target feature: 'visibility_negative.visi2.a1'
+In call: 'f4'
 
 
---CURDIR--/visibility_negative.fz:97:11: error 283: Could not find called feature
-          c1 # 27. should flag an error: feature not found / not visible
+--CURDIR--/visibility_negative.fz:281:11: error 169: Could not find called feature
+      use f5   # 143. should flag an error: feature not found / not visible
 ----------^^
-Feature not found: 'c1' (no arguments)
-Target feature: 'visibility_negative.visi1.a2.b3.c6'
-In call: 'c1'
+Feature not found: 'f5' (no arguments)
+Target feature: 'visibility_negative.visi2.a1'
+In call: 'f5'
 
 
---CURDIR--/visibility_negative.fz:98:11: error 284: Could not find called feature
-          c2 # 28. should flag an error: feature not found / not visible
+--CURDIR--/visibility_negative.fz:282:11: error 170: Could not find called feature
+      use f6   # 144. should flag an error: feature not found / not visible
 ----------^^
-Feature not found: 'c2' (no arguments)
-Target feature: 'visibility_negative.visi1.a2.b3.c6'
-In call: 'c2'
+Feature not found: 'f6' (no arguments)
+Target feature: 'visibility_negative.visi2.a1'
+In call: 'f6'
 
 
---CURDIR--/visibility_negative.fz:99:11: error 285: Could not find called feature
-          c3 # 29. should flag an error: feature not found / not visible
+--CURDIR--/visibility_negative.fz:283:11: error 171: Could not find called feature
+      use f7   # 145. should flag an error: feature not found / not visible
 ----------^^
-Feature not found: 'c3' (no arguments)
-Target feature: 'visibility_negative.visi1.a2.b3.c6'
-In call: 'c3'
+Feature not found: 'f7' (no arguments)
+Target feature: 'visibility_negative.visi2.a1'
+In call: 'f7'
 
 
---CURDIR--/visibility_negative.fz:100:11: error 286: Could not find called feature
-          c4 # 30. should flag an error: feature not found / not visible
+--CURDIR--/visibility_negative.fz:285:11: error 172: Could not find called feature
+      use f9   # 146. should flag an error: feature not found / not visible
 ----------^^
-Feature not found: 'c4' (no arguments)
-Target feature: 'visibility_negative.visi1.a2.b3.c6'
-In call: 'c4'
+Feature not found: 'f9' (no arguments)
+Target feature: 'visibility_negative.visi2.a1'
+In call: 'f9'
 
 
---CURDIR--/visibility_negative.fz:101:11: error 287: Could not find called feature
-          b1 # 31. should flag an error: feature not found / not visible
-----------^^
-Feature not found: 'b1' (no arguments)
-Target feature: 'visibility_negative.visi1.a2.b3.c6'
-In call: 'b1'
+--CURDIR--/visibility_negative.fz:130:13: error 173: Could not find called feature
+        use f2   # 41. should flag an error: feature not found / not visible
+------------^^
+Feature not found: 'f2' (no arguments)
+Target feature: 'visibility_negative.visi2.a1.b1'
+In call: 'f2'
 
 
---CURDIR--/visibility_negative.fz:102:11: error 288: Could not find called feature
-          b2 # 32. should flag an error: feature not found / not visible
-----------^^
-Feature not found: 'b2' (no arguments)
-Target feature: 'visibility_negative.visi1.a2.b3.c6'
-In call: 'b2'
+--CURDIR--/visibility_negative.fz:131:13: error 174: Could not find called feature
+        use f3   # 42. should flag an error: feature not found / not visible
+------------^^
+Feature not found: 'f3' (no arguments)
+Target feature: 'visibility_negative.visi2.a1.b1'
+In call: 'f3'
 
 
---CURDIR--/visibility_negative.fz:527:5: error 289: Could not find called feature
-    b # 273. should flag an error: feature not visible
-----^
-Feature not found: 'b' (no arguments)
-Target feature: 'visibility_negative.visi8'
-In call: 'b'
+--CURDIR--/visibility_negative.fz:132:13: error 175: Could not find called feature
+        use f4   # 43. should flag an error: feature not found / not visible
+------------^^
+Feature not found: 'f4' (no arguments)
+Target feature: 'visibility_negative.visi2.a1.b1'
+In call: 'f4'
 
 
---CURDIR--/visibility_negative.fz:528:5: error 290: Could not find called feature
-    c # 274. should flag an error: feature not visible
-----^
-Feature not found: 'c' (no arguments)
-Target feature: 'visibility_negative.visi8'
-In call: 'c'
+--CURDIR--/visibility_negative.fz:133:13: error 176: Could not find called feature
+        use f5   # 44. should flag an error: feature not found / not visible
+------------^^
+Feature not found: 'f5' (no arguments)
+Target feature: 'visibility_negative.visi2.a1.b1'
+In call: 'f5'
 
 
---CURDIR--/visibility_negative.fz:534:9: error 291: Could not find called feature
+--CURDIR--/visibility_negative.fz:134:13: error 177: Could not find called feature
+        use f6   # 45. should flag an error: feature not found / not visible
+------------^^
+Feature not found: 'f6' (no arguments)
+Target feature: 'visibility_negative.visi2.a1.b1'
+In call: 'f6'
+
+
+--CURDIR--/visibility_negative.fz:135:13: error 178: Could not find called feature
+        use f7   # 46. should flag an error: feature not found / not visible
+------------^^
+Feature not found: 'f7' (no arguments)
+Target feature: 'visibility_negative.visi2.a1.b1'
+In call: 'f7'
+
+
+--CURDIR--/visibility_negative.fz:137:13: error 179: Could not find called feature
+        use f9   # 48. should flag an error: feature not found / not visible
+------------^^
+Feature not found: 'f9' (no arguments)
+Target feature: 'visibility_negative.visi2.a1.b1'
+In call: 'f9'
+
+
+--CURDIR--/visibility_negative.fz:141:13: error 180: Could not find called feature
+        use f3   # 49. should flag an error: feature not found / not visible
+------------^^
+Feature not found: 'f3' (no arguments)
+Target feature: 'visibility_negative.visi2.a1.b1'
+In call: 'f3'
+
+
+--CURDIR--/visibility_negative.fz:142:13: error 181: Could not find called feature
+        use f4   # 50. should flag an error: feature not found / not visible
+------------^^
+Feature not found: 'f4' (no arguments)
+Target feature: 'visibility_negative.visi2.a1.b1'
+In call: 'f4'
+
+
+--CURDIR--/visibility_negative.fz:143:13: error 182: Could not find called feature
+        use f5   # 51. should flag an error: feature not found / not visible
+------------^^
+Feature not found: 'f5' (no arguments)
+Target feature: 'visibility_negative.visi2.a1.b1'
+In call: 'f5'
+
+
+--CURDIR--/visibility_negative.fz:144:13: error 183: Could not find called feature
+        use f6   # 52. should flag an error: feature not found / not visible
+------------^^
+Feature not found: 'f6' (no arguments)
+Target feature: 'visibility_negative.visi2.a1.b1'
+In call: 'f6'
+
+
+--CURDIR--/visibility_negative.fz:145:13: error 184: Could not find called feature
+        use f7   # 53. should flag an error: feature not found / not visible
+------------^^
+Feature not found: 'f7' (no arguments)
+Target feature: 'visibility_negative.visi2.a1.b1'
+In call: 'f7'
+
+
+--CURDIR--/visibility_negative.fz:147:13: error 185: Could not find called feature
+        use f9   # 55. should flag an error: feature not found / not visible
+------------^^
+Feature not found: 'f9' (no arguments)
+Target feature: 'visibility_negative.visi2.a1.b1'
+In call: 'f9'
+
+
+--CURDIR--/visibility_negative.fz:180:13: error 186: Could not find called feature
+        use f3   # 74. should flag an error: feature not found / not visible
+------------^^
+Feature not found: 'f3' (no arguments)
+Target feature: 'visibility_negative.visi2.a1.b1'
+In call: 'f3'
+
+
+--CURDIR--/visibility_negative.fz:181:13: error 187: Could not find called feature
+        use f4   # 75. should flag an error: feature not found / not visible
+------------^^
+Feature not found: 'f4' (no arguments)
+Target feature: 'visibility_negative.visi2.a1.b1'
+In call: 'f4'
+
+
+--CURDIR--/visibility_negative.fz:182:13: error 188: Could not find called feature
+        use f5   # 76. should flag an error: feature not found / not visible
+------------^^
+Feature not found: 'f5' (no arguments)
+Target feature: 'visibility_negative.visi2.a1.b1'
+In call: 'f5'
+
+
+--CURDIR--/visibility_negative.fz:183:13: error 189: Could not find called feature
+        use f6   # 77. should flag an error: feature not found / not visible
+------------^^
+Feature not found: 'f6' (no arguments)
+Target feature: 'visibility_negative.visi2.a1.b1'
+In call: 'f6'
+
+
+--CURDIR--/visibility_negative.fz:184:13: error 190: Could not find called feature
+        use f7   # 78. should flag an error: feature not found / not visible
+------------^^
+Feature not found: 'f7' (no arguments)
+Target feature: 'visibility_negative.visi2.a1.b1'
+In call: 'f7'
+
+
+--CURDIR--/visibility_negative.fz:186:13: error 191: Could not find called feature
+        use f9   # 80. should flag an error: feature not found / not visible
+------------^^
+Feature not found: 'f9' (no arguments)
+Target feature: 'visibility_negative.visi2.a1.b1'
+In call: 'f9'
+
+
+--CURDIR--/visibility_negative.fz:220:13: error 192: Could not find called feature
+        use f3   # 99. should flag an error: feature not found / not visible
+------------^^
+Feature not found: 'f3' (no arguments)
+Target feature: 'visibility_negative.visi2.a1.b1'
+In call: 'f3'
+
+
+--CURDIR--/visibility_negative.fz:221:13: error 193: Could not find called feature
+        use f4   # 100. should flag an error: feature not found / not visible
+------------^^
+Feature not found: 'f4' (no arguments)
+Target feature: 'visibility_negative.visi2.a1.b1'
+In call: 'f4'
+
+
+--CURDIR--/visibility_negative.fz:222:13: error 194: Could not find called feature
+        use f5   # 101. should flag an error: feature not found / not visible
+------------^^
+Feature not found: 'f5' (no arguments)
+Target feature: 'visibility_negative.visi2.a1.b1'
+In call: 'f5'
+
+
+--CURDIR--/visibility_negative.fz:223:13: error 195: Could not find called feature
+        use f6   # 102. should flag an error: feature not found / not visible
+------------^^
+Feature not found: 'f6' (no arguments)
+Target feature: 'visibility_negative.visi2.a1.b1'
+In call: 'f6'
+
+
+--CURDIR--/visibility_negative.fz:224:13: error 196: Could not find called feature
+        use f7   # 103. should flag an error: feature not found / not visible
+------------^^
+Feature not found: 'f7' (no arguments)
+Target feature: 'visibility_negative.visi2.a1.b1'
+In call: 'f7'
+
+
+--CURDIR--/visibility_negative.fz:226:13: error 197: Could not find called feature
+        use f9   # 105. should flag an error: feature not found / not visible
+------------^^
+Feature not found: 'f9' (no arguments)
+Target feature: 'visibility_negative.visi2.a1.b1'
+In call: 'f9'
+
+
+--CURDIR--/visibility_negative.fz:230:13: error 198: Could not find called feature
+        use f3   # 106. should flag an error: feature not found / not visible
+------------^^
+Feature not found: 'f3' (no arguments)
+Target feature: 'visibility_negative.visi2.a1.b1'
+In call: 'f3'
+
+
+--CURDIR--/visibility_negative.fz:231:13: error 199: Could not find called feature
+        use f4   # 107. should flag an error: feature not found / not visible
+------------^^
+Feature not found: 'f4' (no arguments)
+Target feature: 'visibility_negative.visi2.a1.b1'
+In call: 'f4'
+
+
+--CURDIR--/visibility_negative.fz:232:13: error 200: Could not find called feature
+        use f5   # 108. should flag an error: feature not found / not visible
+------------^^
+Feature not found: 'f5' (no arguments)
+Target feature: 'visibility_negative.visi2.a1.b1'
+In call: 'f5'
+
+
+--CURDIR--/visibility_negative.fz:233:13: error 201: Could not find called feature
+        use f6   # 109. should flag an error: feature not found / not visible
+------------^^
+Feature not found: 'f6' (no arguments)
+Target feature: 'visibility_negative.visi2.a1.b1'
+In call: 'f6'
+
+
+--CURDIR--/visibility_negative.fz:236:13: error 202: Could not find called feature
+        use f9   # 111. should flag an error: feature not found / not visible
+------------^^
+Feature not found: 'f9' (no arguments)
+Target feature: 'visibility_negative.visi2.a1.b1'
+In call: 'f9'
+
+
+--CURDIR--/visibility_negative.fz:151:15: error 203: Could not find called feature
+          use f3   # 56. should flag an error: feature not found / not visible
+--------------^^
+Feature not found: 'f3' (no arguments)
+Target feature: 'visibility_negative.visi2.a1.b1.c1'
+In call: 'f3'
+
+
+--CURDIR--/visibility_negative.fz:152:15: error 204: Could not find called feature
+          use f4   # 57. should flag an error: feature not found / not visible
+--------------^^
+Feature not found: 'f4' (no arguments)
+Target feature: 'visibility_negative.visi2.a1.b1.c1'
+In call: 'f4'
+
+
+--CURDIR--/visibility_negative.fz:153:15: error 205: Could not find called feature
+          use f5   # 58. should flag an error: feature not found / not visible
+--------------^^
+Feature not found: 'f5' (no arguments)
+Target feature: 'visibility_negative.visi2.a1.b1.c1'
+In call: 'f5'
+
+
+--CURDIR--/visibility_negative.fz:154:15: error 206: Could not find called feature
+          use f6   # 59. should flag an error: feature not found / not visible
+--------------^^
+Feature not found: 'f6' (no arguments)
+Target feature: 'visibility_negative.visi2.a1.b1.c1'
+In call: 'f6'
+
+
+--CURDIR--/visibility_negative.fz:157:15: error 207: Could not find called feature
+          use f9   # 62. should flag an error: feature not found / not visible
+--------------^^
+Feature not found: 'f9' (no arguments)
+Target feature: 'visibility_negative.visi2.a1.b1.c1'
+In call: 'f9'
+
+
+--CURDIR--/visibility_negative.fz:162:15: error 208: Could not find called feature
+          use f4   # 63. should flag an error: feature not found / not visible
+--------------^^
+Feature not found: 'f4' (no arguments)
+Target feature: 'visibility_negative.visi2.a1.b1.c1'
+In call: 'f4'
+
+
+--CURDIR--/visibility_negative.fz:163:15: error 209: Could not find called feature
+          use f5   # 64. should flag an error: feature not found / not visible
+--------------^^
+Feature not found: 'f5' (no arguments)
+Target feature: 'visibility_negative.visi2.a1.b1.c1'
+In call: 'f5'
+
+
+--CURDIR--/visibility_negative.fz:164:15: error 210: Could not find called feature
+          use f6   # 65. should flag an error: feature not found / not visible
+--------------^^
+Feature not found: 'f6' (no arguments)
+Target feature: 'visibility_negative.visi2.a1.b1.c1'
+In call: 'f6'
+
+
+--CURDIR--/visibility_negative.fz:167:15: error 211: Could not find called feature
+          use f9   # 68. should flag an error: feature not found / not visible
+--------------^^
+Feature not found: 'f9' (no arguments)
+Target feature: 'visibility_negative.visi2.a1.b1.c1'
+In call: 'f9'
+
+
+--CURDIR--/visibility_negative.fz:173:15: error 212: Could not find called feature
+          use f5   # 69. should flag an error: feature not found / not visible
+--------------^^
+Feature not found: 'f5' (no arguments)
+Target feature: 'visibility_negative.visi2.a1.b1.c1'
+In call: 'f5'
+
+
+--CURDIR--/visibility_negative.fz:174:15: error 213: Could not find called feature
+          use f6   # 70. should flag an error: feature not found / not visible
+--------------^^
+Feature not found: 'f6' (no arguments)
+Target feature: 'visibility_negative.visi2.a1.b1.c1'
+In call: 'f6'
+
+
+--CURDIR--/visibility_negative.fz:177:15: error 214: Could not find called feature
+          use f9   # 73. should flag an error: feature not found / not visible
+--------------^^
+Feature not found: 'f9' (no arguments)
+Target feature: 'visibility_negative.visi2.a1.b1.c1'
+In call: 'f9'
+
+
+--CURDIR--/visibility_negative.fz:191:15: error 215: Could not find called feature
+          use f3   # 81. should flag an error: feature not found / not visible
+--------------^^
+Feature not found: 'f3' (no arguments)
+Target feature: 'visibility_negative.visi2.a1.b1.c2'
+In call: 'f3'
+
+
+--CURDIR--/visibility_negative.fz:192:15: error 216: Could not find called feature
+          use f4   # 82. should flag an error: feature not found / not visible
+--------------^^
+Feature not found: 'f4' (no arguments)
+Target feature: 'visibility_negative.visi2.a1.b1.c2'
+In call: 'f4'
+
+
+--CURDIR--/visibility_negative.fz:193:15: error 217: Could not find called feature
+          use f5   # 83. should flag an error: feature not found / not visible
+--------------^^
+Feature not found: 'f5' (no arguments)
+Target feature: 'visibility_negative.visi2.a1.b1.c2'
+In call: 'f5'
+
+
+--CURDIR--/visibility_negative.fz:194:15: error 218: Could not find called feature
+          use f6   # 84. should flag an error: feature not found / not visible
+--------------^^
+Feature not found: 'f6' (no arguments)
+Target feature: 'visibility_negative.visi2.a1.b1.c2'
+In call: 'f6'
+
+
+--CURDIR--/visibility_negative.fz:197:15: error 219: Could not find called feature
+          use f9   # 87. should flag an error: feature not found / not visible
+--------------^^
+Feature not found: 'f9' (no arguments)
+Target feature: 'visibility_negative.visi2.a1.b1.c2'
+In call: 'f9'
+
+
+--CURDIR--/visibility_negative.fz:201:15: error 220: Could not find called feature
+          use f3   # 88. should flag an error: feature not found / not visible
+--------------^^
+Feature not found: 'f3' (no arguments)
+Target feature: 'visibility_negative.visi2.a1.b1.c2'
+In call: 'f3'
+
+
+--CURDIR--/visibility_negative.fz:202:15: error 221: Could not find called feature
+          use f4   # 89. should flag an error: feature not found / not visible
+--------------^^
+Feature not found: 'f4' (no arguments)
+Target feature: 'visibility_negative.visi2.a1.b1.c2'
+In call: 'f4'
+
+
+--CURDIR--/visibility_negative.fz:204:15: error 222: Could not find called feature
+          use f6   # 90. should flag an error: feature not found / not visible
+--------------^^
+Feature not found: 'f6' (no arguments)
+Target feature: 'visibility_negative.visi2.a1.b1.c2'
+In call: 'f6'
+
+
+--CURDIR--/visibility_negative.fz:207:15: error 223: Could not find called feature
+          use f9   # 93. should flag an error: feature not found / not visible
+--------------^^
+Feature not found: 'f9' (no arguments)
+Target feature: 'visibility_negative.visi2.a1.b1.c2'
+In call: 'f9'
+
+
+--CURDIR--/visibility_negative.fz:211:15: error 224: Could not find called feature
+          use f3   # 94. should flag an error: feature not found / not visible
+--------------^^
+Feature not found: 'f3' (no arguments)
+Target feature: 'visibility_negative.visi2.a1.b1.c2'
+In call: 'f3'
+
+
+--CURDIR--/visibility_negative.fz:212:15: error 225: Could not find called feature
+          use f4   # 95. should flag an error: feature not found / not visible
+--------------^^
+Feature not found: 'f4' (no arguments)
+Target feature: 'visibility_negative.visi2.a1.b1.c2'
+In call: 'f4'
+
+
+--CURDIR--/visibility_negative.fz:217:15: error 226: Could not find called feature
+          use f9   # 98. should flag an error: feature not found / not visible
+--------------^^
+Feature not found: 'f9' (no arguments)
+Target feature: 'visibility_negative.visi2.a1.b1.c2'
+In call: 'f9'
+
+
+--CURDIR--/visibility_negative.fz:259:13: error 227: Could not find called feature
+        use f2   # 127. should flag an error: feature not found / not visible
+------------^^
+Feature not found: 'f2' (no arguments)
+Target feature: 'visibility_negative.visi2.a1.b2'
+In call: 'f2'
+
+
+--CURDIR--/visibility_negative.fz:260:13: error 228: Could not find called feature
+        use f3   # 128. should flag an error: feature not found / not visible
+------------^^
+Feature not found: 'f3' (no arguments)
+Target feature: 'visibility_negative.visi2.a1.b2'
+In call: 'f3'
+
+
+--CURDIR--/visibility_negative.fz:261:13: error 229: Could not find called feature
+        use f4   # 129. should flag an error: feature not found / not visible
+------------^^
+Feature not found: 'f4' (no arguments)
+Target feature: 'visibility_negative.visi2.a1.b2'
+In call: 'f4'
+
+
+--CURDIR--/visibility_negative.fz:262:13: error 230: Could not find called feature
+        use f5   # 130. should flag an error: feature not found / not visible
+------------^^
+Feature not found: 'f5' (no arguments)
+Target feature: 'visibility_negative.visi2.a1.b2'
+In call: 'f5'
+
+
+--CURDIR--/visibility_negative.fz:263:13: error 231: Could not find called feature
+        use f6   # 131. should flag an error: feature not found / not visible
+------------^^
+Feature not found: 'f6' (no arguments)
+Target feature: 'visibility_negative.visi2.a1.b2'
+In call: 'f6'
+
+
+--CURDIR--/visibility_negative.fz:264:13: error 232: Could not find called feature
+        use f7   # 132. should flag an error: feature not found / not visible
+------------^^
+Feature not found: 'f7' (no arguments)
+Target feature: 'visibility_negative.visi2.a1.b2'
+In call: 'f7'
+
+
+--CURDIR--/visibility_negative.fz:266:13: error 233: Could not find called feature
+        use f9   # 133. should flag an error: feature not found / not visible
+------------^^
+Feature not found: 'f9' (no arguments)
+Target feature: 'visibility_negative.visi2.a1.b2'
+In call: 'f9'
+
+
+--CURDIR--/visibility_negative.fz:269:13: error 234: Could not find called feature
+        use f2   # 134. should flag an error: feature not found / not visible
+------------^^
+Feature not found: 'f2' (no arguments)
+Target feature: 'visibility_negative.visi2.a1.b2'
+In call: 'f2'
+
+
+--CURDIR--/visibility_negative.fz:270:13: error 235: Could not find called feature
+        use f3   # 135. should flag an error: feature not found / not visible
+------------^^
+Feature not found: 'f3' (no arguments)
+Target feature: 'visibility_negative.visi2.a1.b2'
+In call: 'f3'
+
+
+--CURDIR--/visibility_negative.fz:271:13: error 236: Could not find called feature
+        use f4   # 136. should flag an error: feature not found / not visible
+------------^^
+Feature not found: 'f4' (no arguments)
+Target feature: 'visibility_negative.visi2.a1.b2'
+In call: 'f4'
+
+
+--CURDIR--/visibility_negative.fz:272:13: error 237: Could not find called feature
+        use f5   # 137. should flag an error: feature not found / not visible
+------------^^
+Feature not found: 'f5' (no arguments)
+Target feature: 'visibility_negative.visi2.a1.b2'
+In call: 'f5'
+
+
+--CURDIR--/visibility_negative.fz:273:13: error 238: Could not find called feature
+        use f6   # 138. should flag an error: feature not found / not visible
+------------^^
+Feature not found: 'f6' (no arguments)
+Target feature: 'visibility_negative.visi2.a1.b2'
+In call: 'f6'
+
+
+--CURDIR--/visibility_negative.fz:274:13: error 239: Could not find called feature
+        use f7   # 139. should flag an error: feature not found / not visible
+------------^^
+Feature not found: 'f7' (no arguments)
+Target feature: 'visibility_negative.visi2.a1.b2'
+In call: 'f7'
+
+
+--CURDIR--/visibility_negative.fz:471:13: error 240: Could not find called feature
+      chck (x = "Outer!") "outer x"               # 261. should flag an error: field used before it is declared
+------------^
+Feature not found: 'x' (no arguments)
+Target feature: 'visibility_negative.visi5.a'
+In call: 'x'
+
+
+--CURDIR--/visibility_negative.fz:472:20: error 241: Could not find called feature
+      chck (a.this.x = "Outer!") "a.this.x"       # 262. should flag an error: field used before it is declared
+-------------------^
+Feature not found: 'x' (no arguments)
+Target feature: 'visibility_negative.visi5.a'
+In call: 'a.this.x'
+
+
+--CURDIR--/visibility_negative.fz:483:22: error 242: Could not find called feature
+        chck (b.this.x = "Inner!") "b.this.x"       # 267. should flag an error: feature used before it is declared
+---------------------^
+Feature not found: 'x' (no arguments)
+Target feature: 'visibility_negative.visi5.a.b'
+In call: 'b.this.x'
+
+
+--CURDIR--/visibility_negative.fz:495:24: error 243: Could not find called feature
+          chck (c.this.x = "Inner Inner!") "c.this.x" # 270. should flag an error: feature used before it is declared
+-----------------------^
+Feature not found: 'x' (no arguments)
+Target feature: 'visibility_negative.visi5.a.b.c'
+In call: 'c.this.x'
+
+
+--CURDIR--/visibility_negative.fz:505:16: error 244: Could not find called feature
+    say "x is $x"   # 271. should flag an error: feature used before it is declared
+---------------^
+Feature not found: 'x' (no arguments)
+Target feature: 'visibility_negative.visi6'
+In call: 'x'
+
+
+--CURDIR--/visibility_negative.fz:534:9: error 245: Could not find called feature
         c # 276. should flag an error: feature not visible
 --------^
 Feature not found: 'c' (no arguments)
@@ -2327,12 +1959,380 @@ Target feature: 'visibility_negative.visi8'
 In call: 'c'
 
 
---CURDIR--/visibility_negative.fz:540:9: error 292: Could not find called feature
+--CURDIR--/visibility_negative.fz:540:9: error 246: Could not find called feature
         b # 278. should flag an error: feature not visible
 --------^
 Feature not found: 'b' (no arguments)
 Target feature: 'visibility_negative.visi8'
 In call: 'b'
+
+
+--CURDIR--/visibility_negative.fz:562:12: error 247: Could not find called feature
+           b = 3 && # 285. should flag an error: feature not visible
+-----------^
+Feature not found: 'b' (no arguments)
+Target feature: 'visibility_negative.visi9.loop'
+In call: 'b'
+
+
+--CURDIR--/visibility_negative.fz:563:12: error 248: Could not find called feature
+           q = 3 && # 286. should flag an error: feature not visible
+-----------^
+Feature not found: 'q' (no arguments)
+Target feature: 'visibility_negative.visi9.loop'
+In call: 'q'
+
+
+--CURDIR--/visibility_negative.fz:564:12: error 249: Could not find called feature
+           r = 3 && # 287. should flag an error: feature not visible
+-----------^
+Feature not found: 'r' (no arguments)
+Target feature: 'visibility_negative.visi9.loop'
+In call: 'r'
+
+
+--CURDIR--/visibility_negative.fz:565:12: error 250: Could not find called feature
+           s = 3  ) # 288. should flag an error: feature not visible
+-----------^
+Feature not found: 's' (no arguments)
+Target feature: 'visibility_negative.visi9.loop'
+In call: 's'
+
+
+--CURDIR--/visibility_negative.fz:572:12: error 251: Could not find called feature
+           r = 3 &&  # 292. should flag an error: feature not visible
+-----------^
+Feature not found: 'r' (no arguments)
+Target feature: 'visibility_negative.visi9.loop'
+In call: 'r'
+
+
+--CURDIR--/visibility_negative.fz:573:12: error 252: Could not find called feature
+           s = 3 )   # 293. should flag an error: feature not visible
+-----------^
+Feature not found: 's' (no arguments)
+Target feature: 'visibility_negative.visi9.loop'
+In call: 's'
+
+
+--CURDIR--/visibility_negative.fz:607:12: error 253: Could not find called feature
+    while (r = 3 &&     # 315a. should flag an error: feature not visible
+-----------^
+Feature not found: 'r' (no arguments)
+Target feature: 'visibility_negative.visi10.loop'
+In call: 'r'
+
+
+--CURDIR--/visibility_negative.fz:608:12: error 254: Could not find called feature
+           q = 4)       # 315b. should flag an error: feature not visible
+-----------^
+Feature not found: 'q' (no arguments)
+Target feature: 'visibility_negative.visi10.loop'
+In call: 'q'
+
+
+--CURDIR--/visibility_negative.fz:627:12: error 255: Could not find called feature
+    while (q = 3 &&     # 321a. should flag an error: feature not visible
+-----------^
+Feature not found: 'q' (no arguments)
+Target feature: 'visibility_negative.visi11.loop'
+In call: 'q'
+
+
+--CURDIR--/visibility_negative.fz:628:12: error 256: Could not find called feature
+           r = 4)       # 321b. should flag an error: feature not visible
+-----------^
+Feature not found: 'r' (no arguments)
+Target feature: 'visibility_negative.visi11.loop'
+In call: 'r'
+
+
+--CURDIR--/visibility_negative.fz:646:8: error 257: Could not find called feature
+   say b  # 327. should flag an error: feature not visible
+-------^
+Feature not found: 'b' (no arguments)
+Target feature: 'visibility_negative.visiA'
+In call: 'b'
+
+
+--CURDIR--/visibility_negative.fz:647:8: error 258: Could not find called feature
+   say c  # 328. should flag an error: feature not visible
+-------^
+Feature not found: 'c' (no arguments)
+Target feature: 'visibility_negative.visiA'
+In call: 'c'
+
+
+--CURDIR--/visibility_negative.fz:48:11: error 259: Could not find called feature
+          c3 #  1. should flag an error: feature not found / not visible
+----------^^
+Feature not found: 'c3' (no arguments)
+Target feature: 'visibility_negative.visi1.a1.b1.c1'
+In call: 'c3'
+
+
+--CURDIR--/visibility_negative.fz:49:11: error 260: Could not find called feature
+          c4 #  2. should flag an error: feature not found / not visible
+----------^^
+Feature not found: 'c4' (no arguments)
+Target feature: 'visibility_negative.visi1.a1.b1.c1'
+In call: 'c4'
+
+
+--CURDIR--/visibility_negative.fz:50:11: error 261: Could not find called feature
+          b3 #  3. should flag an error: feature not found / not visible
+----------^^
+Feature not found: 'b3' (no arguments)
+Target feature: 'visibility_negative.visi1.a1.b1.c1'
+In call: 'b3'
+
+
+--CURDIR--/visibility_negative.fz:51:11: error 262: Could not find called feature
+          c5 #  4. should flag an error: feature not found / not visible
+----------^^
+Feature not found: 'c5' (no arguments)
+Target feature: 'visibility_negative.visi1.a1.b1.c1'
+In call: 'c5'
+
+
+--CURDIR--/visibility_negative.fz:52:11: error 263: Could not find called feature
+          c6 #  5. should flag an error: feature not found / not visible
+----------^^
+Feature not found: 'c6' (no arguments)
+Target feature: 'visibility_negative.visi1.a1.b1.c1'
+In call: 'c6'
+
+
+--CURDIR--/visibility_negative.fz:57:11: error 264: Could not find called feature
+          c3 #  6. should flag an error: feature not found / not visible
+----------^^
+Feature not found: 'c3' (no arguments)
+Target feature: 'visibility_negative.visi1.a1.b1.c2'
+In call: 'c3'
+
+
+--CURDIR--/visibility_negative.fz:58:11: error 265: Could not find called feature
+          c4 #  7. should flag an error: feature not found / not visible
+----------^^
+Feature not found: 'c4' (no arguments)
+Target feature: 'visibility_negative.visi1.a1.b1.c2'
+In call: 'c4'
+
+
+--CURDIR--/visibility_negative.fz:59:11: error 266: Could not find called feature
+          b3 #  8. should flag an error: feature not found / not visible
+----------^^
+Feature not found: 'b3' (no arguments)
+Target feature: 'visibility_negative.visi1.a1.b1.c2'
+In call: 'b3'
+
+
+--CURDIR--/visibility_negative.fz:60:11: error 267: Could not find called feature
+          c5 #  9. should flag an error: feature not found / not visible
+----------^^
+Feature not found: 'c5' (no arguments)
+Target feature: 'visibility_negative.visi1.a1.b1.c2'
+In call: 'c5'
+
+
+--CURDIR--/visibility_negative.fz:61:11: error 268: Could not find called feature
+          c6 # 10. should flag an error: feature not found / not visible
+----------^^
+Feature not found: 'c6' (no arguments)
+Target feature: 'visibility_negative.visi1.a1.b1.c2'
+In call: 'c6'
+
+
+--CURDIR--/visibility_negative.fz:67:11: error 269: Could not find called feature
+          c1 # 11. should flag an error: feature not found / not visible
+----------^^
+Feature not found: 'c1' (no arguments)
+Target feature: 'visibility_negative.visi1.a1.b2.c3'
+In call: 'c1'
+
+
+--CURDIR--/visibility_negative.fz:68:11: error 270: Could not find called feature
+          c2 # 12. should flag an error: feature not found / not visible
+----------^^
+Feature not found: 'c2' (no arguments)
+Target feature: 'visibility_negative.visi1.a1.b2.c3'
+In call: 'c2'
+
+
+--CURDIR--/visibility_negative.fz:69:11: error 271: Could not find called feature
+          b3 # 13. should flag an error: feature not found / not visible
+----------^^
+Feature not found: 'b3' (no arguments)
+Target feature: 'visibility_negative.visi1.a1.b2.c3'
+In call: 'b3'
+
+
+--CURDIR--/visibility_negative.fz:70:11: error 272: Could not find called feature
+          c5 # 14. should flag an error: feature not found / not visible
+----------^^
+Feature not found: 'c5' (no arguments)
+Target feature: 'visibility_negative.visi1.a1.b2.c3'
+In call: 'c5'
+
+
+--CURDIR--/visibility_negative.fz:71:11: error 273: Could not find called feature
+          c6 # 15. should flag an error: feature not found / not visible
+----------^^
+Feature not found: 'c6' (no arguments)
+Target feature: 'visibility_negative.visi1.a1.b2.c3'
+In call: 'c6'
+
+
+--CURDIR--/visibility_negative.fz:76:11: error 274: Could not find called feature
+          c1 # 16. should flag an error: feature not found / not visible
+----------^^
+Feature not found: 'c1' (no arguments)
+Target feature: 'visibility_negative.visi1.a1.b2.c4'
+In call: 'c1'
+
+
+--CURDIR--/visibility_negative.fz:77:11: error 275: Could not find called feature
+          c2 # 17. should flag an error: feature not found / not visible
+----------^^
+Feature not found: 'c2' (no arguments)
+Target feature: 'visibility_negative.visi1.a1.b2.c4'
+In call: 'c2'
+
+
+--CURDIR--/visibility_negative.fz:78:11: error 276: Could not find called feature
+          b3 # 18. should flag an error: feature not found / not visible
+----------^^
+Feature not found: 'b3' (no arguments)
+Target feature: 'visibility_negative.visi1.a1.b2.c4'
+In call: 'b3'
+
+
+--CURDIR--/visibility_negative.fz:79:11: error 277: Could not find called feature
+          c5 # 19. should flag an error: feature not found / not visible
+----------^^
+Feature not found: 'c5' (no arguments)
+Target feature: 'visibility_negative.visi1.a1.b2.c4'
+In call: 'c5'
+
+
+--CURDIR--/visibility_negative.fz:80:11: error 278: Could not find called feature
+          c6 # 20. should flag an error: feature not found / not visible
+----------^^
+Feature not found: 'c6' (no arguments)
+Target feature: 'visibility_negative.visi1.a1.b2.c4'
+In call: 'c6'
+
+
+--CURDIR--/visibility_negative.fz:87:11: error 279: Could not find called feature
+          c1 # 21. should flag an error: feature not found / not visible
+----------^^
+Feature not found: 'c1' (no arguments)
+Target feature: 'visibility_negative.visi1.a2.b3.c5'
+In call: 'c1'
+
+
+--CURDIR--/visibility_negative.fz:88:11: error 280: Could not find called feature
+          c2 # 22. should flag an error: feature not found / not visible
+----------^^
+Feature not found: 'c2' (no arguments)
+Target feature: 'visibility_negative.visi1.a2.b3.c5'
+In call: 'c2'
+
+
+--CURDIR--/visibility_negative.fz:89:11: error 281: Could not find called feature
+          c3 # 23. should flag an error: feature not found / not visible
+----------^^
+Feature not found: 'c3' (no arguments)
+Target feature: 'visibility_negative.visi1.a2.b3.c5'
+In call: 'c3'
+
+
+--CURDIR--/visibility_negative.fz:90:11: error 282: Could not find called feature
+          c4 # 24. should flag an error: feature not found / not visible
+----------^^
+Feature not found: 'c4' (no arguments)
+Target feature: 'visibility_negative.visi1.a2.b3.c5'
+In call: 'c4'
+
+
+--CURDIR--/visibility_negative.fz:91:11: error 283: Could not find called feature
+          b1 # 25. should flag an error: feature not found / not visible
+----------^^
+Feature not found: 'b1' (no arguments)
+Target feature: 'visibility_negative.visi1.a2.b3.c5'
+In call: 'b1'
+
+
+--CURDIR--/visibility_negative.fz:92:11: error 284: Could not find called feature
+          b2 # 26. should flag an error: feature not found / not visible
+----------^^
+Feature not found: 'b2' (no arguments)
+Target feature: 'visibility_negative.visi1.a2.b3.c5'
+In call: 'b2'
+
+
+--CURDIR--/visibility_negative.fz:97:11: error 285: Could not find called feature
+          c1 # 27. should flag an error: feature not found / not visible
+----------^^
+Feature not found: 'c1' (no arguments)
+Target feature: 'visibility_negative.visi1.a2.b3.c6'
+In call: 'c1'
+
+
+--CURDIR--/visibility_negative.fz:98:11: error 286: Could not find called feature
+          c2 # 28. should flag an error: feature not found / not visible
+----------^^
+Feature not found: 'c2' (no arguments)
+Target feature: 'visibility_negative.visi1.a2.b3.c6'
+In call: 'c2'
+
+
+--CURDIR--/visibility_negative.fz:99:11: error 287: Could not find called feature
+          c3 # 29. should flag an error: feature not found / not visible
+----------^^
+Feature not found: 'c3' (no arguments)
+Target feature: 'visibility_negative.visi1.a2.b3.c6'
+In call: 'c3'
+
+
+--CURDIR--/visibility_negative.fz:100:11: error 288: Could not find called feature
+          c4 # 30. should flag an error: feature not found / not visible
+----------^^
+Feature not found: 'c4' (no arguments)
+Target feature: 'visibility_negative.visi1.a2.b3.c6'
+In call: 'c4'
+
+
+--CURDIR--/visibility_negative.fz:101:11: error 289: Could not find called feature
+          b1 # 31. should flag an error: feature not found / not visible
+----------^^
+Feature not found: 'b1' (no arguments)
+Target feature: 'visibility_negative.visi1.a2.b3.c6'
+In call: 'b1'
+
+
+--CURDIR--/visibility_negative.fz:102:11: error 290: Could not find called feature
+          b2 # 32. should flag an error: feature not found / not visible
+----------^^
+Feature not found: 'b2' (no arguments)
+Target feature: 'visibility_negative.visi1.a2.b3.c6'
+In call: 'b2'
+
+
+--CURDIR--/visibility_negative.fz:527:5: error 291: Could not find called feature
+    b # 273. should flag an error: feature not visible
+----^
+Feature not found: 'b' (no arguments)
+Target feature: 'visibility_negative.visi8'
+In call: 'b'
+
+
+--CURDIR--/visibility_negative.fz:528:5: error 292: Could not find called feature
+    c # 274. should flag an error: feature not visible
+----^
+Feature not found: 'c' (no arguments)
+Target feature: 'visibility_negative.visi8'
+In call: 'c'
 
 
 --CURDIR--/visibility_negative.fz:542:5: error 293: Could not find called feature

--- a/tests/visibility_scoping/visibility_scoping.fz.expected_err
+++ b/tests/visibility_scoping/visibility_scoping.fz.expected_err
@@ -7,31 +7,7 @@ Target feature: 'visibility_scoping.test4.λ.call'
 In call: 'x'
 
 
---CURDIR--/visibility_scoping.fz:40:9: error 2: Could not find called feature
-    say x     #  1. should flag an error: feature not found
---------^
-Feature not found: 'x' (no arguments)
-Target feature: 'visibility_scoping.test1'
-In call: 'x'
-
-
---CURDIR--/visibility_scoping.fz:68:30: error 3: Could not find called feature
-    say "outside else: q is $q"   #  4. should flag an error: feature not found
------------------------------^
-Feature not found: 'q' (no arguments)
-Target feature: 'visibility_scoping.test5'
-In call: 'q'
-
-
---CURDIR--/visibility_scoping.fz:89:13: error 4: Could not find called feature
-        say x   # 11. should flag an error: feature not found
-------------^
-Feature not found: 'x' (no arguments)
-Target feature: 'visibility_scoping.test9'
-In call: 'x'
-
-
---CURDIR--/visibility_scoping.fz:81:10: error 5: Could not find called feature
+--CURDIR--/visibility_scoping.fz:81:10: error 2: Could not find called feature
     _ := ttt  #  8. should flag an error: feature not found
 ---------^^^
 Feature not found: 'ttt' (no arguments)
@@ -39,7 +15,7 @@ Target feature: 'visibility_scoping.test6'
 In call: 'ttt'
 
 
---CURDIR--/visibility_scoping.fz:82:10: error 6: Could not find called feature
+--CURDIR--/visibility_scoping.fz:82:10: error 3: Could not find called feature
     _ := tt   #  9. should flag an error: feature not found
 ---------^^
 Feature not found: 'tt' (no arguments)
@@ -47,7 +23,7 @@ Target feature: 'visibility_scoping.test6'
 In call: 'tt'
 
 
---CURDIR--/visibility_scoping.fz:83:10: error 7: Could not find called feature
+--CURDIR--/visibility_scoping.fz:83:10: error 4: Could not find called feature
     _ := t    # 10. should flag an error: feature not found
 ---------^
 Feature not found: 't' (no arguments)
@@ -55,7 +31,7 @@ Target feature: 'visibility_scoping.test6'
 In call: 't'
 
 
---CURDIR--/visibility_scoping.fz:79:10: error 8: Could not find called feature
+--CURDIR--/visibility_scoping.fz:79:10: error 5: Could not find called feature
     b => tt   #  6. should flag an error: feature not found
 ---------^^
 Feature not found: 'tt' (no arguments)
@@ -63,7 +39,7 @@ Target feature: 'visibility_scoping.test6.b'
 In call: 'tt'
 
 
---CURDIR--/visibility_scoping.fz:80:10: error 9: Could not find called feature
+--CURDIR--/visibility_scoping.fz:80:10: error 6: Could not find called feature
     c => t    #  7. should flag an error: feature not found
 ---------^
 Feature not found: 't' (no arguments)
@@ -71,7 +47,7 @@ Target feature: 'visibility_scoping.test6.c'
 In call: 't'
 
 
---CURDIR--/visibility_scoping.fz:78:10: error 10: Could not find called feature
+--CURDIR--/visibility_scoping.fz:78:10: error 7: Could not find called feature
     a => ttt  #  5. should flag an error: feature not found
 ---------^^^
 Feature not found: 'ttt' (no arguments)
@@ -79,15 +55,7 @@ Target feature: 'visibility_scoping.test6.a'
 In call: 'ttt'
 
 
---CURDIR--/visibility_scoping.fz:49:13: error 11: Could not find called feature
-        say ar  #  2. should flag an error: feature not found
-------------^^
-Feature not found: 'ar' (no arguments)
-Target feature: 'visibility_scoping.test3.anonymous.call'
-In call: 'ar'
-
-
---CURDIR--/visibility_scoping.fz:115:19: error 12: Could not find called feature
+--CURDIR--/visibility_scoping.fz:115:19: error 8: Could not find called feature
         _ := unit.q   # 12. should flag an error: unit.q does not exist
 ------------------^
 Feature not found: 'q' (no arguments)
@@ -95,7 +63,7 @@ Target feature: 'unit'
 In call: 'unit.q'
 
 
---CURDIR--/visibility_scoping.fz:120:14: error 13: Could not find called feature
+--CURDIR--/visibility_scoping.fz:120:14: error 9: Could not find called feature
         _ := q        # 13. should flag an error: q does not exist
 -------------^
 Feature not found: 'q' (no arguments)
@@ -103,7 +71,7 @@ Target feature: 'visibility_scoping.test10.f'
 In call: 'q'
 
 
---CURDIR--/visibility_scoping.fz:131:19: error 14: Could not find called feature
+--CURDIR--/visibility_scoping.fz:131:19: error 10: Could not find called feature
         _ := unit.q   # 14. should flag an error: unit.q does not exist
 ------------------^
 Feature not found: 'q' (no arguments)
@@ -111,7 +79,7 @@ Target feature: 'unit'
 In call: 'unit.q'
 
 
---CURDIR--/visibility_scoping.fz:134:19: error 15: Could not find called feature
+--CURDIR--/visibility_scoping.fz:134:19: error 11: Could not find called feature
         _ := unit.z1  # 15. should flag an error: unit.z1 not in scope
 ------------------^^
 Feature not found: 'z1' (no arguments)
@@ -119,7 +87,7 @@ Target feature: 'unit'
 In call: 'unit.z1'
 
 
---CURDIR--/visibility_scoping.fz:135:19: error 16: Could not find called feature
+--CURDIR--/visibility_scoping.fz:135:19: error 12: Could not find called feature
         _ := unit.z2  # 16. should flag an error: unit.z2 not in scope
 ------------------^^
 Feature not found: 'z2' (no arguments)
@@ -127,7 +95,7 @@ Target feature: 'unit'
 In call: 'unit.z2'
 
 
---CURDIR--/visibility_scoping.fz:136:14: error 17: Could not find called feature
+--CURDIR--/visibility_scoping.fz:136:14: error 13: Could not find called feature
         _ := q        # 17. should flag an error: q does not exist
 -------------^
 Feature not found: 'q' (no arguments)
@@ -135,7 +103,7 @@ Target feature: 'visibility_scoping.test10.f'
 In call: 'q'
 
 
---CURDIR--/visibility_scoping.fz:139:14: error 18: Could not find called feature
+--CURDIR--/visibility_scoping.fz:139:14: error 14: Could not find called feature
         _ := c1       # 18. should flag an error: c1 not in scope
 -------------^^
 Feature not found: 'c1' (no arguments)
@@ -143,7 +111,7 @@ Target feature: 'visibility_scoping.test10.f'
 In call: 'c1'
 
 
---CURDIR--/visibility_scoping.fz:140:14: error 19: Could not find called feature
+--CURDIR--/visibility_scoping.fz:140:14: error 15: Could not find called feature
         _ := c2       # 19. should flag an error: c2 not in scope
 -------------^^
 Feature not found: 'c2' (no arguments)
@@ -151,7 +119,7 @@ Target feature: 'visibility_scoping.test10.f'
 In call: 'c2'
 
 
---CURDIR--/visibility_scoping.fz:146:17: error 20: Could not find called feature
+--CURDIR--/visibility_scoping.fz:146:17: error 16: Could not find called feature
       _ := unit.q   # 20. should flag an error: unit.q does not exist
 ----------------^
 Feature not found: 'q' (no arguments)
@@ -159,7 +127,7 @@ Target feature: 'unit'
 In call: 'unit.q'
 
 
---CURDIR--/visibility_scoping.fz:148:17: error 21: Could not find called feature
+--CURDIR--/visibility_scoping.fz:148:17: error 17: Could not find called feature
       _ := unit.y   # 21. should flag an error: unit.y not in scope
 ----------------^
 Feature not found: 'y' (no arguments)
@@ -167,7 +135,7 @@ Target feature: 'unit'
 In call: 'unit.y'
 
 
---CURDIR--/visibility_scoping.fz:149:17: error 22: Could not find called feature
+--CURDIR--/visibility_scoping.fz:149:17: error 18: Could not find called feature
       _ := unit.z1  # 22. should flag an error: unit.z1 not in scope
 ----------------^^
 Feature not found: 'z1' (no arguments)
@@ -175,7 +143,7 @@ Target feature: 'unit'
 In call: 'unit.z1'
 
 
---CURDIR--/visibility_scoping.fz:150:17: error 23: Could not find called feature
+--CURDIR--/visibility_scoping.fz:150:17: error 19: Could not find called feature
       _ := unit.z2  # 23. should flag an error: unit.z2 not in scope
 ----------------^^
 Feature not found: 'z2' (no arguments)
@@ -183,7 +151,7 @@ Target feature: 'unit'
 In call: 'unit.z2'
 
 
---CURDIR--/visibility_scoping.fz:151:12: error 24: Could not find called feature
+--CURDIR--/visibility_scoping.fz:151:12: error 20: Could not find called feature
       _ := q        # 24. should flag an error: q does not exist
 -----------^
 Feature not found: 'q' (no arguments)
@@ -191,7 +159,7 @@ Target feature: 'visibility_scoping.test10.g'
 In call: 'q'
 
 
---CURDIR--/visibility_scoping.fz:153:12: error 25: Could not find called feature
+--CURDIR--/visibility_scoping.fz:153:12: error 21: Could not find called feature
       _ := b        # 25. should flag an error: b not in scope
 -----------^
 Feature not found: 'b' (no arguments)
@@ -199,7 +167,7 @@ Target feature: 'visibility_scoping.test10.g'
 In call: 'b'
 
 
---CURDIR--/visibility_scoping.fz:154:12: error 26: Could not find called feature
+--CURDIR--/visibility_scoping.fz:154:12: error 22: Could not find called feature
       _ := c1       # 26. should flag an error: c1 not in scope
 -----------^^
 Feature not found: 'c1' (no arguments)
@@ -207,11 +175,43 @@ Target feature: 'visibility_scoping.test10.g'
 In call: 'c1'
 
 
---CURDIR--/visibility_scoping.fz:155:12: error 27: Could not find called feature
+--CURDIR--/visibility_scoping.fz:155:12: error 23: Could not find called feature
       _ := c2       # 27. should flag an error: c2 not in scope
 -----------^^
 Feature not found: 'c2' (no arguments)
 Target feature: 'visibility_scoping.test10.g'
 In call: 'c2'
+
+
+--CURDIR--/visibility_scoping.fz:40:9: error 24: Could not find called feature
+    say x     #  1. should flag an error: feature not found
+--------^
+Feature not found: 'x' (no arguments)
+Target feature: 'visibility_scoping.test1'
+In call: 'x'
+
+
+--CURDIR--/visibility_scoping.fz:68:30: error 25: Could not find called feature
+    say "outside else: q is $q"   #  4. should flag an error: feature not found
+-----------------------------^
+Feature not found: 'q' (no arguments)
+Target feature: 'visibility_scoping.test5'
+In call: 'q'
+
+
+--CURDIR--/visibility_scoping.fz:89:13: error 26: Could not find called feature
+        say x   # 11. should flag an error: feature not found
+------------^
+Feature not found: 'x' (no arguments)
+Target feature: 'visibility_scoping.test9'
+In call: 'x'
+
+
+--CURDIR--/visibility_scoping.fz:49:13: error 27: Could not find called feature
+        say ar  #  2. should flag an error: feature not found
+------------^^
+Feature not found: 'ar' (no arguments)
+Target feature: 'visibility_scoping.test3.anonymous.call'
+In call: 'ar'
 
 27 errors.


### PR DESCRIPTION
result type propagation was misused in match expression to add a result field. This patch cleans this up and separates result type propagation and result field introduction.
