### PR TITLE
net/connection: instantiate mutate effect inside thread

### DIFF
--- a/modules/base/src/net/connection.fz
+++ b/modules/base/src/net/connection.fz
@@ -80,8 +80,8 @@ module:public connection(desc i32) is
   #
   # NYI: DOCUMENTATION: see tests/sockets_thread_pool for now
   #
-  public in_thread_pool(T type, TP type : concur.thread_pool, LM type : mutate, lm LM, fn ()->T) concur.Future (outcome T)
+  public in_thread_pool(T type, TP type : concur.thread_pool, LM type : mutate, fn ()->T) concur.Future (outcome T)
   =>
     TP.env.submit (outcome T) ()->
-      lm ! ()->
+      LM.default_value.or_panic ! ()->
         with T LM fn

--- a/modules/webserver/src/webserver.fz
+++ b/modules/webserver/src/webserver.fz
@@ -46,22 +46,20 @@ public Webserver(/*NYI: UNDER DEVELOPMENT: custom thread pool TP type : concur.t
           while is_running.read do
             accept_res := net.server.env.accept.bind unit conn->
 
-              lm : racy_mutate is
-
-              _ := conn.in_thread_pool unit concur.thread_pool lm lm ()->
+              _ := conn.in_thread_pool unit concur.thread_pool mutate ()->
 
                 # compute response
                 #
-                response := h.call (http.read_request lm).or_panic
+                response := h.call (http.read_request mutate).or_panic
 
                 # send response
                 #
-                match (io.buffered lm)
+                match (io.buffered mutate)
                     .writer.env
                     .write (response.bytes i32.max)
                   e error => log "writing response failed: {e}"
                   unit =>
-                    flush_ok := (io.buffered lm).writer.env.flush
+                    flush_ok := (io.buffered mutate).writer.env.flush
                     if flush_ok!!
                       log "flushing response failed: {flush_ok.err}"
 

--- a/tests/sockets_thread_pool/sockets_test.fz
+++ b/tests/sockets_thread_pool/sockets_test.fz
@@ -45,14 +45,14 @@ sockets_thread_pool_test is
 
     accept =>
       (net.server.env.accept.bind c->
-        sc := c.in_thread_pool unit concur.thread_pool lm lm ()->
+        sc := c.in_thread_pool unit concur.thread_pool mutate ()->
           chan => net.channel.env
 
           say_silent "$protocol/$family-server, accepted connection"
           say_silent chan.get_peer_address
           say_silent chan.get_peer_port
 
-          rr := (io.buffered lm).read_line_while (s -> !s.is_empty)
+          rr := (io.buffered mutate).read_line_while (s -> !s.is_empty)
 
           say_silent "$protocol/$family-server, read lines: >{rr}<"
 
@@ -62,8 +62,8 @@ sockets_thread_pool_test is
               res := "received: {rr.as_string}\n\n"
 
               w =>
-                match (io.buffered lm).writer.env.write res
-                  unit => (io.buffered lm).writer.env.flush
+                match (io.buffered mutate).writer.env.write res
+                  unit => (io.buffered mutate).writer.env.flush
                   e error => e
 
               match w
@@ -102,7 +102,7 @@ sockets_thread_pool_test is
         say "$protocol/$family-client {sockets_thread_pool_test.client.this.num}, $host: error establishing connection"
       c net.connection =>
 
-        res := c.in_thread_pool String concur.thread_pool lm lm ()->
+        res := c.in_thread_pool String concur.thread_pool mutate ()->
 
             chan => net.channel.env
 
@@ -111,15 +111,15 @@ sockets_thread_pool_test is
               + "Client: {sockets_thread_pool_test.client.this.num}\n\n")
 
             w =>
-              _ := (io.buffered lm).writer.env.write req
-              _ := (io.buffered lm).writer.env.flush
+              _ := (io.buffered mutate).writer.env.write req
+              _ := (io.buffered mutate).writer.env.flush
 
             str := "$protocol/$family-client {sockets_thread_pool_test.client.this.num}, write to $host => {w}"
 
             match protocol
               net.protocol.tcp =>
 
-                rr := (io.buffered lm).read_line_while (s -> !s.is_empty)
+                rr := (io.buffered mutate).read_line_while (s -> !s.is_empty)
 
                 str + "\n" + "$protocol/$family-client {sockets_thread_pool_test.client.this.num}, read lines from  $host: >{rr}<"
 


### PR DESCRIPTION
We cannot pass an instance of mutate from outside anymore since cross-thread mutate is no longer allowed.

N.B.: instatiate is the right word here, because thread assignment to a mutate happens at time of instatiation, not instation!