### PR TITLE
fuir: change `clazzInstantiatedHeirs` to return empty array for value clazzes

### DIFF
--- a/src/dev/flang/be/c/C.java
+++ b/src/dev/flang/be/c/C.java
@@ -442,7 +442,7 @@ public class C extends ANY
           for (var tagNum : tags)
             {
               var tc = _fuir.clazzChoice(subjClazz, tagNum);
-              if (!hasTag && _fuir.clazzIsRef(tc))  // do we need to check the clazzId of a ref?
+              if (!hasTag && _fuir.clazzIsRef(tc))  // NYI: CLEANUP: do we need to check the clazzId of a ref?
                 {
                   for (var h : _fuir.clazzInstantiatedHeirs(tc))
                     {

--- a/src/dev/flang/be/jvm/Choices.java
+++ b/src/dev/flang/be/jvm/Choices.java
@@ -211,18 +211,15 @@ public class Choices extends ANY implements ClassFileConstants
    */
   boolean overlappingRefs(int c1, int c2)
   {
-    if (_fuir.clazzIsRef(c1) && _fuir.clazzIsRef(c2))
+    var h1 = _fuir.clazzInstantiatedHeirs(c1);
+    var h2 = _fuir.clazzInstantiatedHeirs(c2);
+    for (var i1 : h1)
       {
-        var h1 = _fuir.clazzInstantiatedHeirs(c1);
-        var h2 = _fuir.clazzInstantiatedHeirs(c2);
-        for (var i1 : h1)
+        for (var i2 : h2)
           {
-            for (var i2 : h2)
+            if (i1 == i2)
               {
-                if (i1 == i2)
-                  {
-                    return true;
-                  }
+                return true;
               }
           }
       }
@@ -281,19 +278,16 @@ public class Choices extends ANY implements ClassFileConstants
               for (var tagNum = 0; tagNum < nc; tagNum++)
                 {
                   var tc = _fuir.clazzChoice(cl, tagNum);
-                  if (_fuir.clazzIsRef(tc))
+                  for (var h : _fuir.clazzInstantiatedHeirs(tc))
                     {
-                      for (var h : _fuir.clazzInstantiatedHeirs(tc))
-                        {
-                          var hcf = _types.classFile(h);
-                          hcf.addImplements(ci._name);
+                      var hcf = _types.classFile(h);
+                      hcf.addImplements(ci._name);
 
-                          var bc_tag = Expr.iconst(tagNum)
-                            .andThen(Expr.IRETURN);
-                          var code_tag = hcf.codeAttribute(gtn + "in interface for "+_fuir.clazzName(cl),
-                                                           bc_tag, new List<>(), ClassFile.StackMapTable.empty(hcf, new List<>(VerificationType.UninitializedThis), bc_tag));
-                          hcf.method(ACC_PUBLIC, gtn, "()I", new List<>(code_tag));
-                        }
+                      var bc_tag = Expr.iconst(tagNum)
+                        .andThen(Expr.IRETURN);
+                      var code_tag = hcf.codeAttribute(gtn + "in interface for "+_fuir.clazzName(cl),
+                                                        bc_tag, new List<>(), ClassFile.StackMapTable.empty(hcf, new List<>(VerificationType.UninitializedThis), bc_tag));
+                      hcf.method(ACC_PUBLIC, gtn, "()I", new List<>(code_tag));
                     }
                 }
 

--- a/src/dev/flang/be/jvm/Types.java
+++ b/src/dev/flang/be/jvm/Types.java
@@ -269,16 +269,13 @@ public class Types extends ANY implements ClassFileConstants
   {
     var i = new ClassFile(_opt, _names.javaInterface(cl), "java/lang/Object", true, _fuir.clazzSrcFile(cl));
     _interfaceFiles.put(cl, i);
-    if (!_fuir.clazzIsChoice(cl))
+    var hs = _fuir.clazzInstantiatedHeirs(cl);
+    for (var h : hs)
       {
-        var hs = _fuir.clazzInstantiatedHeirs(cl);
-        for (var h : hs)
+        var c = classFile(h);
+        if (c != null)
           {
-            var c = classFile(h);
-            if (c != null)
-              {
-                c.addImplements(i._name);
-              }
+            c.addImplements(i._name);
           }
       }
   }
@@ -412,7 +409,7 @@ public class Types extends ANY implements ClassFileConstants
    */
   JavaType resultType(int cl)
   {
-    if (_fuir.clazzIsRef(cl) && hasRealHeirs(cl))
+    if (hasRealHeirs(cl))
       {
         return interfaceFile(cl).classType();
       }

--- a/src/dev/flang/fuir/GeneratingFUIR.java
+++ b/src/dev/flang/fuir/GeneratingFUIR.java
@@ -1202,12 +1202,14 @@ public class GeneratingFUIR extends FUIR
 
 
   /**
-   * Get all heirs of given clazz that are instantiated.
+   * Get all _real_ heirs of given clazz that are instantiated.
+   * For value clazzes an empty array is returned.
    *
    * @param cl a clazz id
    *
-   * @return an array of the clazz id's of all heirs for cl that are
-   * instantiated, including cl itself, provided that cl is instantiated.
+   * @return an empty array if cl is not a ref.
+   *         An array of the clazz id's of all heirs for cl that are
+   *         instantiated, provided that cl is instantiated.
    */
   @Override
   public int[] clazzInstantiatedHeirs(int cl)
@@ -1216,22 +1218,19 @@ public class GeneratingFUIR extends FUIR
       (cl >= CLAZZ_BASE,
        cl < CLAZZ_BASE + _clazzes.size());
 
-    if (!clazzIsRef(cl))
-      {
-        // NYI: this is sometimes (e.g. in tests/inheritance) called for non-ref
-        // clazzes. Check what this is needed for, seems not to make not so much
-        // sense.
-      }
-
-    var c = id2clazz(cl);
     var result = new List<Clazz>();
-    for (var h : c.heirs())
-      {
-        if (h.isInstantiatedChoice())
-          {
-            result.add(h);
-          }
-      }
+    if (clazzIsRef(cl))
+        {
+          var c = id2clazz(cl);
+          for (var h : c.heirs())
+            {
+              if (h.isInstantiatedChoice())
+                {
+                  result.add(h);
+                }
+            }
+        }
+
     var res = new int[result.size()];
     for (var i = 0; i < result.size(); i++)
       {


### PR DESCRIPTION
Rationale is that we need heirs info only if clazz is Ref, otherwise the info is useless anyway.
