### PR TITLE
bool: add all_of and any_of

### DIFF
--- a/modules/base/src/bool.fz
+++ b/modules/base/src/bool.fz
@@ -179,27 +179,21 @@ public true bool => true_
 # all of them are true
 #
 public all_of (B type..., values B...) bool =>
-  all_of_helper : container.typed_applicator bool is
-    public redef apply(T type, e bool, v T) bool =>
-      if T : bool
-        # NYI: BUG: #6071: cannot use && here
-        v & e
-      else
-        compile_time_panic
-
-  values.typed_foldf true all_of_helper
+  values.typed_foldf true T,e,v->
+    if T : bool
+      # NYI: BUG: #6071: cannot use && here
+      v & e
+    else
+      compile_time_panic
 
 
 # takes an arbitrary amount of bool arguments and returns true if and only if
 # any of them is true
 #
 public any_of (B type..., values B...) bool =>
-  any_of_helper : container.typed_applicator bool is
-    public redef apply(T type, e bool, v T) bool =>
-      if T : bool
-        # NYI: BUG: #6071: cannot use || here
-        v | e
-      else
-        compile_time_panic
-
-  values.typed_foldf false any_of_helper
+  values.typed_foldf false T,e,v->
+    if T : bool
+      # NYI: BUG: #6071: cannot use || here
+      v | e
+    else
+      compile_time_panic


### PR DESCRIPTION
In some cases, this may make code readable that has a large amount of boolean conditions.

These features can unfortunately not go into `bool.type` because they define types, which leads to an error.