### PR TITLE
Xlint: suppress warnings of type restricted

### DIFF
--- a/src/dev/flang/be/interpreter/Executor.java
+++ b/src/dev/flang/be/interpreter/Executor.java
@@ -239,6 +239,7 @@ public class Executor extends ProcessExpression<Value, Object>
   /**
    * @return SymbolLookup for fuzion_rt and libmath
    */
+  @SuppressWarnings("restricted")
   private static SymbolLookup libs()
   {
     SymbolLookup result = null;
@@ -269,6 +270,7 @@ public class Executor extends ProcessExpression<Value, Object>
 
 
   @Override
+  @SuppressWarnings("restricted")
   public Pair<Value, Object> call(int s, Value tvalue, List<Value> args)
   {
     var cc0 = _fuir.accessedClazz(s);

--- a/src/dev/flang/be/jvm/runtime/Runtime.java
+++ b/src/dev/flang/be/jvm/runtime/Runtime.java
@@ -1337,6 +1337,7 @@ public class Runtime extends ANY
   /**
    * @return SymbolLookup for fuzion_rt and libmath
    */
+  @SuppressWarnings("restricted")
   private static SymbolLookup libs()
   {
     SymbolLookup result = null;
@@ -1377,6 +1378,7 @@ public class Runtime extends ANY
    *
    * @return
    */
+  @SuppressWarnings("restricted")
   public static MethodHandle get_method_handle(String str, FunctionDescriptor desc, String[] libraries)
   {
     SymbolLookup llu = libs;
@@ -1547,7 +1549,7 @@ public class Runtime extends ANY
    * create a new fuzion value, an fill
    * it with the data in memSeg.
    */
-  @SuppressWarnings("unchecked")
+  @SuppressWarnings({"restricted", "unchecked"})
   public static <T> T memorySegment2Value(Class<T> cl, MemorySegment memSeg)
     throws InstantiationException, IllegalAccessException, IllegalArgumentException, InvocationTargetException
   {
@@ -1620,6 +1622,7 @@ public class Runtime extends ANY
   }
 
 
+  @SuppressWarnings("restricted")
   public static Object native_array(MemoryLayout memLayout, Object obj, int length)
   {
     var memSeg = ((MemorySegment)obj).reinterpret(length * memLayout.byteSize());
@@ -1718,6 +1721,7 @@ public class Runtime extends ANY
    *
    * @return An upcall which can be passed to other foreign functions as a function pointer
    */
+  @SuppressWarnings("restricted")
   public static MemorySegment upcall(Any outerRef, Class call)
   {
     Method method = null;
@@ -1809,6 +1813,7 @@ public class Runtime extends ANY
    *
    * @return
    */
+  @SuppressWarnings("restricted")
   public static int native_string_length(MemorySegment segment)
   {
     int length = 0;

--- a/src/dev/flang/util/Terminal.java
+++ b/src/dev/flang/util/Terminal.java
@@ -168,6 +168,7 @@ public class Terminal extends ANY
    * does not work, this remains set if stdout/stderr is piped into a file.
    * Hence this hackery
    */
+  @SuppressWarnings("restricted")
   private static boolean isTerminal()
   {
     try


### PR DESCRIPTION
In the cases where we currently use restricted methods, there is no viable alternative.