### PR TITLE
base: add `fuzion.runtime.trace`

### DIFF
--- a/.github/workflows/consistency.yml
+++ b/.github/workflows/consistency.yml
@@ -55,6 +55,10 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install openjdk-25-jdk-headless libgc1 libgc-dev shellcheck asciidoc asciidoctor ruby-asciidoctor-pdf antlr4
+
+          # for DTRACE_PROBE
+          sudo apt-get install systemtap-sdt-dev
+
           echo "JAVA_HOME=/usr/lib/jvm/java-25-openjdk-amd64" >> $GITHUB_ENV
           echo "/usr/lib/jvm/java-25-openjdk-amd64/bin" >> $GITHUB_PATH
 

--- a/.github/workflows/interpreter.yml
+++ b/.github/workflows/interpreter.yml
@@ -48,6 +48,10 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install openjdk-25-jdk-headless sqlite3 libgc1 libgc-dev libclang1 libclang-dev libwolfssl-dev libsodium23 libsodium-dev
+
+          # for DTRACE_PROBE
+          sudo apt-get install systemtap-sdt-dev
+
           echo "JAVA_HOME=/usr/lib/jvm/java-25-openjdk-amd64" >> $GITHUB_ENV
           echo "/usr/lib/jvm/java-25-openjdk-amd64/bin" >> $GITHUB_PATH
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -56,6 +56,10 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install openjdk-25-jdk-headless sqlite3 libgc1 libgc-dev libclang1 libclang-dev libwolfssl-dev libsodium23 libsodium-dev
+
+          # for DTRACE_PROBE
+          sudo apt-get install systemtap-sdt-dev
+
           echo "JAVA_HOME=/usr/lib/jvm/java-25-openjdk-amd64" >> $GITHUB_ENV
           echo "/usr/lib/jvm/java-25-openjdk-amd64/bin" >> $GITHUB_PATH
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,10 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install openjdk-25-jdk-headless libgc1 libgc-dev ruby-asciidoctor-pdf antlr4 asciidoc-base
+
+        # for DTRACE_PROBE
+        sudo apt-get install systemtap-sdt-dev
+
         echo "JAVA_HOME=/usr/lib/jvm/java-25-openjdk-amd64" >> $GITHUB_ENV
         echo "/usr/lib/jvm/java-25-openjdk-amd64/bin" >> $GITHUB_PATH
 

--- a/include/fz.h
+++ b/include/fz.h
@@ -820,4 +820,9 @@ int fzE_cwd(void * buf, size_t size);
 
 int fzE_isnan(double d);
 
+/**
+ * wrapper around DTRACE_PROBE
+ */
+void fzE_dtrace_probe(char col, const char* msg);
+
 #endif /* fz.h  */

--- a/include/posix.c
+++ b/include/posix.c
@@ -61,7 +61,8 @@ Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
 #include <dirent.h>
 #include <pthread.h>
 #ifdef __linux__
-#include <sched.h> // CPU_SET
+#include <sched.h>    // CPU_SET
+#include <sys/sdt.h>  // dtrace_probe
 #endif
 
 #include "fz.h"
@@ -985,4 +986,44 @@ int fzE_cwd(void * buf, size_t size)
 int fzE_isnan(double d)
 {
   return isnan(d);
+}
+
+/**
+ * wrapper around DTRACE_PROBE
+ */
+void fzE_dtrace_probe(char col, const char* msg)
+{
+#ifdef __linux__
+  // we currently use DTRACE_PROBE5(fuzion, probe, col, a0, a1, a2, a3) where
+  //
+  // col is a char representing the color
+  //
+  // a0,a1,a2,a3 each have 8 chars from the msg, with the first characters using the lower bits, i.e,
+  // a0@0..7 is msg[0], a0@1..15 is msg[1], etc.
+  //
+  #define N 4
+  uint64_t args[N];
+  int i = 0;
+  int j = 0;
+  for (i = 0; i<N; i++)
+    {
+      args[i] = 0;
+    }
+  i = 0;
+  char c;
+  do
+    {
+      c = *(msg++);
+      args[i] = args[i] | ((((uint64_t) c) << (8*j)));
+      j = j + 1;
+      if (j == 8)
+        {
+          i = i + 1;
+          j = 0;
+        }
+    }
+  while (i < N && c);
+  DTRACE_PROBE5(fuzion, probe, col, args[0], args[1], args[2], args[3]);
+  #undef N
+#endif
 }

--- a/include/posix.c
+++ b/include/posix.c
@@ -1023,7 +1023,33 @@ void fzE_dtrace_probe(char col, const char* msg)
         }
     }
   while (i < N && c);
+
+  /*  we have do disable '-Wgnu-zero-variadic-macro-arguments', otherwise we get
+
+/home/runner/work/fuzion/fuzion/build/include/posix.c:1049:3: error: must specify at least one argument for '...' parameter of variadic macro [-Werror,-Wgnu-zero-variadic-macro-arguments]
+ 1049 |   DTRACE_PROBE5(fuzion, probe, col, args[0], args[1], args[2], args[3]);
+      |   ^
+/usr/include/x86_64-linux-gnu/sys/sdt.h:492:3: note: expanded from macro 'DTRACE_PROBE5'
+  492 |   STAP_PROBE5(provider,probe,parm1,parm2,parm3,parm4,parm5)
+      |   ^
+/usr/include/x86_64-linux-gnu/sys/sdt.h:378:3: note: expanded from macro 'STAP_PROBE5'
+  378 |   _SDT_PROBE(provider, name, 5, (arg1, arg2, arg3, arg4, arg5))
+      |   ^
+/usr/include/x86_64-linux-gnu/sys/sdt.h:78:75: note: expanded from macro '_SDT_PROBE'
+   78 |     __asm__ __volatile__ (_SDT_ASM_BODY(provider, name, _SDT_ASM_ARGS, (n)) \
+      |                                                                           ^
+/usr/include/x86_64-linux-gnu/sys/sdt.h:283:9: note: macro '_SDT_ASM_BODY' defined here
+  283 | #define _SDT_ASM_BODY(provider, name, pack_args, args, ...)                   \
+      |         ^
+1 error generated.
+  */
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wgnu-zero-variadic-macro-arguments"
+
   DTRACE_PROBE5(fuzion, probe, col, args[0], args[1], args[2], args[3]);
+
+#pragma clang diagnostic pop
+
   #undef N
 #endif
 }

--- a/include/win.c
+++ b/include/win.c
@@ -1250,3 +1250,12 @@ int fzE_isnan(double d)
 {
   return _isnan(d);
 }
+
+
+/**
+ * wrapper around DTRACE_PROBE
+ */
+void fzE_dtrace_probe(char col, const char* msg)
+{
+  // NYI: UNDER DEVELOPMENT: No support for DTRACE_PROBE for windows yet
+}

--- a/modules/base/src/fuzion/runtime/trace.fz
+++ b/modules/base/src/fuzion/runtime/trace.fz
@@ -1,0 +1,49 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion standard library feature fuzion.runtime.trace
+#
+#  Author: Fridtjof Siebert (siebert@tokiwa.software)
+#
+# -----------------------------------------------------------------------
+
+# fuzion.runtime.trace -- tracing probe
+#
+# Perform a runtime tracing probe.  Depending on the target system, this
+# performs executes a function like
+#
+#     DTRACE_PROBE(fuzion, probe, col, msg)
+#
+# That permits tools like feeze to display information on what is happening.
+#
+# NYI: UNDER DEVELOPMENT: Currently, this may infer a significant runtime
+# overhead even if tracing is disabled.
+#
+#
+public trace(# an identifier to chose a unique color for displaying this probe
+             #
+             col u8,
+
+             # an message to be displayed. Note that this message might get
+             # trunkated to, e.g., 16 utf8 bytes.
+             #
+             msg String
+             ) unit
+=>
+  fzE_dtrace_probe col (fuzion.sys.c_string msg)

--- a/modules/base/src/native.fz
+++ b/modules/base/src/native.fz
@@ -439,3 +439,15 @@ module fzE_mmap_offset_multiple i64 => native
 
 
 module fzE_cwd(buf Array u8, size i64) i32 => native
+
+
+# wrapper around DTRACE_PROBE macro if the target supports this.
+#
+# NYI: UNDER DEVELOPMENT: Actual argument passing mechanism is
+# work-in-progress.
+#
+module fzE_dtrace_probe(# color id to display msg with
+                        col u8,
+
+                        # the message to display, as C string
+                        msg Array u8) unit => native


### PR DESCRIPTION
This provides a means to add a `DTRACE_PROBE` that will be displayed by feeze or any other performance tool supporting `DTRACE_PROBE`.
