### PR TITLE
fe: cleanup around createMIR

### DIFF
--- a/src/dev/flang/fe/LibraryModule.java
+++ b/src/dev/flang/fe/LibraryModule.java
@@ -311,14 +311,15 @@ public class LibraryModule extends Module implements MirModule
   {
     if (_mir == null)
       {
-        var d = main == null
-          ? universe()
-          : lookupFeature(universe(), FeatureName.get(main, 0));
-
+        var d = effectiveMain(universe(), main);
         if (CHECKS) check
           (d != null);
 
-        _mir = createMIR(this, universe(), d);
+        _mir = new MIR(universe(), d, this);
+        if (!Errors.any())
+          {
+            new DFA(_mir).check();
+          }
 
         Errors.showAndExit();
       }

--- a/src/dev/flang/fe/Module.java
+++ b/src/dev/flang/fe/Module.java
@@ -533,19 +533,31 @@ public abstract class Module extends ANY implements FeatureLookup
 
 
   /**
-   * Create MIR based on given main feature.
+   * Find the effective main feature from the given main feature name. In case
+   * main is null, this is the universe.  Otherwise, it is a feature with given
+   * name `main` or, if exits, its `preAndCallFeature`.
+   *
+   * @param universe the universe feature, may be null
+   *
+   * @param main the main features name, may be null
+   *
+   * @return the effecive main feature, null in case universe is null or lookup failed.
    */
-  static MIR createMIR(MirModule mirMod, AbstractFeature universe, AbstractFeature main)
+  AbstractFeature effectiveMain(AbstractFeature universe, String main)
   {
-    var result = new MIR(universe, main, mirMod);
-    if (!Errors.any())
+    var result = universe == null || main == null
+      ? universe
+      : lookupFeature(universe, FeatureName.get(main, 0));
+    if (result != null)
       {
-        new DFA(result).check();
+        var pac = result.preAndCallFeature();
+        if (pac != null)
+          {
+            result = pac;
+          }
       }
-
     return result;
   }
-
 
 }
 

--- a/src/dev/flang/fe/SourceModule.java
+++ b/src/dev/flang/fe/SourceModule.java
@@ -267,10 +267,7 @@ public class SourceModule extends Module implements SrcModule
    */
   private void addRuntimeInitCall()
   {
-    var d = _main == null
-      ? _universe
-      : lookupFeature(_universe, FeatureName.get(_main, 0));
-    if (d instanceof Feature f)
+    if (effectiveMain(_universe, _main) instanceof Feature f)
       {
         f
           .impl()

--- a/src/dev/flang/mir/MIR.java
+++ b/src/dev/flang/mir/MIR.java
@@ -74,8 +74,7 @@ public class MIR extends IR
   public MIR(AbstractFeature universe, AbstractFeature main, MirModule module)
   {
     _universe = universe;
-    var pac = main.preAndCallFeature();
-    _main = pac != null ? pac : main;
+    _main = main;
     _module = module;
   }
 


### PR DESCRIPTION
This will be required for #6905 since we need to add code for an explicit effect singularity before the main feature is called and the old code does not ensure this if the main feature has a precondition.

This adds a helper method `Module.effectiveMain` that is used by LibraryModule and SourceModule and that now does the special handling for the main feature's precondition that used to be done mir the constructor of MIR.

Also removed `Module.createMIR` and moved the code inline to the only caller of this method, `LibraryModule.createMIR`.
