### PR TITLE
fuir: improve error message, "Call has an ambiguous result type..."

### DIFF
--- a/src/dev/flang/fuir/Clazz.java
+++ b/src/dev/flang/fuir/Clazz.java
@@ -1857,7 +1857,7 @@ class Clazz extends ANY implements Comparable<Clazz>
     var err = new List<Consumer<AbstractCall>>();
     var ft = t; // final variant of t to be used in lambda
     BiConsumer<AbstractType, AbstractType> foundRef = (from,to) ->
-      { err.add((c)->AstErrors.illegalOuterRefTypeInCall(c, false, feature(), ft, from, to)); };
+      { err.add((c)->AstErrors.illegalOuterRefTypeInCall(c, false, feature(), ft, from, _type)); };
 
     t = handDown(t, select, foundRef, inh);
 

--- a/tests/reg_issue4248/reg_issue4248.fz.expected_err
+++ b/tests/reg_issue4248/reg_issue4248.fz.expected_err
@@ -6,7 +6,7 @@ The result type of this call depends on the target type.  Since the target type 
 Called feature: 'e.me'
 Original result type: 'e.this'
 Type depending on target: 'e.this'
-Target type: 'p.this'
+Target type: 'p.me'
 To solve this, you could try to use a value type as the target type of the call, e,g., 'e', or change the result type of 'e.me' to no longer depend on 'e.this'.
 
 one error.

--- a/tests/reg_issue4250/reg_issue4250.fz.expected_err
+++ b/tests/reg_issue4250/reg_issue4250.fz.expected_err
@@ -6,7 +6,7 @@ The result type of this call depends on the target type.  Since the target type 
 Called feature: 'e.me'
 Original result type: 'option e.this'
 Type depending on target: 'e.this'
-Target type: 'p.this'
+Target type: 'p.me'
 To solve this, you could try to use a value type as the target type of the call, e,g., 'e', or change the result type of 'e.me' to no longer depend on 'e.this'.
 
 one error.

--- a/tests/reg_issue4273/reg_issue4273.fz.expected_err
+++ b/tests/reg_issue4273/reg_issue4273.fz.expected_err
@@ -6,7 +6,7 @@ The result type of this call depends on the target type.  Since the target type 
 Called feature: 'case1.e.me'
 Original result type: 'case1.e.this'
 Type depending on target: 'case1.e.this'
-Target type: 'case1.p.this'
+Target type: 'case1.p.me'
 To solve this, you could try to use a value type as the target type of the call, e,g., 'case1.e', or change the result type of 'case1.e.me' to no longer depend on 'case1.e.this'.
 
 
@@ -17,7 +17,7 @@ The result type of this call depends on the target type.  Since the target type 
 Called feature: 'case3.e.me'
 Original result type: 'option case3.e.this'
 Type depending on target: 'case3.e.this'
-Target type: 'case3.p.this'
+Target type: 'case3.p.me'
 To solve this, you could try to use a value type as the target type of the call, e,g., 'case3.e', or change the result type of 'case3.e.me' to no longer depend on 'case3.e.this'.
 
 
@@ -28,7 +28,7 @@ The result type of this call depends on the target type.  Since the target type 
 Called feature: 'case4.e.me'
 Original result type: 'option case4.e.this'
 Type depending on target: 'case4.e.this'
-Target type: 'case4.p.this'
+Target type: 'case4.p.me'
 To solve this, you could try to use a value type as the target type of the call, e,g., 'case4.e', or change the result type of 'case4.e.me' to no longer depend on 'case4.e.this'.
 
 
@@ -39,7 +39,7 @@ The result type of this call depends on the target type.  Since the target type 
 Called feature: 'option'
 Original result type: 'option case4.e.this'
 Type depending on target: 'case4.e.this'
-Target type: 'case4.p.this'
+Target type: 'case4.p.me'
 To solve this, you could try to use a value type as the target type of the call, e,g., 'universe', or change the result type of 'option' to no longer depend on 'case4.e.this'.
 
 4 errors.

--- a/tests/reg_issue5729/reg_issue5729.fz.expected_err
+++ b/tests/reg_issue5729/reg_issue5729.fz.expected_err
@@ -6,7 +6,7 @@ The result type of this call depends on the target type.  Since the target type 
 Called feature: 'switch.and_then'
 Original result type: 'option Y.this'
 Type depending on target: 'Y.this'
-Target type: 'Y'
+Target type: '(value Y).c'
 To solve this, you could try to use a value type as the target type of the call, e,g., 'switch A B', or change the result type of 'switch.and_then' to no longer depend on 'Y.this'.
 
 
@@ -17,7 +17,7 @@ The result type of this call depends on the target type.  Since the target type 
 Called feature: 'Function.call'
 Original result type: 'option Y.this'
 Type depending on target: 'Y.this'
-Target type: 'Y'
+Target type: 'Y.(λx->Y.this).call'
 To solve this, you could try to use a value type as the target type of the call or change the result type of 'Function.call' to no longer depend on 'Y.this'.
 
 2 errors.


### PR DESCRIPTION
now uses the clazzes type as the target type
fixes #6933
