### PR TITLE
lib: add feature `path`

### DIFF
--- a/modules/base/src/path.fz
+++ b/modules/base/src/path.fz
@@ -1,0 +1,192 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion standard library feature path
+#
+# -----------------------------------------------------------------------
+
+
+# NYI: CLEANUP: where to move this os/io?
+
+
+# a feature denoting a path/file in the filesystem
+#
+# instatiate via path.of, e.g.
+#
+#     path.of "/some/path"
+# or
+#     path.of ["some", "path"] true
+#
+private:public path(public names array String, public is_absolute bool) : property.orderable, property.hashable
+  pre debug: !names.contains "."
+      # allow ".." only at start in relative paths
+      safety: is_absolute && !names.contains ".."
+              || !(names.drop_while ="..").contains ".."
+is
+
+  # resolve o in this path
+  #
+  # e.g.
+  #
+  #     path.of "/tmp/folder" .resolve "file"
+  #
+  # effectively returns
+  #
+  #     path.of "/tmp/folder/file"
+  #
+  public resolve(o path|String) path
+    pre match o
+          p path => !p.is_absolute
+          String => true
+  =>
+    match o
+      p path => path.of names++p.names is_absolute
+      s String => resolve (path.of s)
+
+
+  # get subpath from x (included) to y (excluded)
+  #
+  # e.g.
+  #     path.of "/tmp/folder/file" .subpath 0 2 = path.of "/tmp/folder"
+  #
+  public subpath(x, y i32) path =>
+    sp := names
+      .slice x y
+    path.of sp (is_absolute && x=0)
+
+
+  # consider this to represent a file
+  # and return just name of the file
+  # without its path.
+  #
+  public file_name String
+    pre debug: !names.is_empty
+  =>
+    names.last.get
+
+
+  # return the suffix of the file_name
+  #
+  public suffix String
+    pre debug: !file_name.is_empty
+  =>
+    file_name.split "." .last.get
+
+
+  # get the parent of this path
+  #
+  # if folder is root folder or .
+  # nil is returned
+  #
+  public parent option path
+  =>
+    if names.is_empty
+      nil
+    else
+      path.of names++[".."] is_absolute
+
+
+  # relativize path `p` based on this path.
+  #
+  # e.g. "/tmp/folder".relative "/tmp/folder/file" will return "file"
+  #
+  public relativize(p path) path
+    pre debug: p.starts_with (path.of names is_absolute)
+  =>
+    path.of (p.names.drop names.count) false
+
+
+  # checks if this path starts with path `p`
+  #
+  # both this and path p must either be absolute or relative
+  # for this to return true.
+  #
+  # e.g. (path.of "/tmp/file").starts_with (path.of "/tmp") = true
+  #
+  public starts_with(p path) bool =>
+    is_absolute = p.is_absolute &&
+      p.names.count <= names.count &&
+      (names.take p.names.count) = p.names
+
+
+  # String representation of this path
+  #
+  # e.g. "/folder/file" or "relative_folder/file"
+  #
+  public redef as_string String =>
+    "{if is_absolute then "/" else ""}{if names.is_empty && !is_absolute then "." else String.join names "/"}"
+
+
+  # define order for paths
+  #
+  public redef fixed type.lteq(a, b path) bool =>
+    if a.is_absolute != b.is_absolute
+      b.is_absolute
+    else
+      a.names <= b.names
+
+
+  # create hash code for this instance
+  #
+  # This should satisfy the following condition:
+  #
+  #   (T.equality a b) : (T.hash_code a = T.hash_code b)
+  #
+  public redef fixed type.hash_code(a path) u64 =>
+    xxh_next
+      (if a.is_absolute then 0 else 1) # NYI: BUG: bad hash_codes!, bool should implement hashable
+      ((array String).type.hash_code a.names)
+
+
+  # instatiates a path via a given String
+  # if paths starts with / it is considered to be
+  # absolute rather than realive.
+  #
+  public type.of(str String) path =>
+    t := str.trim
+    path.of (t.split "/").as_array (t.starts_with "/")
+
+
+  # instatiates a path
+  #
+  # e.g.
+  #
+  #     path.of ["tmp", "some_file"] true
+  #
+  public type.of(seq Sequence String, is_absolute bool) path
+    pre debug: seq ∀ s->
+          !(s.contains "/" || s.contains "\0")
+  =>
+    dotdot, names := seq
+      .reverse
+      .filter !="."
+      .filter !=""
+      .reduce (0, Sequence String .empty) (r,t)->
+        if t = ".."
+          # we have double dots, ignore them and increase counter
+          (r.0+1, r.1)
+        else if r.0 > 0
+          # we previously encountered double dots.
+          # ignore this element too and decrease the counter.
+          (r.0-1, r.1)
+        else
+          # no double dots encountered previously,
+          # we need to include this element in the final path
+          (r.0, [t]++r.1)
+    path ([".."]*dotdot ++ names).as_array is_absolute


### PR DESCRIPTION
copied from fzweb but changed to inherit orderable and hashable instead of equatable

does not work on windows yet.

