### PR TITLE
profiler: strip `dev.flang.` prefix

### DIFF
--- a/src/dev/flang/util/Profiler.java
+++ b/src/dev/flang/util/Profiler.java
@@ -308,7 +308,7 @@ public class Profiler extends ANY
                       var format = "%" + _results_.get(s[s.length-1]).toString().length() + "d";
                       for(var m : s)
                         {
-                          out.println("PROF: "+String.format(format, _results_.get(m)) + ": " + deMangle(m));
+                          out.println("PROF: "+String.format(format, _results_.get(m)) + ": " + deMangle(m).replace("dev.flang.", ""));
                         }
                     }
                   catch (IOException e)
@@ -322,7 +322,7 @@ public class Profiler extends ANY
               StringBuilder result = new StringBuilder();
               for (var key : _resultsForFlameGraphKeys_)
                 {
-                  result.append(key)
+                  result.append(key.replace("dev.flang.", ""))
                     .append(" ")
                     .append(_resultsForFlameGraph_.get(key))
                     .append("\n");


### PR DESCRIPTION
more readable to me e.g.:
```
PROF: 405: fuir.analysis.dfa.DFA.new_fuir(DFA.java:1234)
PROF: 411: tools.Fuzion.fuir(Fuzion.java:1266)
PROF: 567: tools.Fuzion$Backend.processFrontEnd(Fuzion.java:631)
PROF: 567: tools.Fuzion.lambda$parseArgsForBackend$0(Fuzion.java:1211)
PROF: 598: tools.Tool.lambda$run$0(Tool.java:142)
PROF: 598: tools.Fuzion.main(Fuzion.java:761)
PROF: 598: tools.Tool.run(Tool.java:142)
PROF: 697: util.Errors.runAndExit(Errors.java:912)
```
<img width="539" height="216" alt="image" src="https://github.com/user-attachments/assets/64f29eb5-6864-4d90-add4-0aef49d1d5d7" />

