### PR TITLE
base: Add `time.Period` and `time.frequency`, fix #5650

### DIFF
--- a/modules/base/src/time/Clock.fz
+++ b/modules/base/src/time/Clock.fz
@@ -37,6 +37,28 @@ public Clock ref : effect is
   public read time.instant => abstract
 
 
+  # halt the current thread until the given instant. In case `t` is in the past,
+  # return immediately.
+  #
+  public sleep_until(# the instant we should wait for
+                     t time.instant
+                     ) unit
+  =>
+    sleep_until t read
+
+
+  # internal helper to implement `sleep_unil` if the current time has already been
+  # read and is passed as `ima`.
+  #
+  sleep_until(# the instant we should wait for
+              t,
+
+              # the current instant that has just been `read`.
+              ima time.instant)
+  =>
+    if ima < t
+      sleep t-ima
+
   # halt the current thread during the given period of time
   #
   public sleep(d time.duration) unit => abstract
@@ -69,34 +91,37 @@ public Clock ref : effect is
     abstract
 
 
-  # run the given code periodically at time `first`, `first+p`, `first+p*2`, etc.
-  # until this clock has reached `last`.
+  # run the given `code` periodically at time `first+p*0`, `first+p*1`, `first+p*2`,
+  # etc. until this clock has reached the time `last`.
   #
-  # In case any of the instants `first`, `first+p`, `first+p*2`, etc. happen to
-  # be in the past when this is called or after the previous execution of code,
-  # respectively, do not run code for that instant.
+  # In case any of the instants `first+p*0`, `first+p*1`, `first+p*2`, etc. happen to
+  # be in the past when this is called or after the previous execution of `code`,
+  # respectively, do not run `code` for that instant.
   #
-  # return the number of times the code was run
+  # In case `period.is_infinity`, run `code` once unless `first > last`.
   #
-  public run_periodic(first time.instant,
-                      period time.duration,
+  # return the number of times the `code` was run.
+  #
+  public run_periodic(P type : Period,
+                      first time.instant,
+                      period P,
                       last time.instant,
                       code ()->unit) u64
   pre
-    debug: period > time.duration.ns 0
+    debug: period.is_infinity || period.as_duration > time.duration.ns 0
   post
-    debug: ((last >= first): result <= ((last- first) / period) + 1)
+    debug: ((last >= first): result <= ((last - first) / period.as_duration) + 1)
     debug: ((last <  first): result = 0)
   =>
     for
       cnt := u64 0, cnt + 1
       ima := read
-      next1 := first, next + period
-      skip := if ima > next1 then (ima - next1 + period - time.duration.ns 1) / period else 0
-      next := next1 + period * skip
+      next1 := first + period * cnt
+      skipped := if ima > next1 then (ima - next1) / period.as_duration + 1
+                                else 0
+      next := first + period * (cnt + skipped)
     while next <= last
-      if ima < next
-        sleep next-ima
+      sleep_until next ima
       code()
     else
       cnt

--- a/modules/base/src/time/Period.fz
+++ b/modules/base/src/time/Period.fz
@@ -1,0 +1,64 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion standard library feature time.Period
+#
+#  Author: Fridtjof Siebert (siebert@tokiwa.software)
+#
+# -----------------------------------------------------------------------
+
+# time.Period -- template for periods
+#
+# This provices abstract features that define a period of time and that
+# permit multiplications with large integers avoiding drift.
+#
+# An example is a period of 1/60sec. Using `time.duration`, which is a child
+# of `Period`, this can only be represented as `16666667 ns`, resulting in
+# a drift of 1/3ns per period, which would result in a drift of 1.7ms (a whole
+# period) per day. Such inaccuracy can result in catastrophic failure, see
+# (The Patriot Missile Failure)[https://www-users.cse.umn.edu/~arnold/disasters/patriot.html].
+#
+public Period
+is
+
+  # this Period represented as a duration.  Note that the duration might
+  # be inaccurate since it will be rounded or truncated to full nanoseconds.
+  #
+  public as_duration time.duration
+  pre
+    !is_infinity
+  => abstract
+
+
+  # is this period infinite, i.e., it never ends?
+  #
+  public is_infinity bool
+  =>
+    abstract
+
+
+  # this Period multiplied by factor n
+  #
+  # If n=0, the result is `time.duration.zero` even if `is_infinity`.
+  #
+  public infix *(n u64) time.duration
+  pre
+    debug: !is_infinity || n=0
+  =>
+    abstract

--- a/modules/base/src/time/duration.fz
+++ b/modules/base/src/time/duration.fz
@@ -37,9 +37,28 @@ module:public duration (
   # the duration in nano seconds
   #
   public nanos u64
-  ) : property.orderable
+  )
+  : Period, property.orderable
 
 is
+
+  # For `duration`, this feature redefined form `Period` will just return an equal `duration`
+  # like `duration.this`.
+  #
+  public redef fixed as_duration time.duration
+  =>
+    # NYI: UNDER DEVELOPMENT: #5595: Once `time` is declared `final` or similar, this should work:
+    #
+    #   duration.this
+    time.duration nanos
+
+
+  # is this period infinite, i.e., it never ends?
+  #
+  public redef is_infinity bool
+  =>
+    false
+
 
   # this duration in micro seconds, omitting fractional part
   #
@@ -94,17 +113,23 @@ is
 
   # this duration multiplied by factor n
   #
-  public infix *(n u64) duration => duration nanos*n
+  public redef infix * (n u64) time.duration
+  =>
+    time.duration nanos*n
 
 
   # this duration multiplied by factor f
   #
-  public times(f f64) duration => duration (nanos.as_f64 * f).as_i64.as_u64
+  public times(f f64) time.duration
+  =>
+    time.duration (nanos.as_f64 * f).as_i64.as_u64
 
 
-  # this duration divided by duration d, rounding down
+  # this duration divided by duration other, rounding down
   #
-  public infix / (other duration) u64 => nanos / other.nanos
+  public infix / (other duration.this) u64
+  =>
+    nanos / other.nanos
 
 
   # create a string representation of this duration. The string

--- a/modules/base/src/time/frequency.fz
+++ b/modules/base/src/time/frequency.fz
@@ -1,0 +1,70 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion standard library feature time.frequency
+#
+#  Author: Fridtjof Siebert (siebert@tokiwa.software)
+#
+# -----------------------------------------------------------------------
+
+# time.frequncy -- a child of Period that is defined by a frequency per duration
+#
+# This provices abstract features that define a period of time and that
+# permit multiplications with large integers avoiding drift.
+#
+# An example is a frequency of 60Hz that can be specified as
+#
+#     f := frequence 60 (time.duration.s 1)
+#
+# This is different to `duration.s 1 / 60` since `duration` can only be represented as
+# `16666667 ns`, resulting in a drift of 1/3ns per period.  This would result in a drift
+# of 1.7ms (a whole period) per day. Such inaccuracy can result in catastrophic failure, see
+# (The Patriot Missile Failure)[https://www-users.cse.umn.edu/~arnold/disasters/patriot.html].
+#
+public frequency(# the frequence per base
+                 f u64,
+
+                 # the base duration
+                 base time.duration)
+                 : Period
+is
+
+
+  public redef is_infinity bool
+  =>
+    f = 0
+
+  # this frequency represented as a duration.  Note that the duration might
+  # be inaccurate, it will be truncated to full nanoseconds.
+  #
+  public redef as_duration time.duration
+  =>
+    time.duration (base.nanos / f)
+
+
+  # this frequency multiplied by factor n
+  #
+  # NYI: UNDER DEVELOPMENT: #5801: rename as `divide_by` or similar since `infix *` is inappropriate for a frequency.
+  #
+  public redef infix *(n u64) time.duration
+  =>
+    ns := base.nanos.as_u128
+    nn := n         .as_u128
+    ff := f         .as_u128
+    time.duration (ns * nn / ff).as_u64


### PR DESCRIPTION
`time.Period` is a template feature that can be used to specify periods that may be repeated a large number of times.

Different implementation may provide solutions to avoid drift. `time.duration` is one implementation that permits `Period`s with an integer number of `ns`, while `fequency` provides fractional frequencies like `1/60sec` without drift when `infix *` is used.
