### PR TITLE
lib: add os.mmap_offset_multiple

### DIFF
--- a/include/fz.h
+++ b/include/fz.h
@@ -765,6 +765,8 @@ int32_t fzE_path_max(void);
 
 int64_t fzE_page_size(void);
 
+int64_t fzE_mmap_offset_multiple(void);
+
 int fzE_cwd(void * buf, size_t size);
 
 #endif /* fz.h  */

--- a/include/posix.c
+++ b/include/posix.c
@@ -968,6 +968,11 @@ int64_t fzE_page_size(void)
   return sysconf(_SC_PAGESIZE);
 }
 
+int64_t fzE_mmap_offset_multiple(void)
+{
+  return sysconf(_SC_PAGESIZE);
+}
+
 int fzE_cwd(void * buf, size_t size)
 {
   return getcwd(buf, size) == NULL

--- a/include/win.c
+++ b/include/win.c
@@ -1148,6 +1148,13 @@ int64_t fzE_page_size(void)
   return (int64_t)(uint64_t)sys_info.dwPageSize;
 }
 
+int64_t fzE_mmap_offset_multiple(void)
+{
+  SYSTEM_INFO sys_info;
+  GetSystemInfo(&sys_info);
+  return (int64_t)(uint64_t)sys_info.dwAllocationGranularity;
+}
+
 int fzE_cwd(void * buf, size_t size)
 {
   return _getcwd(buf, size) == NULL

--- a/modules/base/src/io/file/open.fz
+++ b/modules/base/src/io/file/open.fz
@@ -45,7 +45,7 @@ module:public open(fd File_Descriptor,
 
   # install mmap effect an run code
   #
-  # note: the offset must be a multiple of the pagesize which usually is 4096, windows 65536?
+  # note: the offset must be a multiple of the `os.mmap_offset_multiple` which usually is 4096, windows 65536?
   # note: offset+size must not exceed size of file
   #
   # example usage:
@@ -55,7 +55,7 @@ module:public open(fd File_Descriptor,
   #         io.file.open.mmap[99] := 42
   #
   public mmap(R type, offset i64, size i64, code ()->R) outcome R
-    pre safety: offset % os.page_size = 0
+    pre safety: offset % os.mmap_offset_multiple = 0
   =>
 
     res := fuzion.sys.internal_array_init i32 1

--- a/modules/base/src/native.fz
+++ b/modules/base/src/native.fz
@@ -414,4 +414,7 @@ module fzE_path_max i32 => native
 module fzE_page_size i64 => native
 
 
+module fzE_mmap_offset_multiple i64 => native
+
+
 module fzE_cwd(buf Array u8, size i64) i32 => native

--- a/modules/base/src/os/mmap_offset_multiple.fz
+++ b/modules/base/src/os/mmap_offset_multiple.fz
@@ -17,38 +17,13 @@
 #
 #  Tokiwa Software GmbH, Germany
 #
-#  Source code of Fuzion test mmap_test
+#  Source code of Fuzion standard library feature os.mmap_offset_multiple
 #
 # -----------------------------------------------------------------------
 
-mmap_test =>
+# the offset for mmap must be a multiple of this
+#
+public mmap_offset_multiple i64
+  post debug: result > 0
+=> fzE_mmap_offset_multiple
 
-  testfile := "testfile"
-
-  f =>
-    io.file.open
-
-  say <| io.file.use testfile io.file.mode.append ()->
-
-    io.file.writer.write (array u8 os.mmap_offset_multiple.as_i32 i->0)
-      .error.get
-    io.file.writer.write "hello!".utf8
-      .error.get
-    io.file.writer.flush
-      .get
-
-    offset := os.mmap_offset_multiple
-
-    # map 6 bytes of file starting from the end of the '+'s.
-    say <| f.mmap offset (i64 6) ()->
-            # change the 'e' in hello to an 'a'.
-            io.file.mapped_buffer.env[1] := io.file.mapped_buffer.env[1] - 4
-
-    # mmap should fail, since offset+size exceeds file size.
-    say <| f.mmap offset (i64 7) ()->
-
-
-  say <| io.file.use testfile io.file.mode.read ()->
-    String.from_bytes ((io.buffered io.file.file_mutate).read_fully.drop os.mmap_offset_multiple.as_i32)
-
-  say (io.file.delete testfile)


### PR DESCRIPTION
on windows mmap offset must be multiple of allocation granularity, not page size.


