### PR TITLE
time/histogram: make `histogram_mutate` public for use in other threads

### DIFF
--- a/examples/jitter/jitter.fz
+++ b/examples/jitter/jitter.fz
@@ -156,7 +156,8 @@ jitter =>
 
   if run_on_dedicated_thread
     thrd := concur.threads.env.spawn ()->
-      test_jitter time.nano time.nano
+      time.histogram_mutate ! ()->
+        test_jitter time.nano time.nano
     match thrd.set_policy concur.scheduling_policy.sched_fifo false 99
       e error => panic "jitter thread priority: $e. Error 38 : backend does not implement thread policy \n Error 1 : insufficient privileges."
       unit    => unit

--- a/modules/base/src/time/histogram.fz
+++ b/modules/base/src/time/histogram.fz
@@ -438,7 +438,7 @@ is
 
 # a local mutate instance we are using to modify our state
 #
-histogram_mutate : mutate
+public histogram_mutate : mutate
 is
 
   # default implementation of mutate


### PR DESCRIPTION
Since it causes histograms being used from other threads break.