### PR TITLE
base: Rename `list.scan` as `list.scan_list`, change result of `Sequence.scan` to `Sequence`

### DIFF
--- a/modules/base/src/Sequence.fz
+++ b/modules/base/src/Sequence.fz
@@ -479,7 +479,7 @@ public Sequence(public T type) ref : property.countable is
   # e.g., for a Sequence of i32 s, s.scan i32.sum creates a list of
   # partial sums (0..).map x->(s.take x).fold i32.sum
   #
-  public scan (m Monoid T) list T => as_list.scan m.e m
+  public scan (m Monoid T) Sequence T => as_list.scan_list m
 
 
   # map this Sequence to a Sequence that contains the result of folding

--- a/modules/base/src/list.fz
+++ b/modules/base/src/list.fz
@@ -273,24 +273,24 @@ public list(public A type) : choice nil (Cons A (list A)), Sequence A is
               | c Cons => f c.head (c.tail.foldrf e f)
 
 
-  # map this Sequence to a list that contains the result of folding
+  # map this list to a list that contains the result of folding
   # all prefixes using the given monoid.
   #
-  # e.g., for a Sequence of i32 s, s.scan i32.sum creates a list of
+  # e.g., for a list of i32 s, s.scan i32.sum creates a list of
   # partial sums (0..).map x->(s.take x).fold i32.sum
   #
-  public redef scan (m Monoid A) list A => scan m.e m
+  public scan_list (m Monoid A) list A => scan_list m.e m
 
 
-  # map this Sequence to a list that contains the result of folding
+  # map this list to a list that contains the result of folding
   # all prefixes using the given monoid and initial value
   #
-  # Used to scan a list tail-recursively
+  # Used to scan a list lazily
   #
-  public scan (s A, m Monoid A) list A =>
+  public scan_list (s A, m Monoid A) list A =>
     list.this ? nil    => nil
               | c Cons => acc := m.op s c.head
-                          list acc (c.tail.scan acc m)
+                          list acc (c.tail.scan_list acc m)
 
 
   # map this list to a list that contains the result of folding


### PR DESCRIPTION
`Sequence.scan` was the only remaining feature in `Sequence` that returned a `list` and not a `Sequence`, so this is fixed now.

Renaming the versions in `list` that produce a `list` is for consistency and to fix the following confusion:

I stumbled into this since I was suprised that adding `as_list` in the following example caused an error:

     > ./build/bin/fz -e "[1,2,3].scan 100 (+) |> say"
    [100, 101, 103, 106]
     > ./build/bin/fz -e "[1,2,3].as_list.scan 100 (+) |> say"

    command line:1:26: error 1: No type information can be inferred from a lambda expression
    [1,2,3].as_list.scan 100 (+) |> say

The reason was that `list` adds another variant of `scan` with 2 arguments.
