### PR TITLE
fzjava: allow passing `nil` when java string is expected

### DIFF
--- a/src/dev/flang/tools/fzjava/FZJava.java
+++ b/src/dev/flang/tools/fzjava/FZJava.java
@@ -270,16 +270,16 @@ public class FZJava extends Tool
     fzp = fzp.resolve("ext.fz");
     try
       {
-        var str = new StringBuilder(
+        var sb = new StringBuilder(
                     "public Java.as_java_object(T type : Java.java.lang.Object, seq Sequence T) fuzion.java.Array T =>\n");
-        str.append("  res := (Java.java.lang.reflect.Array.newInstance_Ljava_7_lang_7_Class_s_I T.get_java_class seq.count).val\n");
-        str.append("  for idx := 0, idx+1\n");
-        str.append("      el in seq\n");
-        str.append("  do\n");
-        str.append("    _ := Java.java.lang.reflect.Array.__k__set res idx el\n");
-        str.append("  fuzion.java.Array T res.java_ref\n");
-        str.append("\n");
-        Files.write(fzp, str.toString().getBytes(StandardCharsets.UTF_8));
+        sb.append("  res := (Java.java.lang.reflect.Array.newInstance_Ljava_7_lang_7_Class_s_I T.get_java_class seq.count).val\n");
+        sb.append("  for idx := 0, idx+1\n");
+        sb.append("      el in seq\n");
+        sb.append("  do\n");
+        sb.append("    _ := Java.java.lang.reflect.Array.__k__set res idx el\n");
+        sb.append("  fuzion.java.Array T res.java_ref\n");
+        sb.append("\n");
+        Files.write(fzp, sb.toString().getBytes(StandardCharsets.UTF_8));
       }
     catch (IOException e)
       {

--- a/src/dev/flang/tools/fzjava/ForClass.java
+++ b/src/dev/flang/tools/fzjava/ForClass.java
@@ -759,7 +759,7 @@ class ForClass extends ANY
           }
         else if (t == String.class)
           {
-            mt = FuzionConstants.STRING_NAME;
+            mt = "option " + FuzionConstants.STRING_NAME;
           }
         else
           {
@@ -882,8 +882,8 @@ class ForClass extends ANY
         else if (t == Float    .TYPE) { res.append("fuzion.jvm.env.f32_to_java_object "   ); }
         else if (t == Double   .TYPE) { res.append("fuzion.jvm.env.f64_to_java_object "   ); }
         else if (t == Boolean  .TYPE) { res.append("fuzion.jvm.env.bool_to_java_object "  ); }
-        else if (t == String.class  ) { res.append("fuzion.jvm.env.string_to_java_object "); }
         res.append( outer + ".this." + mp );
+        if (t == String.class) { res.append(".fold fuzion.jvm.env.string_to_java_object (_ -> (fuzion.jvm.env.null Java.java.lang.__jString).val)"); }
         res.append(")");
       }
     res.append("]");


### PR DESCRIPTION
The goal is to be able to use `null` as an argument, when a java String is expected.

instead of type `String`, `option String` is used


