### PR TITLE
Makefile: fix error caused by missing directory `build/include/`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1180,7 +1180,7 @@ $(BUILD_DIR)/bin/record_simple_example: $(FZ_SRC)/bin/record_simple_example.fz
 # tricky, we need MOD_TERMINAL to build (check|record)_simple_example
 # but we are not adding this to those targets because we do not want
 # (check|record)_simple_example to rebuild any time sth is changed in base lib
-$(BUILD_DIR)/tests: $(FUZION_FILES_TESTS) $(MOD_TERMINAL) $(BUILD_DIR)/bin/check_simple_example $(BUILD_DIR)/bin/record_simple_example
+$(BUILD_DIR)/tests: $(FUZION_FILES_TESTS) $(MOD_TERMINAL) $(BUILD_DIR)/include $(BUILD_DIR)/bin/check_simple_example $(BUILD_DIR)/bin/record_simple_example
 	rm -rf $@
 	mkdir -p $(@D)
 	cp -rf $(FZ_SRC_TESTS) $@


### PR DESCRIPTION
I got this error after doing `make clean`

```
❯ make base-only  
rm -rf build/modules/base
mkdir -p build/modules
cp -rf ./modules/base build/modules
./build/bin/fz -sourceDirs=./build/modules/base/src -XloadBaseModule=off -saveModule=build/modules/base.fum -XenableSetKeyword
 + build/modules/base.fum in 5718ms
./build/bin/fz -XXcheckIntrinsics
rm -rf build/modules/terminal
mkdir -p build/modules
cp -rf ./modules/terminal build/modules
./build/bin/fz -sourceDirs=./build/modules/terminal/src -saveModule=build/modules/terminal.fum
 + build/modules/terminal.fum in 631ms
./build/bin/fz -modules=terminal -c -o=build/bin/check_simple_example bin/check_simple_example.fz
clang: error: no such file or directory: '/home/simon/fuzion/build/include/shared.c'
clang: error: no such file or directory: '/home/simon/fuzion/build/include/posix.c'

error 1: C backend: C compiler failed
C compiler call 'clang --target=x86_64-pc-linux-gnu -ftrapv -Wall -Werror -Wextra -Wpedantic -Wformat=2 -Wshadow -Wwrite-strings -Wold-style-definition -Wredundant-decls -Wnested-externs -Wmissing-include-dirs -O3 -Wno-unused-parameter -Wno-unused-but-set-parameter -Wno-strict-prototypes -Wno-gnu-empty-initializer -Wno-zero-length-array -Wno-trigraphs -Wno-gnu-empty-struct -Wno-unused-variable -Wno-unused-label -Wno-unused-function -Wno-pointer-to-int-cast -Wno-missing-include-dirs -Wno-infinite-recursion -Wno-incompatible-function-pointer-types -Wno-unused-but-set-variable -DGC_THREADS -DGC_PTHREADS -DPTW32_STATIC_LIB -DGC_WIN32_PTHREADS -DFUZION_ENABLE_THREADS -fno-trigraphs -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -lpthread -std=c11 -o build/bin/check_simple_example /home/simon/fuzion/build/include/shared.c /home/simon/fuzion/build/include/posix.c /tmp/check_simple_example_16415467259438516754.c -lgc' failed with exit code '1'

one error.
make: *** [Makefile:1171: build/bin/check_simple_example] Error 1
```