### PR TITLE
base: `buffered.read_bytes`, use `Finger_Tree` to concat the read bytes

### DIFF
--- a/modules/base/src/io/buffered/reader.fz
+++ b/modules/base/src/io/buffered/reader.fz
@@ -87,25 +87,35 @@ is
 # read n bytes using the currently installed byte reader effect
 # if the returned sequence is empty or count is less than n, end of file has been reached.
 #
-public read_bytes(n i32) array u8 ! reader
-  post debug: result.length <= n
+public read_bytes(n i32) outcome (Sequence u8) ! reader
+  post debug: result.count <= n
 =>
 
-  res := LM.array u8 .empty
-
-  _ :=
-    while res.length.as_i32 < n
-    until
-      match reader.env.read
-        outcome => true
-        s Sequence =>
-          a := s.take n-res.length.as_i32 .as_array_backed
-          reader.env.discard a.count
-          for b in a do
-            res.add b
-          false
-
-  res.as_array
+  for res Sequence u8 := container.Finger_Tree u8 .empty,
+            {
+              match r
+                o outcome => res
+                s Sequence =>
+                  a := s.take n-res.count
+                  check debug: a.is_array_backed
+                  reader.env.discard a.count
+                  res ++ a
+            }
+  while res.count < n
+    r := reader.env.read
+  until
+    match r
+      outcome => true
+      Sequence => false
+  then
+    match r
+      o outcome =>
+        match o
+          io.end_of_file => res
+          e error => e
+      Sequence => panic "unexpected"
+  else
+    res
 
 
 # read string, up to n codepoints or until end of file
@@ -200,8 +210,10 @@ public read_line switch String io.end_of_file ! reader =>
 # may need to call this several times or use another api
 # like memory-mapped access.
 #
-public read_fully array u8 ! reader =>
-  read_bytes (array u8).max_length
+public read_fully Sequence u8 ! reader =>
+  read_bytes i32.max
+    # NYI: UNDER DEVELOPMENT: error handling
+    .val
 
 
 # Read input fully and split it at the given delimiter. If specified, delete

--- a/modules/base/src/io/stdin.fz
+++ b/modules/base/src/io/stdin.fz
@@ -58,7 +58,7 @@ public stdin is
   # read all of stdin in an array of u8 bytes using
   # io.buffered.read_fully.
   #
-  public read_fully array u8 =>
+  public read_fully Sequence u8 =>
     lm : mutate is
     lm ! ()->
       reader lm ! (buffered lm).read_fully


### PR DESCRIPTION
Was copied twice, one the add to mutable array and then when mutable array was turned into just array.
