### PR TITLE
base: `Ring_Buffer`, mark `size` as `public`

### DIFF
--- a/modules/base/src/container/Ring_Buffer.fz
+++ b/modules/base/src/container/Ring_Buffer.fz
@@ -41,9 +41,9 @@ public Ring_Buffer(
   #
   M type : mutate,
 
-  # the maximun number of elements that can be stored in
+  # the maximum number of elements that can be stored in
   # this buffer
-  size i64
+  public size i64
 
 ) ref ! M
 is


### PR DESCRIPTION
[ci skip]
