### PR TITLE
remove skip file in `lib_concur_Channel`

### DIFF
--- a/tests/lib_concur_Channel/skip_int
+++ b/tests/lib_concur_Channel/skip_int
@@ -1,1 +1,0 @@
-NYI: BUG: fails in interpreter


### PR DESCRIPTION
[ci skip]

does not fail anymore:

~/openvscode-server-fuzion/vscode-fuzion/fuzion (main)130$ make int -C build/tests/lib_concur_Channel/ make: Entering directory '/home/sam/openvscode-server-fuzion/vscode-fuzion/fuzion/build/tests/lib_concur_Channel'
FUZION_HOME="/home/sam/openvscode-server-fuzion/vscode-fuzion/fuzion/build"                                       ../../bin/check_simple_example int "../../bin/fz " lib_concur_Channel.fz || exit 1
RUN lib_concur_Channel.fz PASSED.
