### PR TITLE
include/posix: remove static assert for ENOSYS

### DIFF
--- a/include/posix.c
+++ b/include/posix.c
@@ -77,7 +77,6 @@ static_assert(SIGTERM == 15, "signal definition different than expected");
 static_assert(SCHED_OTHER == 0, "magic number different than expected");
 static_assert(SCHED_FIFO == 1, "magic number different than expected");
 static_assert(SCHED_RR == 2, "magic number different than expected");
-static_assert(ENOSYS == 38, "error number different than expected");
 
 
 // thread local to hold the last


### PR DESCRIPTION
There's nothing we can really do about different operating systems using different values for this. Also, we never return ENOSYS in include/posix.c itself, only on Windows and in the other backends.

Partly addresses #6914.