### PR TITLE
util: Show failing pre/post/check condition even if it comes from generated code

### DIFF
--- a/src/dev/flang/tools/Fuzion.java
+++ b/src/dev/flang/tools/Fuzion.java
@@ -588,7 +588,10 @@ public class Fuzion extends Tool
    */
   Path _fuzionHome = FuzionHome._fuzionHome;
   {
-    ANY._sourceDirs.add(_fuzionHome.resolve("generated").resolve("src"));
+    if (_fuzionHome != null)
+      {
+        ANY._sourceDirs.add(_fuzionHome.resolve("generated").resolve("src"));
+      }
   }
 
 

--- a/src/dev/flang/tools/Fuzion.java
+++ b/src/dev/flang/tools/Fuzion.java
@@ -63,6 +63,7 @@ import dev.flang.fuir.analysis.dfa.DFA;
 
 import dev.flang.opt.Optimizer;
 
+import dev.flang.util.ANY;
 import dev.flang.util.List;
 import dev.flang.util.Errors;
 import dev.flang.util.FuzionConstants;
@@ -586,6 +587,9 @@ public class Fuzion extends Tool
    * Home directory of the Fuzion installation.
    */
   Path _fuzionHome = FuzionHome._fuzionHome;
+  {
+    ANY._sourceDirs.add(_fuzionHome.resolve("generated").resolve("src"));
+  }
 
 
   /**

--- a/src/dev/flang/util/ANY.java
+++ b/src/dev/flang/util/ANY.java
@@ -113,9 +113,10 @@ public class ANY
                              .map(str -> str.trim())
                              .limit(7)
                              .collect(Collectors.toList());
-                var n = l.stream().takeWhile(s -> !s.endsWith(");")).count()+1;
+                var n = l.stream().takeWhile(s -> !s.endsWith(");"))
+                                  .count()+1;
                 var cond = l.stream().limit(n)
-                            .collect(Collectors.joining(" "));
+                                     .collect(Collectors.joining(" "));
                 return res + Terminal.BLUE + " \"" + cond + "\"" + Terminal.REGULAR_COLOR;
               }
             catch (IOException e)

--- a/src/dev/flang/util/ANY.java
+++ b/src/dev/flang/util/ANY.java
@@ -107,7 +107,7 @@ public class ANY
         p = p.resolve(fn);
         if (Files.exists(p))
           {
-            try (Stream<String> lines = Files.lines(p))
+            try (var lines = Files.lines(p))
               {
                 var l = lines.skip(ln-1)
                              .map(str -> str.trim())


### PR DESCRIPTION
I was annoyed since I did not see a failing check-condition that happened in `build/generated/src/dev/flang/fuir/analysis/AbstractInterpreter2.java`, so I added support for additional source paths and added this.

Also did some cleanup in the path handling stream processing.
