### PR TITLE
ast: do create unnecessary cotypes

### DIFF
--- a/src/dev/flang/ast/Feature.java
+++ b/src/dev/flang/ast/Feature.java
@@ -1697,7 +1697,7 @@ public class Feature extends AbstractFeature
           && !isCotype()
           && !isField() /* NYI: UNDER DEVELOPMENT: does not work yet for fields */
           && !isTypeParameter()
-      : definesType() && (outer().isUniverse() || outer().hasCotype());
+      : definesType();
   }
 
 


### PR DESCRIPTION
No need to create unnused cotypes that can not be used from other modules anyway

old

      ~/openvscode-server-fuzion/vscode-fuzion/fuzion (main)130$ fz -sourceDirs=build/modules/java.base -saveModule=build/modules/java.base.fum
       + build/modules/java.base.fum in 27383ms

new

      ~/openvscode-server-fuzion/vscode-fuzion/fuzion (main)130$ fz -sourceDirs=build/modules/java.base -saveModule=build/modules/java.base.fum
      + build/modules/java.base.fum in 21611ms


cotypes created for java.base old / new: 64737 / 15696
