### PR TITLE
fix check-condition: IncompleteType.java:47

### DIFF
--- a/src/dev/flang/ast/AbstractType.java
+++ b/src/dev/flang/ast/AbstractType.java
@@ -2357,7 +2357,7 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
   /**
    * create String representation of the outer of this type
    */
-  private String outerToString(boolean humanReadable)
+  protected String outerToString(boolean humanReadable)
   {
     var o = outer();
     return isThisType()

--- a/src/dev/flang/ast/IncompleteType.java
+++ b/src/dev/flang/ast/IncompleteType.java
@@ -46,4 +46,5 @@ public class IncompleteType extends ResolvedType {
   @Override public List<AbstractType> generics() { return AbstractCall.NO_GENERICS; }
   @Override public AbstractType outer() { if (CHECKS) check(Errors.any()); return null; }
   @Override public TypeKind kind() { return _typeKind; }
+  @Override protected String outerToString(boolean humanReadable) { return ""; }
 }


### PR DESCRIPTION
occurs in content/tutorial_using_braces/examples/match_generics_ambiguous.fz Problem was that `IncompleteType.toString()`  was broken.


