### PR TITLE
concur: implement pinning a thread to a specific CPU core

### DIFF
--- a/include/fz.h
+++ b/include/fz.h
@@ -428,6 +428,11 @@ void fzE_thread_join(void * thrd);
  */
 int fzE_thread_setschedparam(void * thrd, int policy, int priority);
 
+/*
+ * Set the scheduling CPU affinity of a running thread.
+ */
+int fzE_thread_setaffinity(void * thrd, int core);
+
 /**
  * Global lock
  *

--- a/include/posix.c
+++ b/include/posix.c
@@ -25,6 +25,9 @@ Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
  *---------------------------------------------------------------------*/
 
 #define _POSIX_C_SOURCE 200809L
+#ifdef __linux__
+#define _GNU_SOURCE
+#endif
 
 #ifdef GC_THREADS
 #define GC_DONT_INCLUDE_WINDOWS_H
@@ -57,6 +60,9 @@ Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
 #include <assert.h>
 #include <dirent.h>
 #include <pthread.h>
+#ifdef __linux__
+#include <sched.h> // CPU_SET
+#endif
 
 #include "fz.h"
 
@@ -570,6 +576,7 @@ int fzE_thread_setschedparam_convert_policy(int policy)
     }
 }
 
+
 /*
  * Set the scheduling policy and priority of a running thread.
  */
@@ -579,6 +586,23 @@ int fzE_thread_setschedparam(void * thrd, int policy, int priority)
   param.sched_priority = priority;
   int ret = pthread_setschedparam(*(pthread_t *)thrd, fzE_thread_setschedparam_convert_policy(policy), &param);
   return ret;
+}
+
+
+/*
+ * Set the scheduling CPU affinity of a running thread.
+ */
+int fzE_thread_setaffinity(void * thrd, int core)
+{
+#ifdef __linux__
+  cpu_set_t cpuset;
+  CPU_ZERO(&cpuset);
+  CPU_SET(core, &cpuset);
+
+  return pthread_setaffinity_np(*(pthread_t *)thrd, sizeof(cpu_set_t), &cpuset);
+#else
+  return 38;
+#endif
 }
 
 

--- a/include/win.c
+++ b/include/win.c
@@ -668,6 +668,15 @@ int fzE_thread_setschedparam(void * thrd, int policy, int priority)
 }
 
 
+/*
+ * Set the scheduling CPU affinity of a running thread.
+ */
+int fzE_thread_setaffinity(void * thrd, int core)
+{
+  return 38;
+}
+
+
 /**
  * Global lock
  */

--- a/modules/base/src/concur/thread.fz
+++ b/modules/base/src/concur/thread.fz
@@ -74,6 +74,15 @@ module:public thread(thrd Thread) : property.equatable is
       error "fzE_thread_setschedparam error {e}"
 
 
+  public set_affinity(core i32) outcome unit
+  =>
+    e := fuzion.sys.thread.set_affinity thrd core
+    if e = 0
+      unit
+    else
+      error "fzE_thread_setaffinity error {e}"
+
+
   # equality
   #
   public fixed redef type.equality(a, b thread.this) bool

--- a/modules/base/src/fuzion/sys/thread.fz
+++ b/modules/base/src/fuzion/sys/thread.fz
@@ -49,3 +49,8 @@ module thread is
   # intrinsic to set the scheduling policy and priority
   #
   module set_policy(thread_id Thread, policy, priority i32) i32 => intrinsic
+
+
+  # intrinsic to pin a thread to a specific CPU
+  #
+  module set_affinity(thread_id Thread, core i32) i32 => intrinsic

--- a/src/dev/flang/be/c/Intrinsics.java
+++ b/src/dev/flang/be/c/Intrinsics.java
@@ -523,6 +523,11 @@ public class Intrinsics extends ANY
           return CExpr.call("fzE_thread_setschedparam", new List<>(A0, A1, A2))
                       .ret();
         });
+    put("fuzion.sys.thread.set_affinity", (c,cl,outer,in) ->
+        {
+          return CExpr.call("fzE_thread_setaffinity", new List<>(A0, A1))
+                      .ret();
+        });
 
     put("effect.type.abort0"     ,
         "effect.type.default0"   ,

--- a/src/dev/flang/be/interpreter/Intrinsics.java
+++ b/src/dev/flang/be/interpreter/Intrinsics.java
@@ -475,6 +475,10 @@ public class Intrinsics extends ANY
         {
           return new i32Value(38 /* ENOSYS - Function not implemented */);
         });
+    put("fuzion.sys.thread.set_affinity", (executor, innerClazz) -> args ->
+        {
+          return new i32Value(38 /* ENOSYS - Function not implemented */);
+        });
 
     put("safety"                , (executor, innerClazz) -> args -> new boolValue(executor.options().fuzionSafety()));
     put("debug"                 , (executor, innerClazz) -> args -> new boolValue(executor.options().fuzionDebug()));

--- a/src/dev/flang/be/jvm/runtime/Intrinsics.java
+++ b/src/dev/flang/be/jvm/runtime/Intrinsics.java
@@ -234,6 +234,11 @@ public class Intrinsics extends ANY
     return 38 /* ENOSYS - Function not implemented */;
   }
 
+  public static int fuzion_sys_thread_set_affinity(Object thread, int core)
+  {
+    return 38 /* ENOSYS - Function not implemented */;
+  }
+
 }
 
 /* end of file */

--- a/src/dev/flang/fuir/analysis/dfa/DFA.java
+++ b/src/dev/flang/fuir/analysis/dfa/DFA.java
@@ -2128,6 +2128,7 @@ public class DFA extends ANY
         });
     put("fuzion.sys.thread.join0"        , cl -> Value.UNIT);
     put("fuzion.sys.thread.set_policy"   , cl -> genericNumResult(cl));
+    put("fuzion.sys.thread.set_affinity" , cl -> genericNumResult(cl));
 
     put("effect.type.replace0"              , cl ->
         {

--- a/src/dev/flang/fuir/cfg/CFG.java
+++ b/src/dev/flang/fuir/cfg/CFG.java
@@ -391,6 +391,7 @@ public class CFG extends ANY
     put("fuzion.sys.thread.spawn0"       , (cfg, cl) -> { } );
     put("fuzion.sys.thread.join0"        , (cfg, cl) -> { } );
     put("fuzion.sys.thread.set_policy"   , (cfg, cl) -> { } );
+    put("fuzion.sys.thread.set_affinity" , (cfg, cl) -> { } );
 
     put("effect.type.default0"           , (cfg, cl) -> { } );
     put(FuzionConstants.EFFECT_INSTATE_NAME , (cfg, cl) ->


### PR DESCRIPTION
Like the implementation for specifying a scheduling policy and priority, this is limited to the C backend and only available on Linux for now.