### PR TITLE
base: make `option` `orderable` and `hashable`

### DIFF
--- a/bin/ebnf.fz
+++ b/bin/ebnf.fz
@@ -181,7 +181,7 @@ main =>
     tmp := !!"mktemp --directory"
     _ := !!"mkdir $tmp/fuzion_grammar"
     _ := io.file.write "$tmp/fuzion_grammar/Fuzion.g4" ebnf
-    antlr := if (os.process.start "antlr4").bind u32 p->p.wait = 0 then "antlr4" else "antlr"
+    antlr := if ((os.process.start "antlr4").bind u32 p->p.wait).as_equatable_switch = 0 then "antlr4" else "antlr"
     # NYI: UNDER DEVELOPMENT: add option -Werror
     _ := !!"$antlr -long-messages -o $tmp/fuzion_grammar $tmp/fuzion_grammar/Fuzion.g4"
     _ := !!"rm -Rf $tmp"

--- a/bin/ebnf.fz
+++ b/bin/ebnf.fz
@@ -181,7 +181,7 @@ main =>
     tmp := !!"mktemp --directory"
     _ := !!"mkdir $tmp/fuzion_grammar"
     _ := io.file.write "$tmp/fuzion_grammar/Fuzion.g4" ebnf
-    antlr := if ((os.process.start "antlr4").bind u32 p->p.wait).as_equatable_switch = 0 then "antlr4" else "antlr"
+    antlr := if (os.process.start "antlr4").bind u32 p->p.wait = 0 then "antlr4" else "antlr"
     # NYI: UNDER DEVELOPMENT: add option -Werror
     _ := !!"$antlr -long-messages -o $tmp/fuzion_grammar $tmp/fuzion_grammar/Fuzion.g4"
     _ := !!"rm -Rf $tmp"

--- a/modules/base/src/Sequence/equatable.fz
+++ b/modules/base/src/Sequence/equatable.fz
@@ -149,7 +149,7 @@ replace(old, new,
   match to_be_replaced.find old
     nil   => already_replaced ++ to_be_replaced
     n i32 =>
-      if limit.as_equatable_switch = 0
+      if limit = 0
         already_replaced ++ to_be_replaced
       else
         a := already_replaced ++ (to_be_replaced.take n) ++ new

--- a/modules/base/src/interval.fz
+++ b/modules/base/src/interval.fz
@@ -50,7 +50,7 @@ public interval(T type : integer,
   : container.Set T
 
 pre
-  debug: ((step.sign = 0): through.as_equatable_switch=from)  # step cannot be zero unless from=through
+  debug: ((step.sign = 0): through=from)  # step cannot be zero unless from=through
 is
 
 
@@ -61,7 +61,7 @@ is
   #
   public infix : (step_factor T) interval T
   pre
-    debug: ((step_factor.sign = 0): through.as_equatable_switch=from)  # step cannot be zero unless from=through
+    debug: ((step_factor.sign = 0): through=from)  # step cannot be zero unless from=through
     safety: (step *? step_factor).exists
   =>
     interval from through step*step_factor

--- a/modules/base/src/io/buffered/reader.fz
+++ b/modules/base/src/io/buffered/reader.fz
@@ -166,7 +166,7 @@ public read_delimiter (delim u8, strip_cr bool) switch String io.end_of_file ! r
           # trailing carriage returns are dropped
           add_to_res(a0 Sequence u8) unit =>
             if !a0.is_empty
-              a1 := if strip_cr && a0.last.as_equatable_switch = encodings.ascii.cr
+              a1 := if strip_cr && a0.last = encodings.ascii.cr
                       (a0.slice 0 a0.count-1)
                     else
                       a0

--- a/modules/base/src/option.fz
+++ b/modules/base/src/option.fz
@@ -28,8 +28,68 @@
 # option represents an optional value of type T
 #
 public option(public T type)
-  : switch T nil
+  : switch T nil,
+    property.orderable,
+    property.hashable
+
 is
+
+
+  # equality of two options is true iff `a` and `b` are both nil or `a` and `b` are both
+  # `T` and T.equality a.get b.get.
+  #
+  # This is defined only if T : property.equatable, it will result in a compile-time panic
+  # if this is not the case.
+  #
+  public redef fixed type.equality(a, b option T) bool
+  =>
+    if T : property.equatable then
+      match a
+        av T =>
+          match b
+            bv T => T.equality av bv
+            nil  => false
+        nil =>
+          match b
+            _ T => false
+            nil  => true
+    else
+      compile_time_panic
+
+
+  # A total order between of two options is defined as follows: `nil` is always less-than-or-equal
+  # ny other value and iff `a` and `b` are both `T` and T.lteq a.get b.get.
+  #
+  # This is defined only if T : property.orderable, it will result in a compile-time panic
+  # if this is not the case.
+  #
+  public redef fixed type.lteq(a, b option T) bool
+  =>
+    if T : property.orderable then
+      match a
+        av T =>
+          match b
+            bv T => T.lteq av bv
+            nil  => false
+        nil =>
+          true
+    else
+      compile_time_panic
+
+
+  # create hash code for this option
+  #
+  # This is defined only if T : property.hashable, it will result in a compile-time panic
+  # if this is not the case.
+  #
+  public redef fixed type.hash_code(a option T) u64
+  =>
+    if T : property.hashable then
+      match a
+        v T => T.hash_code v
+        nil => 0xfe6f6476106a56b6  # generated using secure random generator at https://cryptotools.dev/
+    else
+      compile_time_panic
 
 
   # Does this option contain no value of type T?

--- a/modules/base/src/option.fz
+++ b/modules/base/src/option.fz
@@ -43,7 +43,7 @@ is
   #
   public redef fixed type.equality(a, b option T) bool
   =>
-    if T : property.equatable then
+    if T : property.equatable
       match a
         av T =>
           match b
@@ -57,15 +57,16 @@ is
       compile_time_panic
 
 
-  # A total order between of two options is defined as follows: `nil` is always less-than-or-equal
-  # ny other value and iff `a` and `b` are both `T` and T.lteq a.get b.get.
+  # A total order between two options is defined as follows: `nil` is always less-than-or-equal
+  # any other value and iff `a` and `b` are both contains values of type `T`, then
+  # `T.lteq a.get b.get`.
   #
   # This is defined only if T : property.orderable, it will result in a compile-time panic
   # if this is not the case.
   #
   public redef fixed type.lteq(a, b option T) bool
   =>
-    if T : property.orderable then
+    if T : property.orderable
       match a
         av T =>
           match b
@@ -84,7 +85,7 @@ is
   #
   public redef fixed type.hash_code(a option T) u64
   =>
-    if T : property.hashable then
+    if T : property.hashable
       match a
         v T => T.hash_code v
         nil => 0xfe6f6476106a56b6  # generated using secure random generator at https://cryptotools.dev/

--- a/tests/lib_property_equatable/lib_property_equatable.fz
+++ b/tests/lib_property_equatable/lib_property_equatable.fz
@@ -38,5 +38,13 @@ lib_property_equatable =>
   say (option 0).as_equatable_switch=1
   say (option 0).as_equatable_switch=nil
 
+  say (option 0 = 0)
+  say (option 0 = 1)
+  say (option 0 = nil)
+
+  say (0 = option 0)
+  say (0 = option 1)
+  say (0 = option i32 nil)
+
   # NYI: UNDER DEVELOPMENT: ugly that we have to use (id (container.Set i32) ...)
   say (id (container.Set i32) ((container.ps_set i32).empty))=((container.ps_set i32).empty)

--- a/tests/lib_property_equatable/lib_property_equatable.fz.expected_out
+++ b/tests/lib_property_equatable/lib_property_equatable.fz.expected_out
@@ -10,3 +10,9 @@ true
 false
 false
 true
+false
+false
+true
+false
+false
+true

--- a/tests/strings/stringstest.fz
+++ b/tests/strings/stringstest.fz
@@ -50,6 +50,6 @@ stringstest is
 
   chck "Nested: { "-{ a + b }-" * 3 }"="Nested: -7--7--7-" "nested \{}"
 
-  chck ("abcdefabcdefabcdef".find "abcdef" 11).as_equatable=(option 12).as_equatable "find(substring, from)"
+  chck ("abcdefabcdefabcdef".find "abcdef" 11 = 12) "find(substring, from)"
 
   exit


### PR DESCRIPTION
Doing this similar to the way it is done for `tuple` with `compile_time_panic` in case the underlying type `T` is not `orderable` or `hashable`, respectively.
