### PR TITLE
fe: `LibraryModule` cache result of `moduleSourceFilesPos`

### DIFF
--- a/src/dev/flang/fe/LibraryModule.java
+++ b/src/dev/flang/fe/LibraryModule.java
@@ -678,16 +678,21 @@ Module File
   {
     return moduleNumDeclFeaturesPos() + 4;
   }
+  int _moduleSourceFilesPos = -1;
   int moduleSourceFilesPos()
   {
-    var n = moduleNumDeclFeatures();
-    var at = moduleDeclFeaturesPos();
-    while (n > 0)
+    if (_moduleSourceFilesPos < 0)
       {
-        n--;
-        at = declFeaturesNextPos(at);
+        var n = moduleNumDeclFeatures();
+        var at = moduleDeclFeaturesPos();
+        while (n > 0)
+          {
+            n--;
+            at = declFeaturesNextPos(at);
+          }
+        _moduleSourceFilesPos = at;
       }
-    return at;
+    return _moduleSourceFilesPos;
   }
 
 


### PR DESCRIPTION
moduleSourceFilesPos() showed up while profiling, accounted for 3% of time in

    dev_flang_tools_serializeFUIR=true fz -XjavaProf=out.svg - noBackend tests/mod_http_message/http_message_test.fz
