### PR TITLE
fuir: remove special clazz `c_Array`

### DIFF
--- a/src/dev/flang/be/c/C.java
+++ b/src/dev/flang/be/c/C.java
@@ -2436,7 +2436,6 @@ public class C extends ANY
       case c_String :
       case c_false_ :
       case c_true_ :
-      case c_Array :
       case c_u32 :
       case c_u64 :
       case c_u8 :

--- a/src/dev/flang/be/interpreter/ArrayData.java
+++ b/src/dev/flang/be/interpreter/ArrayData.java
@@ -50,9 +50,12 @@ public class ArrayData extends Value
 
 
   /**
-   *
+   * The actual data
    */
-  public final Object _array;
+  public final Object _data;
+
+
+  public final int _clazz;
 
 
   /*--------------------------  constructors  ---------------------------*/
@@ -61,15 +64,16 @@ public class ArrayData extends Value
   /**
    * Constructor
    */
-  public ArrayData(Object array)
+  public ArrayData(Object d, int cl)
   {
     if (PRECONDITIONS) require
-      (array != null,
-       array.getClass().isArray(),
-       array.getClass().componentType().isPrimitive() ||
-       array.getClass().componentType() == Value.class );
+      (d != null,
+       d.getClass().isArray(),
+       d.getClass().componentType().isPrimitive() ||
+       d.getClass().componentType() == Value.class );
 
-    this._array = array;
+    this._data = d;
+    this._clazz = cl;
   }
 
 
@@ -96,18 +100,18 @@ public class ArrayData extends Value
    */
   int length()
   {
-    if      (_array instanceof byte   [] a) { return a.length; }
-    else if (_array instanceof short  [] a) { return a.length; }
-    else if (_array instanceof char   [] a) { return a.length; }
-    else if (_array instanceof int    [] a) { return a.length; }
-    else if (_array instanceof long   [] a) { return a.length; }
-    else if (_array instanceof float  [] a) { return a.length; }
-    else if (_array instanceof double [] a) { return a.length; }
-    else if (_array instanceof boolean[] a) { return a.length; }
-    else if (_array instanceof Object [] a) { return a.length; }
+    if      (_data instanceof byte   [] a) { return a.length; }
+    else if (_data instanceof short  [] a) { return a.length; }
+    else if (_data instanceof char   [] a) { return a.length; }
+    else if (_data instanceof int    [] a) { return a.length; }
+    else if (_data instanceof long   [] a) { return a.length; }
+    else if (_data instanceof float  [] a) { return a.length; }
+    else if (_data instanceof double [] a) { return a.length; }
+    else if (_data instanceof boolean[] a) { return a.length; }
+    else if (_data instanceof Object [] a) { return a.length; }
     else
       {
-        throw new Error("Unexpected array type " + _array);
+        throw new Error("Unexpected array type " + _data);
       }
   }
 
@@ -138,18 +142,18 @@ public class ArrayData extends Value
     checkIndex(x);
     switch (fuir.getSpecialClazz(elementType))
     {
-      case c_i8 ->          ((byte   [])_array)[x] = (byte   ) v.i8Value();
-      case c_i16 ->         ((short  [])_array)[x] = (short  ) v.i16Value();
-      case c_i32 ->         ((int    [])_array)[x] =           v.i32Value();
-      case c_i64 ->         ((long   [])_array)[x] =           v.i64Value();
-      case c_u8 ->          ((byte   [])_array)[x] = (byte   ) v.u8Value();
-      case c_u16 ->         ((char   [])_array)[x] = (char   ) v.u16Value();
-      case c_u32 ->         ((int    [])_array)[x] =           v.u32Value();
-      case c_u64 ->         ((long   [])_array)[x] =           v.u64Value();
-      case c_f32 ->         ((float  [])_array)[x] =           v.f32Value();
-      case c_f64 ->         ((double [])_array)[x] =           v.f64Value();
-      case c_bool ->        ((boolean[])_array)[x] =           v.boolValue();
-      default ->            ((Value  [])_array)[x] =           v;
+      case c_i8 ->          ((byte   [])_data)[x] = (byte   ) v.i8Value();
+      case c_i16 ->         ((short  [])_data)[x] = (short  ) v.i16Value();
+      case c_i32 ->         ((int    [])_data)[x] =           v.i32Value();
+      case c_i64 ->         ((long   [])_data)[x] =           v.i64Value();
+      case c_u8 ->          ((byte   [])_data)[x] = (byte   ) v.u8Value();
+      case c_u16 ->         ((char   [])_data)[x] = (char   ) v.u16Value();
+      case c_u32 ->         ((int    [])_data)[x] =           v.u32Value();
+      case c_u64 ->         ((long   [])_data)[x] =           v.u64Value();
+      case c_f32 ->         ((float  [])_data)[x] =           v.f32Value();
+      case c_f64 ->         ((double [])_data)[x] =           v.f64Value();
+      case c_bool ->        ((boolean[])_data)[x] =           v.boolValue();
+      default ->            ((Value  [])_data)[x] =           v;
     }
   }
 
@@ -169,18 +173,18 @@ public class ArrayData extends Value
     checkIndex(x);
     return switch (fuir.getSpecialClazz(elementType))
     {
-      case c_i8 ->          new i8Value  (((byte   [])_array)[x]       );
-      case c_i16 ->         new i16Value (((short  [])_array)[x]       );
-      case c_i32 ->         new i32Value (((int    [])_array)[x]       );
-      case c_i64 ->         new i64Value (((long   [])_array)[x]       );
-      case c_u8 ->          new u8Value  (((byte   [])_array)[x] & 0xff);
-      case c_u16 ->         new u16Value (((char   [])_array)[x]       );
-      case c_u32 ->         new u32Value (((int    [])_array)[x]       );
-      case c_u64 ->         new u64Value (((long   [])_array)[x]       );
-      case c_f32 ->         new f32Value (((float  [])_array)[x]       );
-      case c_f64 ->         new f64Value (((double [])_array)[x]       );
-      case c_bool ->        new boolValue(((boolean[])_array)[x]       );
-      default ->            (((Value[])_array)[x])        ;
+      case c_i8 ->          new i8Value  (((byte   [])_data)[x]       );
+      case c_i16 ->         new i16Value (((short  [])_data)[x]       );
+      case c_i32 ->         new i32Value (((int    [])_data)[x]       );
+      case c_i64 ->         new i64Value (((long   [])_data)[x]       );
+      case c_u8 ->          new u8Value  (((byte   [])_data)[x] & 0xff);
+      case c_u16 ->         new u16Value (((char   [])_data)[x]       );
+      case c_u32 ->         new u32Value (((int    [])_data)[x]       );
+      case c_u64 ->         new u64Value (((long   [])_data)[x]       );
+      case c_f32 ->         new f32Value (((float  [])_data)[x]       );
+      case c_f64 ->         new f64Value (((double [])_data)[x]       );
+      case c_bool ->        new boolValue(((boolean[])_data)[x]       );
+      default ->            (((Value[])_data)[x])        ;
     };
   }
 
@@ -192,22 +196,22 @@ public class ArrayData extends Value
    * @param elementType the elements type
    * @return
    */
-  public static ArrayData alloc(int sz, FUIR fuir, int elementType)
+  public static ArrayData alloc(int cl, int sz, FUIR fuir, int elementType)
   {
     return switch (fuir.getSpecialClazz(elementType))
     {
-      case c_i8 ->          new ArrayData(new byte   [sz]);
-      case c_i16 ->         new ArrayData(new short  [sz]);
-      case c_i32 ->         new ArrayData(new int    [sz]);
-      case c_i64 ->         new ArrayData(new long   [sz]);
-      case c_u8 ->          new ArrayData(new byte   [sz]);
-      case c_u16 ->         new ArrayData(new char   [sz]);
-      case c_u32 ->         new ArrayData(new int    [sz]);
-      case c_u64 ->         new ArrayData(new long   [sz]);
-      case c_f32 ->         new ArrayData(new float  [sz]);
-      case c_f64 ->         new ArrayData(new double [sz]);
-      case c_bool ->        new ArrayData(new boolean[sz]);
-      default ->            new ArrayData(new Value  [sz]);
+      case c_i8 ->          new ArrayData(new byte   [sz], cl);
+      case c_i16 ->         new ArrayData(new short  [sz], cl);
+      case c_i32 ->         new ArrayData(new int    [sz], cl);
+      case c_i64 ->         new ArrayData(new long   [sz], cl);
+      case c_u8 ->          new ArrayData(new byte   [sz], cl);
+      case c_u16 ->         new ArrayData(new char   [sz], cl);
+      case c_u32 ->         new ArrayData(new int    [sz], cl);
+      case c_u64 ->         new ArrayData(new long   [sz], cl);
+      case c_f32 ->         new ArrayData(new float  [sz], cl);
+      case c_f64 ->         new ArrayData(new double [sz], cl);
+      case c_bool ->        new ArrayData(new boolean[sz], cl);
+      default ->            new ArrayData(new Value  [sz], cl);
     };
   }
 
@@ -219,7 +223,7 @@ public class ArrayData extends Value
    */
   public String toString()
   {
-    return "data[" + length() + ", " + _array.getClass().componentType() + "]";
+    return "data[" + length() + ", " + _data.getClass().componentType() + "]";
   }
 
 
@@ -238,36 +242,36 @@ public class ArrayData extends Value
   {
     for (int i = 0; i < length(); i++)
       {
-        if      (_array instanceof byte   [] arr) { memSegment.setAtIndex(ValueLayout.JAVA_BYTE,   i, arr[i]);}
-        else if (_array instanceof short  [] arr) { memSegment.setAtIndex(ValueLayout.JAVA_SHORT,  i, arr[i]);}
-        else if (_array instanceof char   [] arr) { memSegment.setAtIndex(ValueLayout.JAVA_CHAR,   i, arr[i]);}
-        else if (_array instanceof int    [] arr) { memSegment.setAtIndex(ValueLayout.JAVA_INT,    i, arr[i]);}
-        else if (_array instanceof long   [] arr) { memSegment.setAtIndex(ValueLayout.JAVA_LONG,   i, arr[i]);}
-        else if (_array instanceof float  [] arr) { memSegment.setAtIndex(ValueLayout.JAVA_FLOAT,  i, arr[i]);}
-        else if (_array instanceof double [] arr) { memSegment.setAtIndex(ValueLayout.JAVA_DOUBLE, i, arr[i]);}
-        else if (_array instanceof boolean[] arr) { memSegment.setAtIndex(ValueLayout.JAVA_BOOLEAN,i, arr[i]);}
-        else if (_array instanceof Value  [] arr)
+        if      (_data instanceof byte   [] arr) { memSegment.setAtIndex(ValueLayout.JAVA_BYTE,   i, arr[i]);}
+        else if (_data instanceof short  [] arr) { memSegment.setAtIndex(ValueLayout.JAVA_SHORT,  i, arr[i]);}
+        else if (_data instanceof char   [] arr) { memSegment.setAtIndex(ValueLayout.JAVA_CHAR,   i, arr[i]);}
+        else if (_data instanceof int    [] arr) { memSegment.setAtIndex(ValueLayout.JAVA_INT,    i, arr[i]);}
+        else if (_data instanceof long   [] arr) { memSegment.setAtIndex(ValueLayout.JAVA_LONG,   i, arr[i]);}
+        else if (_data instanceof float  [] arr) { memSegment.setAtIndex(ValueLayout.JAVA_FLOAT,  i, arr[i]);}
+        else if (_data instanceof double [] arr) { memSegment.setAtIndex(ValueLayout.JAVA_DOUBLE, i, arr[i]);}
+        else if (_data instanceof boolean[] arr) { memSegment.setAtIndex(ValueLayout.JAVA_BOOLEAN,i, arr[i]);}
+        else if (_data instanceof Value  [] arr)
         {
           for (int j = 0; j < arr.length; j++)
             {
               memSegment.set(ValueLayout.ADDRESS, j * 8, (MemorySegment)arr[j].toNative());
             }
         }
-        else throw new Error("NYI: UNDER DEVELOPMENT: copyToMemSegment: " + _array.getClass());
+        else throw new Error("NYI: UNDER DEVELOPMENT: copyToMemSegment: " + _data.getClass());
       }
   }
 
   private int elementByteSize()
   {
-    if      (_array instanceof byte   []) { return 1; }
-    else if (_array instanceof short  []) { return 2; }
-    else if (_array instanceof char   []) { return 2; }
-    else if (_array instanceof int    []) { return 4; }
-    else if (_array instanceof long   []) { return 8; }
-    else if (_array instanceof float  []) { return 4; }
-    else if (_array instanceof double []) { return 8; }
-    else if (_array instanceof boolean[]) { return 4; }
-    else if (_array instanceof Value  []) { return 8; }
+    if      (_data instanceof byte   []) { return 1; }
+    else if (_data instanceof short  []) { return 2; }
+    else if (_data instanceof char   []) { return 2; }
+    else if (_data instanceof int    []) { return 4; }
+    else if (_data instanceof long   []) { return 8; }
+    else if (_data instanceof float  []) { return 4; }
+    else if (_data instanceof double []) { return 8; }
+    else if (_data instanceof boolean[]) { return 4; }
+    else if (_data instanceof Value  []) { return 8; }
     throw new Error("NYI: ArrayData.elementByteSize");
   }
 
@@ -276,16 +280,16 @@ public class ArrayData extends Value
   {
     for (int i = 0; i < length(); i++)
       {
-        if      (_array instanceof byte   [] arr) { arr[i] = memSegment.getAtIndex(ValueLayout.JAVA_BYTE, i); }
-        else if (_array instanceof short  [] arr) { arr[i] = memSegment.getAtIndex(ValueLayout.JAVA_SHORT, i); }
-        else if (_array instanceof char   [] arr) { arr[i] = memSegment.getAtIndex(ValueLayout.JAVA_CHAR, i); }
-        else if (_array instanceof int    [] arr) { arr[i] = memSegment.getAtIndex(ValueLayout.JAVA_INT, i); }
-        else if (_array instanceof long   [] arr) { arr[i] = memSegment.getAtIndex(ValueLayout.JAVA_LONG, i); }
-        else if (_array instanceof float  [] arr) { arr[i] = memSegment.getAtIndex(ValueLayout.JAVA_FLOAT, i); }
-        else if (_array instanceof double [] arr) { arr[i] = memSegment.getAtIndex(ValueLayout.JAVA_DOUBLE, i); }
-        else if (_array instanceof boolean[] arr) { arr[i] = memSegment.getAtIndex(ValueLayout.JAVA_BOOLEAN, i); }
-        else if (_array instanceof Value  [] arr) { /* NYI: UNDER DEVELOPMENT */ }
-        else throw new Error("NYI: UNDER DEVELOPMENT: set: " + _array.getClass());
+        if      (_data instanceof byte   [] arr) { arr[i] = memSegment.getAtIndex(ValueLayout.JAVA_BYTE, i); }
+        else if (_data instanceof short  [] arr) { arr[i] = memSegment.getAtIndex(ValueLayout.JAVA_SHORT, i); }
+        else if (_data instanceof char   [] arr) { arr[i] = memSegment.getAtIndex(ValueLayout.JAVA_CHAR, i); }
+        else if (_data instanceof int    [] arr) { arr[i] = memSegment.getAtIndex(ValueLayout.JAVA_INT, i); }
+        else if (_data instanceof long   [] arr) { arr[i] = memSegment.getAtIndex(ValueLayout.JAVA_LONG, i); }
+        else if (_data instanceof float  [] arr) { arr[i] = memSegment.getAtIndex(ValueLayout.JAVA_FLOAT, i); }
+        else if (_data instanceof double [] arr) { arr[i] = memSegment.getAtIndex(ValueLayout.JAVA_DOUBLE, i); }
+        else if (_data instanceof boolean[] arr) { arr[i] = memSegment.getAtIndex(ValueLayout.JAVA_BOOLEAN, i); }
+        else if (_data instanceof Value  [] arr) { /* NYI: UNDER DEVELOPMENT */ }
+        else throw new Error("NYI: UNDER DEVELOPMENT: set: " + _data.getClass());
       }
   }
 }

--- a/src/dev/flang/be/interpreter/ChoiceIdAsRef.java
+++ b/src/dev/flang/be/interpreter/ChoiceIdAsRef.java
@@ -154,8 +154,11 @@ public class ChoiceIdAsRef extends Value
            idAsRef instanceof JavaRef        ||
            idAsRef instanceof ArrayData  );
 
-        var cl = (idAsRef instanceof ValueWithClazz id) ? id._clazz
-                                                        : fuir().clazz(SpecialClazzes.c_Array);
+        var cl = (idAsRef instanceof ValueWithClazz id)
+          ? id._clazz
+          : idAsRef instanceof JavaRef
+          ? fuir().clazz(SpecialClazzes.c_Java_Ref)
+          : ((ArrayData)idAsRef)._clazz;
         do
           {
             result++;

--- a/src/dev/flang/be/interpreter/Executor.java
+++ b/src/dev/flang/be/interpreter/Executor.java
@@ -457,7 +457,11 @@ public class Executor extends ProcessExpression<Value, Object>
             var bb = ByteBuffer.wrap(d).order(ByteOrder.LITTLE_ENDIAN);
             var elCount = bb.getInt();
 
-            var arrayData = ArrayData.alloc(elCount, _fuir, elementType);
+            Instance result = new Instance(constCl);
+            var internalArray = _fuir.lookup_array_internal_array(constCl);
+            var saCl = _fuir.clazzResultClazz(internalArray);
+
+            var arrayData = ArrayData.alloc(saCl, elCount, _fuir, elementType);
 
             for (int idx = 0; idx < elCount; idx++)
               {
@@ -466,13 +470,9 @@ public class Executor extends ProcessExpression<Value, Object>
                 arrayData.set(idx, c, fuir(), elementType);
               }
 
-            Instance result = new Instance(constCl);
-            var internalArray = _fuir.lookup_array_internal_array(constCl);
-            var sysArray = _fuir.clazzResultClazz(internalArray);
-            var saCl = sysArray;
             Instance sa = new Instance(saCl);
-            Interpreter.setField(_fuir.lookup_fuzion_sys_internal_array_length(sysArray), saCl,                               sa,     new i32Value(elCount));
-            Interpreter.setField(_fuir.lookup_fuzion_sys_internal_array_data(sysArray)  , saCl,                               sa,     arrayData);
+            Interpreter.setField(_fuir.lookup_fuzion_sys_internal_array_length(saCl), saCl,                               sa,     new i32Value(elCount));
+            Interpreter.setField(_fuir.lookup_fuzion_sys_internal_array_data(saCl)  , saCl,                               sa,     arrayData);
             Interpreter.setField(internalArray                                          , constCl,                            result, sa);
             yield result;
           }

--- a/src/dev/flang/be/interpreter/Interpreter.java
+++ b/src/dev/flang/be/interpreter/Interpreter.java
@@ -118,7 +118,7 @@ public class Interpreter extends FUIRContext
     var saCl = fuir().clazz_fuzionSysArray_u8();
     Instance sa = new Instance(saCl);
     setField(fuir().clazz_fuzionSysArray_u8_length(), saCl, sa, new i32Value(bytes.length));
-    var arrayData = new ArrayData(bytes);
+    var arrayData = new ArrayData(bytes, saCl);
     setField(fuir().clazz_fuzionSysArray_u8_data(), saCl, sa, arrayData);
     setField(fuir().lookup_array_internal_array(clArr), clArr, arr, sa);
     setField(fuir().clazz_const_string_utf8_data(), cl, result, arr);

--- a/src/dev/flang/be/interpreter/Intrinsics.java
+++ b/src/dev/flang/be/interpreter/Intrinsics.java
@@ -137,7 +137,7 @@ public class Intrinsics extends ANY
   private static String utf8ByteArrayDataToString(Value internalArray)
   {
     var strA = internalArray.arrayData();
-    var ba = (byte[]) strA._array;
+    var ba = (byte[]) strA._data;
     var l = 0;
     while (l < ba.length && ba[l] != 0)
       {
@@ -387,7 +387,7 @@ public class Intrinsics extends ANY
           var res = Interpreter
             .getField(executor.fuir().lookup_fuzion_sys_internal_array_data(sac), sac, argz, false)
             .arrayData()
-            ._array;
+            ._data;
           return new JavaRef(res);
         });
     putUnsafe("fuzion.jvm.create_jvm", (executor, innerClazz) -> args -> new i32Value(0));
@@ -423,7 +423,8 @@ public class Intrinsics extends ANY
     put("fuzion.sys.type.alloc", (executor, innerClazz) -> args ->
         {
           var et = executor.fuir().clazzActualGeneric(innerClazz, 0); // element type
-          return ArrayData.alloc(/* size */ args.get(1).i32Value(),
+          return ArrayData.alloc(executor.fuir().clazzResultClazz(innerClazz),
+                                 /* size */ args.get(1).i32Value(),
                                  executor.fuir(),
                                  /* type */ et);
         });

--- a/src/dev/flang/be/interpreter/JavaInterface.java
+++ b/src/dev/flang/be/interpreter/JavaInterface.java
@@ -198,7 +198,6 @@ public class JavaInterface extends FUIRContext
         case SpecialClazzes.c_bool -> o instanceof Boolean z ? new boolValue(z): new boolValue(((Value) o).boolValue());
         case SpecialClazzes.c_unit -> new Instance(rc);
         // NYI: UNDER DEVELOPMENT: remove this, abusing javaObjectToPlainInstance in mtx_*, cnd_* intrinsics
-        case SpecialClazzes.c_Array -> new JavaRef(o);
         case SpecialClazzes.c_Mutex -> new JavaRef(o);
         case SpecialClazzes.c_Condition -> new JavaRef(o);
         case SpecialClazzes.c_File_Descriptor -> new JavaRef(o);
@@ -266,7 +265,7 @@ public class JavaInterface extends FUIRContext
     var result = new Object[sz];
     for (var ix = 0; ix < sz; ix++)
       {
-        result[ix] = ((JavaRef)(((Object[])a._array)[ix]))._javaRef;
+        result[ix] = ((JavaRef)(((Object[])a._data)[ix]))._javaRef;
       }
     return result;
   }

--- a/src/dev/flang/be/jvm/Intrinsix.java
+++ b/src/dev/flang/be/jvm/Intrinsix.java
@@ -517,8 +517,7 @@ public class Intrinsix extends ANY implements ClassFileConstants
             Expr.checkcast(new ClassType("java/lang/Boolean"))
               .andThen(Expr.invokeVirtual("java/lang/Boolean", "booleanValue", "()Z", PrimitiveType.type_boolean)));
       }
-      case c_Array,
-           c_Mutex,
+      case c_Mutex,
            c_Condition,
            c_File_Descriptor,
            c_Directory_Descriptor,

--- a/src/dev/flang/fuir/GeneratingFUIR.java
+++ b/src/dev/flang/fuir/GeneratingFUIR.java
@@ -640,7 +640,6 @@ public class GeneratingFUIR extends FUIR
               case "Directory_Descriptor"      -> SpecialClazzes.c_Directory_Descriptor;
               case "Java_Ref"                  -> SpecialClazzes.c_Java_Ref;
               case "Mapped_Memory"             -> SpecialClazzes.c_Mapped_Memory;
-              case "Array"                     -> SpecialClazzes.c_Array;
               case "Native_Ref"                -> SpecialClazzes.c_Native_Ref;
               case "Thread"                    -> SpecialClazzes.c_Thread;
               default                          -> SpecialClazzes.c_NOT_FOUND   ;

--- a/src/dev/flang/fuir/SpecialClazzes.java
+++ b/src/dev/flang/fuir/SpecialClazzes.java
@@ -65,7 +65,6 @@ public enum SpecialClazzes
   c_Directory_Descriptor("Directory_Descriptor", 0, c_universe  ),
   c_Java_Ref    ("Java_Ref"                   , 0, c_universe  ),
   c_Mapped_Memory("Mapped_Memory"             , 0, c_universe  ),
-  c_Array       ("Array"                      , 0, c_universe  ),
   c_Native_Ref  ("Native_Ref"                 , 0, c_universe  ),
   c_Thread      ("Thread"                     , 0, c_universe  ),
   ;


### PR DESCRIPTION
Array has a type parameter, so this is now wrong since there could be many different `c_Array` clazzes. This is the reason that #5881 currently fails.
