### PR TITLE
add workaround for libLLVM overriding jvm signal handlers

### DIFF
--- a/tests/native_value/Makefile
+++ b/tests/native_value/Makefile
@@ -23,6 +23,10 @@
 
 override NAME = native_value
 
+# NYI: UNDER DEVELOPMENT: workaround for libLLVM overriding jvm signal handlers
+LD_PRELOAD=$(JAVA_HOME)/lib/server/libjsig.so
+DYLD_INSERT_LIBRARIES=$(JAVA_HOME)/lib/server/libjsig.dylib
+
 # NYI: CLEANUP: use generic include paths
 CLANG_VERSION = $(shell clang --version | head -n 1 | awk '{print $$4}' | cut -d. -f1)
 export C_INCLUDE_PATH = /usr/lib/llvm-$(CLANG_VERSION)/include:/opt/homebrew/opt/llvm/include:/opt/homebrew/Cellar/llvm@15/15.0.7/include/

--- a/tests/native_value/skip_jvm
+++ b/tests/native_value/skip_jvm
@@ -1,2 +1,0 @@
-# NYI: BUG: #5026
-test native_value fails in github action with exit code 134


### PR DESCRIPTION
found via -Xcheck:jni which showed:
```
Warning: SIGSEGV handler modified!
Warning: SIGILL handler modified!
Warning: SIGFPE handler modified!
Warning: SIGBUS handler modified!
Signal Handlers:
   SIGSEGV: 0x00007efcc8ff40e0 in libLLVM.so.19.1+14631136, mask=00000000000000000000000000000000, flags=none, unblocked
  *** Handler was modified!
  *** Expected: javaSignalHandler in libjvm.so, mask=11100100110111111111111111111110, flags=SA_RESTART|SA_SIGINFO
    SIGBUS: 0x00007efcc8ff40e0 in libLLVM.so.19.1+14631136, mask=00000000000000000000000000000000, flags=none, unblocked
  *** Handler was modified!
  *** Expected: javaSignalHandler in libjvm.so, mask=11100100110111111111111111111110, flags=SA_RESTART|SA_SIGINFO
    SIGFPE: 0x00007efcc8ff40e0 in libLLVM.so.19.1+14631136, mask=00000000000000000000000000000000, flags=none, unblocked
  *** Handler was modified!
  *** Expected: javaSignalHandler in libjvm.so, mask=11100100110111111111111111111110, flags=SA_RESTART|SA_SIGINFO
   SIGPIPE: javaSignalHandler in libjvm.so, mask=11100100010111111101111111111110, flags=SA_RESTART|SA_SIGINFO, unblocked
   SIGXFSZ: javaSignalHandler in libjvm.so, mask=11100100010111111101111111111110, flags=SA_RESTART|SA_SIGINFO, unblocked
    SIGILL: 0x00007efcc8ff40e0 in libLLVM.so.19.1+14631136, mask=00000000000000000000000000000000, flags=none, unblocked
  *** Handler was modified!
  *** Expected: javaSignalHandler in libjvm.so, mask=11100100110111111111111111111110, flags=SA_RESTART|SA_SIGINFO
   SIGUSR2: SR_handler in libjvm.so, mask=00000000000000000000000000000000, flags=SA_RESTART|SA_SIGINFO, unblocked
    SIGHUP: UserHandler in libjvm.so, mask=11100100010111111101111111111110, flags=SA_RESTART|SA_SIGINFO, unblocked
    SIGINT: UserHandler in libjvm.so, mask=11100100010111111101111111111110, flags=SA_RESTART|SA_SIGINFO, unblocked
   SIGTERM: UserHandler in libjvm.so, mask=11100100010111111101111111111110, flags=SA_RESTART|SA_SIGINFO, unblocked
   SIGQUIT: UserHandler in libjvm.so, mask=11100100010111111101111111111110, flags=SA_RESTART|SA_SIGINFO, blocked
   SIGTRAP: 0x00007efcc8ff40e0 in libLLVM.so.19.1+14631136, mask=00000000000000000000000000000000, flags=none, unblocked
Consider using jsig library.
```