### PR TITLE
dockerfile: upgrade to ubuntu 26

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:24.04@sha256:c4a8d5503dfb2a3eb8ab5f807da5bc69a85730fb49b5cfca2330194ebcc41c7b AS builder
+FROM ubuntu:26.04@sha256:f3d28607ddd78734bb7f71f117f3c6706c666b8b76cbff7c9ff6e5718d46ff64 AS builder
 WORKDIR /fuzion
 COPY . .
 RUN apt-get update && apt-get -y --no-install-recommends install \
@@ -20,7 +20,7 @@ RUN ln -s /usr/bin/clang-18 /usr/bin/clang
 ENV FUZION_REPRODUCIBLE_BUILD="true" PRECONDITIONS="true" POSTCONDITIONS="true"
 RUN make all build/apidocs_git/index.html
 
-FROM ubuntu:24.04@sha256:c4a8d5503dfb2a3eb8ab5f807da5bc69a85730fb49b5cfca2330194ebcc41c7b AS runner
+FROM ubuntu:26.04@sha256:f3d28607ddd78734bb7f71f117f3c6706c666b8b76cbff7c9ff6e5718d46ff64 AS runner
 # NYI: HACK: chmod is a workaround for Jenkins permission issue
 COPY --from=builder --chmod=o=g /fuzion/build /fuzion
 RUN apt-get update && apt-get -y --no-install-recommends install \
@@ -36,7 +36,7 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
   libsodium-dev \
   libsodium23 \
   libwolfssl-dev \
-  libwolfssl42t64 \
+  libwolfssl44 \
   locales \
   make \
   openjdk-25-jdk-headless \
@@ -46,5 +46,6 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
   unzip \
   wget
 RUN ln -s /usr/bin/clang-18 /usr/bin/clang
-RUN localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+RUN locale-gen en_US.UTF-8 && \
+    update-locale LANG=en_US.UTF-8
 ENV LANG=en_US.utf8 PATH="/fuzion/bin:${PATH}" PRECONDITIONS="true" POSTCONDITIONS="true" dev_flang_tools_serializeFUIR="true" dev_flang_fuir_analysis_dfa_DFA_MAX_ITERATIONS="50" FUZION_HOME="/fuzion"


### PR DESCRIPTION
[ci skip]

```
~/openvscode-server-fuzion/vscode-fuzion/fuzion (main)1$ docker build -t "fuzion_tmp" .
[+] Building 320.4s (15/15) FINISHED                                                                                                                                                                                   docker:default
 => [internal] load build definition from Dockerfile                                                                                                                                                                             0.0s
 => => transferring dockerfile: 1.49kB                                                                                                                                                                                           0.0s
 => [internal] load metadata for docker.io/library/ubuntu:26.04@sha256:f3d28607ddd78734bb7f71f117f3c6706c666b8b76cbff7c9ff6e5718d46ff64                                                                                          0.7s
 => [internal] load .dockerignore                                                                                                                                                                                                0.0s
 => => transferring context: 46B                                                                                                                                                                                                 0.0s
 => [internal] load build context                                                                                                                                                                                                0.1s
 => => transferring context: 271.14kB                                                                                                                                                                                            0.1s
 => CACHED [builder 1/6] FROM docker.io/library/ubuntu:26.04@sha256:f3d28607ddd78734bb7f71f117f3c6706c666b8b76cbff7c9ff6e5718d46ff64                                                                                             0.0s
 => CACHED [builder 2/6] WORKDIR /fuzion                                                                                                                                                                                         0.0s
 => [builder 3/6] COPY . .                                                                                                                                                                                                       0.2s
 => [builder 4/6] RUN apt-get update && apt-get -y --no-install-recommends install   openjdk-25-jdk-headless   git   make   patch   libgc1   libgc-dev   shellcheck   asciidoc   asciidoctor   ruby-asciidoctor-pdf   antlr4    46.0s
 => [builder 5/6] RUN ln -s /usr/bin/clang-18 /usr/bin/clang                                                                                                                                                                     0.2s 
 => [builder 6/6] RUN make all build/apidocs_git/index.html                                                                                                                                                                    194.6s 
 => [runner 2/5] COPY --from=builder --chmod=o=g /fuzion/build /fuzion                                                                                                                                                           1.7s 
 => [runner 3/5] RUN apt-get update && apt-get -y --no-install-recommends install   antlr4   asciidoc   asciidoctor   clang-18   ditaa   git   inkscape   libgc-dev   libgc1   libsodium-dev   libsodium23   libwolfssl-dev     71.6s 
 => [runner 4/5] RUN ln -s /usr/bin/clang-18 /usr/bin/clang                                                                                                                                                                      0.2s 
 => [runner 5/5] RUN locale-gen en_US.UTF-8 &&     update-locale LANG=en_US.UTF-8                                                                                                                                                1.0s 
 => exporting to image                                                                                                                                                                                                           2.8s 
 => => exporting layers                                                                                                                                                                                                          2.8s 
 => => writing image sha256:f4ca2d81381cdfe718cb041e96a94eca091e58c7cf901b32871a2283626a07bb                                                                                                                                     0.0s 
 => => naming to docker.io/library/fuzion_tmp      
```