### PR TITLE
run_tests: re-add slowest tests

### DIFF
--- a/bin/run_tests.fz
+++ b/bin/run_tests.fz
@@ -267,6 +267,18 @@ main =>
       .map x->"make record -C $x" # NYI: UNDER DEVELOPMENT: if _target file exists: "make record_$target -C $x"
       .as_string " && "
 
-    exit 1
+    check (set_exit_code 1).ok
+
+
+  num_slowest := 10
+  say "\n\nSlowest $num_slowest tests using $target backend:\n"
+  slowest_tests := ![
+    "bash",
+    "-c",
+    "sed -E 's|\\./build/tests/([^\\]+)\\sin\\s(.*):\\sok|\\2 \\1|g' $build_dir/run_tests.results | sort -t 'm' -k1,1nr | head -n $num_slowest"]
+
+  say slowest_tests.out
+
+  exit
 
 _ := main


### PR DESCRIPTION
e.g:
```
testing JVM backend: 4 tests, running 1 tests in parallel.
....
4/4 tests passed, 0 skipped, 0 failed in 15s.

Slowest 5 tests using jvm backend:

5505ms abstractfeatures_negative
4311ms inherit_postcondition
3593ms inference_choice_generics
2253ms infer_via_contraints_type_parameter
```
