### PR TITLE
dfa: for native result clazzes, mark all arg fields as read

### DIFF
--- a/modules/clang/src/clang.fz
+++ b/modules/clang/src/clang.fz
@@ -224,24 +224,6 @@ public clang is
 
     check !(ffi.is_null ci)
 
-    # NYI: DFA mark value arg fields as read/written
-    cxc := CXCursor 0 0 ffi.null ffi.null ffi.null
-    cxs := CXString ffi.null 0 0
-    cxt := CXType 0 0 ffi.null ffi.null
-    _ := cxc.kind
-    _ := cxc.xdata
-    _ := cxc.data1
-    _ := cxc.data2
-    _ := cxc.data3
-    _ := cxs.data
-    _ := cxs.private_flags
-    _ := cxs.padding
-    _ := cxt.kind
-    _ := cxt.padding
-    _ := cxt.data1
-    _ := cxt.data2
-
-
     tu := lm ! ()->
       clang_parseTranslationUnit ci (header_file.as_c_string lm) ((lm.array Native_Ref).empty) 0 ffi.null 0 0
 

--- a/src/dev/flang/fuir/analysis/dfa/Call.java
+++ b/src/dev/flang/fuir/analysis/dfa/Call.java
@@ -331,6 +331,7 @@ public class Call extends ANY implements Comparable<Call>, Context
         markSysArrayArgsAsInitialized();
         markFunctionArgsAsCalled();
         markArrayArgsAsRead();
+        markValueFieldsAsRead(_dfa._fuir.clazzResultClazz(calledClazz()));
 
         result = genericResult();
         if (result == null)
@@ -344,6 +345,18 @@ public class Call extends ANY implements Comparable<Call>, Context
         result = _result;
       }
     return result;
+  }
+
+  /**
+   * Mark all arg fields of `cl` as read/used so
+   * that they aren't optimized out later.
+   */
+  private void markValueFieldsAsRead(int cl)
+  {
+    for (int i = 0; i < _dfa._fuir.clazzArgCount(cl); i++)
+      {
+        _dfa.readField(_dfa._fuir.clazzArg(cl, i));
+      }
   }
 
 

--- a/tests/native_value/native_value.fz
+++ b/tests/native_value/native_value.fz
@@ -145,30 +145,6 @@ ex =>
 
   header_file := "./fz.h"
 
-
-  # NYI: DFA mark value arg fields as read/written
-  cxc := CXCursor 0 0 ffi.null ffi.null ffi.null
-  cxs := CXString ffi.null 0 0
-  cxt := CXType 0 0 ffi.null ffi.null
-  _ := cxc.kind
-  _ := cxc.xdata
-  _ := cxc.data1
-  _ := cxc.data2
-  _ := cxc.data3
-  _ := cxs.data
-  _ := cxs.private_flags
-  _ := cxs.padding
-  _ := cxt.kind
-  _ := cxt.padding
-  _ := cxt.data1
-  _ := cxt.data2
-
-
-  # fzE_to_native(arr mutate.array u8) Native_Ref => native
-  # args := ["-I/usr/include"]
-  #   .map (arg -> fzE_to_native (arg.as_c_string mutate))
-  #   .as_array
-
   tu := clang_parseTranslationUnit ci (header_file.as_c_string mutate) (mutate.array Native_Ref).empty 0 ffi.null 0 0
 
   check !(ffi.is_null tu)


### PR DESCRIPTION
... to prevent for them being optimized away.
