### PR TITLE
fe: When read from fum file, the result type was used instead of the constraint

### DIFF
--- a/src/dev/flang/fe/LibraryFeature.java
+++ b/src/dev/flang/fe/LibraryFeature.java
@@ -511,7 +511,7 @@ public class LibraryFeature extends AbstractFeature
     if (PRECONDITIONS) require
       (isTypeParameter());
 
-    var result = _libModule.type(_libModule.featureResultTypePos(_index));
+    var result = _libModule.type(_libModule.featureConstraintPos(_index));
 
     if (POSTCONDITIONS) ensure
       (result != null);

--- a/src/dev/flang/fe/LibraryModule.java
+++ b/src/dev/flang/fe/LibraryModule.java
@@ -1126,11 +1126,11 @@ Feature
   {
     var k = featureKind(at) & FuzionConstants.MIR_FILE_KIND_MASK;
     return
-      (k != FuzionConstants.MIR_FILE_KIND_CONSTRUCTOR_REF   &&
-       k != FuzionConstants.MIR_FILE_KIND_CONSTRUCTOR_VALUE &&
-       k != AbstractFeature.Kind.Choice.ordinal()
-       // NYI: && k != AbstractFeature.Kind.TypeParameter.ordinal()
-       //      && k != AbstractFeature.Kind.OpenTypeParameter.ordinal()
+      (k != FuzionConstants.MIR_FILE_KIND_CONSTRUCTOR_REF    &&
+       k != FuzionConstants.MIR_FILE_KIND_CONSTRUCTOR_VALUE  &&
+       k != AbstractFeature.Kind.Choice           .ordinal() &&
+       k != AbstractFeature.Kind.TypeParameter    .ordinal() &&
+       k != AbstractFeature.Kind.OpenTypeParameter.ordinal()
        );
 
   }
@@ -1147,9 +1147,25 @@ Feature
   {
     return feature(data().getInt(featureValuesAsOpenTypeFeaturePos(at)));
   }
-  int featureInheritsCountPos(int at)
+  int featureConstraintPos(int at)
   {
     return featureValuesAsOpenTypeFeaturePos(at) + (featureHasOpenTypeFeature(at) ? 4 : 0);
+  }
+  boolean featureHasConstraint(int at)
+  {
+    var k = featureKind(at) & FuzionConstants.MIR_FILE_KIND_MASK;
+    return
+      (k == AbstractFeature.Kind.TypeParameter    .ordinal() ||
+       k == AbstractFeature.Kind.OpenTypeParameter.ordinal()    );
+  }
+  int featureInheritsCountPos(int at)
+  {
+    var i = featureConstraintPos(at);
+    if (featureHasConstraint(at))
+      {
+        i = typeNextPos(i);
+      }
+    return i;
   }
   int featureInheritsCount(int at)
   {


### PR DESCRIPTION
This was no problem since result type and constraint happened to be at the same position in the .fum file, but this results in massive problems once the .fum files changes.
