### PR TITLE
dfa: slightly modify debug output

### DIFF
--- a/src/dev/flang/fuir/analysis/dfa/DFA.java
+++ b/src/dev/flang/fuir/analysis/dfa/DFA.java
@@ -1427,6 +1427,7 @@ public class DFA extends ANY
   int findFixPoint()
   {
     var cnt = 0;
+    var start = System.currentTimeMillis();
     _changedSetBy = () -> "*** change not set ***";
     do
       {
@@ -1435,9 +1436,13 @@ public class DFA extends ANY
 
         if (_options.verbose(2))
           {
+            var now = System.currentTimeMillis();
+            var delta = now - start;
+            start = now;
             _options.verbosePrintln(2,
                                     "DFA " + (_real ? "real " : "pre  ") +
-                                    "iteration #" + String.format("%02d", cnt) + ": ---------- " +
+                                    "iteration #" + String.format("%02d", cnt)
+                                    + ", prev " + String.format("%4d", delta) + "ms: ---------- " +
                                     (_options.verbose(3) ? ("calls:"   + String.format("%5d", _calls.size()) +
                                                             ",values:" + String.format("%5d",_numUniqueValues) +
                                                             ",envs:"   + String.format("%3d",(_envsQuick.size() + _envs.size())) +


### PR DESCRIPTION
    ~/openvscode-server-fuzion/vscode-fuzion/fuzion (main)130$ m6 no-java && fz -verbose=4 tests/hello/HelloWorld.fz
    mkdir -p ./build/classes
    javac -Xlint:all,-serial,-this-escape -encoding UTF8 --release 25 -g --class-path ./build/classes -d ./build/classes ./src/dev/flang/tools/fzjava/FeatureWriter.java ./src/dev/flang/tools/fzjava/ForClass.java ./src/dev/flang/tools/fzjava/FZJava.java ./src/dev/flang/tools/fzjava/FZJavaOptions.java
    touch build/classes/dev/flang/tools/fzjava/__marker_for_make__
    4 features 6 types and 1 source files included in fum file.
    DFA pre  iteration #01: ---------- calls:    0,values:    2,envs:  0 ---- *** change not set ***
    DFA pre  iteration #02: ---------- calls:  812,values:  917,envs:  0 ---- Escapes: HelloWorld
    DFA pre  iteration #03: ---------- calls:  838,values:  940,envs:  0 ---- setField: new values option u32[tag:0,val:u32:--any value--] (was option u32[tag:0,val:u32:1114111]) for (option u32).or_else#1@{base.fum}/interval.fz:103:45:
    DFA pre  iteration #04: ---------- calls:  838,values:  940,envs:  0 ---- setField: new values i32:--any value-- (was i32:0) for (container.expanding_array u8).slice#2.array_slice.#preandcall_container_abstract_array#array_cons (container.expanding_array u8)@{base.fum}/container/abstract_array.fz:193:11:
    DFA done:
    Values: 940
    DFA real iteration #01: ---------- calls:    0,values:  940,envs:  0 ---- *** change not set ***
    DFA real iteration #02: ---------- calls:  812,values: 1774,envs:  0 ---- DFA: new instance HelloWorld
    DFA real iteration #03: ---------- calls:  838,values: 1797,envs:  0 ---- setField: new values option u32[tag:0,val:u32:--any value--] (was option u32[tag:0,val:u32:1114111]) for (option u32).or_else#1@{base.fum}/interval.fz:103:45:
    DFA real iteration #04: ---------- calls:  838,values: 1797,envs:  0 ---- setField: new values i32:--any value-- (was i32:0) for (container.expanding_array u8).slice#2.array_slice.#preandcall_container_abstract_array#array_cons (container.expanding_array u8)@{base.fum}/container/abstract_array.fz:193:11:
    DFA done:
    Values: 1797
    DFA needed 8 iterations (pre/real) (4/4).
    Elapsed time for phases: prep 65ms, fe 230ms, createMIR 82ms, ir 14ms, dfa_pre 1284ms, dfa_real 265ms, opt 5ms, be 478ms
    Hello World!
