### PR TITLE
dfa: rename switch `DO_NOT_TRACE_ENVS` to `TRACE_ENVS`

### DIFF
--- a/src/dev/flang/fuir/analysis/dfa/Call.java
+++ b/src/dev/flang/fuir/analysis/dfa/Call.java
@@ -582,7 +582,7 @@ public class Call extends ANY implements Comparable<Call>, Context
       {
         result = _env != null ? _env.getActualEffectValues(ecl)
                               : _dfa._defaultEffects.get(ecl);
-        if (result == null && DFA.DO_NOT_TRACE_ENVS)
+        if (result == null && !DFA.TRACE_ENVS)
           {
             result = _dfa._allValuesForEnv.get(ecl);
           }
@@ -638,7 +638,7 @@ public class Call extends ANY implements Comparable<Call>, Context
 
     if ((_env == null || !_env.hasEffect(ecl)) && _dfa._defaultEffects.get(ecl) == null)
       {
-        if (_dfa._reportResults && !DFA.DO_NOT_TRACE_ENVS)
+        if (_dfa._reportResults && DFA.TRACE_ENVS)
           {
             // NYI: Make this a normal error similar to DfaErrors.usedEffectnotinstalled:
             Errors.fatal("Trying to replace effect " + Errors.code(_dfa._fuir.clazzAsString(ecl))

--- a/src/dev/flang/fuir/analysis/dfa/DFA.java
+++ b/src/dev/flang/fuir/analysis/dfa/DFA.java
@@ -852,8 +852,8 @@ public class DFA extends ANY
   static final String  TRACE_ALL_EFFECT_ENVS_NAME = "dev.flang.fuir.analysis.dfa.TRACE_ALL_EFFECT_ENVS";
   static final boolean TRACE_ALL_EFFECT_ENVS = FuzionOptions.boolPropertyOrEnv(TRACE_ALL_EFFECT_ENVS_NAME, true);
 
-  static final String  DO_NOT_TRACE_ENVS_NAME = "dev.flang.fuir.analysis.dfa.DO_NOT_TRACE_ENVS";
-  static final boolean DO_NOT_TRACE_ENVS = FuzionOptions.boolPropertyOrEnv(DO_NOT_TRACE_ENVS_NAME, true);
+  static final String  TRACE_ENVS_NAME = "dev.flang.fuir.analysis.dfa.TRACE_ENVS";
+  static final boolean TRACE_ENVS = FuzionOptions.boolPropertyOrEnv(TRACE_ENVS_NAME, false);
   TreeMap<Integer, Value> _allValuesForEnv = new TreeMap<>();
 
 
@@ -2287,7 +2287,7 @@ public class DFA extends ANY
           Value ev;
           if (cl._dfa._real)
             {
-              if (DO_NOT_TRACE_ENVS)
+              if (!TRACE_ENVS)
                 {
                   ev = cl._dfa._allValuesForEnv.get(ecl);
                 }
@@ -2347,7 +2347,7 @@ public class DFA extends ANY
         });
     put("effect.type.is_instated0"          , cl ->
         cl.useAndGetEffect(cl.site(), fuir(cl).effectTypeFromIntrinsic(cl.calledClazz()), true) != null &&
-        !DO_NOT_TRACE_ENVS
+        TRACE_ENVS
         ? cl._dfa.True()
         : cl._dfa.bool()  /* NYI: currently, this is never FALSE since a default effect might get installed turning this into TRUE
                            * should reconsider if handling of default effects changes
@@ -3528,7 +3528,7 @@ public class DFA extends ANY
    */
   Env newEnv(Env env, int ecl, Value ev)
   {
-    if (DO_NOT_TRACE_ENVS)
+    if (!TRACE_ENVS)
       {
         var v0 = _allValuesForEnv.get(ecl);
         var v1 = v0 == null ? ev : v0.join(this, ev, ecl);

--- a/src/dev/flang/fuir/analysis/dfa/Env.java
+++ b/src/dev/flang/fuir/analysis/dfa/Env.java
@@ -410,7 +410,7 @@ public class Env extends ANY implements Comparable<Env>
    */
   Value getActualEffectValues(int ecl)
   {
-    if (DFA.DO_NOT_TRACE_ENVS)
+    if (!DFA.TRACE_ENVS)
       {
         return _dfa._allValuesForEnv.get(ecl);
       }

--- a/tests/effect_installed_negative/Makefile
+++ b/tests/effect_installed_negative/Makefile
@@ -24,5 +24,5 @@
 # -----------------------------------------------------------------------
 
 override NAME = test_effect_neg
-override FUZION_JAVA_OPTIONS=-Ddev.flang.fuir.analysis.dfa.DO_NOT_TRACE_ENVS=false
+override FUZION_JAVA_OPTIONS=-Ddev.flang.fuir.analysis.dfa.TRACE_ENVS=true
 include ../simple_and_negative.mk

--- a/tests/local_mutate_negative/Makefile
+++ b/tests/local_mutate_negative/Makefile
@@ -24,5 +24,5 @@
 # -----------------------------------------------------------------------
 
 override NAME = test_local_mutate_neg
-override FUZION_JAVA_OPTIONS=-Ddev.flang.fuir.analysis.dfa.DO_NOT_TRACE_ENVS=false
+override FUZION_JAVA_OPTIONS=-Ddev.flang.fuir.analysis.dfa.TRACE_ENVS=true
 include ../simple.mk

--- a/tests/reg_issue4592/Makefile
+++ b/tests/reg_issue4592/Makefile
@@ -22,5 +22,5 @@
 # -----------------------------------------------------------------------
 
 override NAME = reg_issue4592
-override FUZION_JAVA_OPTIONS=-Ddev.flang.fuir.analysis.dfa.DO_NOT_TRACE_ENVS=false
+override FUZION_JAVA_OPTIONS=-Ddev.flang.fuir.analysis.dfa.TRACE_ENVS=true
 include ../simple.mk


### PR DESCRIPTION
more readable, I hope.