### PR TITLE
Makefile: Make `all` first rule, fix paths to source files using `$(FZ_SRC)`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -470,13 +470,15 @@ C_FILES = $(shell find $(FZ_SRC) \( -path ./build -o -path ./.git \) -prune -o -
 .DELETE_ON_ERROR:
 
 
+# default make target
+.PHONY: all
+all: $(FUZION_BASE) $(FUZION_JAVA_MODULES) $(FUZION_FILES) $(MOD_FZ_CMD) $(FUZION_EBNF) $(LSP_JAR)
+
+
 # rules relevant for language server protocol
 #
 include $(FZ_SRC)/lsp.mk
 
-
-.PHONY: all
-all: $(FUZION_BASE) $(FUZION_JAVA_MODULES) $(FUZION_FILES) $(MOD_FZ_CMD) $(FUZION_EBNF) $(LSP_JAR)
 
 # everything but rarely used java modules
 .PHONY: min-java
@@ -1152,14 +1154,14 @@ $(MOD_JDK_ZIPFS): $(MOD_JAVA_BASE) $(MOD_JDK_ZIPFS_FZ_FILES)
 
 # this target may fail when executed standalone, see comment on $(BUILD_DIR)/tests
 #
-$(BUILD_DIR)/bin/check_simple_example: bin/check_simple_example.fz
-	$(FZ) -modules=terminal -c -o=$@ bin/check_simple_example.fz
+$(BUILD_DIR)/bin/check_simple_example: $(FZ_SRC)/bin/check_simple_example.fz
+	$(FZ) -modules=terminal -c -o=$@ $^
 	@echo " + $@"
 
 # this target may fail when executed standalone, see comment on $(BUILD_DIR)/tests
 #
-$(BUILD_DIR)/bin/record_simple_example: bin/record_simple_example.fz
-	$(FZ) -modules=terminal -c -o=$@ bin/record_simple_example.fz
+$(BUILD_DIR)/bin/record_simple_example: $(FZ_SRC)/bin/record_simple_example.fz
+	$(FZ) -modules=terminal -c -o=$@ $^
 	@echo " + $@"
 
 # tricky, we need MOD_TERMINAL to build (check|record)_simple_example

--- a/Makefile
+++ b/Makefile
@@ -472,12 +472,7 @@ C_FILES = $(shell find $(FZ_SRC) \( -path ./build -o -path ./.git \) -prune -o -
 
 # default make target
 .PHONY: all
-all: $(FUZION_BASE) $(FUZION_JAVA_MODULES) $(FUZION_FILES) $(MOD_FZ_CMD) $(FUZION_EBNF) $(LSP_JAR)
-
-
-# rules relevant for language server protocol
-#
-include $(FZ_SRC)/lsp.mk
+all: $(FUZION_BASE) $(FUZION_JAVA_MODULES) $(FUZION_FILES) $(MOD_FZ_CMD) $(FUZION_EBNF) $(BUILD_DIR)/lsp.jar
 
 
 # everything but rarely used java modules
@@ -1537,3 +1532,8 @@ endif
 
 $(DOC_JAVA): $(JAVA_FILE_UTIL_VERSION) $(JAVA_FILE_FUIR_ANALYSIS_ABSTRACT_INTERPRETER2)
 	javadoc --release $(JAVA_VERSION) --enable-preview -d $(dir $(DOC_JAVA)) $(JAVA_FILES_FOR_JAVA_DOC)
+
+
+# rules relevant for language server protocol
+#
+include $(FZ_SRC)/lsp.mk

--- a/lsp.mk
+++ b/lsp.mk
@@ -37,8 +37,6 @@ JARS_LSP_LSP4J_GENERATOR = $(BUILD_DIR)/jars/org.eclipse.lsp4j.generator-0.23.1.
 JARS_LSP_LSP4J_JSONRPC   = $(BUILD_DIR)/jars/org.eclipse.lsp4j.jsonrpc-0.23.1.jar
 JARS_LSP_GSON            = $(BUILD_DIR)/jars/gson-2.11.0.jar
 
-LSP_JAR = $(BUILD_DIR)/lsp.jar
-
 $(JARS_LSP_LSP4J):
 	mkdir -p $(@D)
 	curl $(LSP_LSP4J_URL) --output $@
@@ -97,5 +95,5 @@ lsp/debug/socket: $(CLASS_FILES_LSP)
 	mkdir -p runDir
 	java -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=127.0.0.1:8000 -cp $(CLASSES_DIR):$(CLASSES_DIR_LSP):$(JARS_LSP_LSP4J):$(JARS_LSP_LSP4J_GENERATOR):$(JARS_LSP_LSP4J_JSONRPC):$(JARS_LSP_GSON) $(LSP_JAVA_ARGS) dev.flang.lsp.Main -socket --port=$(LANGUAGE_SERVER_PORT)
 
-$(LSP_JAR): $(CLASS_FILES_LSP)
-	jar cfm $(LSP_JAR) assets/Manifest.txt -C $(BUILD_DIR)/classes . -C $(CLASSES_DIR_LSP) .
+$(BUILD_DIR)/lsp.jar: $(CLASS_FILES_LSP)
+	jar cfm $@ assets/Manifest.txt -C $(BUILD_DIR)/classes . -C $(CLASSES_DIR_LSP) .


### PR DESCRIPTION
Calling `make` without an explicit target executed some lsp rules instead.

Building `build/tests/check_simple_example` binary failed if the current dir is not `$(FZ_SRC)`.
