### PR TITLE
dfa: mark dependent calls as hot (again) once call is detected to return

### DIFF
--- a/src/dev/flang/fuir/analysis/dfa/DFA.java
+++ b/src/dev/flang/fuir/analysis/dfa/DFA.java
@@ -385,7 +385,7 @@ public class DFA extends ANY
             if (_fuir.clazzNeedsCode(cc))
               {
                 var ca = newCall(_call, cc, s, tvalue.value(), args, _call._env, _call);
-                res = ca.result();
+                res = ca.result(_call);
                 if (_options.needsEscapeAnalysis() && res != null && res != Value.UNIT && !_fuir.clazzIsRef(_fuir.clazzResultClazz(cc)))
                   {
                     res = newEmbeddedValue(s, res.value());
@@ -2259,7 +2259,7 @@ public class DFA extends ANY
                                     cl);
           cll._group.mayHaveEffect(ecl);
 
-          var result = cll.result();
+          var result = cll.result(cl);
           Value ev;
           if (cl._dfa._real)
             {
@@ -2292,7 +2292,7 @@ public class DFA extends ANY
           if (aborted)
             { // default result, only if abort is ever called
               var def = cl._dfa.newCall(cl, call_def, NO_SITE, a2, new List<>(ev), cl._env, cl);
-              var res = def.result();
+              var res = def.result(cl);
               result =
                 result != null && res != null ? result.value().join(cl._dfa, res.value(), fuir(cl).clazzResultClazz(cl.calledClazz())) :
                 result != null                ? result
@@ -3303,8 +3303,6 @@ public class DFA extends ANY
               (false);
           }
         e = r;
-        var rf = r;
-        wasChanged(() -> "DFA.newCall to " + rf);
         analyzeNewCall(r);
       }
     else

--- a/src/dev/flang/fuir/analysis/dfa/Instance.java
+++ b/src/dev/flang/fuir/analysis/dfa/Instance.java
@@ -174,7 +174,10 @@ public class Instance extends Value
     if (oldv != v)
       {
         var fv = v;
-        _dfa.wasChanged(() -> "setField: new values " + fv + " (was " + oldv + ") for " + this);
+        if (dfa.isRead(field))
+          {
+            _dfa.wasChanged(() -> "setField: new values " + fv + " (was " + oldv + ") for " + this);
+          }
       }
     dfa._writtenFields.set(field);
     _fields.put(field, v);


### PR DESCRIPTION
example timings for fzweb:

before
> DFA took 158 iterations (pre/real) (56/102).
> Elapsed time for phases: prep 34ms, fe 1458ms, createMIR 358ms, ir 13ms, dfa_pre 12019ms, dfa_real 19571ms, opt 3ms, be 1954ms

after
> DFA needed 47 iterations (pre/real) (23/24).
> Elapsed time for phases: prep 34ms, fe 741ms, createMIR 171ms, ir 5ms, dfa_pre 7662ms, dfa_real 5227ms, opt 3ms, be 2199ms
