### PR TITLE
lib: add io.Out/Err.blackhole

### DIFF
--- a/modules/base/src/io/Err.fz
+++ b/modules/base/src/io/Err.fz
@@ -31,6 +31,20 @@ public Err ref : print_effect is
     io.Err.default io.default_err
 
 
+  # implementation of io.Err that just
+  # discards everything, writing nothing, nowhere.
+  #
+  # usage example:
+  #
+  #     io.Err.instate _ io.Err.blackhole ()->
+  #        ... your code ...
+  #
+  public type.blackhole io.Err =>
+    ref : io.Err is
+      public redef write(b Sequence u8) outcome unit => unit
+      public redef flush outcome unit => unit
+
+
 # default implementation for io.Err
 #
 module default_err : io.Err is

--- a/modules/base/src/io/Out.fz
+++ b/modules/base/src/io/Out.fz
@@ -31,6 +31,20 @@ public Out ref : print_effect is
     io.Out.default io.default_out
 
 
+  # implementation of io.Out that just
+  # discards everything, writing nothing, nowhere.
+  #
+  # usage example:
+  #
+  #     io.Out.instate _ io.Out.blackhole ()->
+  #        ... your code ...
+  #
+  public type.blackhole io.Out =>
+    ref : io.Out is
+      public redef write(b Sequence u8) outcome unit => unit
+      public redef flush outcome unit => unit
+
+
 # default implementation for io.Out
 #
 module default_out : io.Out is


### PR DESCRIPTION
to suppress any output of e.g. `say