### PR TITLE
base: make `tuple` inherit `property.hashable`

### DIFF
--- a/modules/base/src/container/hash_map.fz
+++ b/modules/base/src/container/hash_map.fz
@@ -28,17 +28,17 @@
 public hash_map(
         public HK type : property.hashable,
         public V  type,
-        ks array HK,
-        vs array V) : Map HK V
+        ks Sequence HK,
+        vs Sequence V) : Map HK V
   pre
-    ks.length = vs.length
+    ks.count = vs.count
 
 is
 
 
   # number of entries in this map
   #
-  public redef size i32 => ks.length
+  public redef size i32 => ks.count
 
 
   # size of allocated contents array, allows for some empty slots

--- a/modules/base/src/container/hash_map.fz
+++ b/modules/base/src/container/hash_map.fz
@@ -31,14 +31,14 @@ public hash_map(
         ks Sequence HK,
         vs Sequence V) : Map HK V
   pre
-    ks.count = vs.count
+    debug: ks.count = vs.count
 
 is
 
 
   # number of entries in this map
   #
-  public redef size i32 => ks.count
+  public redef size i32 := ks.count
 
 
   # size of allocated contents array, allows for some empty slots

--- a/modules/base/src/tuple.fz
+++ b/modules/base/src/tuple.fz
@@ -120,7 +120,9 @@
 #
 public tuple(public A type...,
              public values A...
-             ) : property.orderable is
+             ) : property.orderable,
+                 property.hashable
+is
 
 
   # equality of two tuple `a` and `b` is defined only if all elements of the tuple
@@ -141,13 +143,53 @@ public tuple(public A type...,
   # the `i+1`th element pair.
   #
   # This will result in a runtime `panic` in case any element type is not orderable.
-    #
+  #
   public redef type.lteq(a, b tuple.this) bool
   =>
     # NYI: BUG: omitting type parameters results in crash (Unimplemented method 'generics' in ThisType):
     # a.values.typed_zip_and_fold b.values true (tuple_zip_lteq tuple.this)
 
     a.values.typed_zip_and_fold i32 (tuple_zip_lteq tuple.this) b.values 0 (tuple_zip_lteq tuple.this) <= 0
+
+
+  # create hash code for this tuple
+  #
+  # This should satisfy the following condition:
+  #
+  #   (T.equality a b) : (T.hash_code a = T.hash_code b)
+  #
+  # This will result in a compile-time `panic` in case any element type is not hashable.
+  #
+  # The algorithm used here is a variation of (XXXHash)[https://xxhash.com] as used in
+  # (Python's tuple)[https://github.com/python/cpython/blob/849a80ec412c36bbca5d400a7db5645b8cf54f1f/Objects/tupleobject.c#L305]:
+  #
+  #   we start with a constant `hash_prime1`
+  #   for each value:
+  #     we take its hash code * `hash_prime2` and add it
+  #     then we rotate by `hash_rotate`
+  #     and multiply by `hash_prime3`
+  #
+  public redef fixed type.hash_code(a tuple.this) u64 : container.typed_fold xxh_prime_5 a.values
+  =>
+    public redef apply(T type, h u64, v T) u64
+    =>
+      if T : property.hashable then
+        h2 := h +° T.hash_code v *° xxh_prime_2
+        h3 := (h2 << xxh_rotate) | (h2 >> (u64 64 - xxh_rotate))
+        h3 *° xxh_prime_1
+      else
+        compile_time_panic  # tuple is not hashable since one element type is not
+    res
+
+
+  # XXH constants from https://xxhash.com/doc/v0.8.3/group___x_x_h64__impl.html
+  #
+  private type.xxh_prime_1 => u64 0x9E3779B185EBCA87  # factor after each value's hash code was added and result was rotated
+  private type.xxh_prime_2 => u64 0xC2B2AE3D27D4EB4F  # factor for adding hash code of values
+  private type.xxh_prime_3 => u64 0x165667B19E3779F9  # not needed here
+  private type.xxh_prime_4 => u64 0x85EBCA77C2B2AE63  # not needed here
+  private type.xxh_prime_5 => u64 0x27D4EB2F165667C5  # initial hash used for empty tuple
+  private type.xxh_rotate => u64 31                   # rotation after adding hash code of values
 
 
   # create a String from this instance.

--- a/tests/reg_issue5850_tuple_comparison/reg_issue5850_tuple_comparison.fz
+++ b/tests/reg_issue5850_tuple_comparison/reg_issue5850_tuple_comparison.fz
@@ -94,3 +94,14 @@ reg_issue5850_tuple_comparison =>
   say (map2.sorted_entries .map (.val))
   say "map2 sorted (expecting `false`): {map2.sorted_entries.map (.val) .is_sorted}"
   say "map2 values equals original tuples (expecting `true`): {map2.sorted_entries.map (.val) .zip tuples (=) .fold bool.all}"
+
+  say ""
+  say "hash table: from tuples to their indices"
+  hm := container.hash_map tuples (tuples.indices.map (.bin))
+  say hm
+  for t in tuples
+      i in 0..
+      vbin := hm[t].or_else "0"
+      v := vbin.parse_i32_binary.or_else -1
+  do
+    say "get $t from hm is $v expected $i {v=i ? "OK" : "***FAIL***"}"

--- a/tests/reg_issue5850_tuple_comparison/reg_issue5850_tuple_comparison.fz.expected_out
+++ b/tests/reg_issue5850_tuple_comparison/reg_issue5850_tuple_comparison.fz.expected_out
@@ -32,3 +32,16 @@ printing the sorted values
 [(123, abc, false), (123, abc, true ), (456, def, false), (789, ghi, true ), (123, abd, false), (123, abd, true ), (122, abc, false), (122, abc, true ), (124, abc, false), (124, abc, true )]
 map2 sorted (expecting `false`): false
 map2 values equals original tuples (expecting `true`): true
+
+hash table: from tuples to their indices
+{((124, abc, true ) => 1001), ((122, abc, true ) => 111), ((123, abd, false) => 100), ((123, abc, false) => 0), ((123, abd, true ) => 101), ((122, abc, false) => 110), ((124, abc, false) => 1000), ((123, abc, true ) => 1), ((789, ghi, true ) => 11), ((456, def, false) => 10)}
+get (123, abc, false) from hm is 0 expected 0 OK
+get (123, abc, true ) from hm is 1 expected 1 OK
+get (456, def, false) from hm is 2 expected 2 OK
+get (789, ghi, true ) from hm is 3 expected 3 OK
+get (123, abd, false) from hm is 4 expected 4 OK
+get (123, abd, true ) from hm is 5 expected 5 OK
+get (122, abc, false) from hm is 6 expected 6 OK
+get (122, abc, true ) from hm is 7 expected 7 OK
+get (124, abc, false) from hm is 8 expected 8 OK
+get (124, abc, true ) from hm is 9 expected 9 OK


### PR DESCRIPTION
Add test cases to `reg_issue5850` using `hash_map` of tuples.

Changes arguments to `container.hash_map` to be `Sequence` not `array` for convenience. 