### PR TITLE
fuir: fix typo implementation restriction

### DIFF
--- a/src/dev/flang/fuir/Clazz.java
+++ b/src/dev/flang/fuir/Clazz.java
@@ -329,7 +329,7 @@ class Clazz extends ANY implements Comparable<Clazz>
         !_type.feature().isTypeParameter() &&
         _type.outer().outer().feature() != _type.feature().outer().outer())
       {
-        var x = "IMPLEMANTATION RESTRICTION: illegal inheritance and usage of fixed feature: \n" +
+        var x = "IMPLEMENTATION RESTRICTION: illegal inheritance and usage of fixed feature: \n" +
         _type.toString() + "\n" + _type.outer().outer().feature().toString() + "\n" + _type.feature().outer().outer().toString();
         Errors.fatal(x);
       }

--- a/tests/reg_issue5583/reg_issue5583.fz.expected_err
+++ b/tests/reg_issue5583/reg_issue5583.fz.expected_err
@@ -1,5 +1,5 @@
 
-error 1: IMPLEMANTATION RESTRICTION: illegal inheritance and usage of fixed feature: 
+error 1: IMPLEMENTATION RESTRICTION: illegal inheritance and usage of fixed feature: 
 q.type.b.type.me
 private type.q(private fixed THIS#TYPE Type (type parameter)) q.type : a q.this.type is
 private type.a(private fixed THIS#TYPE Type (type parameter)) a.type : has_me a.this.type is

--- a/tests/reg_issue6957/reg_issue6957.fz.expected_err
+++ b/tests/reg_issue6957/reg_issue6957.fz.expected_err
@@ -1,5 +1,5 @@
 
-error 1: IMPLEMANTATION RESTRICTION: illegal inheritance and usage of fixed feature: 
+error 1: IMPLEMENTATION RESTRICTION: illegal inheritance and usage of fixed feature: 
 f.type.stat.type.default_value
 private type.f(private fixed THIS#TYPE Type (type parameter)) f.type : (io f.this.type).file f.this.type is
 public type.file(private fixed THIS#TYPE Type (type parameter)) io.type.file.type : Any io.file.this.type is


### PR DESCRIPTION
Found by the lack of results when doing a tree-wide search for IMPLEMENTATION RESTRICTION.