### PR TITLE
makefile: add dependency to MOD_TERMINAL for target build/tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1144,7 +1144,7 @@ $(MOD_JDK_XML_DOM): $(MOD_JAVA_BASE) $(MOD_JAVA_XML) $(MOD_JDK_XML_DOM_FZ_FILES)
 $(MOD_JDK_ZIPFS): $(MOD_JAVA_BASE) $(MOD_JDK_ZIPFS_FZ_FILES)
 	$(FZ) -sourceDirs=$(MOD_JDK_ZIPFS_DIR) -modules=java.base -saveModule=$@
 
-$(BUILD_DIR)/tests: $(FUZION_FILES_TESTS)
+$(BUILD_DIR)/tests: $(FUZION_FILES_TESTS) $(MOD_TERMINAL)
 	rm -rf $@
 	mkdir -p $(@D)
 	cp -rf $(FZ_SRC_TESTS) $@


### PR DESCRIPTION
fixes 
```
error 1: Incompatible module hashes encountered
Module LibraryModule for 'terminal' references module LibraryModule for 'base'
Expected hash: c410e32f9d9b1c4f01c278180c1f6acd
Actual hash  : ed8d1df504c1657a8ae7bb89c5933223

*** fatal errors encountered, stopping.
one error.
make: *** [Makefile:1152: build/tests] Error 1
```