### PR TITLE
timer: split dfa into dfa1 and dfa2

### DIFF
--- a/src/dev/flang/fuir/analysis/dfa/DFA.java
+++ b/src/dev/flang/fuir/analysis/dfa/DFA.java
@@ -1358,7 +1358,7 @@ public class DFA extends ANY
     _newCallRecursiveAnalyzeClazzes = new int[MAX_NEW_CALL_RECURSION];
     _real = false;
     findFixPoint();
-    _options.timer("dfa1");
+    _options.timer("dfa_pre");
 
     for (var k : _callGroupsQuick.keySet())
       {
@@ -1387,7 +1387,7 @@ public class DFA extends ANY
 
     _real = true;
     findFixPoint();
-    _options.timer("dfa2");
+    _options.timer("dfa_real");
 
     _fuir.reportAbstractMissing();
     Errors.showAndExit();

--- a/src/dev/flang/fuir/analysis/dfa/DFA.java
+++ b/src/dev/flang/fuir/analysis/dfa/DFA.java
@@ -1227,7 +1227,6 @@ public class DFA extends ANY
   public GeneratingFUIR new_fuir()
   {
     dfa();
-    _options.timer("dfa");
     var res = new GeneratingFUIR(_fuir)
       {
         /**
@@ -1359,6 +1358,7 @@ public class DFA extends ANY
     _newCallRecursiveAnalyzeClazzes = new int[MAX_NEW_CALL_RECURSION];
     _real = false;
     findFixPoint();
+    _options.timer("dfa1");
 
     for (var k : _callGroupsQuick.keySet())
       {
@@ -1387,6 +1387,7 @@ public class DFA extends ANY
 
     _real = true;
     findFixPoint();
+    _options.timer("dfa2");
 
     _fuir.reportAbstractMissing();
     Errors.showAndExit();

--- a/src/dev/flang/tools/Fuzion.java
+++ b/src/dev/flang/tools/Fuzion.java
@@ -1185,7 +1185,7 @@ public class Fuzion extends Tool
     var options = fe._options;
     var mir  = fe.createMIR();                            f.timer("createMIR");
     var fuir = new GeneratingFUIR(fe, mir);               f.timer("ir");
-    var dfuir = new DFA(options, fuir).new_fuir();        f.timer("dfa");
+    var dfuir = new DFA(options, fuir).new_fuir();
     var ofuir = new Optimizer(options, dfuir).fuir();     f.timer("opt");
     return ofuir;
   }


### PR DESCRIPTION
output e.g.
```
Elapsed time for phases: prep 72ms, fe 150ms, createMIR 67ms, ir 7ms, dfa1 1309ms, dfa2 291ms, opt 3ms, be 466ms
```
