### PR TITLE
base: add short-hand, `html.encode str`

### DIFF
--- a/modules/base/src/encodings/html.fz
+++ b/modules/base/src/encodings/html.fz
@@ -67,7 +67,7 @@ public html is
 
   # html encode str, but not its spaces
   #
-  public encode(str String) =>
+  public encode(str String) String =>
     encode str false
 
 


### PR DESCRIPTION
I think this is the common case.