### PR TITLE
ast: remove wrong check condition

### DIFF
--- a/src/dev/flang/ast/FeatureAndOuter.java
+++ b/src/dev/flang/ast/FeatureAndOuter.java
@@ -182,12 +182,6 @@ public class FeatureAndOuter extends ANY
         var fn = f.featureName();
         if (isExact.test(fn))  /* an exact match, so use it: */
           {
-            if (CHECKS) check
-              (Errors.any() ||
-               !match ||
-               fn.argCount() == 0 /* we might have several exact matches for fields */ ||
-               found.get(0)._outer != fo._outer /* we might have several exact matches at different outer levels */
-               );
             if (!match)
               {
                 found = new List<>();

--- a/tests/reg_issue4912/Makefile
+++ b/tests/reg_issue4912/Makefile
@@ -1,0 +1,25 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test Makefile
+#
+# -----------------------------------------------------------------------
+
+override NAME = reg_issue4912
+include ../simple.mk

--- a/tests/reg_issue4912/reg_issue4912.fz
+++ b/tests/reg_issue4912/reg_issue4912.fz
@@ -1,0 +1,35 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test reg_issue4912
+#
+# -----------------------------------------------------------------------
+
+reg_issue4912 =>
+
+  a := "a"
+  b := "b"
+
+  Any.f      => "({Any.this}.f)"
+  Any.f(a)   => "({Any.this}.f $a)"
+  f(x)       => "(f $x)"
+
+  String.prefix ^ => "(^{String.this})"
+
+  say "10. f a^b   : {f a^b}"

--- a/tests/reg_issue4912/reg_issue4912.fz.expected_err
+++ b/tests/reg_issue4912/reg_issue4912.fz.expected_err
@@ -1,0 +1,35 @@
+
+--CURDIR--/reg_issue4912.fz:35:23: error 1: Ambiguous targets found for call to 'f'
+  say "10. f a^b   : {f a^b}"
+----------------------^
+Found several possible call targets within the current feature at the same outer level in 'reg_issue4912' found 'reg_issue4912.f' defined at --CURDIR--/reg_issue4912.fz:31:3:
+  f(x)       => "(f $x)"
+--^
+and in 'reg_issue4912' found 'Any.f' defined at --CURDIR--/reg_issue4912.fz:30:7:
+  Any.f(a)   => "({Any.this}.f $a)"
+------^
+To solve this, you may rename one of these features.
+
+
+--CURDIR--/reg_issue4912.fz:31:5: error 2: Type inference from actual arguments failed since no actual call was found
+  f(x)       => "(f $x)"
+----^
+For the formal argument 'reg_issue4912.f.x' the type can only be derived if there is a call to 'reg_issue4912.f'.
+
+
+--CURDIR--/reg_issue4912.fz:30:9: error 3: Type inference from actual arguments failed since no actual call was found
+  Any.f(a)   => "({Any.this}.f $a)"
+--------^
+For the formal argument 'Any.f.a' the type can only be derived if there is a call to 'Any.f'.
+
+
+--CURDIR--/reg_issue4912.fz:31:3: error 4: Duplicate feature declaration
+  f(x)       => "(f $x)"
+--^
+Feature that was declared repeatedly: 'Any.f'
+originally declared at --CURDIR--/reg_issue4912.fz:30:7:
+  Any.f(a)   => "({Any.this}.f $a)"
+------^
+To solve this, consider renaming one of these two features, e.g., as 'fʼ' (using a unicode modifier letter apostrophe 'ʼ' U+02BC) or adding an additional argument (e.g. '_ unit' for an ignored unit argument used only to disambiguate these two).
+
+4 errors.


### PR DESCRIPTION
we may have a duplicate feature via extension features that only later causes an error. So the assumption in the check is wrong.

fixes #4912