### PR TITLE
mail: use base64 as Content-Transfer-Encoding

### DIFF
--- a/modules/mail/src/mail.fz
+++ b/modules/mail/src/mail.fz
@@ -85,11 +85,12 @@ public mail is
       Subject: =?UTF-8?B?{encodings.base64.encode_to_string subject.utf8.as_array}?=
       MIME-Version: 1.0
       Content-Type: text/plain; charset="UTF-8"
-      Content-Transfer-Encoding: 8bit
+      Content-Transfer-Encoding: base64
 
       {
-        # 2.1.1.  Line Length Limits, see https://datatracker.ietf.org/doc/html/rfc5322#section-2.1.1
-        String.join_lines (text.lines.flat_map (.chunk 78))
+        # https://www.rfc-editor.org/rfc/rfc2045.html#section-6.8
+        b64 := encodings.base64.encode_to_string text.utf8.as_array
+        String.join_lines (b64.chunk 76)
       }
       .
       """.replace "\n" "\r\n"


### PR DESCRIPTION
This enables long lines and use of non-ASCII script.