### PR TITLE
lsp: fix NPE and UnsupportedOperationException

### DIFF
--- a/src/dev/flang/lsp/feature/Rename.java
+++ b/src/dev/flang/lsp/feature/Rename.java
@@ -127,8 +127,12 @@ public class Rename extends ANY
 
     // positions where feature is used as type
     var typePositions = FeatureTool.selfAndDescendants(ParserTool.universe(Util.toURI(params.getTextDocument().getUri())))
-      .filter(f -> !f.equals(featureToRename) && !f.resultType().isGenericArgument()
-        && f.resultType().outer().equals(featureToRename))
+      .filter(f ->
+        !f.equals(featureToRename)
+        && !f.resultType().isGenericArgument()
+        && f.resultType().outer() != null
+        && f.resultType().outer().equals(featureToRename)
+      )
       .flatMap(f -> {
         var tokens = LexerTool.tokensFrom(f.pos()).skip(1).collect(Collectors.toList());
         var whitespace = tokens.get(0);

--- a/src/dev/flang/lsp/shared/TypeTool.java
+++ b/src/dev/flang/lsp/shared/TypeTool.java
@@ -49,7 +49,7 @@ public class TypeTool extends ANY
       {
         return baseName(type);
       }
-    if (!type.isGenericArgument() && type.generics() != UnresolvedType.NONE)
+    if (type.isNormalType() && type.generics() != UnresolvedType.NONE)
       {
         return labelNoErrorOrUndefined(type) + " "
           + type.generics().stream().map(g -> Util.addParens(label(g))).collect(Collectors.joining(" "));


### PR DESCRIPTION
[ci skip]

    [Error - 11:34:43] [signature help] An unexpected error occurred: java.lang.UnsupportedOperationException: Unimplemented method 'generics':
    [Error - 11:34:43] Unimplemented method 'generics'
    dev.flang.fe.ThisType.generics(ThisType.java:55)
    dev.flang.lsp.shared.TypeTool.label(TypeTool.java:52)


==

    [Error - 10:56:58] [rename] An unexpected error occurred: java.lang.NullPointerException: Cannot invoke "Object.equals(Object)" because the return value of "dev.flang.ast.AbstractType.outer()" is null:
    [code lens] finished in 0ms
    [Error - 10:56:58] Cannot invoke "Object.equals(Object)" because the return value of "dev.flang.ast.AbstractType.outer()" is null
    dev.flang.lsp.feature.Rename.lambda$getRenamePositions$1(Rename.java:131)
    java.base/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:196)
    java.base/java.util.stream.Streams$StreamBuilderImpl

