### PR TITLE
ast: do not use `whenResolvedTypes` in `resolveFormalArgumentTypes`

### DIFF
--- a/src/dev/flang/ast/AbstractCall.java
+++ b/src/dev/flang/ast/AbstractCall.java
@@ -561,31 +561,31 @@ public abstract class AbstractCall extends Expr
   {
     // NYI: UNDER DEVELOPMENT: cache this? cache key: calledFeature/target
 
-    // wrap result in Array to make effectively final
-    var result = new AbstractType[][]{new AbstractType[0]};
+    var result = new AbstractType[0];
 
     if (!(this instanceof Call c) || c.calledFeatureKnown())
       {
         var fargs = calledFeature().valueArguments();
-        result[0] = fargs.size() == 0
+        result = fargs.size() == 0
           ? UnresolvedType.NO_TYPES
           : new AbstractType[fargs.size()];
-        Arrays.fill(result[0], Types.t_UNDEFINED);
+        Arrays.fill(result, Types.t_UNDEFINED);
 
         int count = 0;
         for (var frml : fargs)
           {
             int argnum = count;  // effectively final copy of count
-            check(frml.state().atLeast(State.RESOLVED_TYPES));
-            result[0] = resolveFormalArg(res, context, result[0], argnum, frml);
+            if (CHECKS)
+              check(frml.state().atLeast(State.RESOLVED_TYPES));
+            result = resolveFormalArg(res, context, result, argnum, frml);
             count++;
           }
       }
 
     if (POSTCONDITIONS) ensure
-      (result[0] != null);
+      (result != null);
 
-    return result[0];
+    return result;
   }
 
 

--- a/src/dev/flang/ast/AbstractCall.java
+++ b/src/dev/flang/ast/AbstractCall.java
@@ -576,8 +576,8 @@ public abstract class AbstractCall extends Expr
         for (var frml : fargs)
           {
             int argnum = count;  // effectively final copy of count
-            frml.whenResolvedTypes
-              (() -> result[0] = resolveFormalArg(res, context, result[0], argnum, frml));
+            check(frml.state().atLeast(State.RESOLVED_TYPES));
+            result[0] = resolveFormalArg(res, context, result[0], argnum, frml);
             count++;
           }
       }

--- a/src/dev/flang/ast/AbstractCall.java
+++ b/src/dev/flang/ast/AbstractCall.java
@@ -556,30 +556,29 @@ public abstract class AbstractCall extends Expr
    * @param res the resolution instance.
    *
    * @param context the source code context where this Call is used
+   *
+   * @return the resolved formal arguments, due to open type parameters, this
+   * might be shorter or longer than calledFeature().valueArguments().size().
+   * In case the called feature is not known yet, result will be the empty
+   * array.
    */
   AbstractType[] resolvedFormalArgumentTypes(Resolution res, Context context)
   {
     // NYI: UNDER DEVELOPMENT: cache this? cache key: calledFeature/target
+    var fargs = calledFeature().valueArguments();
+    var result = fargs.size() == 0
+      ? UnresolvedType.NO_TYPES
+      : new AbstractType[fargs.size()];
+    Arrays.fill(result, Types.t_UNDEFINED);
 
-    var result = new AbstractType[0];
-
-    if (!(this instanceof Call c) || c.calledFeatureKnown())
+    int count = 0;
+    for (var frml : fargs)
       {
-        var fargs = calledFeature().valueArguments();
-        result = fargs.size() == 0
-          ? UnresolvedType.NO_TYPES
-          : new AbstractType[fargs.size()];
-        Arrays.fill(result, Types.t_UNDEFINED);
-
-        int count = 0;
-        for (var frml : fargs)
-          {
-            int argnum = count;  // effectively final copy of count
-            if (CHECKS)
-              check(frml.state().atLeast(State.RESOLVED_TYPES));
-            result = resolveFormalArg(res, context, result, argnum, frml);
-            count++;
-          }
+        int argnum = count;  // effectively final copy of count
+        if (CHECKS)
+          check(frml.state().atLeast(State.RESOLVED_TYPES));
+        result = resolveFormalArg(res, context, result, argnum, frml);
+        count++;
       }
 
     if (POSTCONDITIONS) ensure

--- a/src/dev/flang/ast/AbstractCall.java
+++ b/src/dev/flang/ast/AbstractCall.java
@@ -571,14 +571,13 @@ public abstract class AbstractCall extends Expr
       : new AbstractType[fargs.size()];
     Arrays.fill(result, Types.t_UNDEFINED);
 
-    int count = 0;
+    int argnum = 0;
     for (var frml : fargs)
       {
-        int argnum = count;  // effectively final copy of count
         if (CHECKS)
           check(frml.state().atLeast(State.RESOLVED_TYPES));
         result = resolveFormalArg(res, context, result, argnum, frml);
-        count++;
+        argnum++;
       }
 
     if (POSTCONDITIONS) ensure

--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -2712,6 +2712,20 @@ public class Call extends AbstractCall
   }
 
 
+  @Override
+  AbstractType[] resolvedFormalArgumentTypes(Resolution res, Context context)
+  {
+    // we might not know the called feature yet, e.g., during propagateExpectedType
+    var result = calledFeatureKnown() ? super.resolvedFormalArgumentTypes(res, context)
+                                      : UnresolvedType.NO_TYPES;
+
+    if (POSTCONDITIONS) ensure
+      (result != null);
+
+    return result;
+  }
+
+
   /**
    * During type inference: Inform this expression that it is used in an
    * environment that expects the given type.  In particular, if this


### PR DESCRIPTION
The original code was using `whenResolvedTypes` which was useless since in case the formal argument type was not resolved yet, the result of the delayed call to `resolveFormalArg` would have been lost (stored in `result[0]` after we had returned from `resolveFormalArgumentTypes`).

Now, I added a check that the types are actually resolved already and removed the `whenResolvedTypes` call.

This is  a first step for #5895.