### PR TITLE
ast: fix bug where omitting type params led to crash

### DIFF
--- a/modules/base/src/tuple.fz
+++ b/modules/base/src/tuple.fz
@@ -132,10 +132,7 @@ is
   #
   public redef type.equality(a, b tuple.this) bool
   =>
-    # NYI: BUG: omitting type parameters results in crash (Unimplemented method 'generics' in ThisType):
-    # a.values.typed_zip_and_fold b.values true (tuple_zip_equals tuple.this)
-
-    a.values.typed_zip_and_fold bool (tuple_zip_equals tuple.this) b.values true (tuple_zip_equals tuple.this)
+    a.values.typed_zip_and_fold b.values true (tuple_zip_equals tuple.this)
 
 
   # A total order between two tuples `a` and `b` is defined by the total order of
@@ -146,10 +143,7 @@ is
   #
   public redef type.lteq(a, b tuple.this) bool
   =>
-    # NYI: BUG: omitting type parameters results in crash (Unimplemented method 'generics' in ThisType):
-    # a.values.typed_zip_and_fold b.values true (tuple_zip_lteq tuple.this)
-
-    a.values.typed_zip_and_fold i32 (tuple_zip_lteq tuple.this) b.values 0 (tuple_zip_lteq tuple.this) <= 0
+    a.values.typed_zip_and_fold b.values 0 (tuple_zip_lteq tuple.this) <= 0
 
 
   # create hash code for this tuple

--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -2202,14 +2202,14 @@ public class Call extends AbstractCall
         var aft = actualType.isGenericArgument() ? null : actualType.feature();
         if (fft == aft)
           {
-            for (int i=0; i < formalType.generics().size(); i++)
+            for (int i=0; i < formalType.actualGenerics().size(); i++)
               {
                 var g = actualType.actualGenerics();
                 if (i < g.size())
                   {
                     inferGeneric(res,
                                  context,
-                                 formalType.generics().get(i),
+                                 formalType.actualGenerics().get(i),
                                  g.get(i),
                                  pos, conflict, foundAt);
                   }


### PR DESCRIPTION
I think there was no issue created for this yet?


