### PR TITLE
use loop in suggested bash command to rerun/rerecord tests

### DIFF
--- a/bin/run_tests.fz
+++ b/bin/run_tests.fz
@@ -255,17 +255,24 @@ main =>
     say (read_file_fully failures)
     say "============= run_tests.failures END ============="
 
-    say "To re-run all failed tests, use this command:"
-    say <| failed_tests
-      .map x->x.split[0]
-      .map x->"make $target -C $x"
-      .as_string " && "
+    failed_test_names := failed_tests
+                           .map x->x.split[0]
+                           .map x->(x.substring 14) # remove "./build/tests/"
+                           .as_string " "
 
-    say "To re-record all failed tests, use this command:"
-    say <| failed_tests
-      .map x->x.split[0]
-      .map x->"make record -C $x" # NYI: UNDER DEVELOPMENT: if _target file exists: "make record_$target -C $x"
-      .as_string " && "
+    say "\nTo re-run all failed tests, use this command:"
+    say """
+        for t in $failed_test_names; do
+          make $target -C ./build/tests/\$t
+        done"""
+
+    say "\nTo re-record all failed tests, use this command:"
+    # NYI: UNDER DEVELOPMENT: if _target file exists: "make record_$target -C $x"
+    say """
+        for t in $failed_test_names; do
+          make record -C ./build/tests/\$t
+        done
+        """
 
     exit 1
 


### PR DESCRIPTION
This is just a suggestion, I'd find useful because it is easier to modify the command. And probably shorter if many tests are failing.

But it will break if tests are in a location other than `./build/tests/`.

It changes the output from this
```
============= run_tests.failures END =============
To re-run all failed tests, use this command:
make jvm -C ./build/tests/reg_issue108 && make jvm -C ./build/tests/reg_issue118
To re-record all failed tests, use this command:
make record -C ./build/tests/reg_issue108 && make record -C ./build/tests/reg_issue118
make: *** [Makefile:1329: run_tests_jvm] Error 1
```
into this
```
============= run_tests.failures END =============

To re-run all failed tests, use this command:
for t in reg_issue108 reg_issue118; do
  make jvm -C ./build/tests/$t
done

To re-record all failed tests, use this command:
for t in reg_issue108 reg_issue118; do
  make record -C ./build/tests/$t
done

make: *** [Makefile:1329: run_tests_jvm] Error 1
```