### PR TITLE
base: improve perf of `String.join(elems Sequence String, sep String)`

### DIFF
--- a/modules/base/src/String.fz
+++ b/modules/base/src/String.fz
@@ -942,11 +942,14 @@ public String ref : property.equatable, property.hashable, property.orderable is
   # sep in between its elements. In case an empty sequence is given, returns the empty string.
   #
   public type.join(elems Sequence String, sep String) String =>
-    elems
-      .as_list
-      .intersperse sep
-      .fold concat
-
+    e := elems.as_array_backed
+    if e.is_empty
+      ""
+    else
+      for res := "", res + e[i] + sep
+          i in 0..e.count-2
+      else
+        res + e[e.count-1]
 
   # Takes a sequence of strings and concatenates its elements.
   # In case an empty sequence is given, returns the empty string.


### PR DESCRIPTION
```
ex =>

  join_old(elems Sequence String, sep String) String =>
    elems
      .as_list
      .intersperse sep
      .fold String.concat

  join_new(elems Sequence String, sep String) String =>
    e := elems.as_array_backed
    if e.is_empty
      ""
    else
      for res := "", res + e[i] + sep
          i in 0..e.count-2
      else
        res + e[e.count-1]

  x := ["hello", "hello", "hello", "hello", "hello", "hello"]
  say <| bench (time.duration.s 1) (time.duration.s 10) (()->_ := join_old x ", ")
  say <| bench (time.duration.s 1) (time.duration.s 10) (()->_ := join_new x ", ")
```

    88881.0
    126873.9
