### PR TITLE
base: add `Any.dynamic_apply` and `Typed_Function`

### DIFF
--- a/modules/base/src/Any.fz
+++ b/modules/base/src/Any.fz
@@ -64,3 +64,52 @@ public Any ref is
   # difference to `dynamic_type`.
   #
   public type.type_value Type => Any.this.type
+
+
+  # dynamic_apply -- apply `f.call` to Any.this's dynamic type and value
+  #
+  # This can be used to perform operation on values depending on their dynamic
+  # type.
+  #
+  # Here is an example that takes a `Sequence Any` that may contain boxed values
+  # of types `i32` and `f64`.  We can now write a feature `get_f64` that extracts
+  # these values converte to `f64` and build a function `sum` that sums them up
+  # as follows:
+  #
+  #     sum(values Sequence Any)
+  #     =>
+  #       get_f64 : Typed_Function f64 is
+  #         public redef call(T type, v T) f64
+  #         =>
+  #           if      T : i32 then v.as_f64
+  #           else if T : f64 then v.val
+  #                           else compile_time_panic
+  #
+  #       values.map (.dynamic_apply get_f64)
+  #             .foldf 0.0 (+)
+  #
+  #     say <| sum [3.14, 32, 16.0, 8]
+  #
+  # NYI: IMPROVEMENT: #5892: If this is fixed, we could write
+  #
+  #     sum(values Sequence Any)
+  #     =>
+  #       values.map .dynamic_apply T,v->
+  #                     if      T : i32 then v.as_f64
+  #                     else if T : f64 then v.val
+  #                                     else compile_time_panic
+  #             .foldf 0.0 (+)
+  #
+  #     say <| sum [3.14, 32, 16.0, 8]
+  #
+  public dynamic_apply(R type,
+                       F type : Typed_Function R,
+                       f F
+                       ) R
+  =>
+    # NYI: BUG: #5894 if fixed, we should be able to write
+    #
+    #   f.call Any.this Any.this
+    #
+    # for now, using type inference for `T` works:
+    f.call Any.this

--- a/modules/base/src/Any.fz
+++ b/modules/base/src/Any.fz
@@ -66,14 +66,14 @@ public Any ref is
   public type.type_value Type => Any.this.type
 
 
-  # dynamic_apply -- apply `f.call` to Any.this's dynamic type and value
+  # dynamic_apply -- apply `f.call` to `Any.this`'s dynamic type and value
   #
   # This can be used to perform operation on values depending on their dynamic
   # type.
   #
   # Here is an example that takes a `Sequence Any` that may contain boxed values
   # of types `i32` and `f64`.  We can now write a feature `get_f64` that extracts
-  # these values converte to `f64` and build a function `sum` that sums them up
+  # these values converted to `f64` and build a function `sum` that sums them up
   # as follows:
   #
   #     sum(values Sequence Any)

--- a/modules/base/src/Typed_Function.fz
+++ b/modules/base/src/Typed_Function.fz
@@ -17,7 +17,7 @@
 #
 #  Tokiwa Software GmbH, Germany
 #
-#  Source code of Fuzion standard library feature Function
+#  Source code of Fuzion standard library feature Typed_Function
 #
 #  Author: Fridtjof Siebert (siebert@tokiwa.software)
 #
@@ -25,7 +25,7 @@
 
 # Typed_Function -- generic function with type parameter `T` and argument `v` of that type
 #
-# R is the result type of the function, A are the argument types of the function in
+# R is the result type of the function, `A` are the argument types of the function in
 # addition to `T` and `v`.
 #
 # This is used, e.g., as an argument to `Any.dynamic_apply`.
@@ -34,7 +34,7 @@ public Typed_Function(public R type,
                       public A type...) ref is
 
 
-  # call this function for type T on arguments a... and v.
+  # call this function for type `T` on arguments `a...` and `v`.
   #
   # NYI: CLEANUP: #5895 if this is fixed, we should change the argument order to
   # macht the order used in `container.typed_applicator`:

--- a/modules/base/src/Typed_Function.fz
+++ b/modules/base/src/Typed_Function.fz
@@ -1,0 +1,44 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion standard library feature Function
+#
+#  Author: Fridtjof Siebert (siebert@tokiwa.software)
+#
+# -----------------------------------------------------------------------
+
+# Typed_Function -- generic function with type parameter `T` and argument `v` of that type
+#
+# R is the result type of the function, A are the argument types of the function in
+# addition to `T` and `v`.
+#
+# This is used, e.g., as an argument to `Any.dynamic_apply`.
+#
+public Typed_Function(public R type,
+                      public A type...) ref is
+
+
+  # call this function for type T on arguments a... and v.
+  #
+  # NYI: CLEANUP: #5895 if this is fixed, we should change the argument order to
+  # macht the order used in `container.typed_applicator`:
+  #
+  #     public call(T type, a A..., v T) R => abstract
+  #
+  public call(T type, v T, a A...) R => abstract


### PR DESCRIPTION
This allows, e.g., calculating the sum of all `i32` and `f64` elements in a `Sequence Any`:

    sum(values Sequence Any)
    =>
      get_f64 : Typed_Function f64 is
        public redef call(T type, v T) f64
        =>
          if      T : i32 then v.as_f64
          else if T : f64 then v.val
                          else compile_time_panic

      values.map (.dynamic_apply get_f64)
            .foldf 0.0 (+)

    say <| sum [3.14, 32, 16.0, 8]

`dynamic_apply` can be used similar to `dynamic_type` to reflect on the dynamic type, but it also provides the value using that type such that we can write write code that gets specialized for specific dynamic types.

Added a new feature `Typed_Function` for this.

Using `dynamic_apply` would be nicer if `Typed_Function` would be supported by our lambda syntax sugar #5892.

`Any.dynamic_apply` should be changed to use an explicit type parameter for readability, but this is not possible due to #5894.

The argument order in `Typed_Function` should IMHO be changed, but cannot because of #5895.
