### PR TITLE
ast: Fix error message in case a lambda is used with wrong number of arguments

### DIFF
--- a/src/dev/flang/ast/AstErrors.java
+++ b/src/dev/flang/ast/AstErrors.java
@@ -1632,16 +1632,20 @@ public class AstErrors extends ANY
           "Min representable value > 0: " + ss(min) + " or " + ss(minH));
   }
 
-  static void wrongNumberOfArgumentsInLambda(SourcePosition pos, List<ParsedName> names, AbstractType funType)
+  static void wrongNumberOfArgumentsInLambda(SourcePosition pos, List<ParsedName> names, AbstractType funType, int ntypes, int nvalues)
   {
-    int req = funType.generics().size() - 1;
+    int req = ntypes + nvalues;
     int delta = names.size() - req;
-    var ns = spn(names);
+    var ns = ss(names.toString("", ",", ""));
+    var expected_args =
+      ntypes  == 0 ? StringHelpers.singularOrPlural(nvalues, "argument"     )
+                   : StringHelpers.singularOrPlural(ntypes , "type argument") + " and " +
+                     StringHelpers.singularOrPlural(nvalues, "value argument");
     error(pos,
           "Wrong number of arguments in lambda expression",
           "Lambda expression has " + StringHelpers.singularOrPlural(names.size(), "argument") + " while the target type expects " +
-          StringHelpers.singularOrPlural(funType.generics().size()-1, "argument") + ".\n" +
-          "Arguments of lambda expression: " + ns + "\n" +
+          expected_args + ".\n" +
+          "Arguments of lambda expression: " + spn(names) + "\n" +
           "Expected function type: " + funType + "\n" +
           "To solve this, " +
           (req == 0 ? "replace the list " + ns + " by " + ss("()") + "."

--- a/src/dev/flang/ast/Function.java
+++ b/src/dev/flang/ast/Function.java
@@ -299,7 +299,7 @@ public class Function extends AbstractLambda
         var argTypes = t.lambdaTargetArgumentTypes(res);
         if (_names.size() != cl.typeArguments().size() + argTypes.size())
           {
-            AstErrors.wrongNumberOfArgumentsInLambda(pos(), _names, t);
+            AstErrors.wrongNumberOfArgumentsInLambda(pos(), _names, t, cl.typeArguments().size(), argTypes.size());
             t = Types.t_ERROR;
             _type = t;
           }

--- a/tests/reg_issue4694/reg_issue4694.fz.expected_err
+++ b/tests/reg_issue4694/reg_issue4694.fz.expected_err
@@ -5,6 +5,6 @@
 Lambda expression has 2 arguments while the target type expects one argument.
 Arguments of lambda expression: 'x', 'y'
 Expected function type: Unary --UNDEFINED-- i32
-To solve this, remove one argument from the list 'x', 'y' before the '->' of the lambda expression.
+To solve this, remove one argument from the list 'x,y' before the '->' of the lambda expression.
 
 one error.


### PR DESCRIPTION
The error was wrong in case the function type was a type that did not use type parameters for the argument count like `Function` does.  In particular, it was wrong for `container.typed_applicator` and similarn functions.

Fixes #6899.

Not adding a regression test since this is just a minor error message change. 

Errors for wrong number of arguments in a lambda now look like this: 
```
 > ./build/bin/fz -e 'f i32 String; f(A type ...) => A.type_foldf unit x,y,z->'

command line:1:50: error 1: Wrong number of arguments in lambda expression
f i32 String; f(A type ...) => A.type_foldf unit x,y,z->

Lambda expression has 3 arguments while the target type expects one type argument and one value argument.
Arguments of lambda expression: 'x', 'y', 'z'
Expected function type: container.type_applicator unit
To solve this, remove one argument from the list 'x,y,z' before the '->' of the lambda expression.

one error.
```
