### PR TITLE
lib: change io.buffered.writer result type

### DIFF
--- a/modules/base/src/String.fz
+++ b/modules/base/src/String.fz
@@ -34,7 +34,7 @@ public String ref : property.equatable, property.hashable, property.orderable is
   #
   # if String is longer than max_codepoints '…' is appended
   #
-  public truncate(max_codepoints i32) String 
+  public truncate(max_codepoints i32) String
     pre
       debug: max_codepoints > 0
   =>
@@ -892,7 +892,7 @@ public String ref : property.equatable, property.hashable, property.orderable is
   # write the bytes of this String to
   # writer of type: (io.buffered LM).writer
   #
-  public write_to(LM type : mutate) (io.buffered LM).writer.write_result ! (io.buffered LM).writer
+  public write_to(LM type : mutate) outcome unit ! (io.buffered LM).writer
   =>
     (io.buffered LM).writer.env.write utf8
 

--- a/modules/base/src/io/Write_Handler.fz
+++ b/modules/base/src/io/Write_Handler.fz
@@ -26,5 +26,5 @@ public Write_Handler ref is
   # write bytes b
   #
   public write(b Sequence u8) outcome unit
-  pre b.finite.is_yes
+    pre b.finite.is_yes
   => abstract

--- a/modules/base/src/io/buffered/writer.fz
+++ b/modules/base/src/io/buffered/writer.fz
@@ -69,49 +69,51 @@ is
       wh.write (buffer.flush n)
 
 
-  # buffered writing of the given byte
+  # store the amount of written bytes
+  # in the last write request
   #
-  public write_byte (b u8) outcome unit =>
-    (write [b]).error
+  bw := LM.env.new i32 0
 
-
-  # helper type for write result
+  # get the amount of bytes that were written successfully
+  # in the last write request
   #
-  private:public write_result(public bytes_written i32, public error outcome unit) is
+  public bytes_written i32 => bw.get
 
-
-    # was writing successful?
-    #
-    public ok bool => error.ok
+  # update bytes_written and replace the effect
+  #
+  bytes_written(n i32) unit =>
+    bw <- n
+    replace
 
 
   # buffered writing of the given array
   #
-  public write (data Sequence u8) write_result =>
-    p := data.as_array
-    n := p.length
-    for n_written := 0, n_written + r
-        e outcome unit := unit, e0
-    while n_written < n
-      y := LM.env.new (outcome unit unit)
-      f =>
-        if buffer.buffered = 0 && (n - n_written) > buf_size
-          # can write directly
-          y <- wh.write (p.slice n_written (n_written + buf_size)).as_array
-          buf_size
-        else if buffer.buffered = 0
-          # start filling buffer, but incompletely
-          y <- buffer.enqueue (p.slice n_written n).as_array
-          n - n_written
-        else
-          # fill up the rest of the buffer
-          a := min (buf_size - buffer.buffered.as_i32) n
-          y <- buffer.enqueue (p.slice n_written (n_written + a)).as_array
-          y <- flush
-          a
-      r := f
-      e0 := y.get
-    until !e
-      write_result n_written e
+  write_array(a array u8) outcome unit =>
+    bytes_written 0
+    # still fits into buffer
+    if buffer.available.as_i32 >= a.count
+      buffer.enqueue a
     else
-      write_result n_written e
+      # flush the buffer first
+      flush.bind _->
+        full_chunks := a.count / buf_size
+        for c in 0..full_chunks
+            wr := wh.write (a.slice c*buf_size c*(buf_size+1))
+        until wr.is_error
+          bytes_written c*buf_size
+          wr
+        else
+          bytes_written full_chunks*buf_size
+          rest := a.slice full_chunks*buf_size a.count
+          buffer.enqueue rest
+
+
+
+  # buffered writing of the given data
+  # where data may be bytes or a String
+  #
+  public write (data choice String (Sequence u8)) outcome unit =>
+    replace
+    match data
+      str String => write_array str.utf8.as_array
+      s Sequence u8 => write_array s.as_array

--- a/modules/base/src/io/file/write.fz
+++ b/modules/base/src/io/file/write.fz
@@ -26,4 +26,4 @@
 #
 public write(f String, s String) outcome unit =>
   use f mode.write ()->
-    (writer.write s.utf8).error
+    writer.write s.utf8

--- a/modules/mail/src/mail.fz
+++ b/modules/mail/src/mail.fz
@@ -112,8 +112,7 @@ public mail is
     #
     write_or_cause(LM type : mutate, s String) =>
       (io.buffered LM).writer.env
-        .write s.utf8
-        .error
+        .write s
         .or_cause unit (x -> error "while writing $s, got $x")
       (io.buffered LM).writer.env
         .flush

--- a/modules/web/src/web/shared.fz
+++ b/modules/web/src/web/shared.fz
@@ -42,7 +42,6 @@ module read_reponse(LM type : mutate) ! LM =>
 module write_request(LM type : mutate, rm http.request_message) ! LM =>
   (io.buffered LM).writer.env
     .write (rm.bytes i32.max)
-    .error
     .bind _->
       (io.buffered LM).writer.env.flush
 

--- a/modules/wolfssl/src/wolfssl.fz
+++ b/modules/wolfssl/src/wolfssl.fz
@@ -55,7 +55,7 @@ public wolfssl(T type, LM type : mutate, LM2 type: mutate, code ()->T) T ! LM, L
   my_IOSend : Function i32 Native_Ref Native_Ref i32 Native_Ref is
     public redef call(ssl Native_Ref, buf Native_Ref, sz i32, ctx Native_Ref) i32 =>
       arr := ffi.from_native_array u8 buf sz
-      check ((io.buffered LM).writer.env.write arr).error.ok
+      check ((io.buffered LM).writer.env.write arr).ok
       check (io.buffered LM).writer.env.flush.ok
       sz
 

--- a/tests/lib_fileio_mmap/mmap_test.fz
+++ b/tests/lib_fileio_mmap/mmap_test.fz
@@ -31,9 +31,9 @@ mmap_test =>
   say <| io.file.use testfile io.file.mode.append ()->
 
     io.file.writer.write (array u8 os.mmap_offset_multiple.as_i32 i->0)
-      .error.get
+      .get
     io.file.writer.write "hello!".utf8
-      .error.get
+      .get
     io.file.writer.flush
       .get
 

--- a/tests/lib_io_dir/lib_io_dir.fz
+++ b/tests/lib_io_dir/lib_io_dir.fz
@@ -32,8 +32,8 @@ lib_io_dir =>
   _ := io.file.delete path
   say (io.dir.make path)
   say (io.dir.make path)
-  _ := io.file.use unit file1 io.file.mode.write ()->(io.file.writer.write []).error
-  _ := io.file.use unit file2 io.file.mode.write ()->(io.file.writer.write []).error
+  _ := io.file.use unit file1 io.file.mode.write ()->(io.file.writer.write [])
+  _ := io.file.use unit file2 io.file.mode.write ()->(io.file.writer.write [])
 
   res := io.dir.use (Sequence String) path ()->
     array 3 _->io.dir.open.read.as_string

--- a/tests/lib_io_file/fileiotests.fz
+++ b/tests/lib_io_file/fileiotests.fz
@@ -41,7 +41,7 @@ fileiotests =>
   say "$file exists: {f.exists file}"
 
   _ := f
-    .use file f.mode.write ()->(f.writer.write content.utf8).error
+    .use file f.mode.write ()->(f.writer.write content.utf8)
     .bind (_ -> say "$file was created")
   say "$file exists: {f.exists file}"
 

--- a/tests/lib_io_utf8/lib_io_utf8.fz
+++ b/tests/lib_io_utf8/lib_io_utf8.fz
@@ -52,7 +52,7 @@ lib_io_utf8 =>
     say "$file exists: {f.exists file}"
 
     _ := f
-      .use file f.mode.write ()->(f.writer.write content.utf8).error
+      .use file f.mode.write ()->(f.writer.write content.utf8)
       .bind (_ -> say "$file was created")
     say "$file exists: {f.exists file}"
 
@@ -96,8 +96,8 @@ lib_io_utf8 =>
     _ := io.file.delete "⚗️🧫"
     say (io.dir.make "⚗️🧫")
     say (io.dir.make "⚗️🧫")
-    _ := io.file.use "⚗️🧫/1️⃣📜" io.file.mode.write ()->(io.file.writer.write []).error
-    _ := io.file.use "⚗️🧫/2️⃣🗒️" io.file.mode.write ()->(io.file.writer.write []).error
+    _ := io.file.use "⚗️🧫/1️⃣📜" io.file.mode.write ()->(io.file.writer.write [])
+    _ := io.file.use "⚗️🧫/2️⃣🗒️" io.file.mode.write ()->(io.file.writer.write [])
 
     res := io.dir.use (Sequence String) "⚗️🧫" ()->
       array 3 _->io.dir.open.read.as_string

--- a/tests/mod_wolfssl/mod_wolfssl.fz
+++ b/tests/mod_wolfssl/mod_wolfssl.fz
@@ -39,6 +39,6 @@ mod_wolfssl =>
         c.with _ net_lm ()->
           ssl_lm ! ()->
             wolfssl _ net_lm ssl_lm ()->
-              check ("GET / HTTP/1.1\r\nHost: fuzion-lang.dev\r\n\r\n".write_to ssl_lm).error.ok
+              check ("GET / HTTP/1.1\r\nHost: fuzion-lang.dev\r\n\r\n".write_to ssl_lm).ok
               check (io.buffered ssl_lm).writer.env.flush.ok
               say (io.buffered ssl_lm).read_line

--- a/tests/sockets/sockets_test.fz
+++ b/tests/sockets/sockets_test.fz
@@ -62,7 +62,7 @@ sockets_test is
               res := "received: {rr.as_string}\n\n"
 
               w =>
-                x := ((io.buffered lm).writer.env.write res.utf8.as_array).error
+                x := (io.buffered lm).writer.env.write res.utf8.as_array
 
                 match x
                   unit => (io.buffered lm).writer.env.flush

--- a/tests/sockets_thread_pool/sockets_test.fz
+++ b/tests/sockets_thread_pool/sockets_test.fz
@@ -62,7 +62,7 @@ sockets_test is
               res := "received: {rr.as_string}\n\n"
 
               w =>
-                x := ((io.buffered lm).writer.env.write res.utf8.as_array).error
+                x := (io.buffered lm).writer.env.write res.utf8.as_array
 
                 match x
                   unit => (io.buffered lm).writer.env.flush


### PR DESCRIPTION
to just return `outcome unit`.
If one still wants to know the successfully written bytes one can use: `writer.env.written_bytes`
