### PR TITLE
lib: fix deadlock in `concur.Channel`

### DIFF
--- a/modules/base/src/concur/Blocking_Queue.fz
+++ b/modules/base/src/concur/Blocking_Queue.fz
@@ -37,6 +37,7 @@ module Blocking_Queue(T type, cnd concur.sync.condition) ref is
   module close =>
     cnd.synchronized ()->
       is_closed.write true
+      check cnd.broadcast
 
 
   # the data this queue currently holds

--- a/tests/lib_concur_Channel/skip
+++ b/tests/lib_concur_Channel/skip
@@ -1,1 +1,0 @@
-NYI: BUG: hangs sometimes, see #5722

--- a/tests/lib_concur_Channel/skip_int
+++ b/tests/lib_concur_Channel/skip_int
@@ -1,0 +1,1 @@
+NYI: BUG: fails in interpreter


### PR DESCRIPTION
fixes #5722

