### PR TITLE
be/interpreter: relax precondition in LValue

### DIFF
--- a/src/dev/flang/be/interpreter/LValue.java
+++ b/src/dev/flang/be/interpreter/LValue.java
@@ -67,8 +67,8 @@ public class LValue extends ValueWithClazz
     if (PRECONDITIONS) require
       (cont != null,
        fuir().clazzIsUnitType(c) || off >= 0,
-       fuir().clazzIsUnitType(c) || off < Layout.get(cont._clazz).size(),
-       fuir().clazzIsUnitType(c) || off < cont.refs.length);
+       fuir().clazzIsUnitType(c) || Layout.get(cont._clazz).size() == 0 || off < Layout.get(cont._clazz).size(),
+       fuir().clazzIsUnitType(c) || Layout.get(cont._clazz).size() == 0 || off < cont.refs.length);
 
     this.container = cont;
     this.offset = off;


### PR DESCRIPTION
This should fix the test failures in interpreter CI. 
[ci skip]
test run: https://github.com/michaellilltokiwa/fuzion/actions/runs/25785884024/job/75739079689

This allows creating LValues for types where isUnitType is false but that are still effectively zero size.