### PR TITLE
io/Read_Handler: allow empty returns from read

### DIFF
--- a/modules/base/src/io/Read_Handler.fz
+++ b/modules/base/src/io/Read_Handler.fz
@@ -32,7 +32,7 @@ public Read_Handler ref is
   # returns either an array of the bytes read, end_of_file or an error
   #
   public read(max_count i32) choice (Sequence u8) io.end_of_file error
-    post debug: (result ? s Sequence => !s.is_empty && s.count<=max_count | * => true)
+    post debug: (result ? s Sequence => s.count<=max_count | * => true)
          debug 10 : (result ? s Sequence => s.is_array_backed | * => true)
   => abstract
 

--- a/modules/base/src/io/buffered/reader.fz
+++ b/modules/base/src/io/buffered/reader.fz
@@ -49,7 +49,6 @@ is
   #
   public read switch (Sequence u8) (outcome io.end_of_file)
     post
-      debug: (result ? outcome => true | s Sequence => !s.is_empty)
       debug: (result ? outcome => true | s Sequence => s.is_array_backed)
   =>
     if buffer.is_empty
@@ -85,7 +84,6 @@ is
 
 
 # read n bytes using the currently installed byte reader effect
-# if the returned sequence is empty or count is less than n, end of file has been reached.
 #
 public read_bytes(n i32) outcome (Sequence u8) ! reader
   post debug: {


### PR DESCRIPTION
This limitation was still in place from when there was no explicit end of file result type.

It can be useful to return an empty read, for example when handling data where something is read by an intermediate reader, which is not part of the result exposed to the downstream reader.