### PR TITLE
fzjava: fix #6384: StringBuilder fuzion wrapper should inherit java.lang.Object

### DIFF
--- a/src/dev/flang/tools/fzjava/FZJava.java
+++ b/src/dev/flang/tools/fzjava/FZJava.java
@@ -501,6 +501,11 @@ public class FZJava extends Tool
             if (sc != null)
               {
                 sfc = forClass(sc);
+                if (sfc == null)
+                  { // if `sc` is not public, `sfc` is null. Use `Object`
+                    // instead (see #6384 or tests/reg_issue6384):
+                    sfc = forClass(java.lang.Object.class);
+                  }
               }
             res = new ForClass(c, sfc);
             _classes.put(c.getName(), res);

--- a/tests/reg_issue6384/Makefile
+++ b/tests/reg_issue6384/Makefile
@@ -1,0 +1,28 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test Makefile
+#
+#  Author: Fridtjof Siebert (siebert@tokiwa.software)
+#
+# -----------------------------------------------------------------------
+
+override NAME = assign_to_object
+FUZION_OPTIONS = -modules=java.base
+include ../simple.mk

--- a/tests/reg_issue6384/assign_to_object.fz
+++ b/tests/reg_issue6384/assign_to_object.fz
@@ -37,6 +37,6 @@ fuzion.jvm.use ()->
       say "***  not ok $T is not Object  ***"
 
   take_obj <| Java.java.lang.__jString.new "hi"
-  take_obj <| Java.java.lang.Object.new
+# take_obj <| Java.java.lang.Object.new   -- this works, but the output contains the object id which differs on different runs
   take_obj <| Java.java.lang.Throwable.new
   take_obj <| Java.java.lang.StringBuilder.new

--- a/tests/reg_issue6384/assign_to_object.fz
+++ b/tests/reg_issue6384/assign_to_object.fz
@@ -1,0 +1,42 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion example assign_to_object
+#
+#  Author: Fridtjof Siebert (siebert@tokiwa.software)
+#
+# -----------------------------------------------------------------------
+
+# the example from #6384: Check that Java refs wrapped into
+# fuzion features are assignable to Java.java.lang.Object
+#
+fuzion.jvm.use ()->
+
+  take_obj(obj T) =>
+    yak "{T.name.pad 28}: "
+    if T : Java.java.lang.Object then
+      yak "ok: is Object, can pass to System.out.println: "
+      Java.java.lang.System.out.println_Ljava_7_lang_7_Object_s_ obj
+    else
+      say "***  not ok $T is not Object  ***"
+
+  take_obj <| Java.java.lang.__jString.new "hi"
+  take_obj <| Java.java.lang.Object.new
+  take_obj <| Java.java.lang.Throwable.new
+  take_obj <| Java.java.lang.StringBuilder.new

--- a/tests/reg_issue6384/assign_to_object.fz.expected_out
+++ b/tests/reg_issue6384/assign_to_object.fz.expected_out
@@ -1,0 +1,4 @@
+Java.java.lang.__jString    : ok: is Object, can pass to System.out.println: hi
+Java.java.lang.Object       : ok: is Object, can pass to System.out.println: java.lang.Object@2f1e4798
+Java.java.lang.Throwable    : ok: is Object, can pass to System.out.println: java.lang.Throwable
+Java.java.lang.StringBuilder: ok: is Object, can pass to System.out.println: 

--- a/tests/reg_issue6384/assign_to_object.fz.expected_out
+++ b/tests/reg_issue6384/assign_to_object.fz.expected_out
@@ -1,4 +1,3 @@
 Java.java.lang.__jString    : ok: is Object, can pass to System.out.println: hi
-Java.java.lang.Object       : ok: is Object, can pass to System.out.println: java.lang.Object@2f1e4798
 Java.java.lang.Throwable    : ok: is Object, can pass to System.out.println: java.lang.Throwable
 Java.java.lang.StringBuilder: ok: is Object, can pass to System.out.println: 

--- a/tests/reg_issue6384/assign_to_object.fz.expected_out_c
+++ b/tests/reg_issue6384/assign_to_object.fz.expected_out_c
@@ -1,4 +1,0 @@
-Java.java.lang.__jString    : ok: is Object, can pass to System.out.println: hi
-Java.java.lang.Object       : ok: is Object, can pass to System.out.println: java.lang.Object@1affbebc
-Java.java.lang.Throwable    : ok: is Object, can pass to System.out.println: java.lang.Throwable
-Java.java.lang.StringBuilder: ok: is Object, can pass to System.out.println: 

--- a/tests/reg_issue6384/assign_to_object.fz.expected_out_c
+++ b/tests/reg_issue6384/assign_to_object.fz.expected_out_c
@@ -1,0 +1,4 @@
+Java.java.lang.__jString    : ok: is Object, can pass to System.out.println: hi
+Java.java.lang.Object       : ok: is Object, can pass to System.out.println: java.lang.Object@1affbebc
+Java.java.lang.Throwable    : ok: is Object, can pass to System.out.println: java.lang.Throwable
+Java.java.lang.StringBuilder: ok: is Object, can pass to System.out.println: 


### PR DESCRIPTION
The problem was that `fzjava` did not add the inheritance relation form `Object` since the super class of `StringBuilder` is not public.  Now, `Object` is used explicitly in this case.
