### PR TITLE
http: change version parsing code

### DIFF
--- a/modules/http/src/http.fz
+++ b/modules/http/src/http.fz
@@ -51,9 +51,11 @@ module crlf => "\r\n"
 # to that protocol within elements that require a minor version identifier.
 # https://datatracker.ietf.org/doc/html/rfc9110#section-2.5-6
 #
-module parse_http_version(ver String, err error->error) =>
-  match ver.find "."
-    nil => (ver.parse_i32.or_cause unit err, 0)
+module parse_http_version(ver String) =>
+  err(_ error) => error "broken format of HTTP version '{ver}'"
+  v := ver.substring 5
+  match v.find "."
+    nil => (v.parse_i32.or_cause unit err, 0)
     idx i32 =>
-      (ver.substring 0 idx .parse_i32.or_cause unit err, ver.substring idx+1 .parse_i32.or_cause unit err)
+      (v.substring 0 idx .parse_i32.or_cause unit err, v.substring idx+1 .parse_i32.or_cause unit err)
 

--- a/modules/http/src/http/request_reader.fz
+++ b/modules/http/src/http/request_reader.fz
@@ -62,8 +62,7 @@ public read_request(
 
     if !rl[2].starts_with "HTTP/" then cause "unsupported protocol {rl[2]}"
 
-    major, minor := parse_http_version (rl[2].substring 5) _->
-      error "broken format of HTTP version '{rl[2]}'"
+    major, minor := parse_http_version rl[2]
 
     tmp_parsed_fields := parse_header_fields LM .or_cause unit id
 

--- a/modules/http/src/http/response_reader.fz
+++ b/modules/http/src/http/response_reader.fz
@@ -56,8 +56,7 @@ public read_response(
 
     if !sl[0].starts_with "HTTP/" then cause "not a HTTP response, protocol is '{sl[0]}'"
 
-    major, minor := parse_http_version (sl[0].substring 5) _->
-      error "broken format of HTTP version '{sl[0]}'"
+    major, minor := parse_http_version sl[0]
 
     code := sl[1].parse_i32.or_cause unit _->(error "invalid status code '{sl[1]}")
 


### PR DESCRIPTION
The main reason for changing this code is that
it used index access on a list.
