### PR TITLE
int: skip test `data_size`, interpreter is too slow for this test

### DIFF
--- a/tests/data_size/skip_int
+++ b/tests/data_size/skip_int
@@ -1,0 +1,1 @@
+NYI: BUG: interpreter is too slow


### PR DESCRIPTION
[ci skip]
