### PR TITLE
base: Use bar symbols in histogram output

### DIFF
--- a/modules/base/src/time/histogram.fz
+++ b/modules/base/src/time/histogram.fz
@@ -389,6 +389,11 @@ is
   =>
     h := highest
     if h > 0
+      empt => " "  # unicode 0x0020 Space
+      hori => "_"  # unicode 0x005f Low Line
+      vert => "|"  # unicode 0x007c Vertical Line
+      bar => "▉"   # unicode 0x2589 LEFT SEVEN EIGHTHS BLOCK
+
       titl := """
               {"---  $title  ---".pad_center 78}
               count
@@ -401,17 +406,20 @@ is
         unit0 := min units.byte_length-1 c/10  # 2^10 is times 1024
         cnt := u64 1 << (c - unit0 * 10).as_u64
         str := for
-                 str1 := "{($cnt).pad_left 3}{units.substring unit0 unit0+1} ", str1 + str2 + str3
+                 hgap := c %% 4 ? hori : empt
+                 str1 := "{($cnt).pad_left 3}{units.substring unit0 unit0+1}$hgap", str1 + str2 + str3
                  i in buckets.indices
-                 str2 := i = num_buckets ? "       " : ""
-                 str3 := buckets[i].log2 < c ? " " : "*"
+                 last := i = num_buckets-1
+                 gap :=  i %% 8 || last ? vert : hgap
+                 str2 := last ? hgap + empt*6 : ""
+                 str3 := buckets[i].log2 < c ? gap : bar
                else
                  str1 + "\n"
       else
-        t2 := (i64 0 .. 64 : 8).map (i-> largest i .as_string.trim.pad_center 8)
+        t2 := (i64 0 .. 64 : 8).map (i -> largest i .as_string.trim.pad_center 8)
                                .as_string ""
-        bot :=    ("     |       |       |       |       |       |       |       |       |       |\n" +
-                    "  "+t2+"   >\n")
+        bot :=    ("     " + (vert + empt*7)*9 + vert + "\n" +
+                   "  "+t2+"   >\n")
         res + bot + "\n" + (" average |" +
                             "   min   |" +
                             "   max   |" +


### PR DESCRIPTION
A typical histogram now looks like this

               ---  period jitter 3906µs, log count / linear time  ---
    count
    256 _|_______|_______|_______|_______▉_______|_______|_______|_______|_      |
    128  |       |       |       |       ▉       |       |       |       |       |
     64  |       |       |       |      ▉▉       |       |       |       |       |
     32  |       |       |       |    ▉ ▉▉▉▉     |       |       |       |       |
     16 _|_______|_______|_______|____▉_▉▉▉▉▉____|_______|_______|_______|_      |
      8  |       |       |       |    ▉▉▉▉▉▉▉    |       |       |       |       |
      4  |       |       |       |   ▉▉▉▉▉▉▉▉    |       |       |       |       |
      2  |       |       |       |   ▉▉▉▉▉▉▉▉▉▉ ▉|       |       |       |       |
      1 _|_______|_______|_______|___▉▉▉▉▉▉▉▉▉▉▉▉|_______|_______|_______|_      |
         |       |       |       |       |       |       |       |       |       |
       120µs   1081µs  2043µs  3004µs  3966µs  4927µs  5889µs  6850µs  7812µs    >

     average |   min   |   max   |  sigma  |  count  |
     3897µs  | 3443µs  | 4777µs  |  172µs  |   536   |

Which in my terminal is displayed like this: 

<img width="820" height="368" alt="grafik" src="https://github.com/user-attachments/assets/832cac5a-e4c1-4bb8-896d-ab0b01a2863c" />

