### PR TITLE
base: stat meta_data, include path

### DIFF
--- a/modules/base/src/io/file/stat.fz
+++ b/modules/base/src/io/file/stat.fz
@@ -46,7 +46,9 @@ private:public meta_data(
           public uid i64,
           # group of the path
           public gid i64
-          ) is
+          )
+    pre debug: path.is_absolute
+  is
 
   public redef as_string String =>
     """
@@ -77,7 +79,8 @@ public stat(ps Stat_Handler) : effect is
     # will contain: [size, time of last modification in seconds, regular file? 1 : 0, dir? 1 : 0]
     res := fuzion.sys.internal_array_init i64 9
     if ps.stats (fuzion.sys.c_string path.as_platform_string) res.data = 0
-      meta_data path res[0] res[1] res[2] res[3] (res[4] = 1) (res[5] = 1) (res[6] = 1) res[7] res[8]
+      path.as_absolute.bind p->
+        meta_data p res[0] res[1] res[2] res[3] (res[4] = 1) (res[5] = 1) (res[6] = 1) res[7] res[8]
     else
       error "stat error {res[0]} for {path}"
 
@@ -93,7 +96,8 @@ public stat(ps Stat_Handler) : effect is
     # will contain: [size, time of last modification in seconds, regular file? 1 : 0, dir? 1 : 0]
     res := fuzion.sys.internal_array_init i64 9
     if ps.lstats (fuzion.sys.c_string path.as_platform_string) res.data = 0
-      meta_data path res[0] res[1] res[2] res[3] (res[4] = 1) (res[5] = 1) (res[6] = 1) res[7] res[8]
+      path.as_absolute.bind p->
+        meta_data p res[0] res[1] res[2] res[3] (res[4] = 1) (res[5] = 1) (res[6] = 1) res[7] res[8]
     else
       error "lstat error {res[0]} for {path}"
 

--- a/modules/base/src/path.fz
+++ b/modules/base/src/path.fz
@@ -179,6 +179,16 @@ is
       (names.take p.names.count) = p.names
 
 
+  # this relative path resolved against
+  # the current working directory (`os.cwd`)
+  #
+  public as_absolute outcome path
+    pre debug: !is_absolute
+  =>
+    os.cwd.bind c->
+      c.resolve (path names is_absolute)
+
+
   # String representation of this path
   #
   # e.g. "/folder/file" or "relative_folder/file"


### PR DESCRIPTION
```
$ fz -e 'say <| io.file.stat.stats (path.of "/tmp")'
path              : /tmp
size in bytes     : 540
access time       : 2026-03-09T21:34:57.000
modification time : 2026-03-10T10:53:04.000
creation time     : 2026-03-10T10:53:04.000
is regular file   : false
is directory      : true
is link           : false
user id           : 0
group id          : 0
```

fixes #5938

