### PR TITLE
parser: rename keyword `inv` as `invariant`

### DIFF
--- a/src/dev/flang/lsp/shared/records/TokenInfo.java
+++ b/src/dev/flang/lsp/shared/records/TokenInfo.java
@@ -305,7 +305,7 @@ public class TokenInfo extends ANY
           // NYI: UNDER DEVELOPMENT: check if all cases are considered
           .orElse(Optional.of(TokenType.Type));
       case t_const, t_leaf, t_infix, t_infix_right, t_prefix, t_postfix, t_private, t_module, t_public -> Optional.of(TokenType.Modifier);
-      case t_abstract,  t_check, t_do, t_else, t_env, t_fixed, t_for, t_if, t_in, t_index, t_intrinsic, t_inv, t_is, t_loop, t_match, t_native, t_period, t_post, t_pre, t_redef, t_ref, t_set, t_ternary, t_then, t_this, t_type, t_universe, t_until, t_var, t_variant, t_while -> Optional.of(TokenType.Keyword);
+      case t_abstract,  t_check, t_do, t_else, t_env, t_fixed, t_for, t_if, t_in, t_index, t_intrinsic, t_invariant, t_is, t_loop, t_match, t_native, t_period, t_post, t_pre, t_redef, t_ref, t_set, t_ternary, t_then, t_this, t_type, t_universe, t_until, t_var, t_variant, t_while -> Optional.of(TokenType.Keyword);
       default -> Optional.empty();
       };
   }

--- a/src/dev/flang/parser/Lexer.java
+++ b/src/dev/flang/parser/Lexer.java
@@ -192,7 +192,7 @@ public class Lexer extends SourceFile
     t_variant("variant"),
     t_pre("pre"),
     t_post("post"),
-    t_inv("inv"),
+    t_invariant("invariant"),
     t_var("var"),                     // unused
     t_match("match"),
     t_ref("ref"),

--- a/src/dev/flang/parser/Parser.java
+++ b/src/dev/flang/parser/Parser.java
@@ -1609,7 +1609,7 @@ actualArgs  : actualSpaces
            t_is              ,
            t_pre             ,
            t_post            ,
-           t_inv             ,
+           t_invariant       ,
            t_if              ,
            t_then            ,
            t_else            ,
@@ -3286,7 +3286,7 @@ invariant   : "inv" block
   List<Cond> invariant()
   {
     List<Cond> result = null;
-    if (skip(true, Token.t_inv))
+    if (skip(true, Token.t_invariant))
       {
         result = Cond.from(block());
       }

--- a/tests/loop/looptest.fz
+++ b/tests/loop/looptest.fz
@@ -98,7 +98,7 @@ looptest is
   testLoop3(data array i32, isWhatWeWant (i32) -> bool) =>
     for ix := 0, ix + 1
     variant (data.length - ix).as_i64
-    inv (0..ix-1) ∀ (x -> !isWhatWeWant data[x])
+    invariant (0..ix-1) ∀ (x -> !isWhatWeWant data[x])
     while ix < data.length
       element := data[ix]
     until isWhatWeWant element
@@ -118,7 +118,7 @@ looptest is
   testLoop4(data array i32, isWhatWeWant (i32) -> bool) =>
     for ix := 0, ix + 1
     variant (data.length - ix).as_i64
-    inv (0..ix-1) ∀ (x -> !isWhatWeWant data[x])
+    invariant (0..ix-1) ∀ (x -> !isWhatWeWant data[x])
     while ix < data.length
     until isWhatWeWant data[ix]
       say "We found it at $ix: {data[ix]}"
@@ -137,7 +137,7 @@ looptest is
   testLoop5(data array i32, isWhatWeWant (i32) -> bool) =>
     for ix := 0, ix + 1
     variant (data.length - ix).as_i64
-    inv (0..ix-1) ∀ (x -> !isWhatWeWant data[x])
+    invariant (0..ix-1) ∀ (x -> !isWhatWeWant data[x])
     until (ix ≥ data.length) || isWhatWeWant data[ix]
       if (ix < data.length)
         say "We found it at $ix: {data[ix]}"
@@ -156,7 +156,7 @@ looptest is
   testLoop6(data array i32, isWhatWeWant (i32) -> bool) =>
     for ix := 0, ix + 1
     variant (data.length - ix).as_i64
-    inv (0..ix-1) ∀ (x -> !isWhatWeWant data[x])
+    invariant (0..ix-1) ∀ (x -> !isWhatWeWant data[x])
     while ix < data.length
       element := data[ix]
     until isWhatWeWant element

--- a/tests/loop_invariant/loop_invariant.fz
+++ b/tests/loop_invariant/loop_invariant.fz
@@ -24,11 +24,11 @@
 loop_invariant =>
 
   for i in 0..1
-  inv i < 2
+  invariant i < 2
   do
     say "iteration $i"
 
   for i in 0..1
-  inv i < 1
+  invariant i < 1
   do
     say "iteration $i"

--- a/tests/loop_invariant/loop_invariant.fz.expected_err_int
+++ b/tests/loop_invariant/loop_invariant.fz.expected_err_int
@@ -22,9 +22,9 @@ fuzion.runtime.invariant_fault.cause#1: {base.fum}/eff/fallible.fz:35:6:
 fuzion.runtime.invariantcondition_fault#1: {base.fum}/fuzion/runtime/invariant_fault.fz:58:53:
 public invariantcondition_fault(msg String) void => invariant_fault.cause msg
 ----------------------------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^
-loop_invariant.loop: --CURDIR--/loop_invariant.fz:32:7:
-  inv i < 1
-------^^^^^
+loop_invariant.loop: --CURDIR--/loop_invariant.fz:32:13:
+  invariant i < 1
+------------^^^^^
 loop_invariant: --CURDIR--/loop_invariant.fz:31:3:
   for i in 0..1
 --^


### PR DESCRIPTION
To ensure consistency between `invariant` and `variant`. The unused `var` keyword remains.