### PR TITLE
ast: Fix check condition failure when comparing tuples

### DIFF
--- a/modules/base/src/container/ordered_map.fz
+++ b/modules/base/src/container/ordered_map.fz
@@ -52,8 +52,8 @@ is
   public entry(i i32) : property.orderable is
 
 
-    key => ks[i]
-    val => vs[i]
+    public key OK => ks[i]
+    public val V  => vs[i]
 
 
     # total order over entries.

--- a/tests/reg_issue5850_tuple_comparison/Makefile
+++ b/tests/reg_issue5850_tuple_comparison/Makefile
@@ -1,0 +1,25 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test Makefile
+#
+# -----------------------------------------------------------------------
+
+override NAME = reg_issue5850_tuple_comparison
+include ../simple.mk

--- a/tests/reg_issue5850_tuple_comparison/reg_issue5850_tuple_comparison.fz
+++ b/tests/reg_issue5850_tuple_comparison/reg_issue5850_tuple_comparison.fz
@@ -1,0 +1,96 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test reg_issue5850_tuple_comparison
+#
+# -----------------------------------------------------------------------
+
+# test comparing of tuples
+#
+reg_issue5850_tuple_comparison =>
+
+  # the original example from #5850
+  #
+  ex =>
+    a := (1,2)
+    b := (1,3)
+    say a=a
+    say a=b
+
+  say ""
+  say "original example, should print `true` and `false`"
+  ex
+
+  # a more complex example
+  twelve_tuples := [ (123, "abc", "false"),
+                     (123, "abc", "true "),
+                     (123, "abc", "true "),
+                     (456, "def", "false"),
+                     (789, "ghi", "true "),
+                     (123, "abc", "false"),
+                     (123, "abd", "false"),
+                     (123, "abd", "true "),
+                     (122, "abc", "false"),
+                     (122, "abc", "true "),
+                     (124, "abc", "false"),
+                     (124, "abc", "true ") ]
+  tuples := twelve_tuples.unique.as_array
+
+  c => container
+
+  say ""
+  say "more complex example: "
+
+  say ""
+  say "first, let's see if dedup and unique work, should print 12, 11 and 10: "
+  say twelve_tuples.count
+  say twelve_tuples.dedup.count
+  say tuples.count
+
+  say ""
+  say "check if tuples is sorted (expecting `false`): {tuples.is_sorted}"
+
+  say ""
+  say "creating map from tuples to their indices:"
+  map1 := c.ordered_map tuples tuples.indices
+  say map1
+  say "map1 sorted (expecting `true`): {map1.sorted_entries.map (.key) .is_sorted}"
+
+  say ""
+  say "show sorted keys from map, should be sorted:"
+  say (map1.sorted_entries .map (.key))
+
+  say ""
+  say "show sorted values from map, should be mixed:"
+  say (map1.sorted_entries .map (.val))
+
+  say ""
+  say "while keys from sorted entries now have a different order than tuples:"
+  say "map1 keys equals original tuples (expecting `false`): {map1.sorted_entries.map (.key) .zip tuples (=) .fold bool.all}"
+
+  say ""
+  say "now, creating a map inverting values and keys, i.e., sorted by the original indices"
+  map2 := c.ordered_map map1.values map1.keys
+  say map2
+
+  say ""
+  say "printing the sorted values"
+  say (map2.sorted_entries .map (.val))
+  say "map2 sorted (expecting `false`): {map2.sorted_entries.map (.val) .is_sorted}"
+  say "map2 values equals original tuples (expecting `true`): {map2.sorted_entries.map (.val) .zip tuples (=) .fold bool.all}"

--- a/tests/reg_issue5850_tuple_comparison/reg_issue5850_tuple_comparison.fz.expected_out
+++ b/tests/reg_issue5850_tuple_comparison/reg_issue5850_tuple_comparison.fz.expected_out
@@ -1,0 +1,34 @@
+
+original example, should print `true` and `false`
+true
+false
+
+more complex example: 
+
+first, let's see if dedup and unique work, should print 12, 11 and 10: 
+12
+11
+10
+
+check if tuples is sorted (expecting `false`): false
+
+creating map from tuples to their indices:
+((123, abc, false) => 0), ((123, abc, true ) => 1), ((456, def, false) => 2), ((789, ghi, true ) => 3), ((123, abd, false) => 4), ((123, abd, true ) => 5), ((122, abc, false) => 6), ((122, abc, true ) => 7), ((124, abc, false) => 8), ((124, abc, true ) => 9)
+map1 sorted (expecting `true`): true
+
+show sorted keys from map, should be sorted:
+[(122, abc, false), (122, abc, true ), (123, abc, false), (123, abc, true ), (123, abd, false), (123, abd, true ), (124, abc, false), (124, abc, true ), (456, def, false), (789, ghi, true )]
+
+show sorted values from map, should be mixed:
+[6, 7, 0, 1, 4, 5, 8, 9, 2, 3]
+
+while keys from sorted entries now have a different order than tuples:
+map1 keys equals original tuples (expecting `false`): false
+
+now, creating a map inverting values and keys, i.e., sorted by the original indices
+(6 => (122, abc, false)), (7 => (122, abc, true )), (0 => (123, abc, false)), (1 => (123, abc, true )), (4 => (123, abd, false)), (5 => (123, abd, true )), (8 => (124, abc, false)), (9 => (124, abc, true )), (2 => (456, def, false)), (3 => (789, ghi, true ))
+
+printing the sorted values
+[(123, abc, false), (123, abc, true ), (456, def, false), (789, ghi, true ), (123, abd, false), (123, abd, true ), (122, abc, false), (122, abc, true ), (124, abc, false), (124, abc, true )]
+map2 sorted (expecting `false`): false
+map2 values equals original tuples (expecting `true`): true


### PR DESCRIPTION
The problem was that after a `fum` file is loaded, the magic done using `FormalGenerics.AsActuals` no longer works.  Since this was only intended as an optimization, it got overlooked that the generic code to replace an open type parameter did not handle open type parameters in cotype correctly.

This patch adds a new method `matchingTypeParameter` that extracts the code relevant for checking if a type parameter comes from a given feature even if it is a clone in the cotype.  This code is now used in in the methods `applyTypeParsLocally` (which does not handle open type parameters) and `applyTypePars()` with List arguments, that handles open type parameters as well.

Also added a regression with the original failing code and more tests using ordered maps from tuples to i32 and vice versa.

