### PR TITLE
Makefile: reorder `include mod_java.mk` after `all` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -218,14 +218,14 @@ C_FILES = $(shell find $(FZ_SRC) \( -path ./build -o -path ./.git \) -prune -o -
 .DELETE_ON_ERROR:
 
 
-# rules to build java modules
-#
-include $(FZ_SRC)/mod_java.mk
-
-
 # default make target
 .PHONY: all
 all: $(FUZION_BASE) $(FUZION_JAVA_MODULES) $(FUZION_FILES) $(MOD_FZ_CMD) $(FUZION_EBNF) $(BUILD_DIR)/lsp.jar
+
+
+# rules to build java modules
+#
+include $(FZ_SRC)/mod_java.mk
 
 
 # everything but rarely used java modules


### PR DESCRIPTION
When just typing `make`, the default target is the first target listed in the Makefile. Due to the include, this was a `__marker_for_make__` target. If we move the include, the default target is `all` again.

The new position needs to be chosen carefully. If any dependency is set on variables declared in mod_java.mk before the include, the build will fail.

Found by @simonvonhackewitz.