### PR TITLE
fe: Do not abuse feature result as type parameter constraint

### DIFF
--- a/src/dev/flang/ast/AbstractFeature.java
+++ b/src/dev/flang/ast/AbstractFeature.java
@@ -273,7 +273,8 @@ public abstract class AbstractFeature extends Expr implements Comparable<Abstrac
 
 
   /**
-   * resultType returns the result type of this feature using.
+   * resultType returns the result type of this feature, i.e., the type of the
+   * value returned when calling this feature.
    *
    * @return the result type, t_ERROR in case of an error.
    * Never null.
@@ -1703,13 +1704,32 @@ public abstract class AbstractFeature extends Expr implements Comparable<Abstrac
     var result = context.constraintFor(this);
     if (result == null)
       {
-        result = resultType();
+        result = constraint();
       }
 
     if (POSTCONDITIONS) ensure
       (result != null);
 
     return result;
+  }
+
+
+  /**
+   * constraint returns the constraint type of this type parameter, Any if no
+   * constraint was set.  This ignores any context constraints like `pre T : numeric`
+   *
+   * @return the constraint.
+   */
+  public AbstractType constraint()
+  {
+    if (PRECONDITIONS) require
+      (state().atLeast(State.RESOLVED_TYPES),
+       isTypeParameter());
+
+    throw new Error("constraint() not redefined for "+getClass());
+
+    // if (POSTCONDITIONS) ensure
+    //   (result != null);
   }
 
 

--- a/src/dev/flang/ast/AstErrors.java
+++ b/src/dev/flang/ast/AstErrors.java
@@ -1497,7 +1497,7 @@ public class AstErrors extends ANY
     error(typeParameter.pos(),
           "Constraint for type parameter must not be a choice type",
           "Affected type parameter: " + s(typeParameter) + "\n" +
-          "constraint: " + s(typeParameter.resultType()) + "\n");
+          "constraint: " + s(typeParameter.constraint()) + "\n");
   }
 
   static void loopElseBlockRequiresWhileOrIterator(SourcePosition pos, Expr elseBlock)

--- a/src/dev/flang/ast/AstErrors.java
+++ b/src/dev/flang/ast/AstErrors.java
@@ -673,20 +673,24 @@ public class AstErrors extends ANY
           }
         else
           {
+            AbstractType originalFrom;
             if (originalArg.isTypeParameter())
               {
                 what = "type parameter constraint";
                 what2 = "constraint of type parameter";
+                originalFrom = originalArg.constraint();
+                is = s(redefinedArg.constraint());
               }
             else
               {
                 what = "argument type";
                 what2 = "type of argument";
+                originalFrom = originalArg.resultType();
+                is = s(redefinedArg.resultType());
               }
-            is = s(redefinedArg.resultType());
             // originalArg.resultType() might be a type parameter that has been replaced by originalArgType, so
             // we explain where this type comes from:
-            should_be1 = typeWithFrom(originalArgType, originalArg.resultType());
+            should_be1 = typeWithFrom(originalArgType, originalFrom);
             should_be2 = s(originalArgType);
           }
         error(redefinedArg.pos(),

--- a/src/dev/flang/ast/AstErrors.java
+++ b/src/dev/flang/ast/AstErrors.java
@@ -2226,6 +2226,14 @@ public class AstErrors extends ANY
     );
   }
 
+  public static void constraintMoreRestrictiveVisibility(AbstractFeature f, Set<AbstractFeature> s)
+  {
+    error(f.pos(), "Type parameter constraint or any of its generics have more restrictive visibility than feature.",
+      "To solve this, increase the visibility of " + slbn(s.stream().map(x -> x.featureName()).collect(List.collector())) +
+      " or specify a different type parameter constraint."
+    );
+  }
+
   public static void redefMoreRestrictiveVisibility(Feature f, AbstractFeature redefined)
   {
     error(f.pos(), "Redefinition must not have more restrictive visibility.",

--- a/src/dev/flang/ast/AstErrors.java
+++ b/src/dev/flang/ast/AstErrors.java
@@ -1488,7 +1488,7 @@ public class AstErrors extends ANY
     error(tp.pos(),
           "Constraint for type parameter must not be a type parameter",
           "Affected type parameter: " + s(tp) + "\n" +
-          "constraint: " + s(tp.resultType()) + "\n" +
+          "constraint: " + s(tp.constraint()) + "\n" +
           "To solve this, change the type provided, e.g. to the unconstrained " + st("type") + ".\n");
   }
 

--- a/src/dev/flang/ast/AstErrors.java
+++ b/src/dev/flang/ast/AstErrors.java
@@ -1306,7 +1306,7 @@ public class AstErrors extends ANY
         cf.resultType().isGenericArgument()                                     &&
         cf.resultType().genericArgument() instanceof Feature tp                 &&
         tp.isFreeType()                                                         &&
-        tp.resultType().compareTo(Types.resolved.t_Any) == 0)
+        tp.constraint().compareTo(Types.resolved.t_Any) == 0)
       {
         solution = "To solve this, you might replace the free type " + s(tp) + " by a different type.  " +
                    "Is the type name spelled correctly?  The free type is declared at " + tp.pos().show();

--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -1348,8 +1348,8 @@ public class Call extends AbstractCall
          *    zip (drop 1) (T.lteq)
          *      .fold bool.all
          */
-        result = _calledFeature.isTypeParameter() && context.constraintFor(_calledFeature) != null
-          ?  context.constraintFor(_calledFeature)
+        result = _calledFeature.isTypeParameter()
+          ? _calledFeature.constraint(context)
           : _calledFeature.resultTypeIfPresentUrgent(res, urgent);
         _recursiveResolveType = false;
 

--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -1891,7 +1891,7 @@ public class Call extends AbstractCall
                               {
                                 var tp = t.genericArgument();
                                 res.resolveTypes(tp);
-                                inferGeneric(res, context, tp.resultType(), actualType, actual.pos(), conflict, foundAt, count-1);
+                                inferGeneric(res, context, tp.constraint(), actualType, actual.pos(), conflict, foundAt, count-1);
                               }
                             inferGeneric(res, context, t, actualType, actual.pos(), conflict, foundAt, count-1);
                             checked[vai] = true;

--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -1349,7 +1349,7 @@ public class Call extends AbstractCall
          *      .fold bool.all
          */
         result = _calledFeature.isTypeParameter()
-          ? _calledFeature.constraint(context)
+          ? _calledFeature.constraint(res, context)
           : _calledFeature.resultTypeIfPresentUrgent(res, urgent);
         _recursiveResolveType = false;
 

--- a/src/dev/flang/ast/Feature.java
+++ b/src/dev/flang/ast/Feature.java
@@ -2378,6 +2378,10 @@ A ((Choice)) declaration must not contain a result type.
           {
             result = outer().outer().thisType(outer().isFixed());
           }
+        else if (isTypeParameter())
+          { // NYI: CLEANUP: handling of isOpenTypeParameter() will be added in PR #5681
+            result = Types.resolved.f_Type.resultType();
+          }
         else
           {
             result = _returnType.functionReturnType(true);

--- a/src/dev/flang/ast/Feature.java
+++ b/src/dev/flang/ast/Feature.java
@@ -2380,7 +2380,7 @@ A ((Choice)) declaration must not contain a result type.
           }
         else if (isTypeParameter())
           { // NYI: CLEANUP: handling of isOpenTypeParameter() will be added in PR #5681
-            result = Types.resolved.f_Type.resultType();
+            result = Types.resolved.f_Type.resultTypeIfPresentUrgent(res, urgent);
           }
         else
           {

--- a/src/dev/flang/ast/Feature.java
+++ b/src/dev/flang/ast/Feature.java
@@ -2055,7 +2055,8 @@ A ((Choice)) declaration must not contain a result type.
   private void checkLegalNativeArg(Resolution res, SourcePosition pos, AbstractType at)
   {
     ensureTypeSetsInitialized(res);
-    if (!(Types.resolved.legalNativeArgumentTypes.contains(at)
+    if (!(isTypeParameter()
+          || Types.resolved.legalNativeArgumentTypes.contains(at)
           || at.selfOrConstraint(Context.NONE).isFunctionTypeExcludingLazy()
           // NYI: BUG: check if array element type is valid
           || !at.isGenericArgument() && at.feature() == Types.resolved.f_array

--- a/src/dev/flang/ast/Feature.java
+++ b/src/dev/flang/ast/Feature.java
@@ -2438,6 +2438,28 @@ A ((Choice)) declaration must not contain a result type.
   }
 
 
+  /**
+   * constraint returns the constraint type of this type parameter, Any if no
+   * constraint was set.  This ignores any context constraints like `pre T : numeric`
+   *
+   * @return the constraint.
+   */
+  @Override
+  public AbstractType constraint()
+  {
+    if (PRECONDITIONS) require
+      (state().atLeast(State.RESOLVED_TYPES),
+       isTypeParameter());
+
+    var result = _returnType.functionReturnType();
+
+    if (POSTCONDITIONS) ensure
+      (result != null);
+
+    return result;
+  }
+
+
   public FeatureName featureName()
   {
     if (CHECKS) check

--- a/src/dev/flang/ast/Feature.java
+++ b/src/dev/flang/ast/Feature.java
@@ -2044,7 +2044,7 @@ A ((Choice)) declaration must not contain a result type.
       {
         for (var arg : arguments())
           {
-            checkLegalNativeArg(res, arg.pos(), arg.resultType());
+            checkLegalNativeArg(res, arg);
           }
 
         checkLegalNativeResultType(res, resultTypePos(), resultType());
@@ -2052,10 +2052,11 @@ A ((Choice)) declaration must not contain a result type.
   }
 
 
-  private void checkLegalNativeArg(Resolution res, SourcePosition pos, AbstractType at)
+  private void checkLegalNativeArg(Resolution res, AbstractFeature arg)
   {
     ensureTypeSetsInitialized(res);
-    if (!(isTypeParameter()
+    var at = arg.resultType();
+    if (!(arg.isTypeParameter()
           || Types.resolved.legalNativeArgumentTypes.contains(at)
           || at.selfOrConstraint(Context.NONE).isFunctionTypeExcludingLazy()
           // NYI: BUG: check if array element type is valid
@@ -2065,7 +2066,7 @@ A ((Choice)) declaration must not contain a result type.
           )
         )
       {
-        AstErrors.illegalNativeType(pos, "Argument type", at);
+        AstErrors.illegalNativeType(arg.pos(), "Argument type", at);
       }
   }
 

--- a/src/dev/flang/fe/LibraryFeature.java
+++ b/src/dev/flang/fe/LibraryFeature.java
@@ -462,6 +462,10 @@ public class LibraryFeature extends AbstractFeature
       {
         return Types.resolved.t_void;
       }
+    else if (isTypeParameter())
+      { // NYI: CLEANUP: handling of isOpenTypeParameter() will be added in PR #5681
+        return Types.resolved.f_Type.resultType();
+      }
     else
       {
         return _libModule.type(_libModule.featureResultTypePos(_index));

--- a/src/dev/flang/fe/LibraryFeature.java
+++ b/src/dev/flang/fe/LibraryFeature.java
@@ -470,6 +470,27 @@ public class LibraryFeature extends AbstractFeature
 
 
   /**
+   * constraint returns the constraint type of this type parameter, Any if no
+   * constraint was set.  This ignores any context constraints like `pre T : numeric`
+   *
+   * @return the constraint.
+   */
+  @Override
+  public AbstractType constraint()
+  {
+    if (PRECONDITIONS) require
+      (isTypeParameter());
+
+    var result = _libModule.type(_libModule.featureResultTypePos(_index));
+
+    if (POSTCONDITIONS) ensure
+      (result != null);
+
+    return result;
+  }
+
+
+  /**
    * The sourcecode position of this feature declaration's result type, null if
    * not available.
    */

--- a/src/dev/flang/fe/LibraryModule.java
+++ b/src/dev/flang/fe/LibraryModule.java
@@ -880,6 +880,7 @@ Feature
    | C=1      | 1      | Feature       | the cotype origin
    | hasRT    | 1      | Type          | optional result type,
                                          hasRT = !isConstructor && !isChoice && !isTypeParameter
+   | isTypeParameter | 1 | Type        | constraint of (open) type parameters
 .2+| true NYI! !isField? !isIntrinsc
               | 1      | int           | inherits count i
               | i      | Code          | inherits calls

--- a/src/dev/flang/fe/LibraryModule.java
+++ b/src/dev/flang/fe/LibraryModule.java
@@ -879,7 +879,7 @@ Feature
    | Y=1      | 1      | Feature       | the cotype
    | C=1      | 1      | Feature       | the cotype origin
    | hasRT    | 1      | Type          | optional result type,
-                                       hasRT = !isConstructor && !isChoice
+                                         hasRT = !isConstructor && !isChoice && !isTypeParameter
 .2+| true NYI! !isField? !isIntrinsc
               | 1      | int           | inherits count i
               | i      | Code          | inherits calls
@@ -925,6 +925,11 @@ Feature
    *   +--------+--------+---------------+-----------------------------------------------+
    *   | hasRT  | 1      | Type          | optional result type,                         |
    *   |        |        |               | hasRT = !isConstructor && !isChoice           |
+   *   |        |        |               |         && !isTypeParameter                   |
+   *   +--------+--------+---------------+-----------------------------------------------+
+   *   | isType | 1      | Type          | constraint of (open) type parameters          |
+   *   | Parame |        |               |                                               |
+   *   | ter    |        |               |                                               |
    *   +--------+--------+---------------+-----------------------------------------------+
    *   | true   | 1      | int           | inherits count i                              |
    *   | NYI!   |        |               |                                               |

--- a/src/dev/flang/fe/LibraryOut.java
+++ b/src/dev/flang/fe/LibraryOut.java
@@ -417,6 +417,11 @@ class LibraryOut extends ANY
    *   +--------+--------+---------------+-----------------------------------------------+
    *   | hasRT  | 1      | Type          | optional result type,                         |
    *   |        |        |               | hasRT = !isConstructor && !isChoice           |
+   *   |        |        |               |         && !isTypeParameter                   |
+   *   +--------+--------+---------------+-----------------------------------------------+
+   *   | isType | 1      | Type          | constraint of (open) type parameters          |
+   *   | Parame |        |               |                                               |
+   *   | ter    |        |               |                                               |
    *   +--------+--------+---------------+-----------------------------------------------+
    *   | true   | 1      | int           | inherits count i                              |
    *   | NYI!   |        |               |                                               |
@@ -486,6 +491,7 @@ class LibraryOut extends ANY
       {
         k = k | FuzionConstants.MIR_FILE_KIND_HAS_POST_CONDITION_FEATURE;
       }
+    var hasRT = !f.isConstructor() && !f.isChoice() && !f.isTypeParameter();
     var n = f.featureName();
     _data.writeShort(k);
     var bn = n.baseName();
@@ -511,9 +517,13 @@ class LibraryOut extends ANY
       }
     if (CHECKS) check
       (f.arguments().size() == argCount);
-    if (!f.isConstructor() && !f.isChoice())
+    if (hasRT)
       {
         type(f.resultType());
+      }
+    if (f.isTypeParameter())
+      {
+        type(f.constraint());
       }
     // NYI: Suppress output of inherits for fields, intrinsics, etc.?
     var i = f.inherits();

--- a/src/dev/flang/fe/SourceModule.java
+++ b/src/dev/flang/fe/SourceModule.java
@@ -1750,7 +1750,7 @@ A feature that is a constructor, choice or a type parameter may not redefine an 
     if (f.isTypeParameter() &&
         !f.outer().isCotype()) // reg_issue1932 shows error twice without this)
       {
-        if (f.resultType().isGenericArgument())
+        if (f.constraint().isGenericArgument())
           {
             AstErrors.constraintMustNotBeGenericArgument(f);
           }

--- a/src/dev/flang/fe/SourceModule.java
+++ b/src/dev/flang/fe/SourceModule.java
@@ -1941,14 +1941,25 @@ A feature that is a constructor, choice or a type parameter may not redefine an 
    */
   private void checkArgTypesVisibility(Feature f)
   {
-    for (AbstractFeature arg : f.arguments())
+    if (!f.isCotype())
       {
-        if (!arg.isCoTypesThisType())
+        for (AbstractFeature arg : f.arguments())
           {
-            var s = arg.resultType().moreRestrictiveVisibility(effectiveFeatureVisibility(f));
-            if (!s.isEmpty())
+            if (arg.isTypeParameter())
               {
-                AstErrors.argTypeMoreRestrictiveVisibility(f, arg, s);
+                var s = arg.constraint().moreRestrictiveVisibility(effectiveFeatureVisibility(f));
+                if (!s.isEmpty())
+                  {
+                    AstErrors.constraintMoreRestrictiveVisibility(arg, s);
+                  }
+              }
+            else
+              {
+                var s = arg.resultType().moreRestrictiveVisibility(effectiveFeatureVisibility(f));
+                if (!s.isEmpty())
+                  {
+                    AstErrors.argTypeMoreRestrictiveVisibility(f, arg, s);
+                  }
               }
           }
       }

--- a/src/dev/flang/fe/SourceModule.java
+++ b/src/dev/flang/fe/SourceModule.java
@@ -1754,7 +1754,7 @@ A feature that is a constructor, choice or a type parameter may not redefine an 
           {
             AstErrors.constraintMustNotBeGenericArgument(f);
           }
-        if (f.resultType().isChoice())
+        if (f.constraint().isChoice())
           {
             AstErrors.constraintMustNotBeChoice(f);
           }

--- a/src/dev/flang/fe/SourceModule.java
+++ b/src/dev/flang/fe/SourceModule.java
@@ -1617,8 +1617,8 @@ A post-condition of a feature that does not redefine an inherited feature must s
     var fixed = (f.modifiers() & FuzionConstants.MODIFIER_FIXED) != 0;
     for (var o : f.redefines())
       {
-        var ra = argTypes(f);
-        var ta = o.handDown(_res, argTypes(o), f.outer());
+        var ra = argTypesOrConstraints(f);
+        var ta = o.handDown(_res, argTypesOrConstraints(o), f.outer());
         if (ta == AbstractFeature.HAND_DOWN_FAILED)
           {
             if (CHECKS) check
@@ -1773,11 +1773,12 @@ A feature that is a constructor, choice or a type parameter may not redefine an 
 
 
   /**
-   * Determine the formal argument types of this feature.
+   * Determine the formal argument types of this feature.  For type parameters,
+   * the result will be the constraint of the type parameter.
    *
    * @return a new array containing this feature's formal argument types.
    */
-  private AbstractType[] argTypes(AbstractFeature af)
+  private AbstractType[] argTypesOrConstraints(AbstractFeature af)
   {
     int argnum = 0;
     var args = af.arguments();
@@ -1787,7 +1788,8 @@ A feature that is a constructor, choice or a type parameter may not redefine an 
         if (CHECKS) check
           (Errors.any() || _res.state(frml).atLeast(State.RESOLVED_DECLARATIONS));
 
-        var frmlT = frml.resultType();
+        var frmlT = frml.isTypeParameter() ? frml.constraint()
+                                           : frml.resultType();
 
         result[argnum] = frmlT;
         argnum++;

--- a/tests/visibility_modules_negative/main.fz.expected_err
+++ b/tests/visibility_modules_negative/main.fz.expected_err
@@ -67,45 +67,39 @@ To solve this, increase the visibility of 'priv' (no arguments) or specify a dif
 To solve this, increase the visibility of 'priv_ce' (no arguments) or specify a different return type.
 
 
---CURDIR--/main.fz:50:10: error 11: Result type or any of its generics have more restrictive visibility than feature.
+--CURDIR--/main.fz:50:15: error 11: Type parameter constraint or any of its generics have more restrictive visibility than feature.
   module mod4(T type : priv_ce) is # should flag an error priv_ce visibility more restrictive than mod4
----------^^^^
-To solve this, increase the visibility of 'priv_ce' (no arguments) or specify a different return type.
+--------------^
+To solve this, increase the visibility of 'priv_ce' (no arguments) or specify a different type parameter constraint.
 
 
---CURDIR--/main.fz:50:10: error 12: Argument types or any of its generics have more restrictive visibility than feature.
-  module mod4(T type : priv_ce) is # should flag an error priv_ce visibility more restrictive than mod4
----------^^^^
-To solve this, increase the visibility of 'priv_ce' (no arguments) or specify a different type for the argument 'T'.
-
-
---CURDIR--/main.fz:51:10: error 13: Argument types or any of its generics have more restrictive visibility than feature.
+--CURDIR--/main.fz:51:10: error 12: Argument types or any of its generics have more restrictive visibility than feature.
   module mod5(arg array priv_ce) is # should flag an error priv_ce visibility more restrictive than mod5
 ---------^^^^
 To solve this, increase the visibility of 'priv_ce' (no arguments) or specify a different type for the argument 'arg'.
 
 
---CURDIR--/main.fz:62:7: error 14: Called feature in precondition has more restrictive visibility than feature.
+--CURDIR--/main.fz:62:7: error 13: Called feature in precondition has more restrictive visibility than feature.
   pre my_false  # should flag an error my_false visibility more restrictive than feat4
 ------^^^^^^^^
 To solve this, increase the visibility of 'm.my_false' or do not use this feature in the precondition.
 
 
---CURDIR--/main.fz:80:18: error 15: Redefinition must not have more restrictive visibility.
+--CURDIR--/main.fz:80:18: error 14: Redefinition must not have more restrictive visibility.
     module redef b unit => # should flag an error Redefinition must not have more restrictive visibility.
 -----------------^
 To solve this, increase the visibility of 'm.redef_test_0.b' to 'public'
 
 
---CURDIR--/main.fz:82:18: error 16: Redefinition must not have more restrictive visibility.
+--CURDIR--/main.fz:82:18: error 15: Redefinition must not have more restrictive visibility.
     module redef e unit => # should flag an error Redefinition must not have more restrictive visibility.
 -----------------^
 To solve this, increase the visibility of 'm.redef_test_0.e' to 'public'
 
 
---CURDIR--/main.fz:89:5: error 17: Abstract features visibility must not be more restrictive than outer features visibility.
+--CURDIR--/main.fz:89:5: error 16: Abstract features visibility must not be more restrictive than outer features visibility.
     inner_abstract i32 => abstract # should flag an error Abstract features visibility must not be more restrictive than outer features visibility.
 ----^^^^^^^^^^^^^^
 To solve this, increase the visibility of 'm.outer.inner_abstract' to 'public'
 
-17 errors.
+16 errors.


### PR DESCRIPTION
This was a hack that appeared convinient, but it is nicer to have a dedicated constraint feature for type features.
