### PR TITLE
allow specifying scheduling policy and priority of a thread

### DIFF
--- a/include/fz.h
+++ b/include/fz.h
@@ -423,6 +423,11 @@ void * fzE_thread_create(void *(*code)(void *),
 // NYI: UNDER DEVELOPMENT:  add return value
 void fzE_thread_join(void * thrd);
 
+/*
+ * Set the scheduling policy and priority of a running thread.
+ */
+int fzE_thread_setschedparam(void * thrd, int policy, int priority);
+
 /**
  * Global lock
  *

--- a/include/posix.c
+++ b/include/posix.c
@@ -74,6 +74,11 @@ static_assert(SIGPIPE == 13, "signal definition different than expected");
 static_assert(SIGALRM == 14, "signal definition different than expected");
 static_assert(SIGTERM == 15, "signal definition different than expected");
 
+static_assert(SCHED_OTHER == 0, "magic number different than expected");
+static_assert(SCHED_FIFO == 1, "magic number different than expected");
+static_assert(SCHED_RR == 2, "magic number different than expected");
+static_assert(ENOSYS == 38, "error number different than expected");
+
 
 // thread local to hold the last
 // error that occurred in fuzion runtime.

--- a/include/posix.c
+++ b/include/posix.c
@@ -552,6 +552,18 @@ void fzE_thread_join(void * thrd)
 }
 
 
+/*
+ * Set the scheduling policy and priority of a running thread.
+ */
+int fzE_thread_setschedparam(void * thrd, int policy, int priority)
+{
+  struct sched_param param;
+  param.sched_priority = priority;
+  int ret = pthread_setschedparam(*(pthread_t *)thrd, policy, &param);
+  return ret;
+}
+
+
 /**
  * Global lock
  */

--- a/include/win.c
+++ b/include/win.c
@@ -659,6 +659,15 @@ void fzE_thread_join(void * thrd) {
 }
 
 
+/*
+ * Set the scheduling policy and priority of a running thread.
+ */
+int fzE_thread_setschedparam(void * thrd, int policy, int priority)
+{
+  return 38; // ENOSYS - Function not implemented
+}
+
+
 /**
  * Global lock
  */

--- a/modules/base/src/concur/scheduling_policy.fz
+++ b/modules/base/src/concur/scheduling_policy.fz
@@ -17,35 +17,14 @@
 #
 #  Tokiwa Software GmbH, Germany
 #
-#  Source code of Fuzion standard library feature fuzion.sys.thread
-#
-#  Author: Fridtjof Siebert (siebert@tokiwa.software)
+#  Source code of Fuzion standard library feature concur.scheduling_policy
 #
 # -----------------------------------------------------------------------
 
-# fuzion.sys.thread -- low-level feature to manage threads
-#
-module thread is
+public scheduling_policy is
 
+  public sched_other is
 
-  # intrinsic to spawn a new thread
-  #
-  module spawn(code ()->unit) =>
-    Do_Call ref : Function unit is
-      public redef call unit =>
-        code()
+  public sched_fifo is
 
-    spawn0 Do_Call
-
-  spawn0(T type : ()->unit, code T) Thread => intrinsic
-
-  # intrinsic to join with a terminated thread
-  #
-  # NOTE: this must only be called once!
-  #
-  module join0(thread_id Thread) unit => intrinsic
-
-
-  # intrinsic to set the scheduling policy and priority
-  #
-  module set_policy(thread_id Thread, policy, priority i32) i32 => intrinsic
+  public sched_rr is

--- a/modules/base/src/concur/thread.fz
+++ b/modules/base/src/concur/thread.fz
@@ -48,6 +48,32 @@ module:public thread(thrd Thread) : property.equatable is
     # thread that it can remove its list of running threads?
 
 
+  public set_policy(policy choice
+                            concur.scheduling_policy.sched_other
+                            concur.scheduling_policy.sched_fifo
+                            concur.scheduling_policy.sched_rr,
+                    reset_on_fork bool,
+                    priority i32) outcome unit
+    pre
+      safety: 0 ≤ priority ≤ 99
+  =>
+    p :=
+      match policy
+        concur.scheduling_policy.sched_other => 0
+        concur.scheduling_policy.sched_fifo => 1
+        concur.scheduling_policy.sched_rr => 2
+    p2 :=
+      if reset_on_fork
+        p | 0x40000000
+      else
+        p
+    e := fuzion.sys.thread.set_policy thrd p2 priority
+    if e = 0
+      unit
+    else
+      error "fzE_thread_setschedparam error {e}"
+
+
   # equality
   #
   public fixed redef type.equality(a, b thread.this) bool

--- a/src/dev/flang/be/c/Intrinsics.java
+++ b/src/dev/flang/be/c/Intrinsics.java
@@ -518,6 +518,11 @@ public class Intrinsics extends ANY
         {
           return CExpr.call("fzE_thread_join", new List<>(A0));
         });
+    put("fuzion.sys.thread.set_policy", (c,cl,outer,in) ->
+        {
+          return CExpr.call("fzE_thread_setschedparam", new List<>(A0, A1, A2))
+                      .ret();
+        });
 
     put("effect.type.abort0"     ,
         "effect.type.default0"   ,

--- a/src/dev/flang/be/c/Intrinsics.java
+++ b/src/dev/flang/be/c/Intrinsics.java
@@ -515,9 +515,9 @@ public class Intrinsics extends ANY
             }
         });
     put("fuzion.sys.thread.join0", (c,cl,outer,in) ->
-    {
-      return CExpr.call("fzE_thread_join", new List<>(A0));
-    });
+        {
+          return CExpr.call("fzE_thread_join", new List<>(A0));
+        });
 
     put("effect.type.abort0"     ,
         "effect.type.default0"   ,

--- a/src/dev/flang/be/interpreter/Intrinsics.java
+++ b/src/dev/flang/be/interpreter/Intrinsics.java
@@ -471,6 +471,10 @@ public class Intrinsics extends ANY
           while (!result);
           return Value.UNIT;
         });
+    put("fuzion.sys.thread.set_policy", (executor, innerClazz) -> args ->
+        {
+          return new i32Value(38 /* ENOSYS - Function not implemented */);
+        });
 
     put("safety"                , (executor, innerClazz) -> args -> new boolValue(executor.options().fuzionSafety()));
     put("debug"                 , (executor, innerClazz) -> args -> new boolValue(executor.options().fuzionDebug()));

--- a/src/dev/flang/be/jvm/runtime/Intrinsics.java
+++ b/src/dev/flang/be/jvm/runtime/Intrinsics.java
@@ -229,6 +229,11 @@ public class Intrinsics extends ANY
     while (!result);
   }
 
+  public static int fuzion_sys_thread_set_policy(Object thread, int policy, int priority)
+  {
+    return 38 /* ENOSYS - Function not implemented */;
+  }
+
 }
 
 /* end of file */

--- a/src/dev/flang/fuir/analysis/dfa/DFA.java
+++ b/src/dev/flang/fuir/analysis/dfa/DFA.java
@@ -2160,6 +2160,7 @@ public class DFA extends ANY
           return genericResult(cl);
         });
     put("fuzion.sys.thread.join0"        , cl -> Value.UNIT);
+    put("fuzion.sys.thread.set_policy"   , cl -> genericNumResult(cl));
 
     put("effect.type.replace0"              , cl ->
         {

--- a/src/dev/flang/fuir/cfg/CFG.java
+++ b/src/dev/flang/fuir/cfg/CFG.java
@@ -390,6 +390,7 @@ public class CFG extends ANY
     put("fuzion.sys.env_vars.get0"       , (cfg, cl) -> { } );
     put("fuzion.sys.thread.spawn0"       , (cfg, cl) -> { } );
     put("fuzion.sys.thread.join0"        , (cfg, cl) -> { } );
+    put("fuzion.sys.thread.set_policy"   , (cfg, cl) -> { } );
 
     put("effect.type.default0"           , (cfg, cl) -> { } );
     put(FuzionConstants.EFFECT_INSTATE_NAME , (cfg, cl) ->


### PR DESCRIPTION
This is limited to the C backend due to the JVM not exposing any
interface for doing so. Likewise, no implementation for Windows is
provided yet.