### PR TITLE
normalize the source file path for cleaner path in error messages

### DIFF
--- a/src/dev/flang/util/SourceFile.java
+++ b/src/dev/flang/util/SourceFile.java
@@ -219,7 +219,7 @@ public class SourceFile extends ANY
     if (PRECONDITIONS) require
       (fileName != null);
 
-    _fileName = fileName;
+    _fileName = fileName.normalize();
     if (sf == null)
       {
         try


### PR DESCRIPTION
Before
```
/home/simon/fuzion❯ fz ../../../tmp/test.fz

/home/simon/fuzion/../../../tmp/test.fz:1:5: error 1: Could not find called feature
say foo

Feature not found: 'foo' (no arguments)
Target feature: 'universe'
In call: 'foo'

one error.
```

Now
```
/home/simon/fuzion❯ fz ../../../tmp/test.fz

/tmp/test.fz:1:5: error 1: Could not find called feature
say foo

Feature not found: 'foo' (no arguments)
Target feature: 'universe'
In call: 'foo'

one error.

```