### PR TITLE
Revert "dfa: mark call as hot only if not already analyzed"

### DIFF
--- a/src/dev/flang/fuir/analysis/dfa/DFA.java
+++ b/src/dev/flang/fuir/analysis/dfa/DFA.java
@@ -3476,10 +3476,7 @@ public class DFA extends ANY
         analyze(e);
         _newCallRecursiveAnalyzeCalls = cnt ;
       }
-    else
-      {
-        hot(e);
-      }
+    hot(e);
   }
 
 


### PR DESCRIPTION
Reverts tokiwa-software/fuzion#6533

This is the reason fzweb now takes many more iterations. 