### PR TITLE
dfa: `_fields.put()` only on changed value

### DIFF
--- a/src/dev/flang/fuir/analysis/dfa/Instance.java
+++ b/src/dev/flang/fuir/analysis/dfa/Instance.java
@@ -170,9 +170,9 @@ public class Instance extends Value
           {
             _dfa.wasChanged(() -> "setField: new values " + fv + " (was " + oldv + ") for " + this);
           }
+        _fields.put(field, v);
       }
     dfa._writtenFields.set(field);
-    _fields.put(field, v);
   }
 
 


### PR DESCRIPTION
probably does not bring much performance but a little less pressure on the GC maybe.
And since I'm seeing TreeMap.put very prominently in the profiler when profiling DFA related stuff.