### PR TITLE
util/Terminal: add environment variable to force ANSI output

### DIFF
--- a/src/dev/flang/util/Terminal.java
+++ b/src/dev/flang/util/Terminal.java
@@ -58,7 +58,8 @@ public class Terminal extends ANY
    */
   public static final boolean ENABLED =
     !FuzionOptions.boolPropertyOrEnv("FUZION_DISABLE_ANSI_ESCAPES") &&
-    isTerminal();
+    isTerminal() ||
+    FuzionOptions.boolPropertyOrEnv("dev.flang.util.Terminal.force_ansi_escapes");
 
   public static final String RESET                     = ENABLED ? "\033[0m" : "";
   public static final String BOLD                      = ENABLED ? "\033[1m" : "";


### PR DESCRIPTION
This will enable fzweb to show pretty printed and highlighted code without emulating a TTY.