### PR TITLE
base: fix lstats

### DIFF
--- a/modules/base/src/io/dir/traverse.fz
+++ b/modules/base/src/io/dir/traverse.fz
@@ -48,7 +48,7 @@ public traverse(
               if descend
                 match io.file.stat x false
                   error => res # NYI
-                  m io.file.meta_data => if m.is_dir && !m.is_link then traverse x descend t red_fn else t
+                  m io.file.meta_data => if m.is_dir then traverse x descend t red_fn else t
               else
                 t
           }

--- a/modules/base/src/io/file/stat.fz
+++ b/modules/base/src/io/file/stat.fz
@@ -90,7 +90,7 @@ public stat(ps Stat_Handler) : effect is
     replace
     # will contain: [size, time of last modification in seconds, regular file? 1 : 0, dir? 1 : 0]
     res := fuzion.sys.internal_array_init i64 9
-    if ps.stats (fuzion.sys.c_string path.as_platform_string) res.data = 0
+    if ps.lstats (fuzion.sys.c_string path.as_platform_string) res.data = 0
       meta_data res[0] res[1] res[2] res[3] (res[4] = 1) (res[5] = 1) (res[6] = 1) res[7] res[8]
     else
       error "lstat error {res[0]} for {path}"


### PR DESCRIPTION
also revert a change in traverse that was done due to poor understanding of the problem.
