### PR TITLE
ast: Relex precondition of `Call.notifyInferred` due to #5866

### DIFF
--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -3083,7 +3083,8 @@ public class Call extends AbstractCall
   public void notifyInferred()
   {
     if (PRECONDITIONS) require
-      (// NYI: CLEANUP: #5866 breaks this precondition, but there are also other case
+      (// NYI: CLEANUP: #5866 breaks this precondition, but there are also other cases where
+       // the actuals still contain t_UNDEFINED that still need to be checked.
        true ||
        !actualTypeParameters().stream().anyMatch(atp -> atp.containsUndefined(false)));
 

--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -1726,14 +1726,11 @@ public class Call extends AbstractCall
    */
   private boolean mustReportMissingImmediately(AbstractType rt, boolean[] conflict)
   {
-    var x = _calledFeature != Types.resolved.f_bool_TERNARY;
-      /*
-      !true || (rt == null ||
-             false && !rt.isGenericArgument() ||
-             false && rt.genericArgument().outer().outer() != _calledFeature.outer()) ||
+    var x = (rt == null ||
+        !rt.isGenericArgument() ||
+         rt.genericArgument().outer().outer() != _calledFeature.outer()) ||
          // NYI: CLEANUP: why true, i.e., must report errors, in case of previous errors in the actuals?
-         false && _actuals.stream().anyMatch(a -> a.typeForInferencing() == Types.t_ERROR);
-      */
+         _actuals.stream().anyMatch(a -> a.typeForInferencing() == Types.t_ERROR);
 
     // see test #5391 for when this might happen
     var y = !_calledFeature.hasOpenGenericsArgList() || foundConflicts(conflict);
@@ -3081,14 +3078,13 @@ public class Call extends AbstractCall
 
 
   /**
-   * Notify this call that it is fully inferred.
+   * Notify this call that it all of its type parameters have been inferred.
    */
   public void notifyInferred()
   {
     if (PRECONDITIONS) require
-      (// NYI: CLEANUP: remove this special handling for `bool.ternary ? :` once #5866 is solved
-       _calledFeature == Types.resolved.f_bool_TERNARY ||
-
+      (// NYI: CLEANUP: #5866 breaks this precondition, but there are also other case
+       true ||
        !actualTypeParameters().stream().anyMatch(atp -> atp.containsUndefined(false)));
 
     for (var r : _whenInferredTypeParameters)


### PR DESCRIPTION
The main reason why there could still be t_UNDEFINED in the actual type parameter is  #5866, so I mention this issue there. Once that is fixed, we might be able to check what other conditions might cause this (looks like some pending error cases might be the culprit here). 