### PR TITLE
ast: add support to infer partial and lambda from type parameter constraint

### DIFF
--- a/src/dev/flang/ast/AbstractFeature.java
+++ b/src/dev/flang/ast/AbstractFeature.java
@@ -1685,7 +1685,7 @@ public abstract class AbstractFeature extends Expr implements Comparable<Abstrac
   AbstractType constraint(Context context)
   {
     if (PRECONDITIONS) require
-      (state().atLeast(State.RESOLVED_TYPES),
+      (state().atLeast(State.RESOLVED_DECLARATIONS),
        isTypeParameter());
 
     var result = context.constraintFor(this);
@@ -1710,7 +1710,7 @@ public abstract class AbstractFeature extends Expr implements Comparable<Abstrac
   public AbstractType constraint()
   {
     if (PRECONDITIONS) require
-      (state().atLeast(State.RESOLVED_TYPES),
+      (state().atLeast(State.RESOLVED_DECLARATIONS),
        isTypeParameter());
 
     throw new Error("constraint() not redefined for "+getClass());

--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -1970,8 +1970,7 @@ public class Call extends AbstractCall
                         if (t.isGenericArgument())
                           {
                             res.resolveTypes(g);
-                            var c = g.constraint().resolve(res, g.context());
-                            res.resolveTypes(c.feature());
+                            var c = g.constraint();
                             if (actualType != null)
                               { /* infer via constraint of type parameter:
                                  *

--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -1854,19 +1854,40 @@ public class Call extends AbstractCall
       {
         if (vai < _actuals.size())
           {
-            var actual = _actuals.get(vai);
-            var t = frml.resultTypeIfPresent(res);
-            if (t != null && t.isFunctionTypeExcludingLazy())
-              {
-                Expr l = actual.propagateExpectedTypeForPartial(res, context, t);
-                if (l != actual && !isDefunct())
-                  {
-                    _actuals = _actuals.setOrClone(vai, l);
-                  }
-              }
+            propagateForPartial(res, context, vai, frml.resultTypeIfPresent(res));
           }
         vai++;
       }
+  }
+
+
+  /**
+   * Helper for propagateForPartial(res, context) and inferGenericsFromArgs to
+   * propagate type for partial application of argument number argnum.
+   *
+   * @param res the resolution instance.
+   *
+   * @param context the source code context where this Call is used
+   *
+   * @param argnum the argument number we want to handle
+   *
+   * @param t the expected type
+   *
+   * @return the original or the new, partially applied expression if it was
+   * replaced.
+   */
+  private Expr propagateForPartial(Resolution res, Context context, int argnum, AbstractType t)
+  {
+    var actual = _actuals.get(argnum);
+    if (t != null && t.isFunctionTypeExcludingLazy())
+      {
+        actual = actual.propagateExpectedTypeForPartial(res, context, t);
+        if (!isDefunct())
+          {
+            _actuals = _actuals.setOrClone(argnum, actual);
+          }
+      }
+    return actual;
   }
 
 
@@ -1946,23 +1967,39 @@ public class Call extends AbstractCall
                     if (t.dependsOnGenerics())
                       {
                         var actualType = typeFromActual(res, context, actual);
+                        if (t.isGenericArgument())
+                          {
+                            res.resolveTypes(g);
+                            var c = g.constraint().resolve(res, g.context());
+                            res.resolveTypes(c.feature());
+                            if (actualType != null)
+                              { /* infer via constraint of type parameter:
+                                 *
+                                 *     a(T type, S type : array T, s S) is
+                                 *     _ := a [32]
+                                 */
+                                inferGeneric(res, context, c, actualType, actual.pos(), conflict, foundAt, argnum);
+                              }
+                            else if (c.isFunctionTypeExcludingLazy())
+                              { /* propagate constraint for partial or lambda:
+                                 *
+                                 *     a(F type : Function bool i32, f F) =>
+                                 *     _ := a x->x>3
+                                 *     _ := a %%2
+                                 */
+                                actual = propagateForPartial(res, context, argnum, c);
+                                actual = actual.propagateExpectedType(res, context, c,
+                                                                      () -> "formal argument type in call to " + AstErrors.s(_calledFeature));
+                                _actuals = _actuals.setOrClone(argnum, actual);
+                                actualType = typeFromActual(res, context, actual);
+                              }
+                          }
                         if (actualType != null)
                           {
-                            /**
-                             * infer via constraint of type parameter:
-                             *
-                             *     a(T type, S type : array T, s S) is
-                             *     _ := a [32]
-                             */
-                            if (t.isGenericArgument())
-                              {
-                                res.resolveTypes(g);
-                                inferGeneric(res, context, g.constraint(), actualType, actual.pos(), conflict, foundAt, argnum);
-                              }
                             inferGeneric(res, context, t, actualType, actual.pos(), conflict, foundAt, argnum);
                             checked[vai] = true;
                           }
-                        else if (resultExpression(actual) instanceof AbstractLambda al)
+                        if (resultExpression(actual) instanceof AbstractLambda al)
                           {
                             checked[vai] = inferGenericLambdaResult(res, context, t, frml, al, actual.pos(), conflict, foundAt);
                           }

--- a/src/dev/flang/ast/Feature.java
+++ b/src/dev/flang/ast/Feature.java
@@ -2583,7 +2583,7 @@ A ((Choice)) declaration must not contain a result type.
   public AbstractType constraint()
   {
     if (PRECONDITIONS) require
-      (state().atLeast(State.RESOLVED_TYPES),
+      (state().atLeast(State.RESOLVED_DECLARATIONS),
        isTypeParameter());
 
     var result = _returnType.functionReturnType();

--- a/tests/reg_issue5987/Makefile
+++ b/tests/reg_issue5987/Makefile
@@ -1,0 +1,25 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test Makefile
+#
+# -----------------------------------------------------------------------
+
+override NAME = reg_issue5987
+include ../simple.mk

--- a/tests/reg_issue5987/reg_issue5987.fz
+++ b/tests/reg_issue5987/reg_issue5987.fz
@@ -1,0 +1,47 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test reg_issue5987
+#
+# -----------------------------------------------------------------------
+
+# test for type inference from type parameter constraint to lambda arguments
+#
+reg_issue5987 =>
+
+  test(F type : i32->i32, f F) =>
+    say "$F {f.call 42}"
+
+  test i32->i32 x->x+1
+  test i32->i32 (-)
+  test i32->i32 (+1)
+
+  # NYI: UNDER DEVELOPMENT: The following should best infer the internal type of lambda for `F`
+  # Instead, they currently infer `Unary i32 i32`, i.e., a ref type that will cause boxing
+  #
+  test x->x+1
+  test (-)
+  test (+1)
+
+  # include this example here just because this code is related and easy to break when
+  # changing the code for the lambda type propagation:
+  #
+  a(T type, S type : array T, s S) is
+    say "$T $S $s"
+  _ := a [32]

--- a/tests/reg_issue5987/reg_issue5987.fz.expected_out
+++ b/tests/reg_issue5987/reg_issue5987.fz.expected_out
@@ -1,0 +1,7 @@
+Type of 'Unary i32 i32' 43
+Type of 'Unary i32 i32' -42
+Type of 'Unary i32 i32' 43
+Type of 'Unary i32 i32' 43
+Type of 'Unary i32 i32' -42
+Type of 'Unary i32 i32' 43
+Type of 'i32' Type of 'array i32' [32]


### PR DESCRIPTION
This fixes #5987 and is a step towards #5892, labdas for `Function` with type parameters.

Added a small test case.
