### PR TITLE
be/c: use `-O3` only if debug=0

### DIFF
--- a/src/dev/flang/be/c/C.java
+++ b/src/dev/flang/be/c/C.java
@@ -778,7 +778,7 @@ public class C extends ANY
           "-Wmissing-include-dirs"
           );
 
-        if (!_options._debugBuild)
+        if (!_options._debugBuild && !_options.fuzionDebug())
           {
             command.addAll("-O3");
           }


### PR DESCRIPTION
motiviation here is compiling check_simple_example quicker:
```
Elapsed time for phases: prep 26ms, fe 332ms, createMIR 48ms, ir 9ms, dfa_pre 2621ms, dfa_real 1055ms, opt 3ms, be 12591ms
```