### PR TITLE
fuir: remove hack for compile_time_type_casts

### DIFF
--- a/src/dev/flang/fuir/Clazz.java
+++ b/src/dev/flang/fuir/Clazz.java
@@ -1032,9 +1032,6 @@ class Clazz extends ANY implements Comparable<Clazz>
   {
     return isVoidType()
       ? this
-      // NYI: HACK for test compile_time_type_casts
-      : !feature().inheritsFrom(c.calledFeature().outer())
-      ? this
       : lookup(new FeatureAndActuals(c.calledFeature(),
                                      typePars),
                c.select(),

--- a/src/dev/flang/fuir/GeneratingFUIR.java
+++ b/src/dev/flang/fuir/GeneratingFUIR.java
@@ -2443,14 +2443,6 @@ public class GeneratingFUIR extends FUIR
     var dynamic = c.isDynamic() && tclazz.isRef();
     var needsCode = !dynamic || explicitTarget != null;
     var typePars = outerClazz.actualGenerics(c.actualTypeParameters(), inh);
-    // NYI: HACK
-    // can happen e.g. in compile_time_type_casts
-    // since toStack currently puts illegal code in _allCode
-    // because it does not consider the context, yet
-    if (tclazz.isVoidType() || !tclazz.feature().inheritsFrom(cf.outer()))
-      {
-        return null;
-      }
     if (!tclazz.isVoidType())
       {
         innerClazz = tclazz.lookup(new FeatureAndActuals(cf, typePars), c.select(), c.isInheritanceCall());


### PR DESCRIPTION
seems like it is not necessary anymore