### PR TITLE
ast: refine heuristic of legal native value types

### DIFF
--- a/src/dev/flang/ast/AbstractBlock.java
+++ b/src/dev/flang/ast/AbstractBlock.java
@@ -224,7 +224,10 @@ public abstract class AbstractBlock extends Expr
   @Override
   public boolean isEmpty()
   {
-    return _expressions.isEmpty();
+    return _expressions
+      .stream()
+      // declarations are NOPs, hence allowed
+      .allMatch(x -> x instanceof AbstractFeature);
   }
 
 

--- a/src/dev/flang/ast/AbstractFeature.java
+++ b/src/dev/flang/ast/AbstractFeature.java
@@ -1706,7 +1706,7 @@ public abstract class AbstractFeature extends Expr implements Comparable<Abstrac
   protected boolean mayBeNativeValue()
   {
     return kind() == Kind.Constructor
-      && !hasOuterRef()
+      && (!hasOuterRef() || outerRef().resultType().feature().isUnitType())
       && typeArguments().isEmpty()
       && inherits().size() == 1
       && !Contract.hasPreConditionsFeature(this)
@@ -1913,7 +1913,7 @@ public abstract class AbstractFeature extends Expr implements Comparable<Abstrac
   {
     return
       isConstructor() &&
-      contract() == dev.flang.ast.Contract.EMPTY_CONTRACT &&
+      contract().isEmpty() &&
       valueArguments().isEmpty() &&
       (isInheritedFeature || !isRef()) &&
       code().isEmpty() &&

--- a/src/dev/flang/ast/Contract.java
+++ b/src/dev/flang/ast/Contract.java
@@ -1147,6 +1147,18 @@ The conditions of a post-condition are checked at run-time in sequential source-
 
 
   /**
+   * Is this a contract without any conditions?
+   */
+  public boolean isEmpty()
+  {
+    return _hasPre == null &&
+      _hasPost == null &&
+      _hasPreElse == null &&
+      _hasPostThen == null;
+  }
+
+
+  /**
    * toString
    *
    * @return


### PR DESCRIPTION
goal is to allow e.g.:

`c.CXCursor(module kind u32 /* from: enum CXCursorKind */, module xdata i32 /* from: int */, module data Native_Ref /* from: void *[3] */) is`
