### PR TITLE
base: change visibility of `handles`, add detailed comment how to clean this up

### DIFF
--- a/modules/base/src/handles.fz
+++ b/modules/base/src/handles.fz
@@ -54,7 +54,13 @@
 # given to other features, only values can. handles essentially provide an
 # abstraction of pointers, implemented natively in Fuzion.
 #
-private /* NYI: CLEANUP: remove eventually */ handles(
+# NYI: CLEANUP: This is currently used as an example for the equivalence of an
+# effect and a monad in the [Fuzion design]("https://fuzion-lang.dev/design/monadic_lifting).
+# We might remove `oneway_monad` from the base lib if this is needed only for the
+# design pages and add code for a `handles` monad to the example code where this
+# is currently used as a monad.
+#
+private:public handles(
   T, X type,
 
   # the inner value of this monad
@@ -181,12 +187,12 @@ public handles(T type, rr ()->unit) unit =>
 
 # short-hand for creating an empty set of handles of given type.
 #
-handles_(T type) handles T unit => handles unit (array T 0 x->do) oneway_monad_mode.plain
+public handles_(T type) handles T unit => handles unit (array T 0 x->do) oneway_monad_mode.plain
 
 
 # short-hand for accessing handles monad for given type in current environment
 #
-handles(T type) handles T unit =>
+public handles(T type) handles T unit =>
   (handles_type T).install_default
   (handles T unit).env
 


### PR DESCRIPTION
`monadiclifting_manorboy_monad.fz` is a test in the [Fuzion design]("https://fuzion-lang.dev/design/monadic_lifting) that requires this change.
