### PR TITLE
base: make `Sequence`, `list` and `array` `equatable`, `orderable` and `hashable`

### DIFF
--- a/bin/ebnf.fz
+++ b/bin/ebnf.fz
@@ -181,7 +181,7 @@ main =>
     tmp := !!"mktemp --directory"
     _ := !!"mkdir $tmp/fuzion_grammar"
     _ := io.file.write "$tmp/fuzion_grammar/Fuzion.g4" ebnf
-    antlr := if (os.process.start "antlr4").bind u32 p->p.wait = 0 then "antlr4" else "antlr"
+    antlr := if ((os.process.start "antlr4").bind u32 p->p.wait).as_equatable_switch = 0 then "antlr4" else "antlr"
     # NYI: UNDER DEVELOPMENT: add option -Werror
     _ := !!"$antlr -long-messages -o $tmp/fuzion_grammar $tmp/fuzion_grammar/Fuzion.g4"
     _ := !!"rm -Rf $tmp"

--- a/bin/ebnf.fz
+++ b/bin/ebnf.fz
@@ -181,7 +181,7 @@ main =>
     tmp := !!"mktemp --directory"
     _ := !!"mkdir $tmp/fuzion_grammar"
     _ := io.file.write "$tmp/fuzion_grammar/Fuzion.g4" ebnf
-    antlr := if ((os.process.start "antlr4").bind u32 p->p.wait).as_equatable_switch = 0 then "antlr4" else "antlr"
+    antlr := if (os.process.start "antlr4").bind u32 p->p.wait = 0 then "antlr4" else "antlr"
     # NYI: UNDER DEVELOPMENT: add option -Werror
     _ := !!"$antlr -long-messages -o $tmp/fuzion_grammar $tmp/fuzion_grammar/Fuzion.g4"
     _ := !!"rm -Rf $tmp"

--- a/modules/base/src/Sequence.fz
+++ b/modules/base/src/Sequence.fz
@@ -40,25 +40,55 @@ public Sequence(public T type) ref
 is
 
 
-  # equality of two Sequences is defined by `list.equality` of `a.as_list` and `b.as_list`.
+  # equality of two Sequences is true iff both a element-wise equal and have
+  # the same `count`.
+  #
+  # This works as long as one of the Sequences is finite, it will diverge if
+  # both are equal and infinite.
   #
   # This is defined only if T : property.equatable, it will result in a compile-time panic
   # if this is not the case.
   #
-  public redef fixed type.equality(a, b Sequence T) bool
+  public redef fixed type.equality(a, b Sequence T /* NYI: UNDER DEVELOPMENT: Sequence.this causes error */
+                                  ) bool
   =>
-    a.as_list = b.as_list
+    if T : property.equatable
+      (a.zip b (=) ∀ id) && count_order a b .is_equal
+    else
+      compile_time_panic  # Sequence is not equatable since element type is not
 
 
-  # A total order between of two Sequences is defined by the total order defined by
-  # `list.lteq` applied to `a.as_list` and `b.as_list`.
+  # A total order between of two Sequences is defined by element-wise comparison.
+  # The first pair of elements that differ define the order.
   #
   # This is defined only if T : property.orderable, it will result in a compile-time panic
   # if this is not the case.
   #
-  public redef fixed type.lteq(a, b Sequence T) bool
+  public redef fixed type.lteq(a, b Sequence T /* NYI: UNDER DEVELOPMENT: Sequence.this causes error */
+                              ) bool
   =>
-    a.as_list <= b.as_list
+    if T : property.orderable
+      a.zip b (<>)
+       .filter (.is_unequal)
+       .first
+       .or_else (count_order a b)
+       .is_less_or_equal
+    else
+      compile_time_panic  # Sequence is not orderable since element type is not
+
+
+  # The total order between of two Sequences defined only by their element count.
+  #
+  # This works as long as one of the Sequences is finite, it will diverge if
+  # both are equal and infinite.
+  #
+  public type.count_order(a, b Sequence T /* NYI: UNDER DEVELOPMENT: Sequence.this causes error */
+                         ) order
+  =>
+    l := a.zip b _,_->unit .count
+    al := a.drop l .take 1
+    bl := b.drop l .take 1
+    al.count <> bl.count
 
 
   # create hash code for this Sequence
@@ -85,7 +115,7 @@ is
       a.map (T.hash_code)
        .foldf h0 xxh_next
     else
-      compile_time_panic  # tuple is not hashable since one element type is not
+      compile_time_panic  # Sequence is not hashable since element type is not
 
 
   # create a list from this Sequence.

--- a/modules/base/src/Sequence.fz
+++ b/modules/base/src/Sequence.fz
@@ -39,8 +39,8 @@ public Sequence(public T type) ref
     property.hashable
 is
 
-  # equality of two Sequences is true iff `a` and `b` are both empty or `a` and `b` are both
-  # `T` and T.equality a.get b.get.
+
+  # equality of two Sequences is defined by `list.equality` of `a.as_list` and `b.as_list`.
   #
   # This is defined only if T : property.equatable, it will result in a compile-time panic
   # if this is not the case.
@@ -50,8 +50,8 @@ is
     a.as_list = b.as_list
 
 
-  # A total order between of two Sequences is defined as follows: `nil` is always less-than-or-equal
-  # ny other value and iff `a` and `b` are both `T` and T.lteq a.get b.get.
+  # A total order between of two Sequences is defined by the total order defined by
+  # `list.lteq` applied to `a.as_list` and `b.as_list`.
   #
   # This is defined only if T : property.orderable, it will result in a compile-time panic
   # if this is not the case.

--- a/modules/base/src/Sequence.fz
+++ b/modules/base/src/Sequence.fz
@@ -62,7 +62,7 @@ is
       compile_time_panic  # Sequence is not equatable since element type is not
 
 
-  # A total order of Sequences is defined by element-wise comparison. The first
+  # A total order for Sequences is defined by element-wise comparison. The first
   # pair of elements that differ define the order.
   #
   # This works as long as one of the Sequences is finite, it will diverge if
@@ -88,7 +88,7 @@ is
       compile_time_panic  # Sequence is not orderable since element type is not
 
 
-  # The total order of Sequences defined only by `i32.lteq` applied to their
+  # The total order for Sequences defined only by `i32.lteq` applied to their
   # element count.
   #
   # This works as long as one of the Sequences is finite, it will diverge if

--- a/modules/base/src/Sequence.fz
+++ b/modules/base/src/Sequence.fz
@@ -44,7 +44,8 @@ is
   # the same `count`.
   #
   # This works as long as one of the Sequences is finite, it will diverge if
-  # both are equal and infinite.
+  # both are equal and infinite.  A `check` will fail if `debug` is enabled and
+  # both `a.finite.is_no` and `b.infinite.is_no`.
   #
   # This is defined only if T : property.equatable, it will result in a compile-time panic
   # if this is not the case.
@@ -52,14 +53,21 @@ is
   public redef fixed type.equality(a, b Sequence T /* NYI: UNDER DEVELOPMENT: Sequence.this causes error */
                                   ) bool
   =>
+    check
+      debug: !(a.finite.is_no && b.finite.is_no)
+
     if T : property.equatable
       (a.zip b (=) ∀ id) && count_order a b .is_equal
     else
       compile_time_panic  # Sequence is not equatable since element type is not
 
 
-  # A total order between of two Sequences is defined by element-wise comparison.
-  # The first pair of elements that differ define the order.
+  # A total order of Sequences is defined by element-wise comparison. The first
+  # pair of elements that differ define the order.
+  #
+  # This works as long as one of the Sequences is finite, it will diverge if
+  # both are equal and infinite.  A `check` will fail if `debug` is enabled and
+  # both `a.finite.is_no` and `b.infinite.is_no`.
   #
   # This is defined only if T : property.orderable, it will result in a compile-time panic
   # if this is not the case.
@@ -67,6 +75,9 @@ is
   public redef fixed type.lteq(a, b Sequence T /* NYI: UNDER DEVELOPMENT: Sequence.this causes error */
                               ) bool
   =>
+    check
+      debug: !(a.finite.is_no && b.finite.is_no)
+
     if T : property.orderable
       a.zip b (<>)
        .filter (.is_unequal)
@@ -77,14 +88,19 @@ is
       compile_time_panic  # Sequence is not orderable since element type is not
 
 
-  # The total order between of two Sequences defined only by their element count.
+  # The total order of Sequences defined only by `i32.lteq` applied to their
+  # element count.
   #
   # This works as long as one of the Sequences is finite, it will diverge if
-  # both are equal and infinite.
+  # both are equal and infinite.  A `check` will fail if `debug` is enabled and
+  # both `a.finite.is_no` and `b.infinite.is_no`.
   #
   public type.count_order(a, b Sequence T /* NYI: UNDER DEVELOPMENT: Sequence.this causes error */
                          ) order
   =>
+    check
+      debug: !(a.finite.is_no && b.finite.is_no)
+
     l := a.zip b _,_->unit .count
     al := a.drop l .take 1
     bl := b.drop l .take 1

--- a/modules/base/src/Sequence.fz
+++ b/modules/base/src/Sequence.fz
@@ -33,7 +33,59 @@
 #
 # Heirs of Sequence must implement 'as_list'.
 #
-public Sequence(public T type) ref : property.countable is
+public Sequence(public T type) ref
+  : property.countable,
+    property.orderable,
+    property.hashable
+is
+
+  # equality of two Sequences is true iff `a` and `b` are both empty or `a` and `b` are both
+  # `T` and T.equality a.get b.get.
+  #
+  # This is defined only if T : property.equatable, it will result in a compile-time panic
+  # if this is not the case.
+  #
+  public redef fixed type.equality(a, b Sequence T) bool
+  =>
+    a.as_list = b.as_list
+
+
+  # A total order between of two Sequences is defined as follows: `nil` is always less-than-or-equal
+  # ny other value and iff `a` and `b` are both `T` and T.lteq a.get b.get.
+  #
+  # This is defined only if T : property.orderable, it will result in a compile-time panic
+  # if this is not the case.
+  #
+  public redef fixed type.lteq(a, b Sequence T) bool
+  =>
+    a.as_list <= b.as_list
+
+
+  # create hash code for this Sequence
+  #
+  # This should satisfy the following condition:
+  #
+  #   (T.equality a b) : (T.hash_code a = T.hash_code b)
+  #
+  # This will result in a compile-time `panic` in case T : property.hashable does not hold.
+  #
+  # The algorithm used here is a variation of (XXXHash)[https://xxhash.com] as used in
+  # (Python's tuple)[https://github.com/python/cpython/blob/849a80ec412c36bbca5d400a7db5645b8cf54f1f/Objects/tupleobject.c#L305]:
+  #
+  #   we start with a constant `hash_prime1`
+  #   for each value:
+  #     we take its hash code * `hash_prime2` and add it
+  #     then we rotate by `hash_rotate`
+  #     and multiply by `hash_prime3`
+  #
+  public redef fixed type.hash_code(a Sequence T) u64
+  =>
+    if T : property.hashable then
+      h0 := xxh_next xxh_first 0x9a632220e62c17c8  # created using https://cryptotools.dev/
+      a.map (T.hash_code)
+       .foldf h0 xxh_next
+    else
+      compile_time_panic  # tuple is not hashable since one element type is not
 
 
   # create a list from this Sequence.
@@ -1188,74 +1240,3 @@ public Sequence(public T type) ref : property.countable is
 # NYI: UNDER DEVELOPMENT: move to Sequence/equatable once we can do universe.find_lm
 module find_lm : mutate is
 module Node(T type, module top Sequence T, module next once find_lm (option (Node T)), module rest option (Node T)) ref is
-
-
-# Wrapper type to make a `Sequence` of an orderable element type itself orderable.
-#
-# NYI: UNDER DEVELOPMENT: move to Sequence/orderable once we can do universe.find_lm
-public orderable_sequence(# the element type of the Sequence we are wrapping
-                          #
-                          public T type : property.orderable,
-
-                          # the wrapped Sequence
-                          #
-                          public unwrap Sequence T)
-
-                          : property.orderable
-is
-
-  # does `a` come before `b` or is equal to `b`?
-  #
-  public redef type.lteq(a, b orderable_sequence.this) bool
-  =>
-    unwrapped_lteq a.unwrap b.unwrap
-
-
-  # does `a` come before `b` or is equal to `b`?
-  #
-  type.unwrapped_lteq(a, b Sequence T) bool
-  =>
-    match a.as_list
-      nil     => true
-      ac Cons =>
-        match b.as_list
-          nil     => false
-          bc Cons =>
-            ac.head <= bc.head &&
-              (ac.head < bc.head || unwrapped_lteq ac.tail bc.tail)
-
-
-
-# Wrapper type to make a `Sequence` of an equatable element type itself equatable.
-#
-# NYI: UNDER DEVELOPMENT: move to Sequence/orderable once we can do universe.find_lm
-public equatable_sequence(# the element type of the Sequence we are wrapping
-                          #
-                          public T type : property.equatable,
-
-                          # the wrapped Sequence
-                          #
-                          public unwrap Sequence T)
-
-                          : property.equatable
-is
-
-  # equality
-  #
-  public redef type.equality(a, b equatable_sequence.this) bool =>
-    equality0(a1, b1 equatable_sequence.this) =>
-      (a1.unwrap.zip b1.unwrap x,y->x=y) ∀ id
-
-    au := a.unwrap
-    bu := b.unwrap
-
-    if au.finite.is_yes && bu.finite.is_yes
-      au.count = bu.count && equality0 a b
-    else if au.finite.is_yes
-      au.count = (bu.take (au.count+1)).count && equality0 a b
-    else if bu.finite.is_yes
-      bu.count = (au.take (bu.count+1)).count && equality0 a b
-    else
-      equality0 a b &&
-        {zip_count := (au.zip bu x,y->unit).count
-         (au.drop zip_count).is_empty && (bu.drop zip_count).is_empty}

--- a/modules/base/src/Sequence/equatable.fz
+++ b/modules/base/src/Sequence/equatable.fz
@@ -247,14 +247,3 @@ public dedup(by (T,T) -> bool) Sequence T
     T : property.equatable
   =>
     as_list.dedup_list by
-
-
-# wrap this sequence into an equatable type.
-#
-# This requires the underlying element type to be equatable.
-#
-public as_equatable equatable_sequence T
-  pre
-    T : property.equatable
-=>
-  equatable_sequence T Sequence.this

--- a/modules/base/src/Sequence/equatable.fz
+++ b/modules/base/src/Sequence/equatable.fz
@@ -149,7 +149,7 @@ replace(old, new,
   match to_be_replaced.find old
     nil   => already_replaced ++ to_be_replaced
     n i32 =>
-      if limit.as_equatable_switch = 0
+      if limit = 0
         already_replaced ++ to_be_replaced
       else
         a := already_replaced ++ (to_be_replaced.take n) ++ new

--- a/modules/base/src/Sequence/orderable.fz
+++ b/modules/base/src/Sequence/orderable.fz
@@ -80,20 +80,3 @@ public is_sorted bool
 =>
   zip (drop 1) (T.lteq)
     .fold bool.all
-
-
-
-# wrap this sequence into an orderable type.
-#
-# This requires the underlying element type to be orderable.
-#
-# An empty `Sequence` is always less or equal to any other `Sequence`. Two non
-# empty `Sequence`s whose first elements are unequal are ordered by the
-# order of those two elements. If those two elements are equal, the tail
-# of both `Sequence`s will be used to find the order.
-#
-public as_orderable orderable_sequence T
-  pre
-    T : property.orderable
-=>
-  orderable_sequence T Sequence.this

--- a/modules/base/src/array.fz
+++ b/modules/base/src/array.fz
@@ -36,9 +36,79 @@ module:public array(
       module internal_array fuzion.sys.internal_array T,
       _ unit,
       _ unit,
-      _ unit) : container.abstract_array T is
+      _ unit)
+  : container.abstract_array T
+is
 
   internal_array.freeze
+
+
+  # equality of two arrays is true iff `a` and `b` have the same length and for all
+  # `in in indices` we have `a[i] = b[i]`.
+  #
+  # For performance, this will compare the length of the arrays first.
+  #
+  # This is defined only if T : property.equatable, it will result in a compile-time panic
+  # if this is not the case.
+  #
+  public redef fixed type.equality(a, b array T) bool
+  =>
+    if T : property.equatable then
+      (a.length = b.length && (for ae in a
+                                   be in b
+                               until ae != be
+                                 false
+                               else
+                                 true))
+    else
+      compile_time_panic  # tuple is not hashable since one element type is not
+
+
+  # A total order between of two arrays is defined by the lowest index `i` for
+  # which `a[i] != b[i]`. If this exists, the result is `a[i] <= b[i]`, otherwise
+  # it is `a.length <= b.length`.
+  #
+  # This is defined only if T : property.orderable, it will result in a compile-time panic
+  # if this is not the case.
+  #
+  public redef fixed type.lteq(a, b array T) bool
+  =>
+    if T : property.orderable then
+      for ae in a
+          be in b
+      until ae != be
+        ae >= be
+      else
+        a.length <= b.length
+    else
+      compile_time_panic  # tuple is not hashable since one element type is not
+
+
+  # create hash code for this array.
+  #
+  # This should satisfy the following condition:
+  #
+  #   (T.equality a b) : (T.hash_code a = T.hash_code b)
+  #
+  # This will result in a compile-time `panic` in case T : property.hashable does not hold.
+  #
+  # The algorithm used here is a variation of (XXXHash)[https://xxhash.com] as used in
+  # (Python's tuple)[https://github.com/python/cpython/blob/849a80ec412c36bbca5d400a7db5645b8cf54f1f/Objects/tupleobject.c#L305]:
+  #
+  #   we start with a constant `hash_prime1`
+  #   for each value:
+  #     we take its hash code * `hash_prime2` and add it
+  #     then we rotate by `hash_rotate`
+  #     and multiply by `hash_prime3`
+  #
+  public redef fixed type.hash_code(a array T) u64
+  =>
+    if T : property.hashable then
+      h0 := xxh_next xxh_first 0x4f8fbfd3cba601a9  # created using https://cryptotools.dev/
+      a.map (T.hash_code)
+       .foldf h0 xxh_next
+    else
+      compile_time_panic  # tuple is not hashable since one element type is not
 
 
   # the length of the array

--- a/modules/base/src/array.fz
+++ b/modules/base/src/array.fz
@@ -64,7 +64,7 @@ is
       compile_time_panic  # tuple is not hashable since one element type is not
 
 
-  # A total order between of two arrays is defined by the lowest index `i` for
+  # A total order for arrays is defined by the lowest index `i` for
   # which `a[i] != b[i]`. If this exists, the result is `a[i] <= b[i]`, otherwise
   # it is `a.length <= b.length`.
   #

--- a/modules/base/src/array.fz
+++ b/modules/base/src/array.fz
@@ -108,7 +108,7 @@ is
       a.map (T.hash_code)
        .foldf h0 xxh_next
     else
-      compile_time_panic  # tuple is not hashable since one element type is not
+      compile_time_panic  # array is not hashable since element type is not
 
 
   # the length of the array

--- a/modules/base/src/int.fz
+++ b/modules/base/src/int.fz
@@ -204,7 +204,7 @@ is
   =>
     if ns
       n.as_i128
-    else if data.as_equatable = [u32 0x8000_0000, 0, 0, 0].as_equatable
+    else if data = [u32 0x8000_0000, 0, 0, 0]
       i128.min
     else
       -n.as_i128

--- a/modules/base/src/interval.fz
+++ b/modules/base/src/interval.fz
@@ -50,7 +50,7 @@ public interval(T type : integer,
   : container.Set T
 
 pre
-  debug: ((step.sign = 0): through.as_equatable_switch=from)  # step cannot be zero unless from=through
+  debug: ((step.sign = 0): through=from)  # step cannot be zero unless from=through
 is
 
 
@@ -61,7 +61,7 @@ is
   #
   public infix : (step_factor T) interval T
   pre
-    debug: ((step_factor.sign = 0): through.as_equatable_switch=from)  # step cannot be zero unless from=through
+    debug: ((step_factor.sign = 0): through=from)  # step cannot be zero unless from=through
     safety: (step *? step_factor).exists
   =>
     interval from through step*step_factor

--- a/modules/base/src/io/buffered/reader.fz
+++ b/modules/base/src/io/buffered/reader.fz
@@ -166,7 +166,7 @@ public read_delimiter (delim u8, strip_cr bool) switch String io.end_of_file ! r
           # trailing carriage returns are dropped
           add_to_res(a0 Sequence u8) unit =>
             if !a0.is_empty
-              a1 := if strip_cr && a0.last.as_equatable_switch = encodings.ascii.cr
+              a1 := if strip_cr && a0.last = encodings.ascii.cr
                       (a0.slice 0 a0.count-1)
                     else
                       a0

--- a/modules/base/src/list.fz
+++ b/modules/base/src/list.fz
@@ -70,8 +70,36 @@ is
   #
   public redef fixed type.lteq(a, b list A) bool
   =>
-    a.head <= b.head && (a.head <  b.head ||
-                         a.tail <= b.tail   )
+    a.head <= b.head && (a.head <  b.head   ||
+                         lteq a.tail b.tail  # a.tail <= b.tail currently does not result in tail recursion optimization
+                        )
+
+
+  # create hash code for this list.
+  #
+  # This should satisfy the following condition:
+  #
+  #   (T.equality a b) : (T.hash_code a = T.hash_code b)
+  #
+  # This will result in a compile-time `panic` in case T : property.hashable does not hold.
+  #
+  # The algorithm used here is a variation of (XXXHash)[https://xxhash.com] as used in
+  # (Python's tuple)[https://github.com/python/cpython/blob/849a80ec412c36bbca5d400a7db5645b8cf54f1f/Objects/tupleobject.c#L305]:
+  #
+  #   we start with a constant `hash_prime1`
+  #   for each value:
+  #     we take its hash code * `hash_prime2` and add it
+  #     then we rotate by `hash_rotate`
+  #     and multiply by `hash_prime3`
+  #
+  public redef fixed type.hash_code(a list A) u64
+  =>
+    if A : property.hashable then
+      h0 := xxh_next xxh_first 0xf9284f0baf063243  # created using https://cryptotools.dev/
+      a.map A.hash_code
+       .foldf h0 xxh_next
+    else
+      compile_time_panic  # list is not hashable since element type is not
 
 
   # Return this list as a list.

--- a/modules/base/src/list.fz
+++ b/modules/base/src/list.fz
@@ -42,9 +42,36 @@
 #
 #
 #
-public list(public A type) : choice nil (Cons A (list A)), Sequence A is
+public list(public A type)
+  : choice nil (Cons A (list A)),
 # NYI: #530 (review comment): The following should work but causes an error:
 # list(A type) : nil | Cons A (list A), Sequence A is
+    Sequence A
+is
+
+  # equality of two list is true iff `a` and `b` are both empty or `a` and `b` are both
+  # non-empty and `T` and T.equality a.get b.get.
+  #
+  # This is defined only if T : property.equatable, it will result in a compile-time panic
+  # if this is not the case.
+  #
+  public redef fixed type.equality(a, b list A) bool
+  =>
+    (a.head = b.head &&
+     a.tail = b.tail    )
+
+
+  # A total order between two lists is defined as follows: An empty list `nil` is always
+  # less-than-or-equal any other value and iff `a` and `b` are both non-empty, and the
+  # `a.head` and `b.head` differ, then `T.lteq a.head b.head`, otherwise `T.lteq a.tail b.tail`.
+  #
+  # This is defined only if T : property.orderable, it will result in a compile-time panic
+  # if this is not the case.
+  #
+  public redef fixed type.lteq(a, b list A) bool
+  =>
+    a.head <= b.head && (a.head <  b.head ||
+                         a.tail <= b.tail   )
 
 
   # Return this list as a list.

--- a/modules/base/src/list.fz
+++ b/modules/base/src/list.fz
@@ -57,8 +57,8 @@ is
   #
   public redef fixed type.equality(a, b list A) bool
   =>
-    (a.head = b.head &&
-     a.tail = b.tail    )
+    (a.head = b.head                 &&
+     (a.is_empty || a.tail = b.tail)    )
 
 
   # A total order between two lists is defined as follows: An empty list `nil` is always

--- a/modules/base/src/list.fz
+++ b/modules/base/src/list.fz
@@ -61,7 +61,7 @@ is
      (a.is_empty || a.tail = b.tail)    )
 
 
-  # A total order between two lists is defined as follows: An empty list `nil` is always
+  # A total order for lists is defined as follows: An empty list `nil` is always
   # less-than-or-equal any other value and iff `a` and `b` are both non-empty, and the
   # `a.head` and `b.head` differ, then `T.lteq a.head b.head`, otherwise `T.lteq a.tail b.tail`.
   #

--- a/modules/base/src/option.fz
+++ b/modules/base/src/option.fz
@@ -28,8 +28,68 @@
 # option represents an optional value of type T
 #
 public option(public T type)
-  : switch T nil
+  : switch T nil,
+    property.orderable,
+    property.hashable
+
 is
+
+
+  # equality of two options is true iff `a` and `b` are both nil or `a` and `b` are both
+  # `T` and T.equality a.get b.get.
+  #
+  # This is defined only if T : property.equatable, it will result in a compile-time panic
+  # if this is not the case.
+  #
+  public redef fixed type.equality(a, b option T) bool
+  =>
+    if T : property.equatable then
+      match a
+        av T =>
+          match b
+            bv T => T.equality av bv
+            nil  => false
+        nil =>
+          match b
+            _ T => false
+            nil  => true
+    else
+      compile_time_panic
+
+
+  # A total order between of two options is defined as follows: `nil` is always less-than-or-equal
+  # ny other value and iff `a` and `b` are both `T` and T.lteq a.get b.get.
+  #
+  # This is defined only if T : property.orderable, it will result in a compile-time panic
+  # if this is not the case.
+  #
+  public redef fixed type.lteq(a, b option T) bool
+  =>
+    if T : property.orderable then
+      match a
+        av T =>
+          match b
+            bv T => T.lteq av bv
+            nil  => false
+        nil =>
+          true
+    else
+      compile_time_panic
+
+
+  # create hash code for this option
+  #
+  # This is defined only if T : property.hashable, it will result in a compile-time panic
+  # if this is not the case.
+  #
+  public redef fixed type.hash_code(a option T) u64
+  =>
+    if T : property.hashable then
+      match a
+        v T => T.hash_code v
+        nil => 0xfe6f6476106a56b6  # generated using secure random generator at https://cryptotools.dev/
+    else
+      compile_time_panic
 
 
   # Does this option contain no value of type T?

--- a/modules/base/src/option.fz
+++ b/modules/base/src/option.fz
@@ -43,7 +43,7 @@ is
   #
   public redef fixed type.equality(a, b option T) bool
   =>
-    if T : property.equatable then
+    if T : property.equatable
       match a
         av T =>
           match b
@@ -57,15 +57,16 @@ is
       compile_time_panic
 
 
-  # A total order between of two options is defined as follows: `nil` is always less-than-or-equal
-  # ny other value and iff `a` and `b` are both `T` and T.lteq a.get b.get.
+  # A total order between two options is defined as follows: `nil` is always less-than-or-equal
+  # any other value and iff `a` and `b` are both contains values of type `T`, then
+  # `T.lteq a.get b.get`.
   #
   # This is defined only if T : property.orderable, it will result in a compile-time panic
   # if this is not the case.
   #
   public redef fixed type.lteq(a, b option T) bool
   =>
-    if T : property.orderable then
+    if T : property.orderable
       match a
         av T =>
           match b
@@ -84,7 +85,7 @@ is
   #
   public redef fixed type.hash_code(a option T) u64
   =>
-    if T : property.hashable then
+    if T : property.hashable
       match a
         v T => T.hash_code v
         nil => 0xfe6f6476106a56b6  # generated using secure random generator at https://cryptotools.dev/

--- a/modules/base/src/option.fz
+++ b/modules/base/src/option.fz
@@ -57,8 +57,8 @@ is
       compile_time_panic
 
 
-  # A total order between two options is defined as follows: `nil` is always less-than-or-equal
-  # any other value and iff `a` and `b` are both contains values of type `T`, then
+  # A total order for options is defined as follows: `nil` is always less-than-or-equal
+  # any other value and iff `a` and `b` both contain values of type `T`, then
   # `T.lteq a.get b.get`.
   #
   # This is defined only if T : property.orderable, it will result in a compile-time panic

--- a/modules/base/src/outcome.fz
+++ b/modules/base/src/outcome.fz
@@ -49,7 +49,9 @@
 # compatible to  'outcome data IO_Error Permission_Error', so everything
 # is fine.
 #
-public outcome(public T type) : switch T error
+public outcome(public T type)
+  : switch T error,
+    property.equatable
 is
 
   # Does this outcome contain an error
@@ -118,6 +120,21 @@ is
   =>
     outcome.this
 
+
+  # equality implementation
+  #
+  # result is only true if both x and y are
+  # of choice type T and the inner values are equal.
+  #
+  public redef fixed type.equality(x, y outcome T) bool
+  =>
+    if T : property.equatable
+      x ? xa T =>
+          y ? ya T => xa = ya
+            | _  error => false
+        | _  error => false
+    else
+      compile_time_panic
 
 
 # outcome with 1 argument provides an short-hand to wrap a value into a

--- a/modules/base/src/property/hashable.fz
+++ b/modules/base/src/property/hashable.fz
@@ -49,8 +49,6 @@ public hashable : equatable is
   #     then we rotate by `hash_rotate`
   #     and multiply by `hash_prime3`
   #
-  # see https://xxhash.com/doc/v0.8.3 for details.
-  #
   module type.xxh_next(# the existing hash code, start with `xxh_first`
                 h0 u64,
 

--- a/modules/base/src/property/hashable.fz
+++ b/modules/base/src/property/hashable.fz
@@ -36,3 +36,42 @@ public hashable : equatable is
   #   (T.equality a b) : (T.hash_code a = T.hash_code b)
   #
   public type.hash_code(a hashable.this) u64 => abstract
+
+
+  # helper for an xxh-style quick hash function.
+  #
+  # The algorithm used here is a variation of (XXXHash)[https://xxhash.com] as used in
+  # (Python's tuple)[https://github.com/python/cpython/blob/849a80ec412c36bbca5d400a7db5645b8cf54f1f/Objects/tupleobject.c#L305]:
+  #
+  #   we start with a constant `hash_prime5`
+  #   for each value:
+  #     we take its hash code * `hash_prime2` and add it
+  #     then we rotate by `hash_rotate`
+  #     and multiply by `hash_prime3`
+  #
+  # see https://xxhash.com/doc/v0.8.3 for details.
+  #
+  module type.xxh_next(# the existing hash code, start with `xxh_first`
+                h0 u64,
+
+                # the additional hash code to be incorporated
+                h1 u64)
+  =>
+    h2 := h0 +° h1 *° xxh_prime_2
+    h3 := (h2 << xxh_rotate) | (h2 >> (u64 64 - xxh_rotate))
+    h3 *° xxh_prime_1
+
+
+  # Preferred initial value für `h0` when calling `xxh_next`.
+  #
+  module type.xxh_first => xxh_prime_5
+
+
+  # XXH constants from https://xxhash.com/doc/v0.8.3/group___x_x_h64__impl.html
+  #
+  type.xxh_prime_1 => u64 0x9E3779B185EBCA87  # factor after each value's hash code was added and result was rotated
+  type.xxh_prime_2 => u64 0xC2B2AE3D27D4EB4F  # factor for adding hash code of values
+  type.xxh_prime_3 => u64 0x165667B19E3779F9  # not needed here
+  type.xxh_prime_4 => u64 0x85EBCA77C2B2AE63  # not needed here
+  type.xxh_prime_5 => u64 0x27D4EB2F165667C5  # initial hash used for empty values list
+  type.xxh_rotate  => u64 31                  # rotation after adding hash code of values

--- a/modules/base/src/switch.fz
+++ b/modules/base/src/switch.fz
@@ -26,10 +26,11 @@
 # e.g.    option  (something/nil)
 #      or outcome (something/error)
 #
-public switch(A type, B type /* NYI: B should be open generic */) :
-  choice A B,
-  monad A switch.this,
-  Sequence A
+public switch(A type, B type /* NYI: B should be open generic */)
+  : choice A B,
+    monad A switch.this,
+    Sequence A,
+    property.equatable
 is
 
   # NYI: CLEANUP: decide name: exists/ok, get/val?
@@ -191,17 +192,6 @@ is
   # public redef type.return (a A) switch.this => a
 
 
-  # this switch as an equatable_switch
-  #
-  public as_equatable_switch equatable_switch A B
-  pre
-    A : property.equatable
-  =>
-    match switch.this
-      a A => a
-      b B => b
-
-
   # get A or cause an `exception T`
   #
   public or_cause(T type, e B->error) A =>
@@ -244,33 +234,17 @@ is
       b B => b.as_string
 
 
-# Wrapper type to make a `switch` of an equatable elements itself equatable.
-#
-public equatable_switch(A type : property.equatable,
-                        B type)
-  : switch A B,
-    property.equatable
-is
-
   # equality implementation
   #
   # result is only true if both x and y or
   # of choice type A and x.A = y.A
   #
-  public fixed redef type.equality(x, y equatable_switch A B) bool =>
-    x ? xa A =>
-        y ? ya A => xa = ya
-          | _  B => false
-      | _  B => false
-
-
-  # as_string copied from `switch.as_string` due to repeated inheritance of
-  # conflicting `switch.as_astring` and `Any.as_string` (via `property.equatable`).
-  #
-  # NYI: UNDER DEVELOPMENT: If we have an Eiffel-style `select` or `undefine`, we could
-  # use that instead and select `switch.as_string` or undefine `Any.as_string`.
-  #
-  public redef as_string String =>
-    match equatable_switch.this
-      a A => a.as_string
-      b B => b.as_string
+  public redef fixed type.equality(x, y switch A B) bool
+  =>
+    if A : property.equatable
+      x ? xa A =>
+          y ? ya A => xa = ya
+            | _  B => false
+        | _  B => false
+    else
+      compile_time_panic

--- a/modules/base/src/tuple.fz
+++ b/modules/base/src/tuple.fz
@@ -160,36 +160,15 @@ is
   #
   # This will result in a compile-time `panic` in case any element type is not hashable.
   #
-  # The algorithm used here is a variation of (XXXHash)[https://xxhash.com] as used in
-  # (Python's tuple)[https://github.com/python/cpython/blob/849a80ec412c36bbca5d400a7db5645b8cf54f1f/Objects/tupleobject.c#L305]:
-  #
-  #   we start with a constant `hash_prime1`
-  #   for each value:
-  #     we take its hash code * `hash_prime2` and add it
-  #     then we rotate by `hash_rotate`
-  #     and multiply by `hash_prime3`
-  #
-  public redef fixed type.hash_code(a tuple.this) u64 : container.typed_fold xxh_prime_5 a.values
+  public redef fixed type.hash_code(a tuple.this) u64 : container.typed_fold xxh_first a.values
   =>
     public redef apply(T type, h u64, v T) u64
     =>
       if T : property.hashable then
-        h2 := h +° T.hash_code v *° xxh_prime_2
-        h3 := (h2 << xxh_rotate) | (h2 >> (u64 64 - xxh_rotate))
-        h3 *° xxh_prime_1
+        xxh_next h (T.hash_code v)
       else
         compile_time_panic  # tuple is not hashable since one element type is not
     res
-
-
-  # XXH constants from https://xxhash.com/doc/v0.8.3/group___x_x_h64__impl.html
-  #
-  type.xxh_prime_1 => u64 0x9E3779B185EBCA87  # factor after each value's hash code was added and result was rotated
-  type.xxh_prime_2 => u64 0xC2B2AE3D27D4EB4F  # factor for adding hash code of values
-  type.xxh_prime_3 => u64 0x165667B19E3779F9  # not needed here
-  type.xxh_prime_4 => u64 0x85EBCA77C2B2AE63  # not needed here
-  type.xxh_prime_5 => u64 0x27D4EB2F165667C5  # initial hash used for empty tuple
-  type.xxh_rotate  => u64 31                  # rotation after adding hash code of values
 
 
   # create a String from this instance.

--- a/tests/free_types_negative/test_free_types_negative.fz.expected_err
+++ b/tests/free_types_negative/test_free_types_negative.fz.expected_err
@@ -119,7 +119,11 @@ expected formal type: 'Sequence U'
 actual type found   : 'Sequence T'
 assignable to       : 'Any',
                       'Sequence T',
-                      'property.ref countable'
+                      'property.ref countable',
+                      'property.ref equatable',
+                      'property.ref hashable',
+                      'property.ref orderable',
+                      'property.ref partially_orderable'
 for value assigned  : 's'
 To solve this, you could change the type of the target 's' to 'Sequence T' or convert the type of the assigned value to 'Sequence U'.
 

--- a/tests/lib_property_equatable/lib_property_equatable.fz
+++ b/tests/lib_property_equatable/lib_property_equatable.fz
@@ -38,5 +38,13 @@ lib_property_equatable =>
   say (option 0).as_equatable_switch=1
   say (option 0).as_equatable_switch=nil
 
+  say (option 0 = 0)
+  say (option 0 = 1)
+  say (option 0 = nil)
+
+  say (0 = option 0)
+  say (0 = option 1)
+  say (0 = option i32 nil)
+
   # NYI: UNDER DEVELOPMENT: ugly that we have to use (id (container.Set i32) ...)
   say (id (container.Set i32) ((container.ps_set i32).empty))=((container.ps_set i32).empty)

--- a/tests/lib_property_equatable/lib_property_equatable.fz
+++ b/tests/lib_property_equatable/lib_property_equatable.fz
@@ -23,10 +23,10 @@
 
 lib_property_equatable =>
 
-  say [0,1,2].as_equatable=[0,1,2].as_equatable
-  say [0,1,2].as_equatable=[0,1,3].as_equatable
-  say ["a","b","c"].as_equatable=["a","b","c"].as_equatable
-  say ["a","b","c"].as_equatable=["a","b","d"].as_equatable
+  say [0,1,2]=[0,1,2]
+  say [0,1,2]=[0,1,3]
+  say ["a","b","c"]=["a","b","c"]
+  say ["a","b","c"]=["a","b","d"]
 
   say (option 0).as_equatable_switch=0
   say (option 0).as_equatable_switch=1

--- a/tests/lib_property_equatable/lib_property_equatable.fz
+++ b/tests/lib_property_equatable/lib_property_equatable.fz
@@ -28,15 +28,15 @@ lib_property_equatable =>
   say ["a","b","c"]=["a","b","c"]
   say ["a","b","c"]=["a","b","d"]
 
-  say (option 0).as_equatable_switch=0
-  say (option 0).as_equatable_switch=1
-  say (option 0).as_equatable_switch=nil
+  say (option 0)=0
+  say (option 0)=1
+  say (option 0)=nil
 
-  say (outcome 0).as_equatable_switch=(error "hello")
+  say (outcome 0)=(error "hello")
 
-  say (option 0).as_equatable_switch=0
-  say (option 0).as_equatable_switch=1
-  say (option 0).as_equatable_switch=nil
+  say (option 0)=0
+  say (option 0)=1
+  say (option 0)=nil
 
   say (option 0 = 0)
   say (option 0 = 1)

--- a/tests/lib_property_equatable/lib_property_equatable.fz.expected_out
+++ b/tests/lib_property_equatable/lib_property_equatable.fz.expected_out
@@ -10,3 +10,9 @@ true
 false
 false
 true
+false
+false
+true
+false
+false
+true

--- a/tests/strings/stringstest.fz
+++ b/tests/strings/stringstest.fz
@@ -50,6 +50,6 @@ stringstest is
 
   chck "Nested: { "-{ a + b }-" * 3 }"="Nested: -7--7--7-" "nested \{}"
 
-  chck ("abcdefabcdefabcdef".find "abcdef" 11).as_equatable=(option 12).as_equatable "find(substring, from)"
+  chck ("abcdefabcdefabcdef".find "abcdef" 11 = 12) "find(substring, from)"
 
   exit

--- a/tests/transducers/transducertest.fz
+++ b/tests/transducers/transducertest.fz
@@ -37,19 +37,19 @@ transducertest is
 
   xf_filter := td1.filter (x -> x > 3)
   r0 := (1..5).into xf_filter
-  chck (r0.as_equatable = [4, 5].as_equatable)                            "filter transducer"
+  chck (r0 = [4, 5])                            "filter transducer"
 
 
   td2 := (transducer (Sequence bool) bool i32).type
   xf_map := td2.map (x -> x > 3)
   r1 := (1..5).into xf_map
-  chck (r1.as_equatable = [false, false, false, true, true].as_equatable) "map transducer"
+  chck (r1 = [false, false, false, true, true]) "map transducer"
 
 
   human(age i32) is
   ages := td1.map (x -> x.age)
   gt_ten := td1.filter (x -> x > 10)
   r2 := [human 4, human 12, human 30].into (ages ∘ gt_ten)
-  chck (r2.as_equatable = [12, 30].as_equatable)                          "compose transducers"
+  chck (r2 = [12, 30])                          "compose transducers"
 
   exit


### PR DESCRIPTION
First, moved code for xxh-style hashes to `property.hashable` such that it can be used at several locations. Then added `equality`, `lteq` and `hashable` to Sequence and to `list`.

Remove `as_equatable` and `as_orderable` since these are no longer needed.

Updated tests.

This depends on #6036, so I make this a draft until that PR is merged. 