### PR TITLE
concur: rename `thread` as `Thread`

### DIFF
--- a/modules/base/src/concur/Thread_List.fz
+++ b/modules/base/src/concur/Thread_List.fz
@@ -34,23 +34,23 @@ module Thread_List ref is
   # set `prev` and `next` to the given values `p` and `n` while this thread
   # is parked.
   #
-  fixed thread.setpn(p, n thread) unit =>
+  fixed Thread.setpn(p, n Thread) unit =>
     set prev := p
     set next := n
 
 
   # the first (oldest) entry in this list
   #
-  module first option thread := nil
+  module first option Thread := nil
 
   # add new entry to this list
   #
-  module add(t thread) unit
+  module add(t Thread) unit
   pre
     debug: t.next = t && t.prev = t   # links are unused
   =>
     match first
-      f thread =>
+      f Thread =>
         # add `t` before `f` in existing list
         p := f.prev
         t.setpn f.prev f
@@ -65,7 +65,7 @@ module Thread_List ref is
   #
   # result is `nil` if list is empty
   #
-  module remove option thread
+  module remove option Thread
   =>
     first >>= (t -> remove t; t)
 
@@ -73,7 +73,7 @@ module Thread_List ref is
   #
   # `t` must be in this list
   #
-  module remove(t thread) unit =>
+  module remove(t Thread) unit =>
     p := t.prev
     n := t.next
     if p = t

--- a/modules/base/src/concur/blocking_mutate.fz
+++ b/modules/base/src/concur/blocking_mutate.fz
@@ -49,7 +49,7 @@ public blocking_mutate : mutate is
   #
   # This is usually `nil`, unless we are in an exclusive section.
   #
-  module redef exclusive_thread option concur.thread := nil
+  module redef exclusive_thread option concur.Thread := nil
 
 
   # perform given code with exclusive access to the mutable values created with
@@ -65,7 +65,7 @@ public blocking_mutate : mutate is
       blocking_mutate.this.replace
 
       match waiting.first
-        f concur.thread =>
+        f concur.Thread =>
           for t := f, nxt
               nxt := t.next
           while !t.park_condition()

--- a/modules/base/src/concur/thread.fz
+++ b/modules/base/src/concur/thread.fz
@@ -25,9 +25,7 @@
 
 # type for a spawned thread
 #
-# NYI: UNDER DEVELOPMENT: rename as `Thread` since this is a `ref`!
-#
-module:public thread(thrd Internal_Thread,
+module:public Thread(thrd Internal_Thread,
 
                      # NYI: CLEANUP: use thread id
                      id u64
@@ -104,7 +102,7 @@ is
 
   # equality
   #
-  public fixed redef type.equality(a, b thread.this) bool
+  public fixed redef type.equality(a, b Thread.this) bool
   =>
     a.id = b.id
 
@@ -151,8 +149,8 @@ is
   # parked threads.  Since a thread can never be parked more than once, these links
   # can be used exclusively by the mechanism using park.
   #
-  module prev thread := thread.this
-  module next thread := thread.this
+  module prev Thread := Thread.this
+  module next Thread := Thread.this
 
 
   # for a parked `thread.this`, this holds a condition that must hold for the
@@ -168,4 +166,4 @@ is
   #
   public redef as_string String
   =>
-    "thread#$id"
+    "Thread#$id"

--- a/modules/base/src/concur/thread.fz
+++ b/modules/base/src/concur/thread.fz
@@ -27,7 +27,7 @@
 #
 # NYI: UNDER DEVELOPMENT: rename as `Thread` since this is a `ref`!
 #
-module:public thread(thrd Thread,
+module:public thread(thrd Internal_Thread,
 
                      # NYI: CLEANUP: use thread id
                      id u64

--- a/modules/base/src/concur/threads.fz
+++ b/modules/base/src/concur/threads.fz
@@ -35,10 +35,10 @@ public threads (
   p Thread_Handler,
 
   # NYI: UNDER DEVELOPMENT: use more suitable data structure
-  public running array concur.thread,
+  public running array concur.Thread,
 
   # the currently running thread
-  public current concur.thread
+  public current concur.Thread
   ) : effect
 is
 
@@ -51,12 +51,12 @@ is
   #
   public spawn(# code to run in the new thread with the teleported effect environemnt
                code ()->unit
-              ) concur.thread =>
+              ) concur.Thread =>
     ewh := effect_wormhole
     tid := unique_id  # NYI: CLEANUP: use thread id
     spawn_without_inherited_effects tid ()->
       ewh.teleport ()->
-        st := concur.thread fuzion.sys.thread.current  tid
+        st := concur.Thread fuzion.sys.thread.current  tid
         (threads p (running++[st]).as_array st).replace
         code()
 
@@ -69,7 +69,7 @@ is
   #
   public spawn_without_inherited_effects(# code ot run int he new thread without an new, empty effect environment
                                          code ()->unit
-                                        ) concur.thread
+                                        ) concur.Thread
   =>
     tid := unique_id  # NYI: CLEANUP: use thread id
     spawn_without_inherited_effects tid code
@@ -83,7 +83,7 @@ is
 
                                          # code ot run int he new thread without an new, empty effect environment
                                          code ()->unit
-                                        ) concur.thread =>
+                                        ) concur.Thread =>
     st := p.spawn tid code
     (threads p (running++[st]).as_array current).replace
     st
@@ -91,7 +91,7 @@ is
 
   # detach a running thread
   #
-  public detach(thrd concur.thread) unit
+  public detach(thrd concur.Thread) unit
   pre debug: running.contains thrd
   =>
     # NYI: UNDER DEVELOPMENT: pthread_detach
@@ -111,7 +111,7 @@ is
   #
   public redef fixed type.default_value option concur.threads
   =>
-    initial := concur.thread fuzion.sys.thread.current 0
+    initial := concur.Thread fuzion.sys.thread.current 0
     concur.threads concur.default_thread_handler [initial] initial
 
 
@@ -125,7 +125,7 @@ default_thread_handler : Thread_Handler is
               tid u64,
               code ()->unit)
   =>
-    concur.thread (fuzion.sys.thread.spawn code) tid
+    concur.Thread (fuzion.sys.thread.spawn code) tid
 
 # Thread_Handler -- abstract source of concurrency
 #
@@ -135,6 +135,6 @@ private:public Thread_Handler ref is
   #
   spawn(# NYI: CLEANUP: remove this argument and use system thread id
         tid u64,
-        code ()->unit) concur.thread
+        code ()->unit) concur.Thread
   =>
     abstract

--- a/modules/base/src/fuzion/sys/thread.fz
+++ b/modules/base/src/fuzion/sys/thread.fz
@@ -37,29 +37,29 @@ module thread is
 
     spawn0 Do_Call
 
-  spawn0(T type : ()->unit, code T) Thread => intrinsic
+  spawn0(T type : ()->unit, code T) Internal_Thread => intrinsic
 
-  # intrinsic to obtain the current Thread
-  module current Thread => intrinsic
+  # intrinsic to obtain the current Internal_Thread
+  module current Internal_Thread => intrinsic
 
   # intrinsic to join with a terminated thread
   #
   # NOTE: this must only be called once!
   #
-  module join0(thread_id Thread) unit => intrinsic
+  module join0(thread_id Internal_Thread) unit => intrinsic
 
 
   # intrinsic to set the scheduling policy and priority
   #
-  module set_policy(thread_id Thread, policy, priority i32) i32 => intrinsic
+  module set_policy(thread_id Internal_Thread, policy, priority i32) i32 => intrinsic
 
 
   # intrinsic to pin a thread to the CPUs given by the array
   #
-  module set_affinity0(thread_id Thread, cores fuzion.sys.internal_array u64) i32 => intrinsic
+  module set_affinity0(thread_id Internal_Thread, cores fuzion.sys.internal_array u64) i32 => intrinsic
 
 
   # pin a thread to the CPUs given in an array
   #
-  module set_affinity(thread_id Thread, cores array u64) i32 =>
+  module set_affinity(thread_id Internal_Thread, cores array u64) i32 =>
     set_affinity0 thread_id cores.internal_array

--- a/modules/base/src/internal.fz
+++ b/modules/base/src/internal.fz
@@ -59,7 +59,7 @@ private:module Array(ET type) ref is
 
 # a type denoting a (started) thread
 #
-private:module Thread ref is
+private:module Internal_Thread ref is
 
 
 # called by backends

--- a/modules/base/src/mutate.fz
+++ b/modules/base/src/mutate.fz
@@ -87,7 +87,7 @@ public mutate : linear_effect is
   # NYI: UNDER DEVELOPMENT: Since effect order is currently not enforced during the
   # big bang singulariy, we set this lazily.
   #
-  tid0 option concur.thread := if concur.threads.is_instated then concur.threads.env.current
+  tid0 option concur.Thread := if concur.threads.is_instated then concur.threads.env.current
                                                              else nil
 
 
@@ -96,7 +96,7 @@ public mutate : linear_effect is
   # currently has exclusive access, or the thread that currently does have exclusive
   # access.
   #
-  module exclusive_thread option concur.thread => tid
+  module exclusive_thread option concur.Thread => tid
 
 
   # check if the current thread is permitted to access mutable state managed by mutate.this

--- a/src/dev/flang/be/interpreter/JavaInterface.java
+++ b/src/dev/flang/be/interpreter/JavaInterface.java
@@ -202,7 +202,7 @@ public class JavaInterface extends FUIRContext
         case SpecialClazzes.c_File_Descriptor -> new JavaRef(o);
         case SpecialClazzes.c_Directory_Descriptor -> new JavaRef(o);
         case SpecialClazzes.c_Mapped_Memory -> new JavaRef(o);
-        case SpecialClazzes.c_Thread -> new JavaRef(o);
+        case SpecialClazzes.c_Internal_Thread -> new JavaRef(o);
         default ->
           {
             var result = Value.UNIT;

--- a/src/dev/flang/be/jvm/Intrinsix.java
+++ b/src/dev/flang/be/jvm/Intrinsix.java
@@ -529,7 +529,7 @@ public class Intrinsix extends ANY implements ClassFileConstants
            c_Directory_Descriptor,
            c_Java_Ref,
            c_Mapped_Memory,
-           c_Thread ->
+           c_Internal_Thread ->
         Expr.aload(slot, JAVA_LANG_OBJECT);
       default -> {
         var res = Expr.ACONST_NULL;

--- a/src/dev/flang/be/jvm/Types.java
+++ b/src/dev/flang/be/jvm/Types.java
@@ -369,7 +369,7 @@ public class Types extends ANY implements ClassFileConstants
            c_Java_Ref,
            c_Mapped_Memory,
            c_Native_Ref,
-           c_Thread -> JAVA_LANG_OBJECT;
+           c_Internal_Thread -> JAVA_LANG_OBJECT;
       default        ->
         {
           if (cl == _fuir.clazzUniverse()                        ||

--- a/src/dev/flang/fuir/GeneratingFUIR.java
+++ b/src/dev/flang/fuir/GeneratingFUIR.java
@@ -704,7 +704,7 @@ public class GeneratingFUIR extends FUIR
               case "Java_Ref"                  -> SpecialClazzes.c_Java_Ref;
               case "Mapped_Memory"             -> SpecialClazzes.c_Mapped_Memory;
               case "Native_Ref"                -> SpecialClazzes.c_Native_Ref;
-              case "Thread"                    -> SpecialClazzes.c_Thread;
+              case "Internal_Thread"           -> SpecialClazzes.c_Internal_Thread;
               case "stackoverflow_cause"       -> SpecialClazzes.c_stackoverflow_cause;
               default                          -> SpecialClazzes.c_NOT_FOUND   ;
               };

--- a/src/dev/flang/fuir/SpecialClazzes.java
+++ b/src/dev/flang/fuir/SpecialClazzes.java
@@ -60,7 +60,7 @@ public enum SpecialClazzes
   c_Java_Ref    ("Java_Ref"                    , 0, c_universe  ),
   c_Mapped_Memory("Mapped_Memory"              , 0, c_universe  ),
   c_Native_Ref  ("Native_Ref"                  , 0, c_universe  ),
-  c_Thread      ("Thread"                      , 0, c_universe  ),
+  c_Internal_Thread("Internal_Thread"          , 0, c_universe  ),
   c_stackoverflow_cause("stackoverflow_cause"  , 1, c_universe  )
   ;
 


### PR DESCRIPTION
Since it is a ref type now.