### PR TITLE
change string representation of relative paths to always start with `./`

### DIFF
--- a/bin/run_tests.fz
+++ b/bin/run_tests.fz
@@ -276,7 +276,7 @@ main =>
     say_section "run_tests.failures END"
 
     failed_test_names := failed_tests
-                           .map (.split[0].substring 12) # remove "build/tests/"
+                           .map (.split[0].substring 14) # remove "./build/tests/"
                            .as_string " "
 
     say """

--- a/modules/base/src/path.fz
+++ b/modules/base/src/path.fz
@@ -181,10 +181,11 @@ is
 
   # String representation of this path
   #
-  # e.g. "/folder/file" or "relative_folder/file"
+  # e.g. "/folder/file" or "./relative_folder/file"
   #
   public redef as_string String =>
-    "{if is_absolute then "/" else ""}{if names.is_empty && !is_absolute then "./" else String.join names "/"}"
+    # relative paths should always start with `./` to avoid problems on Windows
+    "{if is_absolute then "/" else "./"}{String.join names "/"}"
 
 
   # define order for paths

--- a/tests/lib_io_dir/lib_io_dir.fz.expected_out
+++ b/tests/lib_io_dir/lib_io_dir.fz.expected_out
@@ -1,5 +1,5 @@
 unit
---error: an error occurred while creating the following directory: "test_path_😀"--
+--error: an error occurred while creating the following directory: "./test_path_😀"--
 --error: no more directory entries--
-file1_😀
-file2_😀
+./file1_😀
+./file2_😀

--- a/tests/lib_io_file/fileiotests.fz.expected_out
+++ b/tests/lib_io_file/fileiotests.fz.expected_out
@@ -1,23 +1,23 @@
-testdir_😀 exists: false
-testdir_😀 was created
-testdir_😀 exists: true
-testdir_😀/testfile_😀 exists: false
-testdir_😀/testfile_😀 was created
-testdir_😀/testfile_😀 exists: true
-stat resolve=true : testdir_😀/testfile_😀 size is 16
-stat resolve=false: testdir_😀/testfile_😀 size is 16
+./testdir_😀 exists: false
+./testdir_😀 was created
+./testdir_😀 exists: true
+./testdir_😀/testfile_😀 exists: false
+./testdir_😀/testfile_😀 was created
+./testdir_😀/testfile_😀 exists: true
+stat resolve=true : ./testdir_😀/testfile_😀 size is 16
+stat resolve=false: ./testdir_😀/testfile_😀 size is 16
 0
 unit
 1
 unit
 file content bytes: [72, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100, 32, 240, 159, 140, 141]
 file content is Hello world 🌍
-testdir_😀/testfile_😀 was deleted
-testdir_😀/testfile_😀 exists: false
-testdir_😀 exists: true
-newdir_😀 exists: false
-testdir_😀 is now: newdir_😀
-newdir_😀 exists: true
-testdir_😀 exists: false
-newdir_😀 was deleted
-newdir_😀 exists: false
+./testdir_😀/testfile_😀 was deleted
+./testdir_😀/testfile_😀 exists: false
+./testdir_😀 exists: true
+./newdir_😀 exists: false
+./testdir_😀 is now: ./newdir_😀
+./newdir_😀 exists: true
+./testdir_😀 exists: false
+./newdir_😀 was deleted
+./newdir_😀 exists: false

--- a/tests/lib_io_utf8/lib_io_utf8.fz.expected_out
+++ b/tests/lib_io_utf8/lib_io_utf8.fz.expected_out
@@ -1,34 +1,34 @@
 Tests from lib_io_file/fileiotest.fz using unicode:
 
-🧪 exists: false
-🧪 was created
-🧪 exists: true
-🧪/📄 exists: false
-🧪/📄 was created
-🧪/📄 exists: true
-stat resolve=true : 🧪/📄 size is 25
-stat resolve=false: 🧪/📄 size is 25
+./🧪 exists: false
+./🧪 was created
+./🧪 exists: true
+./🧪/📄 exists: false
+./🧪/📄 was created
+./🧪/📄 exists: true
+stat resolve=true : ./🧪/📄 size is 25
+stat resolve=false: ./🧪/📄 size is 25
 0
 unit
 1
 unit
 file content bytes: [240, 159, 145, 139, 240, 159, 143, 162, 240, 159, 167, 145, 226, 128, 141, 240, 159, 146, 187, 226, 152, 175, 239, 184, 143]
 file content is: 👋🏢🧑‍💻☯️
-🧪/📄 was deleted
-🧪/📄 exists: false
-🧪 exists: true
-✨✨✨ exists: false
-🧪 is now: ✨✨✨
-✨✨✨ exists: true
-🧪 exists: false
-✨✨✨ was deleted
-✨✨✨ exists: false
+./🧪/📄 was deleted
+./🧪/📄 exists: false
+./🧪 exists: true
+./✨✨✨ exists: false
+./🧪 is now: ./✨✨✨
+./✨✨✨ exists: true
+./🧪 exists: false
+./✨✨✨ was deleted
+./✨✨✨ exists: false
 
 
 Tests from lib_io_dir/lib_io_dir.fz using unicode:
 
 unit
---error: an error occurred while creating the following directory: "⚗️🧫"--
+--error: an error occurred while creating the following directory: "./⚗️🧫"--
 --error: no more directory entries--
-1️⃣📜
-2️⃣🗒️
+./1️⃣📜
+./2️⃣🗒️

--- a/tests/path/path_test.fz.expected_out
+++ b/tests/path/path_test.fz.expected_out
@@ -1,24 +1,24 @@
 /first/second/third/fourth has 4 levels
-alpha/beta/gamma has 3 levels
-second/third/fourth
+./alpha/beta/gamma has 3 levels
+./second/third/fourth
 /first/second/third/fourth/alpha/beta/gamma
 
 Resolve:
-../../ex.fz
+./../../ex.fz
 /ex.fz
 /first/second/third/fourth/alpha/beta
 
-alpha/beta/gamma/myfile.txt
+./alpha/beta/gamma/myfile.txt
   base: myfile.txt
   stem: myfile
 suffix: txt
 
-alpha/beta/gamma
+./alpha/beta/gamma
   base: gamma
   stem: gamma
 suffix: 
 
-.config
+./.config
   base: .config
   stem: .config
 suffix: 
@@ -28,50 +28,50 @@ suffix:
   stem: no_ext.
 suffix: 
 
-../foo..
+./../foo..
   base: foo..
   stem: foo..
 suffix: 
 
-...
+./...
   base: ...
   stem: ...
 suffix: 
 
-...txt
+./...txt
   base: ...txt
   stem: ..
 suffix: txt
 
-'/first/second/third/fourth/alpha/beta/gamma/foo/bar'.subpath 4 7 -> alpha/beta/gamma
+'/first/second/third/fourth/alpha/beta/gamma/foo/bar'.subpath 4 7 -> ./alpha/beta/gamma
 
 Parents:
-alpha/beta/gamma/myfile.txt
-alpha/beta/gamma
-alpha/beta
-alpha
+./alpha/beta/gamma/myfile.txt
+./alpha/beta/gamma
+./alpha/beta
+./alpha
 ./
-..
-../..
+./..
+./../..
 
 Relativize:
 
-ex.fz
-fourth/ex.fz
-third/fourth/ex.fz
-second/third/fourth/ex.fz
-first/second/third/fourth/ex.fz
+./ex.fz
+./fourth/ex.fz
+./third/fourth/ex.fz
+./second/third/fourth/ex.fz
+./first/second/third/fourth/ex.fz
 
-myfile.txt
-gamma/myfile.txt
-beta/gamma/myfile.txt
-alpha/beta/gamma/myfile.txt
+./myfile.txt
+./gamma/myfile.txt
+./beta/gamma/myfile.txt
+./alpha/beta/gamma/myfile.txt
 
 IN:  '/./././foo/./././../././bar/././././..'
 OUT: '/'
 
 IN:  '...'
-OUT: '...'
+OUT: './...'
 
 IN:  '/...'
 OUT: '/...'
@@ -83,7 +83,7 @@ IN:  '[a, b, c.fz]' absolute
 OUT: '/a/b/c.fz'
 
 IN:  '[a, b, c.fz]' relative
-OUT: 'a/b/c.fz'
+OUT: './a/b/c.fz'
 
 NEGATIVE:
 


### PR DESCRIPTION
This should avoid problems on Windows

