### PR TITLE
fix off-by-one error in `String.split`

### DIFF
--- a/modules/base/src/String.fz
+++ b/modules/base/src/String.fz
@@ -554,7 +554,7 @@ public String ref : property.equatable, property.hashable, property.orderable is
                 c.is_ascii_white_space && i>word_start ? res.add (substring word_start i) : res
         word_start := 0, c.is_ascii_white_space ? i+1 : word_start # next index might start a word
         c in utf8
-    else i > word_start ? res.add (substring word_start i+1) : res
+    else i >= word_start ? res.add (substring word_start i+1) : res
 
 
   # split string at s


### PR DESCRIPTION
fix #6457
