### PR TITLE
fe: fix bug in type inference for array elements

### DIFF
--- a/modules/lock_free/src/lock_free/Map.fz
+++ b/modules/lock_free/src/lock_free/Map.fz
@@ -514,15 +514,12 @@ is
         if xidx = yidx
           # NYI: BUG: type inference
           sub_node := indirection_node CTK CTV (dual x y (lev + width) gen) gen
-          # NYI: BUG: type inference
-          container_node CTK CTV bmp [sub_node] gen
+          container_node bmp [sub_node] gen
         else
           if (xidx < yidx)
-            # NYI: BUG: type inference
-            container_node CTK CTV bmp [x, y] gen
+            container_node bmp [x, y] gen
           else
-            # NYI: BUG: type inference
-            container_node CTK CTV bmp [y, x] gen
+            container_node bmp [y, x] gen
       else
         list_node [(singleton_node x.k x.v), (singleton_node y.k y.v)]
 

--- a/src/dev/flang/ast/InlineArray.java
+++ b/src/dev/flang/ast/InlineArray.java
@@ -200,24 +200,23 @@ public class InlineArray extends ExprWithPos
   @Override
   Expr propagateExpectedType(Resolution res, Context context, AbstractType t, Supplier<String> from)
   {
-    if (_type == null)
-      {
-        // if expected type is choice, examine if there is exactly one
-        // array in choice generics, if so use this for further type propagation.
-        t = t.findInChoice(cg -> !cg.isGenericArgument() && cg.feature() == Types.resolved.f_array, context);
+    // if expected type is choice, examine if there is exactly one
+    // array in choice generics, if so use this for further type propagation.
+    t = t.findInChoice(cg -> !cg.isGenericArgument() && cg.feature() == Types.resolved.f_array, context);
 
-        var elementType = elementType(t);
-        if (elementType != Types.t_ERROR)
+    var elementType = elementType(t);
+    if (elementType != Types.t_ERROR
+      // keep the most general element type
+      && (_type == null || elementType.isAssignableFrom(elementType(_type)).yes()))
+      {
+        var li = _elements.listIterator();
+        while (li.hasNext())
           {
-            var li = _elements.listIterator();
-            while (li.hasNext())
-              {
-                li.set(li.next().propagateExpectedType(res, context, elementType, null));
-              }
-            var arr = Types.resolved.f_array;
-            _type = arr.resultType()
-                       .applyTypePars(arr, new List<>(elementType));
+            li.set(li.next().propagateExpectedType(res, context, elementType, null));
           }
+        var arr = Types.resolved.f_array;
+        _type = arr.resultType()
+                    .applyTypePars(arr, new List<>(elementType));
       }
     return this;
   }


### PR DESCRIPTION
we get propagated a type multiple times in InlineArray. The idea is to keep the one that denotes the most general element type. So if we get `i32` and `choice i32 i64` we assume `choice i32 i64` for the elements type.