### PR TITLE
base: make `containter.type_applicator.apply` a `lambda_target`.

### DIFF
--- a/modules/base/src/container/Typed_Sequence.fz
+++ b/modules/base/src/container/Typed_Sequence.fz
@@ -355,6 +355,6 @@ public type_applicator(E type) is
   #       =>
   #         e + $T
   #
-  public apply(T type, e E) E
+  public apply(T type, e E) E : fuzion.lambda_target
   =>
     abstract


### PR DESCRIPTION
This makes it much easier to perform calls like `T.type_foldf` on open type parameters.
