### PR TITLE
check_simple_example: use `os.cwd` to replace with CURDIR

### DIFF
--- a/bin/check_simple_example.fz
+++ b/bin/check_simple_example.fz
@@ -198,7 +198,7 @@ check_exit_code(run process_result) =>
 # like loop4, preandcall19 etc.
 #
 clean_err(f String) =>
-  check "sed -i s#.*/#--CURDIR--/# $f".execute.ok
+  check "sed -i s#{os.cwd.val}#--CURDIR--# $f".execute.ok
   # line numbers
   check "sed -E -i s/\\.fz:[0-9]+:[0-9]+:/\\.fz:n:n:/g $f".execute.ok
   check "sed -E -i s/\\.fz:[0-9]+/\\.fz:n/g $f".execute.ok


### PR DESCRIPTION
as done in record_simple_example