### PR TITLE
be/jvm: normalize output of filenames stacktraces

### DIFF
--- a/src/dev/flang/be/jvm/runtime/Runtime.java
+++ b/src/dev/flang/be/jvm/runtime/Runtime.java
@@ -27,6 +27,7 @@ Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
 package dev.flang.be.jvm.runtime;
 
 import java.io.BufferedReader;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.StringWriter;
@@ -771,7 +772,7 @@ public class Runtime extends ANY
                   {
                     stacktrace.write("\n");
                   }
-                stacktrace.write(str + " at " + s.getFileName()+ ":" + s.getLineNumber());
+                stacktrace.write(str + " at " + s.getFileName().replace(File.separator, "/") + ":" + s.getLineNumber());
                 last = str;
                 count = 1;
               }


### PR DESCRIPTION
fixes test failures on windows

