### PR TITLE
base: improve `Sequence.find` performance

### DIFF
--- a/modules/base/src/Sequence/equatable.fz
+++ b/modules/base/src/Sequence/equatable.fz
@@ -102,16 +102,16 @@ public find(pattern Sequence T) option i32
         nil => false
         n Node => !n.top.is_empty && n.top[0] = x
 
-    fold_until(acc option (Node T), step (option (Node T), T)->option (Node T), data Sequence T) option i32 =>
+    fold_until(acc option (Node T), idx i32) option i32 =>
       if is_done acc
-        ab.count - data.count - p.count
-      else if data.is_empty
+        ab.count - (ab.count-idx) - p.count
+      else if idx >= ab.count
         nil
       else
-        acc_star := fold_until.this.step acc data[0]
-        fold_until acc_star fold_until.this.step (data.drop 1)
+        acc_star := step acc ab[idx]
+        fold_until acc_star idx+1
 
-    fold_until init step ab
+    fold_until init 0
 
 
 


### PR DESCRIPTION
old

    /home/not_synced/flang_dev/fzweb (main)$ make -f tools.mk run_benchmarks
    /home/sam/openvscode-server-fuzion/vscode-fuzion/fuzion/build/bin/fz -jvm -JLibraries="wolfssl sodium" -modules=http,lock_free,uuid,mail,wolfssl,crypto,sodium,nom,web -sourceDirs=src,benchmarks benchmarks
    session_document.get_content tutorial iter/s: 9.15
    session_document.get_content . iter/s: 40.8
    Session.event_msg tutorial iter/s: 9.2
    Session.event_msg . iter/s: 39.75

new

    /home/not_synced/flang_dev/fzweb (main)$ make -f tools.mk run_benchmarks
    /home/sam/openvscode-server-fuzion/vscode-fuzion/fuzion/build/bin/fz -jvm -JLibraries="wolfssl sodium" -modules=http,lock_free,uuid,mail,wolfssl,crypto,sodium,nom,web -sourceDirs=src,benchmarks benchmarks
    session_document.get_content tutorial iter/s: 10.1
    session_document.get_content . iter/s: 51.55
    Session.event_msg tutorial iter/s: 9.65
    Session.event_msg . iter/s: 47.5
