### PR TITLE
tests: `check_example`, replace `clazzId`s by `XXX`

### DIFF
--- a/bin/check_simple_example.fz
+++ b/bin/check_simple_example.fz
@@ -168,6 +168,8 @@ clean_err(f path) =>
   # line numbers
   "sed -E -i s/\\.fz:[0-9]+:[0-9]+:/\\.fz:n:n:/g $f".execute .or_panic
   "sed -E -i s/\\.fz:[0-9]+/\\.fz:n/g $f".execute .or_panic
+  # replace CLASS_PREFIX_WITH_ID
+  "sed -E -i s/fzC__L[0-9]+/fzC_LXXX/g $f".execute .or_panic
 
 
 # delete temporary files


### PR DESCRIPTION
this

    at fzC_LXXX_reg_issue6__all__INTERN_fun1__call__INTERN_fun2__call.fzRoutine(--CURDIR--/reg_issue6882.fz)
    at fzC_3instate_helper_unit_panic__call_code__call.fzRoutine({base.fum}/effect.fz:422)
    at fzC_3instate_helper_unit_panic.fzRoutine({base.fum}/effect.fz:417)
    at fzC_panic_INTERN_type_panic__3instate_unit.fzRoutine({base.fum}/effect.fz:170)
    at fzC_eff__1try_String_panic_unit__1catch0.fzRoutine({base.fum}/eff/try.fz:63)
    at fzC_eff__1try_String_panic_unit__1catch__INTERN_fun5__call.fzRoutine({base.fum}/eff/try.fz:50)
    at fzC_LXXX_3instate_h__try_String_panic_unit_lm__call_code__call.fzRoutine({base.fum}/effect.fz:422)
    at fzC_3instate_helper__unit__eff_try_String_panic_unit_lm.fzRoutine({base.fum}/effect.fz:417)
    at fzC_LXXX_eff_INTERN__f_try_String_panic_unit_lm__3instate_unit.fzRoutine({base.fum}/effect.fz:170)
    at fzC_LXXX_eff_INTERN__f_try_String_panic_unit_lm__2instate_unit.fzRoutine({base.fum}/effect.fz:191)
    at fzC_eff__1try_String_panic_unit__lm__1instate_self_unit.fzRoutine({base.fum}/effect.fz:212)
    at fzC_eff__1try_String_panic_unit__lm__1infix_not_unit.fzRoutine({base.fum}/effect.fz:229)
    at fzC_eff__1try_String_panic_unit__1catch.fzRoutine({base.fum}/eff/try.fz:49)
    at fzC_reg_issue6882__INTERN_fun0__call__INTERN_fun1__call.fzRoutine(--CURDIR--/reg_issue6882.fz:38)
    at fzC_fuzion__sys__thread__1spawn__Do_Call__call.fzRoutine({base.fum}/fuzion/sys/thread.fz:36)
    at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
    at java.base/java.lang.reflect.Method.invoke(Method.java:565)
    at dev.flang.be.jvm.runtime.FuzionThread.lambda$new$0(FuzionThread.java:100)
    at dev.flang.util.Errors.runAndExit(Errors.java:930)
    at dev.flang.be.jvm.runtime.FuzionThread.lambda$new$2(FuzionThread.java:132)
    at java.base/java.lang.Thread.run(Thread.java:1474)

instead of

    at fzC__L3749_reg_issue6__all__INTERN_fun1__call__INTERN_fun2__call.fzRoutine(--CURDIR--/reg_issue6882.fz)
    at fzC_3instate_helper_unit_panic__call_code__call.fzRoutine({base.fum}/effect.fz:422)
    at fzC_3instate_helper_unit_panic.fzRoutine({base.fum}/effect.fz:417)
    at fzC_panic_INTERN_type_panic__3instate_unit.fzRoutine({base.fum}/effect.fz:170)
    at fzC_eff__1try_String_panic_unit__1catch0.fzRoutine({base.fum}/eff/try.fz:63)
    at fzC_eff__1try_String_panic_unit__1catch__INTERN_fun5__call.fzRoutine({base.fum}/eff/try.fz:50)
    at fzC__L1680_3instate_h__try_String_panic_unit_lm__call_code__call.fzRoutine({base.fum}/effect.fz:422)
    at fzC_3instate_helper__unit__eff_try_String_panic_unit_lm.fzRoutine({base.fum}/effect.fz:417)
    at fzC__L1655_eff_INTERN__f_try_String_panic_unit_lm__3instate_unit.fzRoutine({base.fum}/effect.fz:170)
    at fzC__L1644_eff_INTERN__f_try_String_panic_unit_lm__2instate_unit.fzRoutine({base.fum}/effect.fz:191)
    at fzC_eff__1try_String_panic_unit__lm__1instate_self_unit.fzRoutine({base.fum}/effect.fz:212)
    at fzC_eff__1try_String_panic_unit__lm__1infix_not_unit.fzRoutine({base.fum}/effect.fz:229)
    at fzC_eff__1try_String_panic_unit__1catch.fzRoutine({base.fum}/eff/try.fz:49)
    at fzC_reg_issue6882__INTERN_fun0__call__INTERN_fun1__call.fzRoutine(--CURDIR--/reg_issue6882.fz:38)
    at fzC_fuzion__sys__thread__1spawn__Do_Call__call.fzRoutine({base.fum}/fuzion/sys/thread.fz:36)
    at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
    at java.base/java.lang.reflect.Method.invoke(Method.java:565)
    at dev.flang.be.jvm.runtime.FuzionThread.lambda$new$0(FuzionThread.java:100)
    at dev.flang.util.Errors.runAndExit(Errors.java:930)
    at dev.flang.be.jvm.runtime.FuzionThread.lambda$new$2(FuzionThread.java:132)
    at java.base/java.lang.Thread.run(Thread.java:1474)
