### PR TITLE
fe: mark lambda wrapper `ValueType` instead of `RefType`

### DIFF
--- a/src/dev/flang/ast/Function.java
+++ b/src/dev/flang/ast/Function.java
@@ -388,7 +388,7 @@ public class Function extends AbstractLambda
             _wrapper = new Feature(pos(),
                                    Visi.PRIV,
                                    0,
-                                   RefType.INSTANCE,
+                                   ValueType.INSTANCE,
                                    new List<String>(wrapperName),
                                    AbstractFeature._NO_FEATURES_,
                                    new List<>(_inheritsCall),


### PR DESCRIPTION
boxing can happen later