### PR TITLE
win: fix Wunknown-escape-sequence

### DIFF
--- a/src/dev/flang/be/c/C.java
+++ b/src/dev/flang/be/c/C.java
@@ -106,7 +106,7 @@ public class C extends ANY
               comment,
               CStmnt
                 // NYI: UNDER DEVELOPMENT: re-replace "{base.fum}/" etc. in sourceFile?
-                .directive("line " + pos.line() + " \"" + pos._sourceFile._fileName + "\"")
+                .directive("line " + pos.line() + " \"" + pos._sourceFile._fileName.toString().replace("\\", "/") + "\"")
               );
     }
 


### PR DESCRIPTION
[ci skip]
```
    45 |     #line 28 "{base.fum}\String.fz"
      |                         ^~
{base.fum}String.fz:31:25: error: unknown escape sequence '\p' [-Werror,-Wunknown-escape-sequence]
   31 |     #line 28 "{base.fum}\property\equatable.fz"
      |                         ^~
{base.fum}String.fz:31:34: error: use of non-standard escape character '\e' [-Werror,-Wpedantic]
   31 |     #l
   ....
   ```
