### PR TITLE
be/c: use `-fstack-protector-strong`, `-fstack-clash-protection`, `-fcf-protection`

### DIFF
--- a/src/dev/flang/be/c/C.java
+++ b/src/dev/flang/be/c/C.java
@@ -847,6 +847,9 @@ public class C extends ANY
     // https://lobste.rs/s/avrfxz/ubuntu_24_04_lts_will_enable_frame
     command.addAll("-fno-omit-frame-pointer", "-mno-omit-leaf-frame-pointer");
 
+    // select due to: dpkg-buildflags --get CFLAGS
+    command.addAll("-fstack-protector-strong", "-fstack-clash-protection", "-fcf-protection");
+
     command.add("-lm");
 
     if (usesThreads() && !isWindows())


### PR DESCRIPTION
These are used by debian by default.