### PR TITLE
Dockerfile: make the `builder` part more readable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,24 @@
 FROM ubuntu:24.04@sha256:7c06e91f61fa88c08cc74f7e1b7c69ae24910d745357e0dfe1d2c0322aaf20f9 AS builder
 WORKDIR /fuzion
 COPY . .
-RUN apt-get update && apt-get -y --no-install-recommends install openjdk-21-jdk-headless git make patch libgc1 libgc-dev shellcheck asciidoc asciidoctor ruby-asciidoctor-pdf antlr4 clang-18 wget && ln -s /usr/bin/clang-18 /usr/bin/clang && FUZION_REPRODUCIBLE_BUILD="true" PRECONDITIONS="true" POSTCONDITIONS="true" make all && make PRECONDITIONS="true" POSTCONDITIONS="true" build/apidocs_git/index.html
+RUN apt-get update
+RUN apt-get -y --no-install-recommends install \
+  openjdk-21-jdk-headless \
+  git \
+  make \
+  patch \
+  libgc1 \
+  libgc-dev \
+  shellcheck \
+  asciidoc \
+  asciidoctor \
+  ruby-asciidoctor-pdf \
+  antlr4 \
+  clang-18 \
+  wget
+RUN ln -s /usr/bin/clang-18 /usr/bin/clang
+ENV FUZION_REPRODUCIBLE_BUILD="true" PRECONDITIONS="true" POSTCONDITIONS="true"
+RUN make all build/apidocs_git/index.html
 
 FROM ubuntu:24.04@sha256:7c06e91f61fa88c08cc74f7e1b7c69ae24910d745357e0dfe1d2c0322aaf20f9 AS runner
 COPY --from=builder /fuzion/build /fuzion


### PR DESCRIPTION
We don't need to optimize for image layers in the `builder` image, so we can just break multiple commands up.