### PR TITLE
bin: run_test.fz: do not panic but produce proper error if process start failed

### DIFF
--- a/bin/run_tests.fz
+++ b/bin/run_tests.fz
@@ -94,9 +94,8 @@ record_process(
 #
 Sequence.prefix ! =>
   seq := map x->x.as_string
-  match os.process.start seq.first.val (seq.drop 1) envir_vars
-    e error => panic "failed executing {Sequence.this}, error is $e"
-    p os.process => record_process p Sequence.this.as_string
+  os.process.start seq.first.val (seq.drop 1) envir_vars
+            .bind (p -> record_process p Sequence.this.as_string)
 
 
 # feed this string to a new process
@@ -196,12 +195,11 @@ main =>
   # source: https://stackoverflow.com/questions/45181115/portable-way-to-find-the-number-of-processors-cpus-in-a-shell-script
   # first, try third arg then try a few executables, if everything fails use default value
   thread_count :=
-    fuzion.runtime.contract_fault
-      .try ()->(envir.vars["FUZION_RUN_TESTS_PARALLELISM"]).val.trim.parse_i32.val
-      .or_try _->(!!"nproc --all").out.trim.parse_i32.val
-      .or_try _->(!!"getconf _NPROCESSORS_ONLN").out.trim.parse_i32.val
-      .or_try _->(!!"sysctl -n hw.ncpu").out.trim.parse_i32.val
-      .catch  _->4
+      envir.vars["FUZION_RUN_TESTS_PARALLELISM"]      .flat_map (    .trim.parse_i32) .first
+        .or_else (     (!!"nproc --all"              ).flat_map (.out.trim.parse_i32) .first
+          .or_else (   (!!"getconf _NPROCESSORS_ONLN").flat_map (.out.trim.parse_i32) .first
+            .or_else ( (!!"sysctl -n hw.ncpu"        ).flat_map (.out.trim.parse_i32) .first
+              .or_else 4)))
 
   tests := find_tests "$build_dir/tests"
 
@@ -222,19 +220,25 @@ main =>
       append_line results "$test: skipped"
     else
 
-      res, elapsed_time := time.stopwatch process_result ()->
-        !!"make $target --environment-overrides --directory=$test"
+      opt_res, elapsed_time := time.stopwatch _ ()->
+            !!"make $target --environment-overrides --directory=$test"
 
       test_durations.put test elapsed_time
 
-      if res.exit_code = 0 || target = "fuir" then
-        yak "."
-        append_line results "$test in {elapsed_time}: ok"
-      else
-        yak "#"
-        append_line results "$test in {elapsed_time}: failed"
-        append_line failures res.out
-        append_line failures res.err
+      match opt_res
+        e error =>
+          yak "!"
+          append_line results "$test in {elapsed_time}: $e error"
+          append_line failures "$test: $e"
+        res process_result =>
+          if res.exit_code = 0 || target = "fuir" then
+            yak "."
+            append_line results "$test in {elapsed_time}: ok"
+          else
+            yak "#"
+            append_line results "$test in {elapsed_time}: failed"
+            append_line failures res.out
+            append_line failures res.err
 
 
   say "{tests.count} tests, running $thread_count tests in parallel."
@@ -253,19 +257,17 @@ main =>
     .filter (x -> !x.is_blank)
     .as_array
 
-  ok, skipped, failed := results_content
-    .reduce (0,0,0) (r, t)->
-      if t.ends_with "ok"
-        (r.0+1, r.1, r.2)
-      else if t.ends_with "skipped"
-        (r.0, r.1+1, r.2)
-      else if t.ends_with "failed"
-        (r.0, r.1, r.2+1)
-      else
-        r
+  ok             := results_content.count (.ends_with "ok"     )
+  skipped        := results_content.count (.ends_with "skipped")
+  failed         := results_content.count (.ends_with "failed" )
+  produced_error := results_content.count (.ends_with "error"  )
 
   say ""
-  say "$ok/{tests.count} tests passed, $skipped skipped, $failed failed in {elapsed_time_total.as_string.trim}."
+  say ("$ok/{tests.count} tests passed" +
+       ", $skipped skipped" +
+       ", $failed failed" +
+       (produced_error = 0 ? "" :", $produced_error produced error") +
+       " in {elapsed_time_total.as_string.trim}.")
 
   max_recorded := test_durations
     .values
@@ -276,7 +278,7 @@ main =>
     .for_each h.add
   say h
 
-  if failed > 0
+  if failed + produced_error > 0
     say_section "Failed tests"
 
     failed_tests := results_content.filter (.ends_with "failed")


### PR DESCRIPTION
There is a new failure category now: `produced error` which is for tests that could not be run because spawning the make process failed.

`Sequence.prefix !` now returns an `outcome record_process` instead of doing `panic` in case of an error starting the process.

Also did some cleanup:

 - code to determin num threads no longer catches `contract_fault`. This was IMHO unfortunate since the code would behave differently in case contracts were disabled.  This was used to catch a call to `option.val` for a `nil` option. Now, `first.or_else`  is used instead.

 - restructured the code to count the `ok`/`skipped`/`failed` since there is a fourth kind, `produced_error`, now.

When running tests on my machine, I used to get a `panic` and no further results, now I get this which is more useful:
```
 > PRECONDITIONS=true POSTCONDITIONS=true make run_tests_jvm
./build/bin/fz -modules=lock_free,web -c -CLink=wolfssl -CInclude="wolfssl/options.h wolfssl/ssl.h" ./bin/run_tests.fz -o=build/bin/run_tests
testing JVM backend: 646 tests, running 16 tests in parallel.
..............................................................................................................................................................................................................................................................................................................................................................................................................................................._........................................_.....................!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!.!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!.!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!.............
507/646 tests passed, 2 skipped, 0 failed, 137 produced error in 10m.
                                ---  jvm  ---                                 
count
128  ▉       |       |       |       |       |       |       |       |       |
 64  ▉    ▉  |       |       |       |       |       |       |       |       |
 32  ▉   ▉▉▉ |       | ▉     |       |       |       |       |       |       |
 16 _▉___▉▉▉▉▉▉____▉▉▉▉▉▉_▉__|_______|_______|_______|_______|_______|_      |
  8  ▉   ▉▉▉▉▉▉  ▉ ▉▉▉▉▉▉▉▉▉▉|       |       |       |       |       |       |
  4  ▉  ▉▉▉▉▉▉▉ ▉▉ ▉▉▉▉▉▉▉▉▉▉▉▉▉ ▉ ▉ ▉▉▉     |       |       |       |       |
  2  ▉ ▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉ ▉▉▉▉▉▉  | ▉     |       |       ▉       |
  1 _▉_▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉_▉▉▉▉_▉|▉_▉▉▉__▉___▉▉__▉_      |
     |       |       |       |       |       |       |       |       |       |
   1235ms   11s     21s     30s     40s     50s     60s     70s     80s      >

 average |   min   |   max   |  sigma  |  count  |
   15s   |  270µs  |   80s   |   13s   |   644   |


⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ Failed tests ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯


⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ run_tests.failures START ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯

./build/tests/reg_issue5268: error(code=24): *** error creating process make
./build/tests/inherit_postcondition: error(code=24): *** error creating process make
./build/tests/reg_issue3371: error(code=24): *** error creating process make
./build/tests/reg_issue2559: error(code=24): *** error creating process make
./build/tests/reg_issue4233: error(code=24): *** error creating process make
./build/tests/reg_issue5850_tuple_comparison: error(code=24): *** error creating process make
./build/tests/reg_issue3910: error(code=24): *** error creating process make
./build/tests/reg_issue4621: error(code=24): *** error creating process make
./build/tests/reg_issue2515: error(code=24): *** error creating process make
./build/tests/reg_issue2280: error(code=24): *** error creating process make
./build/tests/reg_issues5821_5835: error(code=24): *** error creating process make
[...]
```
