### PR TITLE
ast: permit free types to be open type parameters, fix #5902

### DIFF
--- a/src/dev/flang/ast/UnresolvedType.java
+++ b/src/dev/flang/ast/UnresolvedType.java
@@ -870,7 +870,8 @@ public abstract class UnresolvedType extends AbstractType implements HasSourcePo
                          freeTypeConstraint().resolve(res, context),
                          _name,
                          Contract.EMPTY_CONTRACT,
-                         Impl.TYPE_PARAMETER)
+                         _followedByDots ? Impl.TYPE_PARAMETER_OPEN
+                                         : Impl.TYPE_PARAMETER)
       {
         /**
          * Is this type a free type?


### PR DESCRIPTION
This enables code like

    say_all(a A...) =>
      say a

    say_all "hi" true [1,2,3]

or even

    say_all(a _...) =>
      say a

    say_all "hi" true [1,2,3]

instead of the somewhat clumsy

    say_all(A type..., a A...) =>
      say a

    say_all "hi" true [1,2,3]
