### PR TITLE
cleanup: don't silently ignore if `universe.fz` was not found

### DIFF
--- a/src/dev/flang/tools/docs/Util.java
+++ b/src/dev/flang/tools/docs/Util.java
@@ -38,6 +38,7 @@ import dev.flang.ast.AbstractFeature;
 import dev.flang.ast.Types;
 import dev.flang.ast.Visi;
 import dev.flang.tools.FuzionHome;
+import dev.flang.util.Errors;
 import dev.flang.util.FuzionConstants;
 
 public class Util
@@ -111,6 +112,7 @@ public class Util
       }
     catch (IOException e)
       {
+        Errors.fatal("File universe.fz not found");
         return "";
       }
   }


### PR DESCRIPTION
Took quite long to notice that the universe comment in the docs was gone.
It broke in #4315 and got fixed in #5819.
