### PR TITLE
base: add `path.as_platform_string` and use it in file operations

### DIFF
--- a/modules/base/src/fuzion/sys/fileio.fz
+++ b/modules/base/src/fuzion/sys/fileio.fz
@@ -74,7 +74,7 @@ module fileio is
   module delete(
                 # the (relative or absolute) file name, using platform specific path separators
                 path path) outcome unit =>
-    arr := fuzion.sys.c_string $path
+    arr := fuzion.sys.c_string path.as_platform_string
     if fzE_rm arr != 0
       error "an error occurred while performing the delete operation on the following file/dir: \"$path\""
 
@@ -88,8 +88,8 @@ module fileio is
               old path,
               # the new (relative or absolute) file name, using platform specific path separators
               new path) outcome unit =>
-    arr0 := fuzion.sys.c_string $old
-    arr1 := fuzion.sys.c_string $new
+    arr0 := fuzion.sys.c_string old.as_platform_string
+    arr1 := fuzion.sys.c_string new.as_platform_string
     if fzE_file_move arr0 arr1 != 0
       error "an error occurred while performing the following move operation: \"$old\" --> \"$new\""
 
@@ -100,7 +100,7 @@ module fileio is
   module create_dir(
                     # the (relative or absolute) dir name, using platform specific path separators
                     path path) outcome unit =>
-    arr := fuzion.sys.c_string $path
+    arr := fuzion.sys.c_string path.as_platform_string
     if fzE_mkdir arr != 0
       error "an error occurred while creating the following directory: \"$path\""
 
@@ -168,7 +168,7 @@ module fileio is
   #
   module open_dir(path path) outcome Directory_Descriptor =>
     open_results := fuzion.sys.internal_array_init i64 1  # [error number]
-    res := fzE_opendir (fuzion.sys.c_string $path) open_results.data
+    res := fzE_opendir (fuzion.sys.c_string path.as_platform_string) open_results.data
     if open_results[0] = 0
       res
     else

--- a/modules/base/src/io/file/stat.fz
+++ b/modules/base/src/io/file/stat.fz
@@ -74,7 +74,7 @@ public stat(ps Stat_Handler) : effect is
     replace
     # will contain: [size, time of last modification in seconds, regular file? 1 : 0, dir? 1 : 0]
     res := fuzion.sys.internal_array_init i64 9
-    if ps.stats (fuzion.sys.c_string $path) res.data = 0
+    if ps.stats (fuzion.sys.c_string path.as_platform_string) res.data = 0
       meta_data res[0] res[1] res[2] res[3] (res[4] = 1) (res[5] = 1) (res[6] = 1) res[7] res[8]
     else
       error "stat error {res[0]} for {path}"
@@ -90,7 +90,7 @@ public stat(ps Stat_Handler) : effect is
     replace
     # will contain: [size, time of last modification in seconds, regular file? 1 : 0, dir? 1 : 0]
     res := fuzion.sys.internal_array_init i64 9
-    if ps.stats (fuzion.sys.c_string $path) res.data = 0
+    if ps.stats (fuzion.sys.c_string path.as_platform_string) res.data = 0
       meta_data res[0] res[1] res[2] res[3] (res[4] = 1) (res[5] = 1) (res[6] = 1) res[7] res[8]
     else
       error "lstat error {res[0]} for {path}"

--- a/modules/base/src/path.fz
+++ b/modules/base/src/path.fz
@@ -181,9 +181,19 @@ is
 
   # String representation of this path
   #
-  # e.g. "/folder/file" or "./relative_folder/file"
+  # e.g. "/folder/file" or "relative_folder/file"
   #
   public redef as_string String =>
+    "{is_absolute ? "/" : names.is_empty ? "." : ""}{String.join names "/"}"
+
+
+  # Platform dependent String representation of this path
+  #
+  # Relative paths start with "./" to avoid problems on Windows
+  #
+  # e.g. "/folder/file" or "./relative_folder/file"
+  #
+  public as_platform_string String =>
     # relative paths should always start with `./` to avoid problems on Windows
     "{if is_absolute then "/" else "./"}{String.join names "/"}"
 

--- a/tests/lib_io_dir/lib_io_dir.fz.expected_out
+++ b/tests/lib_io_dir/lib_io_dir.fz.expected_out
@@ -1,5 +1,5 @@
 unit
---error: an error occurred while creating the following directory: "./test_path_😀"--
+--error: an error occurred while creating the following directory: "test_path_😀"--
 --error: no more directory entries--
-./file1_😀
-./file2_😀
+file1_😀
+file2_😀

--- a/tests/lib_io_file/fileiotests.fz.expected_out
+++ b/tests/lib_io_file/fileiotests.fz.expected_out
@@ -1,23 +1,23 @@
-./testdir_😀 exists: false
-./testdir_😀 was created
-./testdir_😀 exists: true
-./testdir_😀/testfile_😀 exists: false
-./testdir_😀/testfile_😀 was created
-./testdir_😀/testfile_😀 exists: true
-stat resolve=true : ./testdir_😀/testfile_😀 size is 16
-stat resolve=false: ./testdir_😀/testfile_😀 size is 16
+testdir_😀 exists: false
+testdir_😀 was created
+testdir_😀 exists: true
+testdir_😀/testfile_😀 exists: false
+testdir_😀/testfile_😀 was created
+testdir_😀/testfile_😀 exists: true
+stat resolve=true : testdir_😀/testfile_😀 size is 16
+stat resolve=false: testdir_😀/testfile_😀 size is 16
 0
 unit
 1
 unit
 file content bytes: [72, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100, 32, 240, 159, 140, 141]
 file content is Hello world 🌍
-./testdir_😀/testfile_😀 was deleted
-./testdir_😀/testfile_😀 exists: false
-./testdir_😀 exists: true
-./newdir_😀 exists: false
-./testdir_😀 is now: ./newdir_😀
-./newdir_😀 exists: true
-./testdir_😀 exists: false
-./newdir_😀 was deleted
-./newdir_😀 exists: false
+testdir_😀/testfile_😀 was deleted
+testdir_😀/testfile_😀 exists: false
+testdir_😀 exists: true
+newdir_😀 exists: false
+testdir_😀 is now: newdir_😀
+newdir_😀 exists: true
+testdir_😀 exists: false
+newdir_😀 was deleted
+newdir_😀 exists: false

--- a/tests/lib_io_utf8/lib_io_utf8.fz.expected_out
+++ b/tests/lib_io_utf8/lib_io_utf8.fz.expected_out
@@ -1,34 +1,34 @@
 Tests from lib_io_file/fileiotest.fz using unicode:
 
-./🧪 exists: false
-./🧪 was created
-./🧪 exists: true
-./🧪/📄 exists: false
-./🧪/📄 was created
-./🧪/📄 exists: true
-stat resolve=true : ./🧪/📄 size is 25
-stat resolve=false: ./🧪/📄 size is 25
+🧪 exists: false
+🧪 was created
+🧪 exists: true
+🧪/📄 exists: false
+🧪/📄 was created
+🧪/📄 exists: true
+stat resolve=true : 🧪/📄 size is 25
+stat resolve=false: 🧪/📄 size is 25
 0
 unit
 1
 unit
 file content bytes: [240, 159, 145, 139, 240, 159, 143, 162, 240, 159, 167, 145, 226, 128, 141, 240, 159, 146, 187, 226, 152, 175, 239, 184, 143]
 file content is: 👋🏢🧑‍💻☯️
-./🧪/📄 was deleted
-./🧪/📄 exists: false
-./🧪 exists: true
-./✨✨✨ exists: false
-./🧪 is now: ./✨✨✨
-./✨✨✨ exists: true
-./🧪 exists: false
-./✨✨✨ was deleted
-./✨✨✨ exists: false
+🧪/📄 was deleted
+🧪/📄 exists: false
+🧪 exists: true
+✨✨✨ exists: false
+🧪 is now: ✨✨✨
+✨✨✨ exists: true
+🧪 exists: false
+✨✨✨ was deleted
+✨✨✨ exists: false
 
 
 Tests from lib_io_dir/lib_io_dir.fz using unicode:
 
 unit
---error: an error occurred while creating the following directory: "./⚗️🧫"--
+--error: an error occurred while creating the following directory: "⚗️🧫"--
 --error: no more directory entries--
-./1️⃣📜
-./2️⃣🗒️
+1️⃣📜
+2️⃣🗒️

--- a/tests/path/path_test.fz.expected_out
+++ b/tests/path/path_test.fz.expected_out
@@ -1,24 +1,24 @@
 /first/second/third/fourth has 4 levels
-./alpha/beta/gamma has 3 levels
-./second/third/fourth
+alpha/beta/gamma has 3 levels
+second/third/fourth
 /first/second/third/fourth/alpha/beta/gamma
 
 Resolve:
-./../../ex.fz
+../../ex.fz
 /ex.fz
 /first/second/third/fourth/alpha/beta
 
-./alpha/beta/gamma/myfile.txt
+alpha/beta/gamma/myfile.txt
   base: myfile.txt
   stem: myfile
 suffix: txt
 
-./alpha/beta/gamma
+alpha/beta/gamma
   base: gamma
   stem: gamma
 suffix: 
 
-./.config
+.config
   base: .config
   stem: .config
 suffix: 
@@ -28,50 +28,50 @@ suffix:
   stem: no_ext.
 suffix: 
 
-./../foo..
+../foo..
   base: foo..
   stem: foo..
 suffix: 
 
-./...
+...
   base: ...
   stem: ...
 suffix: 
 
-./...txt
+...txt
   base: ...txt
   stem: ..
 suffix: txt
 
-'/first/second/third/fourth/alpha/beta/gamma/foo/bar'.subpath 4 7 -> ./alpha/beta/gamma
+'/first/second/third/fourth/alpha/beta/gamma/foo/bar'.subpath 4 7 -> alpha/beta/gamma
 
 Parents:
-./alpha/beta/gamma/myfile.txt
-./alpha/beta/gamma
-./alpha/beta
-./alpha
-./
-./..
-./../..
+alpha/beta/gamma/myfile.txt
+alpha/beta/gamma
+alpha/beta
+alpha
+.
+..
+../..
 
 Relativize:
 
-./ex.fz
-./fourth/ex.fz
-./third/fourth/ex.fz
-./second/third/fourth/ex.fz
-./first/second/third/fourth/ex.fz
+ex.fz
+fourth/ex.fz
+third/fourth/ex.fz
+second/third/fourth/ex.fz
+first/second/third/fourth/ex.fz
 
-./myfile.txt
-./gamma/myfile.txt
-./beta/gamma/myfile.txt
-./alpha/beta/gamma/myfile.txt
+myfile.txt
+gamma/myfile.txt
+beta/gamma/myfile.txt
+alpha/beta/gamma/myfile.txt
 
 IN:  '/./././foo/./././../././bar/././././..'
 OUT: '/'
 
 IN:  '...'
-OUT: './...'
+OUT: '...'
 
 IN:  '/...'
 OUT: '/...'
@@ -83,7 +83,7 @@ IN:  '[a, b, c.fz]' absolute
 OUT: '/a/b/c.fz'
 
 IN:  '[a, b, c.fz]' relative
-OUT: './a/b/c.fz'
+OUT: 'a/b/c.fz'
 
 NEGATIVE:
 


### PR DESCRIPTION
To fix problems on Windows without adding `./` to string representation of relative paths.
Fixes most windows test, see [this test run](https://github.com/simonvonhackewitz/fuzion/actions/runs/22483024358/job/65125695855)


revert #6718

fix tokiwa-software/fzweb#376

