### PR TITLE
fe: fix confusing missing module file error

### DIFF
--- a/src/dev/flang/fe/FrontEnd.java
+++ b/src/dev/flang/fe/FrontEnd.java
@@ -32,6 +32,7 @@ import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 
 import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 
@@ -268,10 +269,15 @@ public class FrontEnd extends ANY
           }
         _modules.put(m, result);
       }
+    catch (NoSuchFileException io)
+      {
+        Errors.error("Module file " + p.getFileName().toString() + " does not exist.",
+                     "Full path where file was expected: " + p.normalize());
+      }
     catch (IOException io)
       {
-        Errors.error("FrontEnd I/O error when reading module file",
-                     "While trying to read file '"+ p + "' received '" + io + "'");
+        Errors.fatal("FrontEnd I/O error when reading module file",
+                     "While trying to read file '"+ p.normalize() + "' received '" + io + "'");
       }
     return result;
   }


### PR DESCRIPTION
now
```
error 1: Module file module_does_not_exist.fum does not exist.
Full path where file was expected: /home/sam/openvscode-server-fuzion/vscode-fuzion/fuzion/build/modules/module_does_not_exist.fum

one error.
```
fixes #5864 