### PR TITLE
Makefile: use shells realpath instead of the make one

### DIFF
--- a/docs.mk
+++ b/docs.mk
@@ -86,7 +86,7 @@ $(DOC_JAVA): $(JAVA_FILE_UTIL_VERSION) $(JAVA_FILE_FUIR_ANALYSIS_ABSTRACT_INTERP
 
 $(BUILD_DIR)/generated/doc/unicode_version.adoc:
 	mkdir -p $(@D)
-	cd $(FZ_SRC) && git log modules/base/src/encodings/unicode/data.fz  | grep --extended-regexp "^Date:" | head | sed "s-Date:   -:UNICODE_VERSION: -g" | head -n1 > $(realpath $(@D))/unicode_version.adoc
+	cd $(FZ_SRC) && git log modules/base/src/encodings/unicode/data.fz  | grep --extended-regexp "^Date:" | head | sed "s-Date:   -:UNICODE_VERSION: -g" | head -n1 > $$(realpath $(@D))/unicode_version.adoc
 
 $(BUILD_DIR)/generated/doc/codepoints_white_space.adoc: $(CLASS_FILES_PARSER)
 	mkdir -p $(@D)

--- a/docs.mk
+++ b/docs.mk
@@ -84,9 +84,11 @@ REF_MANUAL_ATTRIBUTES = \
 $(DOC_JAVA): $(JAVA_FILE_UTIL_VERSION) $(JAVA_FILE_FUIR_ANALYSIS_ABSTRACT_INTERPRETER2)
 	javadoc --release $(JAVA_VERSION) --enable-preview -d $(dir $(DOC_JAVA)) $(JAVA_FILES_FOR_JAVA_DOC)
 
-$(BUILD_DIR)/generated/doc/unicode_version.adoc:
-	mkdir -p $(@D)
-	cd $(FZ_SRC) && git log modules/base/src/encodings/unicode/data.fz  | grep --extended-regexp "^Date:" | head | sed "s-Date:   -:UNICODE_VERSION: -g" | head -n1 > $$(realpath $(@D))/unicode_version.adoc
+$(BUILD_DIR)/generated/doc:
+	mkdir -p $@
+
+$(BUILD_DIR)/generated/doc/unicode_version.adoc: $(BUILD_DIR)/generated/doc
+	cd $(FZ_SRC) && git log modules/base/src/encodings/unicode/data.fz  | grep --extended-regexp "^Date:" | head | sed "s-Date:   -:UNICODE_VERSION: -g" | head -n1 > $(realpath $(@D))/unicode_version.adoc
 
 $(BUILD_DIR)/generated/doc/codepoints_white_space.adoc: $(CLASS_FILES_PARSER)
 	mkdir -p $(@D)


### PR DESCRIPTION
fixes #6021

Here is what the AI writes:

> 1. $(realpath …) is a Make function, not a shell command
> It is evaluated by make itself, before the shell runs.
> It expects a Make variable or literal path, not shell expressions.
> 2. $(@D) is an automatic variable
> It only has a value inside a recipe during rule execution.
> Outside of a rule (or in the wrong context), it expands to empty.

