### PR TITLE
win: fix `fzE_file_flush`

### DIFF
--- a/include/win.c
+++ b/include/win.c
@@ -1060,7 +1060,14 @@ int64_t fzE_file_position(void *file)
 
 int32_t fzE_file_flush(void *file)
 {
-  return FlushFileBuffers((HANDLE)file)
+  HANDLE h = (HANDLE)file;
+
+  // flushing stdout/stderr does not work
+  if (GetFileType(h) == FILE_TYPE_CHAR)
+  {
+    return 0;
+  }
+  return FlushFileBuffers(h)
     ? 0
     : -1;
 }


### PR DESCRIPTION
Since tests are piped to files this never occurs in a test run. Only when actually running an example in console on windows.

[ci skip]

