### PR TITLE
ast: Fix underline range for interpolated String literals in error msg

### DIFF
--- a/src/dev/flang/ast/AstErrors.java
+++ b/src/dev/flang/ast/AstErrors.java
@@ -509,7 +509,7 @@ public class AstErrors extends ANY
         frml = frmls.next();
       }
     var f = ((c == count+1) && (frml != null)) ? frml : null;
-    incompatibleType(value.pos(),
+    incompatibleType(value.sourceRange(),
                      "when passing argument in a call",
                      "Actual type for argument #" + (count+1) + (f == null ? "" : " " + sbnf(f)) + " does not match expected type.\n" +
                      "In call to          : " + s(calledFeature) + "\n",

--- a/tests/partial_application_negative/partial_application_negative.fz
+++ b/tests/partial_application_negative/partial_application_negative.fz
@@ -38,9 +38,9 @@ partial_application_negative is
   test "data.map *3          " (data.map    *3) "[3,6,9,12,15,18,21,24,27,30]"    # ok
   test "data.map -3          " (data.map    -3) "[3,6,9,12,15,18,21,24,27,30]"    # ok
 
-  test "data.map 3.infix*    " (data.map    3.infix*) "[3,6,9,12,15,18,21,24,27,30]"
-  test "data.map 3.prefix*   " (data.map    3.prefix*) "[3,6,9,12,15,18,21,24,27,30]"    # 1. should flag an error, do not change named prefix call to infix call
-  test "data.map 3.prefix-   " (data.map    3.prefix-) "[3,6,9,12,15,18,21,24,27,30]"    # 2. should flag an error, do not change named prefix call to infix call
+  test "data.map 3.infix*    " (data.map    3.infix*  ) "[3,6,9,12,15,18,21,24,27,30]"
+  test "data.map 3.prefix*   " (data.map    3.prefix* ) "[3,6,9,12,15,18,21,24,27,30]"  # 1. should flag an error, do not change named prefix call to infix call
+  test "data.map 3.prefix-   " (data.map    3.prefix- ) "[3,6,9,12,15,18,21,24,27,30]"  # 2. should flag an error, do not change named prefix call to infix call
   test "data.map 3.postfix*  " (data.map    3.postfix*) "[3,6,9,12,15,18,21,24,27,30]"  # 3. should flag an error, do not change named prefix call to infix call
 
   _ := data.map *3

--- a/tests/partial_application_negative/partial_application_negative.fz.expected_err
+++ b/tests/partial_application_negative/partial_application_negative.fz.expected_err
@@ -52,16 +52,16 @@ To solve this, rename one of the ambiguous features.
 
 
 --CURDIR--/partial_application_negative.fz:42:47: error 6: Could not find called feature
-  test "data.map 3.prefix*   " (data.map    3.prefix*) "[3,6,9,12,15,18,21,24,27,30]"    # 1. should flag an error, do not change named prefix call to infix call
+  test "data.map 3.prefix*   " (data.map    3.prefix* ) "[3,6,9,12,15,18,21,24,27,30]"  # 1. should flag an error, do not change named prefix call to infix call
 ----------------------------------------------^^^^^^^
 Feature not found: 'prefix *' (one argument)
 Target feature: 'i32'
 In call: '3.prefix*'
 
 
---CURDIR--/partial_application_negative.fz:43:47: error 7: Incompatible types when passing argument in a call
-  test "data.map 3.prefix-   " (data.map    3.prefix-) "[3,6,9,12,15,18,21,24,27,30]"    # 2. should flag an error, do not change named prefix call to infix call
-----------------------------------------------^^^^^^^
+--CURDIR--/partial_application_negative.fz:43:45: error 7: Incompatible types when passing argument in a call
+  test "data.map 3.prefix-   " (data.map    3.prefix- ) "[3,6,9,12,15,18,21,24,27,30]"  # 2. should flag an error, do not change named prefix call to infix call
+--------------------------------------------^^^^^^^^^
 Actual type for argument #1 'f' does not match expected type.
 In call to          : 'Sequence.map'
 expected formal type: 'Unary B T'
@@ -86,7 +86,7 @@ This call was created automatically by partial application. To solve this, you m
 Feature not found: 'map' (no arguments)
 Target feature: 'interval'
 In call: 'map'
-To solve this, you might change the actual number of arguments to match the feature 'map' (one type parameter B, one value argument f) at {base.fum}/Sequence.fz:554:10:
+To solve this, you might change the actual number of arguments to match the feature 'map' (one type parameter B, one value argument f) at {base.fum}/Sequence.fz:553:10:
   public map(B type, f T->B) Sequence B
 ---------^^^
 To call 'map', you must provide 2 arguments. The type arguments may be omitted or `_` may be used in place of a type argument if they can be inferred from the value arguments..

--- a/tests/reg_issue4419/reg_issue4419.fz.expected_err
+++ b/tests/reg_issue4419/reg_issue4419.fz.expected_err
@@ -1,7 +1,7 @@
 
---CURDIR--/reg_issue4419.fz:25:9: error 1: Incompatible types when passing argument in a call
+--CURDIR--/reg_issue4419.fz:25:8: error 1: Incompatible types when passing argument in a call
 _ => m (id (Sequence i32) [])
---------^^
+-------^^^^^^^^^^^^^^^^^^^^^^
 Actual type for argument #1 's' does not match expected type.
 In call to          : 'm'
 expected formal type: 'array i32'

--- a/tests/reg_issue6012/Makefile
+++ b/tests/reg_issue6012/Makefile
@@ -1,0 +1,25 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test Makefile
+#
+# -----------------------------------------------------------------------
+
+override NAME = reg_issue6012
+include ../simple.mk

--- a/tests/reg_issue6012/reg_issue6012.fz
+++ b/tests/reg_issue6012/reg_issue6012.fz
@@ -1,0 +1,26 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test reg_issue6012
+#
+# -----------------------------------------------------------------------
+
+reg_issue6012 =>
+
+  ignore i32 "abcd{unit}efgt"

--- a/tests/reg_issue6012/reg_issue6012.fz.expected_err
+++ b/tests/reg_issue6012/reg_issue6012.fz.expected_err
@@ -1,0 +1,13 @@
+
+--CURDIR--/reg_issue6012.fz:26:14: error 1: Incompatible types when passing argument in a call
+  ignore i32 "abcd{unit}efgt"
+-------------^^^^^^^^^^^^^^^^
+Actual type for argument #1 'x' does not match expected type.
+In call to          : 'ignore'
+expected formal type: 'i32'
+actual type found   : 'String'
+assignable to       : 'String'
+for value assigned  : '"abcd{unit}efgt"'
+To solve this, you could change the type of the target 'x' to 'String' or convert the type of the assigned value to 'i32'.
+
+one error.

--- a/tests/reg_issue6026/reg_issue6026.fz.expected_err
+++ b/tests/reg_issue6026/reg_issue6026.fz.expected_err
@@ -1,7 +1,7 @@
 
---CURDIR--/reg_issue6026.fz:29:12: error 1: Incompatible types when passing argument in a call
+--CURDIR--/reg_issue6026.fz:29:11: error 1: Incompatible types when passing argument in a call
   a i32 _ (option 42) (option -12) |> type_of |> say
------------^^^^^^
+----------^^^^^^^^^^^
 Actual type for argument #1 'x' does not match expected type.
 In call to          : 'reg_issue6026.a'
 expected formal type: 'i32'

--- a/tests/this_type_negative/test_this_type_negative.fz.expected_err
+++ b/tests/this_type_negative/test_this_type_negative.fz.expected_err
@@ -1,7 +1,7 @@
 
---CURDIR--/test_this_type_negative.fz:57:17: error 1: Incompatible types when passing argument in a call
+--CURDIR--/test_this_type_negative.fz:57:16: error 1: Incompatible types when passing argument in a call
   _ := xa1.op0 (xb "xb")   # 3. should flag an error: incompatible type
-----------------^^
+---------------^^^^^^^^^
 Actual type for argument #1 'v' does not match expected type.
 In call to          : 'test_this_type_negative.xa.op0'
 expected formal type: 'test_this_type_negative.this.xa'

--- a/tests/typeinference_for_formal_args_negative/typeinference_for_args_negative.fz.expected_err
+++ b/tests/typeinference_for_formal_args_negative/typeinference_for_args_negative.fz.expected_err
@@ -43,9 +43,9 @@ for value assigned  : '1.0'
 To solve this, you could change the type of the target 'a' to 'f64' or convert the type of the assigned value to 'String'.
 
 
---CURDIR--/typeinference_for_args_negative.fz:43:14: error 7: Incompatible types when passing argument in a call
+--CURDIR--/typeinference_for_args_negative.fz:43:11: error 7: Incompatible types when passing argument in a call
   say (a3 10.as_f64   " world!")
--------------^^^^^^
+----------^^^^^^^^^
 Actual type for argument #1 'a' does not match expected type.
 In call to          : 'typeinference_for_args_negative.a3'
 expected formal type: 'String'
@@ -67,9 +67,9 @@ for value assigned  : '1.1'
 To solve this, you could change the type of the target 'a' to 'f64' or convert the type of the assigned value to 'String'.
 
 
---CURDIR--/typeinference_for_args_negative.fz:47:33: error 9: Incompatible types when passing argument in a call
+--CURDIR--/typeinference_for_args_negative.fz:47:23: error 9: Incompatible types when passing argument in a call
   say (a4 "1.0"       " world!".byte_count)
---------------------------------^^^^^^^^^^
+----------------------^^^^^^^^^^^^^^^^^^^^
 Actual type for argument #2 'b' does not match expected type.
 In call to          : 'typeinference_for_args_negative.a4'
 expected formal type: 'String'
@@ -91,9 +91,9 @@ for value assigned  : '3.14'
 To solve this, you could change the type of the target 'b' to 'f64' or convert the type of the assigned value to 'String'.
 
 
---CURDIR--/typeinference_for_args_negative.fz:49:32: error 11: Incompatible types when passing argument in a call
+--CURDIR--/typeinference_for_args_negative.fz:49:23: error 11: Incompatible types when passing argument in a call
   say (a4 "1.1"       " world!"=" monde!")
--------------------------------^
+----------------------^^^^^^^^^^^^^^^^^^^
 Actual type for argument #2 'b' does not match expected type.
 In call to          : 'typeinference_for_args_negative.a4'
 expected formal type: 'String'


### PR DESCRIPTION
fix #6012