### PR TITLE
ast: Type.toString omit `.type` on humanReadable=true

### DIFF
--- a/src/dev/flang/ast/AbstractType.java
+++ b/src/dev/flang/ast/AbstractType.java
@@ -2455,7 +2455,7 @@ there is no common super type of the two types (Types.t_ERROR)
           {
             result = result + ".this";
           }
-        if (cotypeType)
+        if (!humanReadable && cotypeType)
           {
             result = result + ".type";
           }


### PR DESCRIPTION
This aligns better to what actually has to written in Fuzion source code.


