### PR TITLE
lib: change visiblity of atomic to `private:public`

### DIFF
--- a/modules/base/src/concur/Blocking_Queue.fz
+++ b/modules/base/src/concur/Blocking_Queue.fz
@@ -31,7 +31,7 @@ module Blocking_Queue(T type, cnd concur.sync.condition) ref is
   #
   # accessed only by one thread at a time
   #
-  is_closed := concur.atomic false
+  is_closed := concur.atomic bool .new false
 
 
   module close =>
@@ -45,7 +45,7 @@ module Blocking_Queue(T type, cnd concur.sync.condition) ref is
   #
   # accessed only by one thread at a time
   #
-  data := concur.atomic (array T) []
+  data := concur.atomic (array T) .new []
 
 
   # enqueue an element

--- a/modules/base/src/concur/atomic.fz
+++ b/modules/base/src/concur/atomic.fz
@@ -28,7 +28,7 @@
 # Atomic values can be used for communication between threads in a safe
 # way.
 #
-public atomic (
+private:public atomic (
   T type,
   v T
   ) : auto_unwrap T atomic_access
@@ -166,4 +166,12 @@ is
         new_value := current_value-1
     while !(compare_and_set current_value new_value)
     else new_value
+
+
+  # create a new atomic of type T
+  #
+  public type.new(v T) concur.atomic T =>
+    concur.atomic v
+
+
 

--- a/modules/base/src/concur/sync.fz
+++ b/modules/base/src/concur/sync.fz
@@ -74,7 +74,7 @@ public sync is
   #
   private:public condition(mtx Mutex, cnd Condition) is
 
-    public is_locked concur.atomic bool := concur.atomic false
+    public is_locked concur.atomic bool := concur.atomic bool .new false
 
     # run code synchronized across all threads
     # that also use this condition

--- a/modules/base/src/concur/thread.fz
+++ b/modules/base/src/concur/thread.fz
@@ -29,7 +29,7 @@ module:public thread(thrd Thread) : property.equatable is
 
   id := unique_id
 
-  joined := concur.atomic trit.no
+  joined := concur.atomic trit .new trit.no
 
   # wait for this thread to finish execution
   #

--- a/modules/base/src/concur/thread_pool.fz
+++ b/modules/base/src/concur/thread_pool.fz
@@ -46,7 +46,7 @@ Computable_Future(
 
   cnd := concur.sync.condition.new.val # NYI: error handling
 
-  compute_result := concur.atomic (option T) nil
+  compute_result := concur.atomic (option T) .new nil
 
   compute =>
     cr := task.call

--- a/modules/base/src/effect.fz
+++ b/modules/base/src/effect.fz
@@ -479,4 +479,4 @@ public linear_effect : effect is
 
 Depleted_Wrapper ref is
 
-  depleted := concur.atomic false
+  depleted := concur.atomic bool .new false

--- a/modules/lock_free/src/lock_free/Map.fz
+++ b/modules/lock_free/src/lock_free/Map.fz
@@ -149,7 +149,7 @@ Main_Node(CTK type : property.hashable, CTV type, data choice (container_node CT
   id := unique_id
 
   # a previous node that gets set during a generational aware compare and set
-  prev := concur.atomic (prev_node CTK CTV) p
+  prev := concur.atomic (prev_node CTK CTV) .new p
 
   public fixed redef type.equality(a, b Main_Node.this) bool =>
     a.id = b.id
@@ -185,7 +185,7 @@ failed_node(CTK type : property.hashable, CTV type, prev Main_Node CTK CTV) is
 
 # shorthand for creating a new indirection node from Main_Node and gen
 indirection_node(CTK type : property.hashable, CTV type, data Main_Node CTK CTV, gen u64) =>
-  Indirection_Node (concur.atomic data) gen
+  Indirection_Node (concur.atomic (Main_Node CTK CTV) .new data) gen
 
 
 # an indirection node
@@ -250,7 +250,7 @@ is
 
   # this field does not have to be atomic
   # but it probably does not hurt either.
-  committed := concur.atomic false
+  committed := concur.atomic bool .new false
 
   public redef as_string String =>
     "Rdcss_Descriptor($ov, $exp, $nv)"
@@ -672,7 +672,7 @@ is
     descriptor := Rdcss_Descriptor r expmain (copy_to_gen r new_gen)
     if rdcss_root descriptor
       # new ctrie by changing generation of r
-      Map (concur.atomic (root_node CTK CTV) (copy_to_gen r new_gen)) snapshot.this.read_only
+      Map (concur.atomic (root_node CTK CTV) .new (copy_to_gen r new_gen)) snapshot.this.read_only
     else
       snapshot snapshot.this.read_only
 
@@ -710,7 +710,7 @@ is
     initial_root_node lock_free.root_node CTK CTV :=
       lock_free.indirection_node (lock_free.Main_Node (lock_free.container_node CTK CTV 0 [] initial_gen) nil) initial_gen
 
-    lock_free.Map (concur.atomic initial_root_node) false
+    lock_free.Map (concur.atomic (lock_free.root_node CTK CTV) .new initial_root_node) false
 
 
   # lock_free.Map.from_entries -- routine to initialize a ctrie from a sequence of key value tuples

--- a/modules/lock_free/src/lock_free/Sieve_Cache.fz
+++ b/modules/lock_free/src/lock_free/Sieve_Cache.fz
@@ -47,9 +47,9 @@ public Sieve_Cache(K type : property.hashable, V type, public capacity i32) ref 
 
   # Using atomic here to be able to read and write in a
   # multi threaded environment.
-  head  := concur.atomic (option (lock_free.Node K V)) nil
-  tail  := concur.atomic (option (lock_free.Node K V)) nil
-  hand  := concur.atomic (option (lock_free.Node K V)) nil
+  head  := concur.atomic (option (lock_free.Node K V)) .new nil
+  tail  := concur.atomic (option (lock_free.Node K V)) .new nil
+  hand  := concur.atomic (option (lock_free.Node K V)) .new nil
 
   add_to_head(n lock_free.Node K V) =>
     n.next.write head.read
@@ -102,7 +102,7 @@ public Sieve_Cache(K type : property.hashable, V type, public capacity i32) ref 
         v := val()
         if cache.size >= capacity
           evict
-        new_node := lock_free.Node (key, v) (concur.atomic false) (concur.atomic (option (lock_free.Node K V)) nil) (concur.atomic (option (lock_free.Node K V)) nil)
+        new_node := lock_free.Node (key, v) (concur.atomic bool .new false) (concur.atomic (option (lock_free.Node K V)) .new nil) (concur.atomic (option (lock_free.Node K V)) .new nil)
         add_to_head new_node
         cache.put key new_node
         new_node.visited.write false

--- a/modules/lock_free/src/lock_free/stack.fz
+++ b/modules/lock_free/src/lock_free/stack.fz
@@ -28,7 +28,7 @@ public stack(T type) : container.Stack T is
 
   Node(data T, next option Node) ref is
 
-  top := concur.atomic (option Node) nil
+  top := concur.atomic (option Node) .new nil
 
 
   # push an element to the stack

--- a/tests/atomic/test_atomic.fz
+++ b/tests/atomic/test_atomic.fz
@@ -38,7 +38,7 @@ test_atomic is
     chck0 x y (a,b)->a=b
 
   test0(T type, a, b, c, d T, eq (T,T)->bool) =>
-    a1 := concur.atomic a
+    a1 := concur.atomic T .new a
     chck0 a1.read a eq
     a1.write b
     chck0 a1.read b eq
@@ -159,11 +159,11 @@ test_atomic is
 
   test =>
 
-    a1 := concur.atomic i64 0x0000000080000000
-    c1 := concur.atomic i64 0
-    s1 := concur.atomic i64 -1
-    c2 := concur.atomic i64 0
-    s2 := concur.atomic i64 -1
+    a1 := concur.atomic i64 .new 0x0000000080000000
+    c1 := concur.atomic i64 .new 0
+    s1 := concur.atomic i64 .new -1
+    c2 := concur.atomic i64 .new 0
+    s2 := concur.atomic i64 .new -1
 
     thrd1 := concur.threads.spawn (()->
       end := time.nano.read + (time.duration.seconds 5)

--- a/tests/lib_concur_thread_pool/lib_concur_thread_pool.fz
+++ b/tests/lib_concur_thread_pool/lib_concur_thread_pool.fz
@@ -28,7 +28,7 @@ lib_concur_thread_pool =>
   # that add `i` to sum. print result of sum.
   #
   test_1 =>
-    sum := concur.atomic 0
+    sum := concur.atomic i32 .new 0
 
     _ := concur.thread_pool 3 ()->
 

--- a/tests/lock_free_stack/test.fz
+++ b/tests/lock_free_stack/test.fz
@@ -2,7 +2,7 @@ test =>
 
   s := lock_free.stack i32
 
-  cnt := concur.atomic 0
+  cnt := concur.atomic i32 .new 0
   count(n i32) =>
     c := cnt.read
     cnt.compare_and_set c c+n

--- a/tests/reg_issue1604_cmp_swap_choice/test_issue1604.fz
+++ b/tests/reg_issue1604_cmp_swap_choice/test_issue1604.fz
@@ -9,7 +9,7 @@ test_issue1604 is
 
     s := small 0x11
     l := large 0xCCCC_CCCC_CCCC_CCCC 0xCCCC_CCCC_CCCC_CCCC 0xCCCC_CCCC_CCCC_CCCC 0xCCCC_CCCC_CCCC_CCCC
-    a := concur.atomic c s
+    a := concur.atomic c .new s
 
     match a.compare_and_swap s l
       small => #  ok
@@ -35,7 +35,7 @@ test_issue1604 is
 
     s := small 0x11
     _ := large 0xCCCC_CCCC_CCCC_CCCC 0xCCCC_CCCC_CCCC_CCCC 0xCCCC_CCCC_CCCC_CCCC 0xCCCC_CCCC_CCCC_CCCC
-    a0 := concur.atomic c s
+    a0 := concur.atomic c .new s
 
     test(n i32) unit =>
       if n > 0

--- a/tests/reg_issue2111/reg_issue2111.fz
+++ b/tests/reg_issue2111/reg_issue2111.fz
@@ -22,7 +22,7 @@
 # -----------------------------------------------------------------------
 
 test(T type : property.equatable, a T) =>
-  a1 := concur.atomic a
+  a1 := concur.atomic T .new a
   _ := a1.read = a
 
   on is

--- a/tests/reg_issue3527/reg_issue3527.fz
+++ b/tests/reg_issue3527/reg_issue3527.fz
@@ -28,7 +28,7 @@ reg_issue3527 =>
   sieve_cache(T type : property.hashable, capacity u64) is
 
     Node(val T) ref is
-      _ concur.atomic (option Node) := concur.atomic (option Node) nil
+      _ concur.atomic (option Node) := concur.atomic (option Node) .new nil
 
     _ := (lock_free.Map T Node).type.empty
-    _ := concur.atomic (option Node) nil
+    _ := concur.atomic (option Node) .new nil

--- a/tests/sockets/sockets_test.fz
+++ b/tests/sockets/sockets_test.fz
@@ -26,10 +26,10 @@ sockets_test is
   lm : mutate is
 
   servers :=
-    concur.atomic [(u16 0),
-                   (u16 0),
-                   (u16 0),
-                   (u16 0)]
+    concur.atomic (array u16) .new [(u16 0),
+                                    (u16 0),
+                                    (u16 0),
+                                    (u16 0)]
 
   set_server_port(idx i32, new u16) =>
     _ :=

--- a/tests/sockets_thread_pool/sockets_test.fz
+++ b/tests/sockets_thread_pool/sockets_test.fz
@@ -26,10 +26,10 @@ sockets_test is
   lm : mutate is
 
   servers :=
-    concur.atomic [(u16 0),
-                   (u16 0),
-                   (u16 0),
-                   (u16 0)]
+    concur.atomic (array u16) .new [(u16 0),
+                                    (u16 0),
+                                    (u16 0),
+                                    (u16 0)]
 
   set_server_port(idx i32, new u16) =>
     _ :=

--- a/tests/unwrap/test_unwrap.fz
+++ b/tests/unwrap/test_unwrap.fz
@@ -24,7 +24,7 @@
 test_unwrap =>
 
   a := mut.new 3
-  b := concur.atomic 5
+  b := concur.atomic i32 .new 5
 
   say2(v i32) => say v
 


### PR DESCRIPTION
inheriting from atomic would be bad since it has intrinsics as child features.

related #5335