### PR TITLE
mark some `type.empty` as `fixed`

### DIFF
--- a/modules/base/src/bitset.fz
+++ b/modules/base/src/bitset.fz
@@ -107,7 +107,7 @@ is
 
   # an empty bitset
   #
-  public type.empty bitset => nil
+  public fixed type.empty bitset => nil
 
   # monoid of bitset with infix ∪ operation.
   #

--- a/modules/base/src/container/expanding_array.fz
+++ b/modules/base/src/container/expanding_array.fz
@@ -210,7 +210,7 @@ is
   #
   # Complexity: O(1)
   #
-  public type.empty container.expanding_array T
+  public fixed type.empty container.expanding_array T
   =>
     empty default_capacity
 
@@ -221,7 +221,7 @@ is
   #
   # Complexity: O(1)
   #
-  public type.empty(initial_capacity i32) container.expanding_array T
+  public fixed type.empty(initial_capacity i32) container.expanding_array T
     pre
       debug: initial_capacity >= 0
   =>

--- a/modules/base/src/io/Read_Handler.fz
+++ b/modules/base/src/io/Read_Handler.fz
@@ -35,7 +35,7 @@ public Read_Handler ref is
 
   # Read_Handler that only ever returns end_of_file
   #
-  public type.empty io.Read_Handler =>
+  public fixed type.empty io.Read_Handler =>
     _ : io.Read_Handler is
       public redef read(c i32) choice (Sequence u8) io.end_of_file error => io.end_of_file
 


### PR DESCRIPTION
These are more or less constructors, does not make sense the inherit those.
