### PR TITLE
fe: fix `InlineArray.syntaxSugar2`, target of array call

### DIFF
--- a/src/dev/flang/ast/InlineArray.java
+++ b/src/dev/flang/ast/InlineArray.java
@@ -430,9 +430,15 @@ public class InlineArray extends ExprWithPos
                                          unit,
                                          unit,
                                          unit);
-    var arrayCall       = new Call(SourcePosition.builtIn, null, FuzionConstants.ARRAY_NAME, FuzionConstants.NO_SELECT,
-                                   eT,
-                                   sysArrArgsE, null).resolveTypes(res, context);
+    var arrayCall = new Call(
+        SourcePosition.builtIn,
+        Universe.instance,
+        FuzionConstants.ARRAY_NAME,
+        FuzionConstants.NO_SELECT,
+        eT,
+        sysArrArgsE,
+        null)
+      .resolveTypes(res, context);
     exprs.add(arrayCall);
 
     // we do not "replace" this inline array by instantiation code

--- a/src/dev/flang/ast/Types.java
+++ b/src/dev/flang/ast/Types.java
@@ -358,7 +358,7 @@ public class Types extends ANY
     {
       if (_fuzionSysCall == null)
         {
-          var fuzion       = new Call(SourcePosition.builtIn, null, "fuzion").resolveTypes(res, context);
+          var fuzion       = new Call(SourcePosition.builtIn, Universe.instance, "fuzion").resolveTypes(res, context);
           _fuzionSysCall   = new Call(SourcePosition.builtIn, fuzion, "sys" ).resolveTypes(res, context);
         }
       return _fuzionSysCall;

--- a/tests/reg_issue3168_parsing_tuples/reg_issue3168_parsing_tuples.fz
+++ b/tests/reg_issue3168_parsing_tuples/reg_issue3168_parsing_tuples.fz
@@ -34,7 +34,7 @@ reg_issue3168_parsing_tuples is
     _ := array (Sequence (tuple i32 String)) 0 i->[]
     _ := array (Sequence (i32, String)) 0 i->[]
     lm : mutate is
-      lm.instate_self unit ()->
+    lm.instate_self unit ()->
       _ := lm.array (Sequence (tuple i32 String i32)) .new 0 []
       _ := lm.array (Sequence (i32, i32)) .new 0 []
 

--- a/tests/reg_issue6959/Makefile
+++ b/tests/reg_issue6959/Makefile
@@ -1,0 +1,25 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test Makefile
+#
+# -----------------------------------------------------------------------
+
+override NAME = reg_issue6959
+include ../simple.mk

--- a/tests/reg_issue6959/reg_issue6959.fz
+++ b/tests/reg_issue6959/reg_issue6959.fz
@@ -1,0 +1,26 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test reg_issue6959
+#
+# -----------------------------------------------------------------------
+
+lm : mutate is
+  _ := lm.array (Sequence (tuple i32 String i32)) .new 0 []
+  _ := lm.array (Sequence (i32, i32)) .new 0 []

--- a/tests/reg_issue6959/reg_issue6959.fz.expected_err
+++ b/tests/reg_issue6959/reg_issue6959.fz.expected_err
@@ -1,0 +1,18 @@
+
+{base.fum}/mutate/array.fz:115:5: error 1: Failed to verify that effect 'lm' is installed in current environment.
+    mutate.this.env.array data length unit
+----^^^^^^^^^^^^^^^
+Callchain that lead to this point:
+
+effect environment '--empty--' for call to 'lm.type.from_env' at {base.fum}/mutate/array.fz:115:5:
+    mutate.this.env.array data length unit
+----^^^^^^^^^^^^^^^
+effect environment '--empty--' for call to '(lm.type.array.type (Sequence (tuple i32 String i32))).new#2' at --CURDIR--/reg_issue6959.fz:25:8:
+  _ := lm.array (Sequence (tuple i32 String i32)) .new 0 []
+-------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+effect environment '--empty--' for call to 'lm'
+effect environment '--empty--' at program entry
+
+To fix this, you should make sure that an effect for type 'lm' is instated along all call paths to this effect use.
+
+one error.


### PR DESCRIPTION
The target for the call to `array`  was specified as `null` in `InlineArray.syntaxSugar2` so in this example for `[]` a call to `lm.this.array` was created but should have been `universe.array`

```
lm : mutate is
  _ := lm.array (Sequence i32) .new 0 []
```

fixes #6959
