### PR TITLE
fuir: fix replace this-type in box-type.

### DIFF
--- a/src/dev/flang/fuir/Clazz.java
+++ b/src/dev/flang/fuir/Clazz.java
@@ -561,19 +561,8 @@ class Clazz extends ANY implements Comparable<Clazz>
         for (var inh_call : feature().inherits())
           {
             var pt = inh_call.type();
-            var t0 = handDown(pt, NO_SELECT, (_,_)->{}, new List<>());
-            // NYI: BUG: remove replaceThisType, should be done by handDown
-            // but this types that refer to inheritance call targets are not
-            // properly replaced yet as in e.g.
-            //   o is
-            //     a is
-            //       (_ : i is).a
-            //     i is
-            //       a => say "a"
-            //   b : o.a is
-            //   ignore b
-            var t1 = replaceThisType(t0, new List<>());
-            var pc = _fuir.newClazz(t1);
+            var t0 = handDownAndReplaceThisType(pt, NO_SELECT, (_,_)->{}, new List<>());
+            var pc = _fuir.newClazz(t0);
 
             if (!result.contains(pc))
               {
@@ -588,6 +577,23 @@ class Clazz extends ANY implements Comparable<Clazz>
         _parents = result;
       }
     return result;
+  }
+
+
+  private AbstractType handDownAndReplaceThisType(AbstractType t, int select, BiConsumer<AbstractType, AbstractType> foundRef, List<AbstractCall> inh)
+  {
+    var t0 = handDown(t, select, foundRef, inh);
+    // NYI: BUG: remove replaceThisType, should be done by handDown
+    // but this types that refer to inheritance call targets are not
+    // properly replaced yet as in e.g.
+    //   o is
+    //     a is
+    //       (_ : i is).a
+    //     i is
+    //       a => say "a"
+    //   b : o.a is
+    //   ignore b
+    return replaceThisType(t0, inh);
   }
 
 
@@ -1864,7 +1870,7 @@ class Clazz extends ANY implements Comparable<Clazz>
     BiConsumer<AbstractType, AbstractType> foundRef = (from,to) ->
       { err.add((c)->AstErrors.illegalOuterRefTypeInCall(c, false, feature(), ft, from, to)); };
 
-    t = handDown(t, select, foundRef, inh);
+    t = handDownAndReplaceThisType(t, select, foundRef, inh);
 
     var res = _fuir.type2clazz(t);
     if (res.feature().isCotype())

--- a/tests/reg_issue6990/Makefile
+++ b/tests/reg_issue6990/Makefile
@@ -1,0 +1,25 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test Makefile
+#
+# -----------------------------------------------------------------------
+
+override NAME = reg_issue6990
+include ../simple.mk

--- a/tests/reg_issue6990/reg_issue6990.fz
+++ b/tests/reg_issue6990/reg_issue6990.fz
@@ -1,0 +1,39 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test reg_issue6990
+#
+# -----------------------------------------------------------------------
+
+reg_issue6990 =>
+
+  b is
+    c is
+      d =>
+        say <| type_of c.this
+        say <| b.this.feat
+        type_of b.this
+
+    type.feat String => "b"
+
+  e : b is
+    redef type.feat String => "e"
+
+
+  say (_ : e.c is).d

--- a/tests/reg_issue6990/reg_issue6990.fz.expected_out
+++ b/tests/reg_issue6990/reg_issue6990.fz.expected_out
@@ -1,0 +1,3 @@
+Type of 'reg_issue6990.anonymous'
+e
+Type of 'reg_issue6990.e'


### PR DESCRIPTION
type_of is defined as: `type_of(T type, _ Lazy T) Type => ...`
The box-type that still contained a this-type: `Lazy reg_issue6990.b.this`

