### PR TITLE
win: fix `check_simple_example`

### DIFF
--- a/bin/check_simple_example.fz
+++ b/bin/check_simple_example.fz
@@ -162,8 +162,8 @@ clean_err(f path) =>
     "sed -i s|/|#|g $f".execute .or_panic
     # 8 slashes here intentional, unclear why so many are needed though...
     "sed -i s|\\\\\\\\|#|g $f".execute .or_panic
-    say "3"
     "sed -i s|{os.cwd.or_panic.as_string.replace "\\" "#" .replace "/" "#"}|--CURDIR--| $f".execute .or_panic
+    "sed -i s|{("{os.cwd.or_panic.as_string.substring 1 2}:{os.cwd.or_panic.as_string.substring 2}").replace "\\" "#" .replace "/" "#"}|--CURDIR--| $f".execute .or_panic
   "sed -i s#{os.cwd.or_panic.as_string}#--CURDIR--# $f".execute .or_panic
   # line numbers
   "sed -E -i s/\\.fz:[0-9]+:[0-9]+:/\\.fz:n:n:/g $f".execute .or_panic


### PR DESCRIPTION
needed to be changed due to recent change of `fzE_cwd` in win.c. Specifically mismatch between assumption `C:` vs. `/C`

[ci skip]

