### PR TITLE
base: processes, close pipes on exhaustion

### DIFF
--- a/modules/base/src/os/process.fz
+++ b/modules/base/src/os/process.fz
@@ -58,8 +58,12 @@ module:public process(public pid i64, module std_in, std_out, std_err i64, name 
       arr := array u8 pipe_buffer_size i->0
       res := fzE_pipe_read desc arr.internal_array.data arr.count
       if res = -1
+        # NYI: UNDER DEVELOPMENT: register failures
+        _ := fzE_pipe_close desc
         error "error reading from stdout."
       else if res = 0
+        # NYI: UNDER DEVELOPMENT: register failures
+        _ := fzE_pipe_close desc
         io.end_of_file
       else
         arr

--- a/modules/base/src/os/processes.fz
+++ b/modules/base/src/os/processes.fz
@@ -43,6 +43,8 @@ public processes (ph os.Process_Handler, public running_processes container.Set 
     running_processes.for_each p->
       # NYI: UNDER DEVELOPMENT: register failures
       _ := p.wait
+      _ := fzE_pipe_close p.std_out
+      _ := fzE_pipe_close p.std_err
 
 
   # wait for process to finish
@@ -73,9 +75,6 @@ public processes (ph os.Process_Handler, public running_processes container.Set 
       time.nano.sleep (min timeout-elapsed_time polling_time)
     else
       if r >= 0
-        # NYI: UNDER DEVELOPMENT: close these:
-        # check fzE_pipe_close p.std_out = 0
-        # check fzE_pipe_close p.std_err = 0
         r.as_u32
       else
         if elapsed_time > timeout


### PR DESCRIPTION
In testrunner.fz I have to problem of a resource exhaustion after some amount of tests. This hopefully fixes this.
```
+ /testrunner noBackend
1314 tests, running 16 tests in parallel.
............................................................................................_................_....._.................__............_................................_................................................._....._........_.................._.............................#........_..#.......#.__.............#........#.......................#....#...........#..#.....#.........._............#.#..#....................#...#...#_.....#........._.#............##...#..........._.#........#.__######################################################################################_#########################.#######################_################_####################.######.##############################_############_###################_##########################################_#######################################################################################################################################################################################_#################_###_#################_#_#############_###############################_###############################################_#######_########_#################_#######################__#_##_#_##_#___#_##___#_#_#_#_____#_##_#_#___#___#_#_#__#_##_#_#_#_#__#__#______#__#___##__##______________#_#_#__#_#___##............finished running all tests
```
