### PR TITLE
base: `traverse`, do not descend into dirs that are symlinks

### DIFF
--- a/modules/base/src/io/dir/traverse.fz
+++ b/modules/base/src/io/dir/traverse.fz
@@ -48,7 +48,7 @@ public traverse(
               if descend
                 match io.file.stat x false
                   error => res # NYI
-                  m io.file.meta_data => if m.is_dir then traverse x descend t red_fn else t
+                  m io.file.meta_data => if m.is_dir && !m.is_link then traverse x descend t red_fn else t
               else
                 t
           }


### PR DESCRIPTION
I wrongly assumed that when `.is_dir` is true `.is_link` is always false.