### PR TITLE
ast: Avoid crash during type inference of defunc call

### DIFF
--- a/src/dev/flang/ast/AbstractCall.java
+++ b/src/dev/flang/ast/AbstractCall.java
@@ -295,9 +295,15 @@ public abstract class AbstractCall extends Expr
    * be used to check for AstErrors.illegalOuterRefTypeInCall.
    *
    */
-  protected AbstractType adjustResultType(Resolution res, Context context, AbstractType tt, AbstractType rt, BiConsumer<AbstractType, AbstractType> foundRef, boolean forArg /* NYI: UNDER DEVELOPMENT: try to remove this parameter */)
+  protected AbstractType adjustResultType(Resolution res,
+                                          Context context,
+                                          AbstractType tt,
+                                          AbstractType rt,
+                                          BiConsumer<AbstractType, AbstractType> foundRef,
+                                          boolean forArg /* NYI: UNDER DEVELOPMENT: try to remove this parameter */)
   {
-    var t1 = rt == Types.t_ERROR                           ? rt : adjustThisTypeForTarget(context, rt, foundRef);
+    var t0 = calledFeature() == Types.f_ERROR ? Types.t_ERROR : rt;
+    var t1 = t0 == Types.t_ERROR                           ? t0 : adjustThisTypeForTarget(context, t0, foundRef);
     var t2 = t1 == Types.t_ERROR                           ? t1 : calledFeature().outer().handDownToType(t1, tt);  // NYI: CLEANUP: try to use handDownAndApply
     var t3 = t2 == Types.t_ERROR                           ? t2 : t2.applyTypePars(tt);
     var t4 = t3 == Types.t_ERROR                           ? t3 : t3.applyTypePars(calledFeature(), actualTypeParameters());


### PR DESCRIPTION
This avoids the crash seen after the output of two errors in #6849 by just replacing any adjusted result type by `Types.t_ERROR` in case of previous errors in the call.