### PR TITLE
fe: do not try to infer type args that were given by user

### DIFF
--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -112,6 +112,12 @@ public class Call extends AbstractCall
 
 
   /**
+   * the generics that were determined by splitOffTypeArgs
+   * We must not change those as those were given by user
+   */
+  List<AbstractType> _splitOffGenerics;
+
+  /**
    * actual generic arguments, set by parser
    */
   /*final*/ List<AbstractType> _generics; // NYI: Make this final again when resolveTypes can replace a call
@@ -2238,7 +2244,7 @@ public class Call extends AbstractCall
           { // we found a use of a generic type, so record it:
             var i = g.typeParameterIndex();
             var gt = _generics.get(i);
-            if (!conflict[i] && gt != Types.t_ERROR)
+            if (!conflict[i] && gt != Types.t_ERROR && changingGenericAllowed(i))
               {
                 var nt = actualType.containsUndefined() ? gt :
                          gt == Types.t_UNDEFINED        ? actualType
@@ -2349,6 +2355,19 @@ public class Call extends AbstractCall
               }
           }
       }
+  }
+
+
+  /**
+   * Is it allowed to change/infer actual type argument with index i?
+   *
+   * @param i the index of the actual type argument
+   *
+   * @return
+   */
+  private boolean changingGenericAllowed(int i)
+  {
+    return _splitOffGenerics == null || i >= _splitOffGenerics.size() || _splitOffGenerics.get(i) == Types.t_UNDEFINED;
   }
 
 

--- a/src/dev/flang/ast/ParsedCall.java
+++ b/src/dev/flang/ast/ParsedCall.java
@@ -739,6 +739,7 @@ A `_` may be used as placeholder for a xref:fuzion_actual_typeparameter[actual t
             i++;
           }
         _generics = g;
+        _splitOffGenerics = g.freeze();
         _actuals = a;
       }
   }

--- a/tests/reg_issue6026/Makefile
+++ b/tests/reg_issue6026/Makefile
@@ -1,0 +1,25 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test Makefile
+#
+# -----------------------------------------------------------------------
+
+override NAME = reg_issue6026
+include ../simple.mk

--- a/tests/reg_issue6026/reg_issue6026.fz
+++ b/tests/reg_issue6026/reg_issue6026.fz
@@ -1,0 +1,29 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test reg_issue6026
+#
+# -----------------------------------------------------------------------
+
+reg_issue6026 =>
+
+  a(X,Y type, x X, y Y) is
+    say "$X $Y"
+
+  a i32 _ (option 42) (option -12) |> type_of |> say

--- a/tests/reg_issue6026/reg_issue6026.fz.expected_err
+++ b/tests/reg_issue6026/reg_issue6026.fz.expected_err
@@ -1,0 +1,13 @@
+
+--CURDIR--/reg_issue6026.fz:29:12: error 1: Incompatible types when passing argument in a call
+  a i32 _ (option 42) (option -12) |> type_of |> say
+-----------^^^^^^
+Actual type for argument #1 'x' does not match expected type.
+In call to          : 'reg_issue6026.a'
+expected formal type: 'i32'
+actual type found   : 'option i32'
+assignable to       : 'option i32'
+for value assigned  : '(option 42)'
+To solve this, you could change the type of the target 'x' to 'option i32' or convert the type of the assigned value to 'i32'.
+
+one error.


### PR DESCRIPTION
fixes #6026
