### PR TITLE
fuir: cache lookup

### DIFF
--- a/src/dev/flang/fuir/GeneratingFUIR.java
+++ b/src/dev/flang/fuir/GeneratingFUIR.java
@@ -2731,11 +2731,7 @@ public class GeneratingFUIR extends FUIR
   {
     Long key = (long)s << 32 | (tclazz & 0xFFFFFFFFL);
     var innerClazz = lookupCache.get(key);
-    if (innerClazz != null)
-      {
-        return innerClazz;
-      }
-    else
+    if (innerClazz == null)
       {
         if (PRECONDITIONS) require
           (s >= SITE_BASE,
@@ -2775,8 +2771,8 @@ public class GeneratingFUIR extends FUIR
           }
 
         lookupCache.put(key, innerClazz);
-        return innerClazz;
       }
+    return innerClazz;
   }
 
 


### PR DESCRIPTION
While investigating #5963 I found that fuir.lookup takes a lot of time.

Introducing a simple cache reduced the time for the test by about ~20%

