### PR TITLE
lib: fix soundness issue

### DIFF
--- a/modules/base/src/time/Clock.fz
+++ b/modules/base/src/time/Clock.fz
@@ -102,7 +102,7 @@ public Clock ref : effect is
   #
   # return the number of times the `code` was run.
   #
-  public run_periodic(P type : Period,
+  public run_periodic(P type : time.Period,
                       first time.instant,
                       period P,
                       last time.instant,


### PR DESCRIPTION
currently Frontend does not show this error becuase #5786 is not merged yet.

examples/jitter/jitter.fz:116:22: error 1: Incompatible type parameter
        _ := C.clock.run_periodic start period end run_one_release
---------------------^^^^^^^^^^^^
formal type parameter 'P : time.this.Period' with constraint 'C.Period' actual type parameter 'time.duration'

one error.

