### PR TITLE
concur/sync: add check to ensure wait and signal never fail

### DIFF
--- a/modules/base/src/concur/sync.fz
+++ b/modules/base/src/concur/sync.fz
@@ -111,6 +111,7 @@ public sync is
     #
     public signal bool
       pre is_locked.read
+      post debug: result
     => cnd_signal cnd
 
 
@@ -118,6 +119,7 @@ public sync is
     #
     public broadcast bool
       pre is_locked.read
+      post debug: result
     => cnd_broadcast cnd
 
 
@@ -125,6 +127,7 @@ public sync is
     #
     public wait bool
       pre is_locked.read
+      post debug: result
     => cnd_wait cnd mtx.mtx
 
 


### PR DESCRIPTION
We can do this since the pthread implementation guarantees that these will never fail. The Windows API does not, but we don't really care about this (yet).

Related: https://github.com/tokiwa-software/fuzion/issues/7075