### PR TITLE
lib: use `[]` instead of `list.empty`

### DIFF
--- a/modules/base/src/Sequence.fz
+++ b/modules/base/src/Sequence.fz
@@ -1273,7 +1273,7 @@ is
       result.finite.is_yes_or_unknown
       result.count = 0
   =>
-    (list T).type.empty
+    []
 
 
   # monoid of Sequences with infix concatenation operation.
@@ -1289,7 +1289,7 @@ is
       # identity element
       #
       public redef e Sequence T =>
-        (list T).empty
+        []
 
 
   # Maximum number of elements shown for on a call to `as_string` for a non-finite

--- a/modules/base/src/container/mutable_tree_map.fz
+++ b/modules/base/src/container/mutable_tree_map.fz
@@ -51,7 +51,7 @@ is
   public redef items Sequence (tuple KEY VAL) =>
     match root.get
       e Entry => e.items
-      nil => (list (tuple KEY VAL)).empty
+      nil => []
 
 
   # freeze the map, such that it is no longer mutable afterwards

--- a/modules/base/src/container/ordered_map.fz
+++ b/modules/base/src/container/ordered_map.fz
@@ -122,6 +122,4 @@ is
   # create an empty instance of ordered_map
   #
   public fixed redef type.empty container.ordered_map OK V =>
-    container.ordered_map
-      (list OK).empty.as_array
-      (list V).empty.as_array
+    container.ordered_map OK V [] []


### PR DESCRIPTION
Has the additional benefit that is_finite returns true.

