### PR TITLE
fix cryptic error of check_simple_example

### DIFF
--- a/bin/check_simple_example.fz
+++ b/bin/check_simple_example.fz
@@ -119,7 +119,7 @@ record_process(
       if feed_stdin && io.file.exists stdin_file
         lm ! ()->
           _ := p.with_in unit lm ()->
-            _ := (io.buffered lm).writer.env.write (read_file_fully stdin_file).val.utf8
+            _ := (io.buffered lm).writer.env.write (read_file_fully stdin_file).or_panic.utf8
 
       match p.wait
         e error => panic "failed waiting for $cmd, error is: $e"
@@ -160,7 +160,7 @@ write_to_file(dest String, data String) =>
 # write file from src to dest
 #
 copy(src, dest String) =>
-  contents := (io.file.use src io.file.mode.read (() -> String.from_bytes (io.buffered io.file.file_mutate).read_fully)).val
+  contents := (io.file.use src io.file.mode.read (() -> String.from_bytes (io.buffered io.file.file_mutate).read_fully)).or_panic
   write_to_file dest contents
 
 # read file f fully

--- a/modules/base/src/fuzion/sys/fileio.fz
+++ b/modules/base/src/fuzion/sys/fileio.fz
@@ -129,7 +129,7 @@ module fileio is
     if open_results[0] = 0
       res
     else
-      error "failed opening file, error number: {open_results[0]}"
+      error "failed opening file \"$path\", error number: {open_results[0]}"
 
 
   # Closes an IO source using an i64 representing the source handler (file descriptor)
@@ -182,4 +182,4 @@ module fileio is
     if open_results[0] = 0
       res
     else
-      error "failed opening directory, error number: {open_results[0]}"
+      error "failed opening directory \"$path\", error number: {open_results[0]}"

--- a/modules/base/src/switch.fz
+++ b/modules/base/src/switch.fz
@@ -208,6 +208,14 @@ is
       b B => (exception T).env.cause (e b)
 
 
+  # get A or panic with `B.as_string`
+  #
+  public or_panic A =>
+    match switch.this
+      a A => a
+      b B => panic b.as_string
+
+
   # converts switch to a string
   #
   public redef as_string String =>


### PR DESCRIPTION
fixes #5720

error now looks like this:
```
RUN asdf2.fz *** failed *** panic ***: `error: failed opening file "asdf2.fz.expected_err", error number: 2`
make: *** [../simple.mk:69: jvm] Error 1
```
