### PR TITLE
lib: add String.quoted, putting String in double quotes

### DIFF
--- a/modules/base/src/String.fz
+++ b/modules/base/src/String.fz
@@ -891,6 +891,14 @@ public String ref : property.equatable, property.hashable, property.orderable is
     (String.this + codepoint 0).utf8.as_array
 
 
+  # this String but put in double quotes
+  #
+  public quoted String
+    pre debug: !starts_with "\""
+        debug: !ends_with "\""
+  =>
+    "\"{String.this}\""
+
 
   # monoid of strings with infix + operation.
   #

--- a/tests/lib_string/stringtest.fz
+++ b/tests/lib_string/stringtest.fz
@@ -47,3 +47,5 @@ stringtest is
   mi : mutate is
   mi ! ()->
     say (String.from_mutable_array mi ((mutate.array Any).new mi 1 nil))
+
+  say "abcd".quoted

--- a/tests/lib_string/stringtest.fz.expected_out
+++ b/tests/lib_string/stringtest.fz.expected_out
@@ -8,3 +8,4 @@ true
 [0, 1, 2]
 hell😀
 --nil--
+"abcd"


### PR DESCRIPTION
since writing `"\"$my_string\""` is rather ugly
