### PR TITLE
fe: raise error if inferred lambda result type, refers to itself

### DIFF
--- a/src/dev/flang/ast/AbstractFeature.java
+++ b/src/dev/flang/ast/AbstractFeature.java
@@ -2167,6 +2167,15 @@ public abstract class AbstractFeature extends Expr implements Comparable<Abstrac
   }
 
 
+  /**
+   * return true if this == f or if this is an inner feature of f.
+   */
+  public boolean isSelfOrInnerFeatureOf(Feature f)
+  {
+    return this == f || outer() != null && outer().isSelfOrInnerFeatureOf(f);
+  }
+
+
 
 
 }

--- a/src/dev/flang/ast/AstErrors.java
+++ b/src/dev/flang/ast/AstErrors.java
@@ -2669,6 +2669,11 @@ public class AstErrors extends ANY
     );
   }
 
+  public static void inferredResultTypeOfLambdaIllegal(Function fun, AbstractType t)
+  {
+    error(fun.pos(), "Result type of lambda must not refer to itself.", "The inferred result type of the lambda: " + s(t));
+  }
+
 }
 
 /* end of file */

--- a/src/dev/flang/ast/Function.java
+++ b/src/dev/flang/ast/Function.java
@@ -399,7 +399,14 @@ public class Function extends AbstractLambda
             res.resolveTypes(_feature);
             if (inferResultType)
               {
-                result = refineResultType(res, context, rt0, _feature.resultType());
+                var frt = _feature.resultType();
+                frt.selfOuterAndGenerics(rtt -> {
+                  if (rtt.backingFeature().isSelfOrInnerFeatureOf(_wrapper))
+                    {
+                      AstErrors.inferredResultTypeOfLambdaIllegal(this, frt);
+                    }
+                });
+                result = refineResultType(res, context, rt0, frt);
                 var g = t.lambdaTargetResultTypeParameter(res);
                 if (g != null && !_inheritsCall.isDefunct())
                   {

--- a/tests/reg_issue4428/Makefile
+++ b/tests/reg_issue4428/Makefile
@@ -1,0 +1,25 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test Makefile
+#
+# -----------------------------------------------------------------------
+
+override NAME = reg_issue4428
+include ../simple.mk

--- a/tests/reg_issue4428/reg_issue4428.fz
+++ b/tests/reg_issue4428/reg_issue4428.fz
@@ -1,0 +1,28 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test reg_issue4428
+#
+# -----------------------------------------------------------------------
+
+f(x ()->T) =>
+f ()->
+  a is
+    x => a
+  a.x

--- a/tests/reg_issue4428/reg_issue4428.fz.expected_err
+++ b/tests/reg_issue4428/reg_issue4428.fz.expected_err
@@ -1,0 +1,13 @@
+
+--CURDIR--/reg_issue4428.fz:25:3: error 1: Result type of lambda must not refer to itself.
+f ()->
+--^^^^
+  a is
+--^^^^
+    x => a
+----^^^^^^
+  a.x
+--^^^
+The inferred result type of the lambda: '(λ()-> a is x => a a.x).call.this.a'
+
+one error.


### PR DESCRIPTION
fixes #4428
