### PR TITLE
be/c: use O2 instead of O3

### DIFF
--- a/src/dev/flang/be/c/C.java
+++ b/src/dev/flang/be/c/C.java
@@ -780,7 +780,7 @@ public class C extends ANY
 
         if (!_options._debugBuild)
           {
-            command.addAll("-O3");
+            command.addAll("-O2");
           }
       }
 


### PR DESCRIPTION
O2 is the _default_ in most distributions

