### PR TITLE
parser: allow defining extension features on `universe`

### DIFF
--- a/src/dev/flang/fe/SourceModule.java
+++ b/src/dev/flang/fe/SourceModule.java
@@ -674,7 +674,7 @@ part of the (((inner features))) declarations of the corresponding
         }
         @Override public Feature   action(Feature   f, AbstractFeature outer)
         {
-          f._declaredInScope = !_scope.isEmpty() ? outer : null;
+          f._declaredInScope = (!_scope.isEmpty() || f.isExtensionFeature()) ? outer : null;
           findDeclarations(f, outer);
           return f;
         }

--- a/src/dev/flang/fe/SourceModule.java
+++ b/src/dev/flang/fe/SourceModule.java
@@ -550,11 +550,13 @@ part of the (((inner features))) declarations of the corresponding
           {
             AstErrors.typeFeaturesMustOnlyBeDeclaredInFeaturesThatDefineType(inner);
           }
-        var o =
-          n != FuzionConstants.TYPE_NAME ? lookupType(inner.pos(), outer, n, at == 0,
+        var o = n.equals(FuzionConstants.UNIVERSE_NAME)
+            ? _universe
+            : n != FuzionConstants.TYPE_NAME
+            ? lookupType(inner.pos(), outer, n, at == 0,
                                                       false /* ignore ambiguous */,
                                                       false /* ignore not found */)._feature
-                                        : _res.cotype(outer);
+            : _res.cotype(outer);
         if (at < q.size()-2)
           {
             setOuterAndAddInnerForQualifiedRec(inner, at+1, o);
@@ -672,7 +674,7 @@ part of the (((inner features))) declarations of the corresponding
         }
         @Override public Feature   action(Feature   f, AbstractFeature outer)
         {
-          f._declaredInScope = (!_scope.isEmpty() || f.isExtensionFeature()) ? outer : null;
+          f._declaredInScope = !_scope.isEmpty() ? outer : null;
           findDeclarations(f, outer);
           return f;
         }

--- a/src/dev/flang/parser/Parser.java
+++ b/src/dev/flang/parser/Parser.java
@@ -344,7 +344,7 @@ field       : returnType
     return
       isNonEmptyVisibilityPrefix() ||
       isModifiersPrefix() ||
-      (isNamePrefix() && !isAnonymousPrefix() || current() == Token.t_type) && fork().skipFeaturePrefix();
+      (isNamePrefix(false, true) && !isAnonymousPrefix() || current() == Token.t_type) && fork().skipFeaturePrefix();
   }
 
 
@@ -469,11 +469,12 @@ visiFlag    : "private" colon "module"
   /**
    * Parse qualified name
    *
-qual        : namequal
-            | "type" dot namequal
+qual        : "type" dot namequal
+            | "universe" dot namequal
+            | namequal
             ;
-namequal    : name
-            | name dot qual
+namequal    : name dot qual
+            | name
             ;
    */
   List<ParsedName> qual(boolean mayBeAtMinIndent)
@@ -483,7 +484,12 @@ namequal    : name
       {
         if (skip(mayBeAtMinIndent, Token.t_type))
           {
-            result.add(new ParsedName(SourcePosition.builtIn, FuzionConstants.TYPE_NAME));
+            result.add(new ParsedName(tokenSourcePos(), FuzionConstants.TYPE_NAME));
+            dot();
+          }
+        else if (skip(mayBeAtMinIndent, Token.t_universe))
+          {
+            result.add(new ParsedName(tokenSourcePos(), FuzionConstants.UNIVERSE_NAME));
             dot();
           }
         result.add(name(mayBeAtMinIndent, false));
@@ -503,6 +509,10 @@ namequal    : name
   boolean skipQual()
   {
     if (skip(Token.t_type))
+      {
+        return skipDot() && skipQual();
+      }
+    else if (skip(Token.t_universe))
       {
         return skipDot() && skipQual();
       }
@@ -536,7 +546,7 @@ name        : IDENT                            // all parts of name must be in s
   {
     var result = ParsedName.ERROR_NAME;
     int pos = tokenPos();
-    if (isNamePrefix(mayBeAtMinIndent))
+    if (isNamePrefix(mayBeAtMinIndent, false))
       {
         var oldLine = sameLine(line());
         switch (current(mayBeAtMinIndent))
@@ -641,9 +651,9 @@ name        : IDENT                            // all parts of name must be in s
    */
   boolean isNamePrefix()
   {
-    return isNamePrefix(false);
+    return isNamePrefix(false, false);
   }
-  boolean isNamePrefix(boolean mayBeAtMinIndent)
+  boolean isNamePrefix(boolean mayBeAtMinIndent, boolean allowUniverseQualifier)
   {
     switch (current(mayBeAtMinIndent))
       {
@@ -655,6 +665,7 @@ name        : IDENT                            // all parts of name must be in s
       case t_ternary    :
       case t_index      :
       case t_set        : return true;
+      case t_universe   : return allowUniverseQualifier;
       default           : return false;
       }
   }

--- a/tests/reg_issue4836/Makefile
+++ b/tests/reg_issue4836/Makefile
@@ -1,0 +1,25 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test Makefile
+#
+# -----------------------------------------------------------------------
+
+override NAME = reg_issue4836
+include ../simple.mk

--- a/tests/reg_issue4836/reg_issue4836.fz
+++ b/tests/reg_issue4836/reg_issue4836.fz
@@ -1,0 +1,31 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test reg_issue4836
+#
+# -----------------------------------------------------------------------
+
+reg_issue4836 is
+  universe.some_feature =>
+    say "hello"
+  universe.reg_issue4836.some_other_feature =>
+      say "world"
+
+some_feature
+reg_issue4836.some_other_feature

--- a/tests/reg_issue4836/reg_issue4836.fz
+++ b/tests/reg_issue4836/reg_issue4836.fz
@@ -27,5 +27,5 @@ reg_issue4836 is
   universe.reg_issue4836.some_other_feature =>
       say "world"
 
-some_feature
-reg_issue4836.some_other_feature
+  some_feature
+  some_other_feature

--- a/tests/reg_issue4836/reg_issue4836.fz.expected_out
+++ b/tests/reg_issue4836/reg_issue4836.fz.expected_out
@@ -1,0 +1,2 @@
+hello
+world


### PR DESCRIPTION
fixes #4836
