### PR TITLE
makefile: show_development_env_vars

### DIFF
--- a/src/dev/flang/ast/Loop.java
+++ b/src/dev/flang/ast/Loop.java
@@ -168,8 +168,12 @@ public class Loop extends ANY
 
   /**
    * env var to enable debug output for code generated for loops:
+   *
+   * To enable, use fz with:
+   *
+   *   dev_flang_ast_FUZION_DEBUG_LOOPS=true
    */
-  static private final boolean FUZION_DEBUG_LOOPS = FuzionOptions.boolPropertyOrEnv("FUZION_DEBUG_LOOPS");
+  static private final boolean FUZION_DEBUG_LOOPS = FuzionOptions.boolPropertyOrEnv("dev.flang.ast.FUZION_DEBUG_LOOPS");
 
 
   /*----------------------------  constants  ----------------------------*/

--- a/src/dev/flang/fe/LibraryModule.java
+++ b/src/dev/flang/fe/LibraryModule.java
@@ -94,8 +94,12 @@ public class LibraryModule extends Module implements MirModule
   /**
    * NYI: Instead of using env var, create a new tool "fzdump" or similar to
    * dump intermediate files.
+   *
+   * To enable, use fz with:
+   *
+   *   dev_flang_fe_FUZION_DUMP_MODULE_FILE=true
    */
-  static final boolean DUMP = FuzionOptions.boolPropertyOrEnv("FUZION_DUMP_MODULE_FILE");
+  static final boolean DUMP = FuzionOptions.boolPropertyOrEnv("dev.flang.fe.FUZION_DUMP_MODULE_FILE");
 
 
   /**

--- a/tools.mk
+++ b/tools.mk
@@ -118,3 +118,9 @@ lint-pmd: $(BUILD_DIR)/pmd
 .PHONY: lint-c
 lint-c:
 	clang-tidy $(C_FILES) -- -std=c11
+
+# show env vars that can be used during development
+#
+.PHONY: show_development_env_vars
+show_development_env_vars:
+	grep -rhoE 'dev_flang_[A-Za-z0-9_]+=' . | sed 's/=//' | sort -u


### PR DESCRIPTION
[ci skip]
```
~/openvscode-server-fuzion/vscode-fuzion/fuzion (main)1$ make show_development_env_vars
grep -rhoE 'dev_flang_[A-Za-z0-9_]+=' . | sed 's/=//' | sort -u
dev_flang_ast_FUZION_DEBUG_LOOPS
dev_flang_be_jvm_JVM_CODE_COMMENTS
dev_flang_be_jvm_JVM_TRACE
dev_flang_be_jvm_JVM_TRACE_RETURN
dev_flang_fe_FUZION_DUMP_MODULE_FILE
dev_flang_fuir_analysis_AbstractInterpreter_DEBUG
dev_flang_fuir_analysis_AbstractInterpreter_DEBUG_AFTER
dev_flang_fuir_analysis_dfa_DFA_MAX_ITERATIONS
dev_flang_fuir_analysis_dfa_DFA_ONLY_ONE_INSTANCE
dev_flang_fuir_analysis_dfa_DFA_SHOW_CALLS
dev_flang_fuir_analysis_dfa_DFA_SHOW_VALUES
dev_flang_fuir_analysis_dfa_DFA_SITE_SENSITIVE
dev_flang_fuir_analysis_dfa_DFA_USE_EMBEDDED_VALUES
dev_flang_fuir_analysis_dfa_TRACE_ALL_EFFECT_ENVS
dev_flang_fuir_GeneratingFUIR_SHOW_NEW_CLAZZES
dev_flang_fuir_util_Errors_STACK_TRACE_ON_ERROR
dev_flang_tools_serializeFUIR
```

