### PR TITLE
ast: Avoid subsequent `Incompatible types when passing argument` error in #6849

### DIFF
--- a/src/dev/flang/ast/AbstractType.java
+++ b/src/dev/flang/ast/AbstractType.java
@@ -579,7 +579,7 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
    *  - no       if not assignable
    *  - dontKnow if contains error
    */
-  YesNo isAssignableFrom(AbstractType actual, Context context, boolean allowBoxing, boolean allowTagging, Set<String> assignableTo)
+  YesNo isAssignableFrom(AbstractType actual, Context context, boolean allowBoxing, boolean allowTagging, Set<AbstractType> assignableTo)
   {
     if (PRECONDITIONS) require
       (this  .isGenericArgument() || this  .feature() != null || Errors.any(),
@@ -587,7 +587,7 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
 
     if (assignableTo != null)
       {
-        assignableTo.add(actual.toString(true));
+        assignableTo.add(actual);
       }
     var target_type = this  .remove_type_parameter_used_for_this_type_in_cotype();
     var actual_type = actual.remove_type_parameter_used_for_this_type_in_cotype();
@@ -769,7 +769,7 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
         if (
           switch (g.kind())
             {
-              case GenericArgument -> 
+              case GenericArgument ->
                                       // NYI: BUG: #5002: check recursive type, e.g.:
                                       // this  = monad monad.A monad.MA
                                       // other = monad option.T (option option.T)

--- a/src/dev/flang/ast/AstErrors.java
+++ b/src/dev/flang/ast/AstErrors.java
@@ -393,15 +393,16 @@ public class AstErrors extends ANY
           }
         else
           {
-            var assignableTo = new TreeSet<String>();
+            var assignableTo = new TreeSet<AbstractType>();
             frmlT.isAssignableFrom(actlT, context, false, true, assignableTo);
             for (var ts : assignableTo)
               {
+                errorOrUndefinedFound |= (ts == Types.t_ERROR);
                 assignableToSB
                   .append(assignableToSB.length() == 0
                           ?    "assignable to       : "
                           : ",\n                      ")
-                  .append(st(ts));
+                  .append(st(ts.toString(true)));
               }
           }
         if (remedy == null && !frmlT.isGenericArgument() && frmlT.asRef(true).isAssignableFromWithoutBoxing(actlT, context).yes())

--- a/tests/typecheck_negative/typecheck_negative.fz.expected_err
+++ b/tests/typecheck_negative/typecheck_negative.fz.expected_err
@@ -103,8 +103,8 @@ To solve this you could:
 assignment to field : 'typecheck_negative.assign.v'
 expected formal type: '((typecheck_negative.assign.this.D i64).E u64).F bool'
 actual type found   : '((typecheck_negative.assign.this.D i32).E u64).F bool'
-assignable to       : '((typecheck_negative.assign.this.D i32).E u64).F bool',
-                      'Any'
+assignable to       : 'Any',
+                      '((typecheck_negative.assign.this.D i32).E u64).F bool'
 for value assigned  : 'u'
 To solve this, you could change the type of the target 'typecheck_negative.assign.v' to '((typecheck_negative.assign.this.D i32).E u64).F bool' or convert the type of the assigned value to '((typecheck_negative.assign.this.D i64).E u64).F bool'.
 
@@ -115,8 +115,8 @@ To solve this, you could change the type of the target 'typecheck_negative.assig
 assignment to field : 'typecheck_negative.assign.w'
 expected formal type: '((typecheck_negative.assign.this.D i32).E bool).F bool'
 actual type found   : '((typecheck_negative.assign.this.D i32).E u64).F bool'
-assignable to       : '((typecheck_negative.assign.this.D i32).E u64).F bool',
-                      'Any'
+assignable to       : 'Any',
+                      '((typecheck_negative.assign.this.D i32).E u64).F bool'
 for value assigned  : 'u'
 To solve this, you could change the type of the target 'typecheck_negative.assign.w' to '((typecheck_negative.assign.this.D i32).E u64).F bool' or convert the type of the assigned value to '((typecheck_negative.assign.this.D i32).E bool).F bool'.
 
@@ -127,8 +127,8 @@ To solve this, you could change the type of the target 'typecheck_negative.assig
 assignment to field : 'typecheck_negative.assign.v'
 expected formal type: '((typecheck_negative.assign.this.D i64).E u64).F bool'
 actual type found   : '((typecheck_negative.assign.this.D i32).E bool).F bool'
-assignable to       : '((typecheck_negative.assign.this.D i32).E bool).F bool',
-                      'Any'
+assignable to       : 'Any',
+                      '((typecheck_negative.assign.this.D i32).E bool).F bool'
 for value assigned  : 'w'
 To solve this, you could change the type of the target 'typecheck_negative.assign.v' to '((typecheck_negative.assign.this.D i32).E bool).F bool' or convert the type of the assigned value to '((typecheck_negative.assign.this.D i64).E u64).F bool'.
 
@@ -139,8 +139,8 @@ To solve this, you could change the type of the target 'typecheck_negative.assig
 assignment to field : 'typecheck_negative.assign.w'
 expected formal type: '((typecheck_negative.assign.this.D i32).E bool).F bool'
 actual type found   : '((typecheck_negative.assign.this.D i64).E u64).F bool'
-assignable to       : '((typecheck_negative.assign.this.D i64).E u64).F bool',
-                      'Any'
+assignable to       : 'Any',
+                      '((typecheck_negative.assign.this.D i64).E u64).F bool'
 for value assigned  : 'v'
 To solve this, you could change the type of the target 'typecheck_negative.assign.w' to '((typecheck_negative.assign.this.D i64).E u64).F bool' or convert the type of the assigned value to '((typecheck_negative.assign.this.D i32).E bool).F bool'.
 
@@ -151,8 +151,8 @@ To solve this, you could change the type of the target 'typecheck_negative.assig
 assignment to field : 'typecheck_negative.assign.x'
 expected formal type: '((typecheck_negative.assign.this.D i32).E u64).F u32'
 actual type found   : '((typecheck_negative.assign.this.D i32).E u64).F bool'
-assignable to       : '((typecheck_negative.assign.this.D i32).E u64).F bool',
-                      'Any'
+assignable to       : 'Any',
+                      '((typecheck_negative.assign.this.D i32).E u64).F bool'
 for value assigned  : 'u'
 To solve this, you could change the type of the target 'typecheck_negative.assign.x' to '((typecheck_negative.assign.this.D i32).E u64).F bool' or convert the type of the assigned value to '((typecheck_negative.assign.this.D i32).E u64).F u32'.
 
@@ -163,8 +163,8 @@ To solve this, you could change the type of the target 'typecheck_negative.assig
 assignment to field : 'typecheck_negative.assign.x'
 expected formal type: '((typecheck_negative.assign.this.D i32).E u64).F u32'
 actual type found   : '((typecheck_negative.assign.this.D i64).E u64).F bool'
-assignable to       : '((typecheck_negative.assign.this.D i64).E u64).F bool',
-                      'Any'
+assignable to       : 'Any',
+                      '((typecheck_negative.assign.this.D i64).E u64).F bool'
 for value assigned  : 'v'
 To solve this, you could change the type of the target 'typecheck_negative.assign.x' to '((typecheck_negative.assign.this.D i64).E u64).F bool' or convert the type of the assigned value to '((typecheck_negative.assign.this.D i32).E u64).F u32'.
 
@@ -175,8 +175,8 @@ To solve this, you could change the type of the target 'typecheck_negative.assig
 assignment to field : 'typecheck_negative.assign.x'
 expected formal type: '((typecheck_negative.assign.this.D i32).E u64).F u32'
 actual type found   : '((typecheck_negative.assign.this.D i32).E bool).F bool'
-assignable to       : '((typecheck_negative.assign.this.D i32).E bool).F bool',
-                      'Any'
+assignable to       : 'Any',
+                      '((typecheck_negative.assign.this.D i32).E bool).F bool'
 for value assigned  : 'w'
 To solve this, you could change the type of the target 'typecheck_negative.assign.x' to '((typecheck_negative.assign.this.D i32).E bool).F bool' or convert the type of the assigned value to '((typecheck_negative.assign.this.D i32).E u64).F u32'.
 


### PR DESCRIPTION
Suppress this error in case of previous errors and any any types in the `assignableTo` set is the error type.
