### PR TITLE
win: try aligin semantics of `fzE_file_read`

### DIFF
--- a/include/win.c
+++ b/include/win.c
@@ -987,11 +987,11 @@ int32_t fzE_file_read(void * file, void * buf, int32_t size)
   DWORD bytesRead = 0;
   BOOL success = ReadFile(file, buf, (DWORD)size, &bytesRead, NULL);
 
-  return !success
-    ? -2 // ERROR
-    : bytesRead == 0
+  return success && bytesRead != 0
+    ? (int32_t)bytesRead
+    : GetLastError() == ERROR_BROKEN_PIPE
     ? -1 // EOF
-    : (int32_t)bytesRead;
+    : -2; // ERROR
 }
 
 


### PR DESCRIPTION
Not sure if this fixes the bug in the windows tests but here it worked at least once:
https://github.com/michaellilltokiwa/fuzion/actions/runs/21435619047/job/61725472535