### PR TITLE
ast: fix null pointer exception

### DIFF
--- a/src/dev/flang/ast/FunctionReturnType.java
+++ b/src/dev/flang/ast/FunctionReturnType.java
@@ -62,6 +62,9 @@ public class FunctionReturnType extends ReturnType
    */
   public FunctionReturnType(AbstractType t)
   {
+    if (PRECONDITIONS) require
+      (t != null);
+
     _type = t;
     _pos = t instanceof UnresolvedType ut ? ut.pos() : SourcePosition.builtIn;
   }
@@ -133,6 +136,8 @@ public class FunctionReturnType extends ReturnType
   public void visit(FeatureVisitor v, AbstractFeature outer)
   {
     _type = _type.visit(v, outer);
+    if (CHECKS) check
+      (_type != null);
   }
 
 
@@ -154,6 +159,8 @@ public class FunctionReturnType extends ReturnType
 
     res.resolveDeclarations(outer);
     _type = _type.resolve(res, outer.context());
+    if (CHECKS) check
+      (_type != null);
   }
 
 

--- a/src/dev/flang/ast/UnresolvedType.java
+++ b/src/dev/flang/ast/UnresolvedType.java
@@ -553,6 +553,10 @@ public abstract class UnresolvedType extends AbstractType implements HasSourcePo
             if (CHECKS) check
               (tolerant || Errors.any() || fo != FeatureAndOuter.ERROR);
           }
+        else if (!tolerant)
+          {
+            _resolved = Types.t_ERROR;
+          }
       }
 
     if (_resolved != null && _resolved != Types.t_ERROR && (_resolved.isOpenGeneric() != _followedByDots))
@@ -567,6 +571,9 @@ public abstract class UnresolvedType extends AbstractType implements HasSourcePo
           }
         _resolved = Types.t_ERROR;
       }
+
+    if (POSTCONDITIONS) ensure
+      (tolerant || _resolved != null);
 
     return _resolved;
   }


### PR DESCRIPTION
reproduce via:
fz tests/mod_http_message/http_message_test.fz
```
java.lang.NullPointerException: Cannot invoke "dev.flang.ast.AbstractType.visit(dev.flang.ast.FeatureVisitor, dev.flang.ast.AbstractFeature)" because "this._type" is null
        at dev.flang.ast.FunctionReturnType.visit(FunctionReturnType.java:138)
        at dev.flang.ast.Feature.visit(Feature.java:1324)
        at dev.flang.ast.Feature.internalResolveTypes(Feature.java:1627)
        at dev.flang.ast.Resolution.resolveTypes(Resolution.java:505)
        at dev.flang.ast.Feature.resultTypeIfPresentUrgent(Feature.java:2455)
        at dev.flang.ast.Call.getActualResultType(Call.java:1401)
        at dev.flang.ast.Call.setActualResultType(Call.java:2732)
        at dev.flang.ast.Call.resolveTypes0(Call.java:2616)
        at dev.flang.ast.Call.resolveTypes(Call.java:2569)
```
