### PR TITLE
dfa: `NumericValue` of unknown _contains_ all other values

### DIFF
--- a/src/dev/flang/fuir/analysis/dfa/NumericValue.java
+++ b/src/dev/flang/fuir/analysis/dfa/NumericValue.java
@@ -233,6 +233,18 @@ public class NumericValue extends Value
 
 
   /**
+   * Does this Value cover the values in other?
+   */
+  @Override boolean contains(Value other)
+  {
+    if (PRECONDITIONS) require
+      (_clazz == other._clazz);
+
+    return _value == null;
+  }
+
+
+  /**
    * Add v to the set of values of given field within this instance.
    */
   public void setField(DFA dfa, int field, Value v)


### PR DESCRIPTION
I noticed ValueSets were created of e.b. NumVal --any-- and NumVal --0--. With this change no value set is created anymore but we just use NumVal --any--
