### PR TITLE
be/c: raise identifier length

### DIFF
--- a/src/dev/flang/be/c/CNames.java
+++ b/src/dev/flang/be/c/CNames.java
@@ -67,11 +67,10 @@ public class CNames extends ANY
 
 
   /**
-   * Maximum length of (external) function names in C.  Since name mangling
+   * Maximum length of (internal) function names in C.  Since name mangling
    * easily results in lengthy names, we have to be careful not to exceed this.
    */
   private static final int MAX_C99_INTERNAL_IDENTIFIER_LENGTH = 63;
-  private static final int MAX_C99_EXTERNAL_IDENTIFIER_LENGTH = 31;
 
 
   /**


### PR DESCRIPTION
source:
https://rgambord.github.io/c99-doc/sections/5/2/4/1/index.html

helps with debugging when using `-gdb`