### PR TITLE
run_tests: histogram, add arg max_recorded

### DIFF
--- a/bin/run_tests.fz
+++ b/bin/run_tests.fz
@@ -253,7 +253,11 @@ main =>
   say ""
   say "$ok/{tests.count} tests passed, $skipped skipped, $failed failed in {elapsed_time_total.as_string.trim}."
 
-  h := time.histogram target nil nil 0 0
+  max_recorded := test_durations
+    .values
+    .sort
+    .last
+  h := time.histogram target nil max_recorded 0 0
   test_durations
     .values
     .for_each h.add

--- a/bin/run_tests.fz
+++ b/bin/run_tests.fz
@@ -255,8 +255,7 @@ main =>
 
   max_recorded := test_durations
     .values
-    .sort
-    .last
+    .max
   h := time.histogram target nil max_recorded 0 0
   test_durations
     .values


### PR DESCRIPTION
more useful than log-scale histogram
```
                                ---  jvm  ---                                 
count
 64  |   ▉▉  |       |       |       |       |       |       |       |       |
 32  |  ▉▉▉▉▉▉▉▉▉▉   |       |       |       |       |       |       |       |
 16 _|__▉▉▉▉▉▉▉▉▉▉▉▉_|_______|_______|_______|_______|_______|_______|_      |
  8  |  ▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉      |       |       |       |       |       |       |
  4  |  ▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉   |       |       |       |       |       |       |
  2  |▉ ▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉ ▉    ▉  |       |       |       |       |       |
  1 _|▉_▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉___▉▉__|_▉__▉__|______▉|_______|_▉_____▉_      |
     |       |       |       |       |       |       |       |       |       |
   1138ms   10s     19s     28s     37s     46s     55s     64s     74s      >
 average |   min   |   max   |  sigma  |  count  |
    10s  | 1476ms  |    74s  | 6611ms  |   618   |
```