### PR TITLE
fe: add reg test #5998

### DIFF
--- a/tests/reg_issue5998/Makefile
+++ b/tests/reg_issue5998/Makefile
@@ -1,0 +1,25 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test Makefile
+#
+# -----------------------------------------------------------------------
+
+override NAME = reg_issue5998
+include ../simple.mk

--- a/tests/reg_issue5998/reg_issue5998.fz
+++ b/tests/reg_issue5998/reg_issue5998.fz
@@ -1,0 +1,39 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test reg_issue5998
+#
+# -----------------------------------------------------------------------
+
+# Original error message was bad:
+#
+# myfun.fz:4:3: error 1: Wrong number of arguments in lambda expression
+# q a->a>0
+#
+# Lambda expression has one argument while the target type expects -1 arguments.
+# Arguments of lambda expression: 'a'
+# Expected function type: myf
+# To solve this, remove 2 arguments from the list 'a' before the '->' of the lambda expression.
+#
+# one error.
+
+myf : Function bool i32 is
+q(f myf) => f.call 1 |> say
+
+q a->a>0

--- a/tests/reg_issue5998/reg_issue5998.fz.expected_err
+++ b/tests/reg_issue5998/reg_issue5998.fz.expected_err
@@ -1,0 +1,13 @@
+
+--CURDIR--/reg_issue5998.fz:39:3: error 1: Incompatible types when passing argument in a call
+q a->a>0
+--^^^^^^
+Actual type for argument #1 'f' does not match expected type.
+In call to          : 'q'
+expected formal type: 'myf'
+actual type found   : '(λa->a>0)'
+assignable to       : '(λa->a>0)'
+for value assigned  : 'a->a>0'
+To solve this, you could change the type of 'f' to a 'ref' type like 'ref myf'.
+
+one error.


### PR DESCRIPTION
fixes #5998

This just works:
```
myf : Function bool i32 is
q(MYF type: myf, f MYF) => f.call 1 |> say

q a->a>0
```

The error message is now much better. So I just had to add the reg test.
