### PR TITLE
http: handle extensions for chunked transfer encoding

### DIFF
--- a/modules/http/src/http/Message.fz
+++ b/modules/http/src/http/Message.fz
@@ -239,6 +239,7 @@ body_reader_chunked(LM type : mutate) : io.Read_Handler is
 
   chunk_start is
   chunk_size is
+  chunk_extension is
   chunk_post_size is
   chunk_end_start is
   chunk_end_finalize is
@@ -250,6 +251,7 @@ body_reader_chunked(LM type : mutate) : io.Read_Handler is
   chunk_enum : choice
     chunk_start
     chunk_size
+    chunk_extension
     chunk_post_size
     chunk_end_start
     chunk_end_finalize
@@ -258,8 +260,11 @@ body_reader_chunked(LM type : mutate) : io.Read_Handler is
     chunk_post_body_finalize
     chunk_end_of_file is
 
+  extension_limit := (u64 1024) * 64 # arbitrary value, see below
+
   position := mut chunk_enum chunk_start
   current_chunk_size := mut u64 0
+  extension_size := mut u64 0
 
   update_current_chunk_size (new option u64) choice (Sequence u8) io.end_of_file error =>
     match new
@@ -299,6 +304,9 @@ body_reader_chunked(LM type : mutate) : io.Read_Handler is
       update_current_chunk_size ((current_chunk_size.get *? 16) +? (c + 10 - 0x61))
     else if c = 0x0d
       position <- chunk_post_size
+      Sequence u8 .empty
+    else if c = 0x3b
+      position <- chunk_extension
       Sequence u8 .empty
     else
       error "chunk size invalid"
@@ -388,6 +396,34 @@ body_reader_chunked(LM type : mutate) : io.Read_Handler is
       error "invalid termination of body, expected LF found {c}"
 
 
+  handle_extension (s Sequence u8) choice (Sequence u8) io.end_of_file error =>
+    c := s.first.or_panic
+
+    (io.buffered LM).reader.env.discard 1
+
+    if c = 0x0d
+      position <- chunk_end_finalize
+      Sequence u8 .empty
+    else if c = 0x0a
+      error "invalid newline in chunk extension"
+    else
+      extension_size <- extension_size.get + 1
+
+      if extension_size.get > extension_limit
+        # this static limit is kinda arbitrary, we could add more magic to allow
+        # extensions proportional to the content size, but this does not matter
+        # yet
+        #
+        # the limit exists to protect against DoS attacks where the sender of
+        # the message sends a small chunk with a long extension part
+        error "chunk extensions too long"
+      else
+        # we do nothing with the extensions, as per the spec they must be
+        # ignored if they are not understood
+        position <- chunk_extension
+        Sequence u8 .empty
+
+
   public redef read(max_count i32) choice (Sequence u8) io.end_of_file error =>
     match (io.buffered LM).reader.env.read
       s Sequence =>
@@ -397,6 +433,7 @@ body_reader_chunked(LM type : mutate) : io.Read_Handler is
           match position.get
             chunk_start => handle_start s
             chunk_size => handle_size s
+            chunk_extension => handle_extension s
             chunk_post_size => handle_post_size s
             chunk_end_start => handle_end_start s
             chunk_end_finalize => handle_end_finalize s


### PR DESCRIPTION
Per the spec, clients that do not understand the chunk extensions must ignore them.