### PR TITLE
cleanup: `List.freeze`, return itself, allowing fluent interface

### DIFF
--- a/src/dev/flang/ast/AbstractCall.java
+++ b/src/dev/flang/ast/AbstractCall.java
@@ -56,8 +56,7 @@ public abstract class AbstractCall extends Expr
    * generics ({@code a.b(x,y)}) from a call with an empty actual generics list
    * ({@code a.b<>(x,y)}).
    */
-  public static final List<AbstractType> NO_GENERICS = new List<>();
-  { NO_GENERICS.freeze(); }
+  public static final List<AbstractType> NO_GENERICS = new List<AbstractType>().freeze();
 
 
   /*-----------------------------  methods  -----------------------------*/

--- a/src/dev/flang/ast/AbstractFeature.java
+++ b/src/dev/flang/ast/AbstractFeature.java
@@ -106,16 +106,14 @@ public abstract class AbstractFeature extends Expr implements Comparable<Abstrac
   /**
    * empty list of AbstractFeature
    */
-  public static final List<AbstractFeature> _NO_FEATURES_ = new List<>();
-  static { _NO_FEATURES_.freeze(); }
+  public static final List<AbstractFeature> _NO_FEATURES_ = new List<AbstractFeature>().freeze();
 
 
   /**
    * Result of `handDown(Resolution, AbstractType[], AbstractFeature) in case of
    * failure due to previous errors.
    */
-  public static final List<AbstractType> HAND_DOWN_FAILED = new List<>();
-  static { HAND_DOWN_FAILED.freeze(); }
+  public static final List<AbstractType> HAND_DOWN_FAILED = new List<AbstractType>().freeze();
 
 
 

--- a/src/dev/flang/ast/Contract.java
+++ b/src/dev/flang/ast/Contract.java
@@ -49,8 +49,7 @@ public class Contract extends ANY
   /**
    * Empty list of conditions.
    */
-  static final List<Cond> NO_COND = new List<>();
-  static { NO_COND.freeze(); }
+  static final List<Cond> NO_COND = new List<Cond>().freeze();
 
 
   /**

--- a/src/dev/flang/ast/UnresolvedType.java
+++ b/src/dev/flang/ast/UnresolvedType.java
@@ -54,8 +54,7 @@ public abstract class UnresolvedType extends AbstractType implements HasSourcePo
    * {@code Call.NO_GENERICS} which is used to distinguish {@code a.b<>()} (using {@code UnresolvedType.NONE})
    * from {@code a.b()} (using {@code Call.NO_GENERICS}).
    */
-  public static final List<AbstractType> NONE = new List<AbstractType>();
-  static { NONE.freeze(); }
+  public static final List<AbstractType> NONE = new List<AbstractType>().freeze();
 
 
   /**

--- a/src/dev/flang/be/jvm/classfile/ClassFile.java
+++ b/src/dev/flang/be/jvm/classfile/ClassFile.java
@@ -310,8 +310,7 @@ public class ClassFile extends ANY implements ClassFileConstants
      */
     List<Expr.TryCatch> _exceptionTable = NO_EXC_TABLE;
 
-    static List<Expr.TryCatch> NO_EXC_TABLE = new List<Expr.TryCatch>();
-    static { NO_EXC_TABLE.freeze(); }
+    static List<Expr.TryCatch> NO_EXC_TABLE = new List<Expr.TryCatch>().freeze();
 
 
     /**

--- a/src/dev/flang/fuir/GeneratingFUIR.java
+++ b/src/dev/flang/fuir/GeneratingFUIR.java
@@ -680,8 +680,7 @@ public class GeneratingFUIR extends FUIR
   }
 
 
-  private static List<AbstractCall> NO_INH = new List<>();
-  static { NO_INH.freeze(); }
+  private static List<AbstractCall> NO_INH = new List<AbstractCall>().freeze();
 
 
   /**

--- a/src/dev/flang/util/List.java
+++ b/src/dev/flang/util/List.java
@@ -472,9 +472,10 @@ public class List<T>
    * Forbid modifications to this list.  This should be called to ensure that a
    * list that is used as a key in a map or similar is no longer modified.
    */
-  public void freeze()
+  public List<T> freeze()
   {
     _isFrozen = true;
+    return this;
   }
 
 


### PR DESCRIPTION
I find this a bit cleaner.

