### PR TITLE
fe: fix inheriting from feature with open type parameters

### DIFF
--- a/src/dev/flang/ast/AbstractCall.java
+++ b/src/dev/flang/ast/AbstractCall.java
@@ -221,9 +221,9 @@ public abstract class AbstractCall extends Expr
                                   new List<>(),
                                   null);
     var typeParameters = new List<AbstractType>(selfType);
-    typeParameters.addAll(actualTypeParameters().map(that::rebaseTypeForCotype));
     if (this instanceof Call cpc && cpc.needsToInferTypeParametersFromArgs())
       {
+        typeParameters.addAll(actualTypeParameters());
         cpc.whenInferredTypeParameters(() ->
           {
             if (CHECKS) check
@@ -239,6 +239,10 @@ public abstract class AbstractCall extends Expr
                 typeParameters.addAll(actualTypeParameters().map(that::rebaseTypeForCotype));
               }
           });
+      }
+    else
+      {
+        typeParameters.addAll(actualTypeParameters().map(that::rebaseTypeForCotype));
       }
 
     return calledFeature().cotypeInheritanceCall(pos(), typeParameters, res, that, target());

--- a/src/dev/flang/ast/AbstractCall.java
+++ b/src/dev/flang/ast/AbstractCall.java
@@ -236,10 +236,7 @@ public abstract class AbstractCall extends Expr
             else
               {
                 typeParameters.removeTail(1);
-                for (var atp : actualTypeParameters())
-                  {
-                    typeParameters.add(that.rebaseTypeForCotype(atp));
-                  }
+                typeParameters.addAll(actualTypeParameters().map(that::rebaseTypeForCotype));
               }
           });
       }

--- a/src/dev/flang/ast/AstErrors.java
+++ b/src/dev/flang/ast/AstErrors.java
@@ -634,12 +634,17 @@ public class AstErrors extends ANY
                                             String detail1,
                                             String detail2)
   {
-    error(pos,
-          "Wrong number of type parameters",
-          "Wrong number of actual type parameters in " + detail1 + ":\n" +
-          detail2 +
-          "expected " + fg.sizeText() + (fg._feature.typeArguments().isEmpty() ? "" : " for " + s(fg) + "") + "\n" +
-          "found " + (actualGenerics.size() == 0 ? "none" : "" + actualGenerics.size() + ": " + s(actualGenerics) + "" ) + ".\n");
+    // supress errors in cotypes unless we found the original error (in the
+    // original feature):
+    if (!fg._feature.isCotype() || !Errors.any())
+      {
+        error(pos,
+              "Wrong number of type parameters",
+              "Wrong number of actual type parameters in " + detail1 + ":\n" +
+              detail2 +
+              "expected " + fg.sizeText() + (fg._feature.typeArguments().isEmpty() ? "" : " for " + s(fg) + "") + "\n" +
+              "found " + (actualGenerics.size() == 0 ? "none" : "" + actualGenerics.size() + ": " + s(actualGenerics) + "" ) + ".\n");
+      }
   }
 
   /**

--- a/src/dev/flang/ast/AstErrors.java
+++ b/src/dev/flang/ast/AstErrors.java
@@ -634,8 +634,8 @@ public class AstErrors extends ANY
                                             String detail1,
                                             String detail2)
   {
-    // supress errors in cotypes unless we found the original error (in the
-    // original feature):
+    // supress errors in cotypes unless we did not find the original error (in
+    // the original feature):
     if (!fg._feature.isCotype() || !Errors.any())
       {
         error(pos,

--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -3082,7 +3082,19 @@ public class Call extends AbstractCall
   public void notifyInferred()
   {
     if (PRECONDITIONS) require
-      (!actualTypeParameters().stream().anyMatch(atp -> atp.containsUndefined(false)));
+      (/* NYI: UNDER DEVELOPMENT: This currently fails within loops as in
+
+                    call to (loop.this.i.infix %% 5).ternary ? : --UNDEFINED-- 0 loop.this.n ATP --UNDEFINED-- ./build/modules/base/src/encodings/base32.fz:61:31:
+                          last_n u64 := 0, i %% 5 ?  0 : n
+                                                  ^
+
+          need to check why actualTypeParameters still contain t_UNDEFINED in this case.
+
+          For now, let's just ignore this as long as there is nothing to do anyway, i.e.,
+          as long as `_whenInferredTypeParameters.isEmpty()`.
+       */
+       _whenInferredTypeParameters.isEmpty() ||
+       !actualTypeParameters().stream().anyMatch(atp -> atp.containsUndefined(false)));
 
     for (var r : _whenInferredTypeParameters)
       {

--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -2567,10 +2567,6 @@ public class Call extends AbstractCall
             if (needsToInferTypeParametersFromArgs())
               {
                 inferGenericsFromArgs(res, context);
-                for (var r : _whenInferredTypeParameters)
-                  {
-                    r.run();
-                  }
               }
             if (!genericSizesMatch())
               {
@@ -2580,6 +2576,7 @@ public class Call extends AbstractCall
             setActualResultType(res, context);
           }
         resolveTypesOfActuals(res, context);
+        notifyInferred();
 
         result = isErroneous(res)
           ? resolveTypesErrorResult()
@@ -3091,6 +3088,7 @@ public class Call extends AbstractCall
       {
         r.run();
       }
+    _whenInferredTypeParameters = NO_RUNNABLE;
   }
 
 

--- a/src/dev/flang/util/List.java
+++ b/src/dev/flang/util/List.java
@@ -383,6 +383,15 @@ public class List<T>
 
 
   /**
+   * Remove all elements at indices >=from.
+   */
+  public void removeTail(int from)
+  {
+    removeRange(from, size());
+  }
+
+
+  /**
    * Remove the last element of the list.
    */
   public T removeLast()

--- a/src/dev/flang/util/List.java
+++ b/src/dev/flang/util/List.java
@@ -387,6 +387,9 @@ public class List<T>
    */
   public void removeTail(int from)
   {
+    if (ANY.PRECONDITIONS) ANY.require
+      (!isFrozen() || from == size());
+
     removeRange(from, size());
   }
 
@@ -396,6 +399,9 @@ public class List<T>
    */
   public T removeLast()
   {
+    if (ANY.PRECONDITIONS) ANY.require
+      (!isFrozen());
+
     return remove(size()-1);
   }
 

--- a/tests/reg_issues5821_5835/Makefile
+++ b/tests/reg_issues5821_5835/Makefile
@@ -1,0 +1,25 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test Makefile
+#
+# -----------------------------------------------------------------------
+
+override NAME = reg_issues5821_5835
+include ../simple.mk

--- a/tests/reg_issues5821_5835/reg_issues5821_5835.fz
+++ b/tests/reg_issues5821_5835/reg_issues5821_5835.fz
@@ -46,6 +46,8 @@ reg_issues5821_5835 =>
   b12 : a1 unit     is {}; ignore b12.dynamic_type; say b12$
   b13 : a1 unit i32 is {}; ignore b13.dynamic_type; say b13$
 
+  say "\n------\n"
+
 
   # Same test, but using an additional, closed type parameter
   #
@@ -57,6 +59,8 @@ reg_issues5821_5835 =>
   b21 : a2 String        is {}; ignore b21.dynamic_type; say b11$
   b22 : a2 bool unit     is {}; ignore b22.dynamic_type; say b22$
   b23 : a2 void unit i32 is {}; ignore b23.dynamic_type; say b23$
+
+  say "\n------\n"
 
 
   # test of #5835: try to use arguments of open type in inheritance
@@ -72,6 +76,9 @@ reg_issues5821_5835 =>
   b33 : a3 "" unit is {}; ignore b33.dynamic_type; say b33$
   */
 
+  say "\n------\n"
+
+
   # test of #5835: try to use closed type parameter, one argument of that closed type
   # parameter type and 0, 1 and 2 actual types passed to open type in inheritance
   # call
@@ -81,7 +88,7 @@ reg_issues5821_5835 =>
   a4(A type, B type..., va A, vb B...) is
     postfix $ => "$A $B $va $vb"
   b41 : a4 3.14                        is {}; ignore b41.dynamic_type; say b41$
-  /*
+  /* NYI: BUG #5835: this does not work for more than zero args yet
   b42 : a4 nil true                    is {}; ignore b42.dynamic_type; say b42$
   b43 : a4 (option bool false) "" unit is {}; ignore b43.dynamic_type; say b43$
   */

--- a/tests/reg_issues5821_5835/reg_issues5821_5835.fz
+++ b/tests/reg_issues5821_5835/reg_issues5821_5835.fz
@@ -1,0 +1,87 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test reg_issues5821_5835
+#
+# -----------------------------------------------------------------------
+
+# inheriting from a feature with open type parameters
+#
+reg_issues5821_5835 =>
+
+  # the original code from #5821
+  #
+  say "original test:"
+
+  a(B type...) is
+  b : a is
+  ignore b.dynamic_type
+
+
+  # a more comprehensive set of tests using 0, 1 and 2 actual
+  # type parameters in the inheritance call and printing the
+  # actual values to io.out:
+  #
+  say "tests using 0, 1 and 2 actual types passed to open type:"
+
+  a1(B type...) is
+    postfix $ => $B
+  b11 : a1          is {}; ignore b11.dynamic_type; say b11$
+  b12 : a1 unit     is {}; ignore b12.dynamic_type; say b12$
+  b13 : a1 unit i32 is {}; ignore b13.dynamic_type; say b13$
+
+
+  # Same test, but using an additional, closed type parameter
+  #
+  #
+  say "tests using one plain type parameter and 0, 1 and 2 actual types passed to open type:"
+
+  a2(A type, B type...) is
+    postfix $ => "$A $B"
+  b21 : a2 String        is {}; ignore b21.dynamic_type; say b11$
+  b22 : a2 bool unit     is {}; ignore b22.dynamic_type; say b22$
+  b23 : a2 void unit i32 is {}; ignore b23.dynamic_type; say b23$
+
+
+  # test of #5835: try to use arguments of open type in inheritance
+  # call
+  #
+  say "tests using argument of open type and 0, 1 and 2 actual types passed to open type:"
+
+  a3(B type..., vb B...) is
+    postfix $ => "$B $vb"
+  b31 : a3         is {}; ignore b31.dynamic_type; say b31$
+  /* NYI: BUG #5835: this does not work for more than zero args yet
+  b32 : a3 true    is {}; ignore b32.dynamic_type; say b32$
+  b33 : a3 "" unit is {}; ignore b33.dynamic_type; say b33$
+  */
+
+  # test of #5835: try to use closed type parameter, one argument of that closed type
+  # parameter type and 0, 1 and 2 actual types passed to open type in inheritance
+  # call
+  #
+  say "tests using one plain type parameter and value argument and 0, 1 and 2 actual types passed to open type and corresponding value argument:"
+
+  a4(A type, B type..., va A, vb B...) is
+    postfix $ => "$A $B $va $vb"
+  b41 : a4 3.14                        is {}; ignore b41.dynamic_type; say b41$
+  /*
+  b42 : a4 nil true                    is {}; ignore b42.dynamic_type; say b42$
+  b43 : a4 (option bool false) "" unit is {}; ignore b43.dynamic_type; say b43$
+  */

--- a/tests/reg_issues5821_5835/reg_issues5821_5835.fz
+++ b/tests/reg_issues5821_5835/reg_issues5821_5835.fz
@@ -70,8 +70,8 @@ reg_issues5821_5835 =>
 
   a3(B type..., vb B...) is
     postfix $ => "$B $vb"
+  /* NYI: BUG #5835: this does not work yet
   b31 : a3         is {}; ignore b31.dynamic_type; say b31$
-  /* NYI: BUG #5835: this does not work for more than zero args yet
   b32 : a3 true    is {}; ignore b32.dynamic_type; say b32$
   b33 : a3 "" unit is {}; ignore b33.dynamic_type; say b33$
   */
@@ -87,8 +87,8 @@ reg_issues5821_5835 =>
 
   a4(A type, B type..., va A, vb B...) is
     postfix $ => "$A $B $va $vb"
+  /* NYI: BUG #5835: this does not work yet
   b41 : a4 3.14                        is {}; ignore b41.dynamic_type; say b41$
-  /* NYI: BUG #5835: this does not work for more than zero args yet
   b42 : a4 nil true                    is {}; ignore b42.dynamic_type; say b42$
   b43 : a4 (option bool false) "" unit is {}; ignore b43.dynamic_type; say b43$
   */

--- a/tests/reg_issues5821_5835/reg_issues5821_5835.fz.expected_out
+++ b/tests/reg_issues5821_5835/reg_issues5821_5835.fz.expected_out
@@ -14,9 +14,7 @@ Type of 'void' [Type of 'unit', Type of 'i32']
 ------
 
 tests using argument of open type and 0, 1 and 2 actual types passed to open type:
-[] []
 
 ------
 
 tests using one plain type parameter and value argument and 0, 1 and 2 actual types passed to open type and corresponding value argument:
-Type of 'f64' [] 3.14 []

--- a/tests/reg_issues5821_5835/reg_issues5821_5835.fz.expected_out
+++ b/tests/reg_issues5821_5835/reg_issues5821_5835.fz.expected_out
@@ -1,19 +1,22 @@
-problem 0 vs. 1 for b31.this.#^<reg_issues5821_5835.b31>.a3 at /home/fridi/fuzion/fuzion/build/tests/reg_issues5821_5835/reg_issues5821_5835.fz:69:9:
-  b31 : a3         is {}; ignore b31.dynamic_type; say b31$
---------^^
-problem 1 vs. 2 for b41.this.#^<reg_issues5821_5835.b41>.a4 f64 (LibraryFeature.Constant of type f64) at /home/fridi/fuzion/fuzion/build/tests/reg_issues5821_5835/reg_issues5821_5835.fz:83:9:
-  b41 : a4 3.14                        is {}; ignore b41.dynamic_type; say b41$
---------^^
 original test:
 tests using 0, 1 and 2 actual types passed to open type:
 []
 [Type of 'unit']
 [Type of 'unit', Type of 'i32']
+
+------
+
 tests using one plain type parameter and 0, 1 and 2 actual types passed to open type:
 []
 Type of 'bool' [Type of 'unit']
 Type of 'void' [Type of 'unit', Type of 'i32']
+
+------
+
 tests using argument of open type and 0, 1 and 2 actual types passed to open type:
 [] []
+
+------
+
 tests using one plain type parameter and value argument and 0, 1 and 2 actual types passed to open type and corresponding value argument:
 Type of 'f64' [] 3.14 []

--- a/tests/reg_issues5821_5835/reg_issues5821_5835.fz.expected_out
+++ b/tests/reg_issues5821_5835/reg_issues5821_5835.fz.expected_out
@@ -1,0 +1,19 @@
+problem 0 vs. 1 for b31.this.#^<reg_issues5821_5835.b31>.a3 at /home/fridi/fuzion/fuzion/build/tests/reg_issues5821_5835/reg_issues5821_5835.fz:69:9:
+  b31 : a3         is {}; ignore b31.dynamic_type; say b31$
+--------^^
+problem 1 vs. 2 for b41.this.#^<reg_issues5821_5835.b41>.a4 f64 (LibraryFeature.Constant of type f64) at /home/fridi/fuzion/fuzion/build/tests/reg_issues5821_5835/reg_issues5821_5835.fz:83:9:
+  b41 : a4 3.14                        is {}; ignore b41.dynamic_type; say b41$
+--------^^
+original test:
+tests using 0, 1 and 2 actual types passed to open type:
+[]
+[Type of 'unit']
+[Type of 'unit', Type of 'i32']
+tests using one plain type parameter and 0, 1 and 2 actual types passed to open type:
+[]
+Type of 'bool' [Type of 'unit']
+Type of 'void' [Type of 'unit', Type of 'i32']
+tests using argument of open type and 0, 1 and 2 actual types passed to open type:
+[] []
+tests using one plain type parameter and value argument and 0, 1 and 2 actual types passed to open type and corresponding value argument:
+Type of 'f64' [] 3.14 []


### PR DESCRIPTION
The problem was that the actual number of type parameters could change and even become smaller if open type parameters are involved.

This patch also simplifies the code by first using the type parameters from the original (non-cotype) feature and replacing them once the type parameters of that feature have been inferred.

Fix #5821 and add disabled tests for #5835.
