### PR TITLE
`String.join` use `fold` instead of `foldr`

### DIFF
--- a/modules/base/src/String.fz
+++ b/modules/base/src/String.fz
@@ -931,7 +931,10 @@ public String ref : property.equatable, property.hashable, property.orderable is
   # sep in between its elements. In case an empty sequence is given, returns the empty string.
   #
   public type.join(elems Sequence String, sep String) String =>
-    (elems.as_list.intersperse sep).foldr concat
+    elems
+      .as_list
+      .intersperse sep
+      .fold concat
 
 
   # Takes a sequence of strings and concatenates its elements.


### PR DESCRIPTION
fixes the OOM when visiting fzweb/docs/base/index.html I don't fully understand why foldr leads to an explosion of `tail` evaluations. I set the heap in fzweb to `-Xmx100m` when testing this.

