### PR TITLE
ir: don't add type_as_value calls

### DIFF
--- a/src/dev/flang/ir/IR.java
+++ b/src/dev/flang/ir/IR.java
@@ -38,6 +38,7 @@ import dev.flang.ast.AbstractType;
 import dev.flang.ast.Expr; // NYI: remove dependency
 import dev.flang.ast.InlineArray; // NYI: remove dependency
 import dev.flang.ast.NumLiteral; // NYI: remove dependency
+import dev.flang.ast.Types;
 import dev.flang.ast.Universe; // NYI: remove dependency
 
 import dev.flang.util.ANY;
@@ -296,13 +297,16 @@ public abstract class IR extends ANY
       }
     else if (e instanceof AbstractCall c)
       {
-        toStack(l, c.target());
-        var fat = c.formalArgumentTypes();
-        for (int i = 0; i < c.actuals().size(); i++)
+        if (c.calledFeature() != Types.resolved.f_type_as_value)
           {
-            toStack(l, boxAndTag(c.actuals().get(i), fat[i]));
+            toStack(l, c.target());
+            var fat = c.formalArgumentTypes();
+            for (int i = 0; i < c.actuals().size(); i++)
+              {
+                toStack(l, boxAndTag(c.actuals().get(i), fat[i]));
+              }
+            l.add(c);
           }
-        l.add(c);
         if (dumpResult)
           {
             l.add(ExprKind.Pop);


### PR DESCRIPTION
a little less Calls/Values in DFA, e.g. HelloWorld
old:
```
DFA pre  iteration #01, prev    0ms: ---------- calls:    0,values:    1,envs:  0
DFA pre  iteration #02, prev  616ms: ---------- calls:  469,values:  678,envs:  0
DFA pre  iteration #03, prev  174ms: ---------- calls:  654,values:  814,envs:  0
DFA pre  iteration #04, prev   38ms: ---------- calls:  654,values:  814,envs:  0
DFA real iteration #01, prev    0ms: ---------- calls:    0,values:    0,envs:  0
DFA real iteration #02, prev   46ms: ---------- calls:  469,values:  677,envs:  0
DFA real iteration #03, prev   64ms: ---------- calls:  654,values:  813,envs:  0
DFA real iteration #04, prev   28ms: ---------- calls:  654,values:  813,envs:  0
DFA needed 8 iterations (pre/real) (4/4).
```
new:
```
4 features 6 types and 1 source files included in fum file.
DFA pre  iteration #01, prev    1ms: ---------- calls:    0,values:    1,envs:  0
DFA pre  iteration #02, prev  838ms: ---------- calls:  451,values:  660,envs:  0
DFA pre  iteration #03, prev  136ms: ---------- calls:  635,values:  795,envs:  0
DFA pre  iteration #04, prev   34ms: ---------- calls:  635,values:  795,envs:  0
DFA real iteration #01, prev    0ms: ---------- calls:    0,values:    0,envs:  0
DFA real iteration #02, prev   44ms: ---------- calls:  451,values:  659,envs:  0
DFA real iteration #03, prev   59ms: ---------- calls:  635,values:  794,envs:  0
DFA real iteration #04, prev   29ms: ---------- calls:  635,values:  794,envs:  0
DFA needed 8 iterations (pre/real) (4/4).
```