### PR TITLE
base: add enhanced effect composition means

### DIFF
--- a/modules/base/src/io/file/use.fz
+++ b/modules/base/src/io/file/use.fz
@@ -72,26 +72,18 @@ public use(R type, file_name path, m mode.val, code ()-> outcome R) outcome R =>
 
   (fuzion.sys.fileio.open file_name mode_num).bind fd->
 
-    # NYI: BUG: "Failed to verify that effect 'io.file.file_mutate' is installed in current environment."
-    # e.g. in tests/lib_io_file
     #
-    # DFA does not or even can not understand the control flow
-    # here yet. We need to first instantiate file_mutate explicitly.
+    # file_mutate needs to be instated when
+    # initializing reader/writer
     #
-    # file_mutate
-    #   .and (outcome R) open (open fd file_name)
-    #   .and ((io.buffered file_mutate).reader (read_handler fd))
-    #   .and ((io.buffered file_mutate).writer (write_handler fd))
-    #   .call code
 
     file_mutate ! ()->
+
       match m
         mode.read =>
-          open fd file_name
-            .and (outcome R) _ ((io.buffered file_mutate).reader (read_handler fd))
-            .call code
+          (open fd file_name,
+           io.buffered file_mutate .reader (read_handler fd)) ! code
         * =>
-          open fd file_name
-            .and (outcome R) _ ((io.buffered file_mutate).reader (read_handler fd))
-            .and ((io.buffered file_mutate).writer (write_handler fd))
-            .call code
+          (open fd file_name,
+           io.buffered file_mutate .reader (read_handler fd),
+           io.buffered file_mutate .writer (write_handler fd)) ! code

--- a/modules/base/src/tuple.fz
+++ b/modules/base/src/tuple.fz
@@ -125,6 +125,28 @@ public tuple(public A type...,
 is
 
 
+  # given a tuple of several effect instances
+  # instate the in order of declaration and
+  # run code in their context
+  #
+  #
+  public infix !(# result type
+                 R type,
+
+                 # the code to execute with `e` instated.
+                 code () -> R
+  ) R
+    # NYI: BUG: cannot constraint open type parameter yet: pre A : effect
+  =>
+    (values.typed_foldf (option (Functional R) nil) T,e,v->
+      if T : effect
+        match e
+          nil => v.as_functional R
+          f (Functional R) => f.and v
+      else
+        compile_time_panic).or_panic.call code
+
+
   # equality of two tuple `a` and `b` is defined only if all elements of the tuple
   # are equatable and all elements are equal.
   #


### PR DESCRIPTION
This adds syntax sugar to instate multiple effects and run code in their context:
```
(open fd file_name,
 io.buffered file_mutate .reader (read_handler fd),
 io.buffered file_mutate .writer (write_handler fd)) ! code
```
instead of 
```
(open fd file_name) ! ()->
  io.buffered file_mutate .reader (read_handler fd) ! ()->
    io.buffered file_mutate .writer (write_handler fd)) ! code
```