### PR TITLE
fe: make unit orderable

### DIFF
--- a/modules/base/src/unit.fz
+++ b/modules/base/src/unit.fz
@@ -103,6 +103,7 @@ public unit : property.orderable, property.hashable is
       public redef infix ∙ (a, b unit) unit => unit
       public redef e unit => unit
 
+
   # equality for two `unit` values always returns `true`
   #
   public redef fixed type.equality(a, b unit) bool

--- a/src/dev/flang/ast/AbstractFeature.java
+++ b/src/dev/flang/ast/AbstractFeature.java
@@ -1909,15 +1909,16 @@ public abstract class AbstractFeature extends Expr implements Comparable<Abstrac
   }
 
 
-  private boolean isUnitType(boolean allowRef)
+  private boolean isUnitType(boolean isInheritedFeature)
   {
     return
       isConstructor() &&
       contract() == dev.flang.ast.Contract.EMPTY_CONTRACT &&
       valueArguments().isEmpty() &&
-      (allowRef || !isRef()) &&
+      (isInheritedFeature || !isRef()) &&
       code().isEmpty() &&
-      !hasOuterRef() &&
+      // unit inheriting e.g. property.orderable is fine
+      (!hasOuterRef() || isInheritedFeature && outerRef().resultType().feature().isUnitType()) &&
       inherits().stream().allMatch(c -> c.calledFeature().isUnitType(true));
   }
 


### PR DESCRIPTION
builds on top of a commit of @fridis in #5878

I had to relax `AbstractFeature.isUnitType()` a little.