### PR TITLE
tests: fix implementation of rosetta 100doors in test for #2273

### DIFF
--- a/tests/reg_issue2273/reg_issue2273.fz
+++ b/tests/reg_issue2273/reg_issue2273.fz
@@ -32,7 +32,7 @@ door : choice open closed is
     closed => "closed"
 
 d := (mutate.array door).new 100 closed
-for i in (i64 0)..99 do
-  for j in (i64 i)..99 do
+for i in 0..99 do
+  for j in i..99:(i+1) do
     d[j] := d[j].toggle
 say d


### PR DESCRIPTION
The index increments were missing, see https://rosettacode.org/wiki/100_doors.

This still results in an error, which will be fixed by #6905.
