### PR TITLE
Revert "base/error: do not allow line breaks at the end of the message"

### DIFF
--- a/modules/base/src/error.fz
+++ b/modules/base/src/error.fz
@@ -41,11 +41,6 @@ public error (
 
   ) : property.equatable
 
-pre
-  # enforce no linefeed at end of message
-  #
-  debug 2 : !msg.ends_with "\n"
-
 is
 
 


### PR DESCRIPTION
This reverts commit 5062ae11d848ee68d738e2ea48765403a62f2aba.