### PR TITLE
fe: improve error message when `from_u32` for numliteral is not found in target

### DIFF
--- a/src/dev/flang/ast/AstErrors.java
+++ b/src/dev/flang/ast/AstErrors.java
@@ -1400,7 +1400,9 @@ public class AstErrors extends ANY
         var solution5 = solutionLambda(call);
         error(call.pos(), msg,
               "Feature not found: " + sbnf(calledName) + "\n" +
-              (targetFeature != null ? "Target feature: " + s(targetFeature) + "\n" : "") +
+              (targetFeature != null
+                ? (targetFeature.isCotype() ? "Target expression: " + expr(target.toString()) + "\n" : "Target feature: " + s(targetFeature) + "\n")
+                : "") +
               "In call: " + s(call) + "\n" +
               (solution0 != "" ? solution0 :
                solution1 != "" ? solution1 :

--- a/src/dev/flang/ast/AstErrors.java
+++ b/src/dev/flang/ast/AstErrors.java
@@ -2621,6 +2621,14 @@ public class AstErrors extends ANY
       "The feature that "+ s(c) + " inherits that has a contract:\n" + s_feat_with_pos(f));
   }
 
+  public static void illegalNumLiteral(ParsedCall c)
+  {
+    error(c.pos(),
+      "Illegal use of numeric literal.",
+      s(((Call)c.target()).calledFeature()) + " or its constraint does not implement " + sbn("from_u32") + "."
+    );
+  }
+
 }
 
 /* end of file */

--- a/src/dev/flang/ast/NumLiteral.java
+++ b/src/dev/flang/ast/NumLiteral.java
@@ -936,6 +936,21 @@ public class NumLiteral extends Constant
                       new ParsedCall(new ParsedName(pos(), _propagatedType.genericArgument().featureName().baseName())),
                       new ParsedName(pos(), "from_u32"),
                       new List<>(this))
+              {
+                @Override
+                Call resolveTypes(Resolution res, Context context)
+                {
+                  var result = super.resolveTypes(res, context);
+                  if (_calledFeature == null)
+                    {
+                      _pendingError = ()->
+                        {
+                          AstErrors.illegalNumLiteral(this);
+                        };
+                    }
+                  return result;
+                }
+              }
                   .resolveTypes(res, _context);
           }
 

--- a/tests/reg_issue5609/Makefile
+++ b/tests/reg_issue5609/Makefile
@@ -1,0 +1,25 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test Makefile
+#
+# -----------------------------------------------------------------------
+
+override NAME = reg_issue5609
+include ../simple.mk

--- a/tests/reg_issue5609/reg_issue5609.fz
+++ b/tests/reg_issue5609/reg_issue5609.fz
@@ -1,0 +1,36 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test reg_issue5609
+#
+# -----------------------------------------------------------------------
+
+reg_issue5609 =>
+
+  a(T type, x T) is
+    c T
+    =>
+      x
+
+  b(X type) : a X 4 is
+    redef c X
+      pre else X : i32
+    => x
+
+  say (b i32).c

--- a/tests/reg_issue5609/reg_issue5609.fz.expected_err
+++ b/tests/reg_issue5609/reg_issue5609.fz.expected_err
@@ -1,0 +1,9 @@
+
+--CURDIR--/reg_issue5609.fz:31:19: error 1: Could not find called feature
+  b(X type) : a X 4 is
+------------------^
+Feature not found: 'from_u32' (one argument)
+Target expression: 'b.this.X'
+In call: '4'
+
+one error.

--- a/tests/reg_issue5609/reg_issue5609.fz.expected_err
+++ b/tests/reg_issue5609/reg_issue5609.fz.expected_err
@@ -1,9 +1,7 @@
 
---CURDIR--/reg_issue5609.fz:31:19: error 1: Could not find called feature
+--CURDIR--/reg_issue5609.fz:31:19: error 1: Illegal use of numeric literal.
   b(X type) : a X 4 is
 ------------------^
-Feature not found: 'from_u32' (one argument)
-Target expression: 'b.this.X'
-In call: '4'
+'reg_issue5609.b.X' or its constraint does not implement 'from_u32'.
 
 one error.


### PR DESCRIPTION
fixes #5609
