### PR TITLE
os: add upper bound for polling_time when waiting on process

### DIFF
--- a/modules/base/src/os/processes.fz
+++ b/modules/base/src/os/processes.fz
@@ -53,7 +53,7 @@ public processes (ph os.Process_Handler, public running_processes container.Set 
   =>
     start := time.nano.read
 
-    # the min poll time for process exit
+    # the maximum poll time for process exit
     #
     upper_bound_poll_time := time.duration.s 1
 


### PR DESCRIPTION
fixes #5905
