### PR TITLE
fe: confusing error: "expected formal type: 'T' actual type found : 'T'"

### DIFF
--- a/src/dev/flang/ast/AbstractType.java
+++ b/src/dev/flang/ast/AbstractType.java
@@ -2420,7 +2420,13 @@ there is no common super type of the two types (Types.t_ERROR)
     if (isGenericArgument())
       {
         var ga = genericArgument();
-        result = (ga.isCoTypesThisType() ? ga.qualifiedName(context, humanReadable) : (humanReadable ? ga.baseNameHuman() : ga.baseName())) + (isRef() ? " (boxed)" : "");
+        result =
+          (ga.isCoTypesThisType()
+            ? ga.qualifiedName(context, humanReadable)
+            : ga.isTypeFeature()
+            ? ga.qualifiedName(humanReadable)
+            : (humanReadable ? ga.baseNameHuman() : ga.baseName())) +
+          (isRef() ? " (boxed)" : "");
       }
     else
       {

--- a/tests/reg_issue6921/Makefile
+++ b/tests/reg_issue6921/Makefile
@@ -1,0 +1,25 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test Makefile
+#
+# -----------------------------------------------------------------------
+
+override NAME = reg_issue6921
+include ../simple.mk

--- a/tests/reg_issue6921/reg_issue6921.fz
+++ b/tests/reg_issue6921/reg_issue6921.fz
@@ -1,0 +1,27 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test reg_issue6921
+#
+# -----------------------------------------------------------------------
+
+a(T type) is
+  b T => abstract
+  type.new(F type: i32->T, f F) a T=> a T
+  public transpose a T => (a T).new _ i->b

--- a/tests/reg_issue6921/reg_issue6921.fz.expected_err
+++ b/tests/reg_issue6921/reg_issue6921.fz.expected_err
@@ -1,0 +1,12 @@
+
+--CURDIR--/reg_issue6921.fz:27:42: error 1: Incompatible types in assignment
+  public transpose a T => (a T).new _ i->b
+-----------------------------------------^
+assignment to field : 'a.transpose.(λi->b).call.result'
+expected formal type: 'a.type.T'
+actual type found   : 'T'
+assignable to       : 'T'
+for value assigned  : 'b'
+To solve this, you could change the type of the target 'a.transpose.(λi->b).call.result' to 'T' or convert the type of the assigned value to 'a.type.T'.
+
+one error.

--- a/tests/reg_issues4992_5001_negative/reg_issues4992_5001_negative.fz.expected_err
+++ b/tests/reg_issues4992_5001_negative/reg_issues4992_5001_negative.fz.expected_err
@@ -24,14 +24,14 @@ actual type parameter 'tuple unit true_'
 --CURDIR--/reg_issues4992_5001_negative.fz:150:9: error 4: Incompatible type parameter
       X.i (tuple i32 i32 i32) (42,43,44)  # 4. should flag an error: wrong type parameter `tuple i32 i32 i32` instead of `tuple Any unit f32`
 --------^
-formal type parameter 'U : tuple A B C' with constraint 'tuple Any unit f32'
+formal type parameter 'U : tuple reg_issues4992_5000.case6.x.type.A reg_issues4992_5000.case6.x.type.B reg_issues4992_5000.case6.x.type.C' with constraint 'tuple Any unit f32'
 actual type parameter 'tuple i32 i32 i32'
 
 
 --CURDIR--/reg_issues4992_5001_negative.fz:162:13: error 5: Incompatible type parameter
     (x f32).i (box i32)  # 5. should flag an error: wrong type parameter `box i32` instead of `box f32`
 ------------^
-formal type parameter 'U : reg_issues4992_5000.case7.this.box A' with constraint 'reg_issues4992_5000.case7.this.box f32'
+formal type parameter 'U : reg_issues4992_5000.case7.this.box reg_issues4992_5000.case7.x.type.A' with constraint 'reg_issues4992_5000.case7.this.box f32'
 actual type parameter 'reg_issues4992_5000.case7.this.box i32'
 
 5 errors.


### PR DESCRIPTION
fixes #6921

In essence this changes `toString` for a type parameter, if the outer is a co-type to also include this in the name. Normal type parameters are still stringified as just  the baseName of the feature.