### PR TITLE
run_tests: emit histogram of test times

### DIFF
--- a/bin/run_tests.fz
+++ b/bin/run_tests.fz
@@ -253,6 +253,12 @@ main =>
   say ""
   say "$ok/{tests.count} tests passed, $skipped skipped, $failed failed in {elapsed_time_total.as_string.trim}."
 
+  h := time.histogram target nil nil 0 0
+  test_durations
+    .values
+    .for_each h.add
+  say h
+
   if failed > 0
     say "Failed tests:"
 


### PR DESCRIPTION
e.g.
```
                             ---  Tests jvm  ---
count
  4  |       |       |       |       |       |     ▉▉|       |       |       |
  2  |       |       |       |       |       |     ▉▉|       |       |       |
  1 _|_______|_______|_______|_______|_______|____▉▉▉▉_______|_______|_      |
     |       |       |       |       |       |       |       |       |       |
    1ns     90ns   4979ns  273µs    15ms   825ms    45s     41m     38h      >

 average |   min   |   max   |  sigma  |  count  |
    18s  | 7143ms  |    29s  | 6785ms  |   14    |
```
