### PR TITLE
base: use qualifier `debug 10`  instead of `pedantic`

### DIFF
--- a/modules/base/src/String.fz
+++ b/modules/base/src/String.fz
@@ -387,7 +387,7 @@ public String ref : property.equatable, property.hashable, property.orderable is
       debug: from=to || String.is_valid_utf8_first_byte utf8[from]
       debug: from=to || !String.is_multi_byte_start_byte utf8[to-1]
     post
-      pedantic: result.codepoints_and_errors ∀ x->x.ok
+      debug 10 : result.codepoints_and_errors ∀ x->x.ok
   =>
     String.from_bytes (String.this.utf8.slice from to)
 

--- a/modules/base/src/io/Read_Handler.fz
+++ b/modules/base/src/io/Read_Handler.fz
@@ -33,7 +33,7 @@ public Read_Handler ref is
   #
   public read(max_count i32) choice (Sequence u8) io.end_of_file error
     post debug: (result ? s Sequence => !s.is_empty && s.count<=max_count | * => true)
-         pedantic: (result ? s Sequence => s.is_array_backed | * => true)
+         debug 10 : (result ? s Sequence => s.is_array_backed | * => true)
   => abstract
 
 


### PR DESCRIPTION
Our fzweb benchmarks showed a drop in performance. This change should fix this.
(pedantic is currently always true, while debug is off for the fzweb benchmarks)
