### PR TITLE
ast: suppress followup error for result type `**error**` in native feat

### DIFF
--- a/src/dev/flang/ast/AstErrors.java
+++ b/src/dev/flang/ast/AstErrors.java
@@ -2579,14 +2579,19 @@ public class AstErrors extends ANY
 
   public static void explicitTypeRequired(AbstractFeature f, AbstractType inf)
   {
-    String inferredMsg = (inf != null && inf != Types.t_ERROR) ?
-                           "\nInferred type is " + s(inf) : "\nNo type could be inferred";
+    String inferredMsg = (inf != null && inf != Types.t_ERROR) ? " Inferred type is " + s(inf)
+                                                               : "";
+
+    String reason = f.isAbstract()                                   ? skw("abstract")  :
+                    f.isIntrinsic()                                  ? skw("intrinsic") :
+                    f.isNative()                                     ? skw("native")    :
+                    f.visibility().eraseTypeVisibility() == Visi.PUB ? skw("public")
+                                                                     : "argument of a " + skw("public") + " feature";
 
     error(f.pos(),
-          (f.visibility().eraseTypeVisibility() == Visi.PUB)
-            ? "Public features must have explicit result type"
-            : "Arguments of public features must have explicit type",
-          "Feature " + s(f) + " is " + skw("public") + " but has no explicit type specified"
+          "Explicit type required",
+          "Feature " + s(f) + " is " + reason + ", but has no type specified.\n"
+          + "To solve this, please specify a type explicitly."
           + inferredMsg);
   }
 

--- a/src/dev/flang/ast/Feature.java
+++ b/src/dev/flang/ast/Feature.java
@@ -2515,7 +2515,14 @@ A pre-condition of a feature that does not redefine an inherited feature must st
           {
             if (urgent)
               {
-                AstErrors.failedToInferResultType(this);
+                if ( !(isAbstract() || isIntrinsic() || isNative()) )
+                  {
+                    AstErrors.failedToInferResultType(this);
+                  }
+                else if (!(Errors.any() && impl() == Impl.ERROR))
+                  {
+                    AstErrors.explicitTypeRequired(this, null);
+                  }
               }
             result = urgent ? Types.t_ERROR : null;
           }

--- a/src/dev/flang/ast/Feature.java
+++ b/src/dev/flang/ast/Feature.java
@@ -2221,7 +2221,8 @@ A pre-condition of a feature that does not redefine an inherited feature must st
   private void checkLegalNativeResultType(Resolution res, SourcePosition pos, AbstractType rt)
   {
     ensureTypeSetsInitialized(res);
-    if (!(Types.resolved.legalNativeResultTypes.contains(rt) || !rt.isGenericArgument() && rt.feature().mayBeNativeValue()))
+    if (!(Types.resolved.legalNativeResultTypes.contains(rt) || !rt.isGenericArgument() && rt.feature().mayBeNativeValue())
+        && !(Errors.any() && rt == Types.t_ERROR))
       {
         AstErrors.illegalNativeType(pos, "Result type", rt);
       }

--- a/tests/reg_issue3003/reg_issue3003.fz.expected_err
+++ b/tests/reg_issue3003/reg_issue3003.fz.expected_err
@@ -1,7 +1,8 @@
 
---CURDIR--/reg_issue3003.fz:27:5: error 1: Failed to infer result type for feature 'reg_issue3003.a.f'.
+--CURDIR--/reg_issue3003.fz:27:5: error 1: Explicit type required
     f => abstract
 ----^
-To solve this, please specify a result type explicitly.
+Feature 'reg_issue3003.a.f' is 'abstract', but has no type specified.
+To solve this, please specify a type explicitly.
 
 one error.

--- a/tests/reg_issue5106/reg_issue5106.fz.expected_err
+++ b/tests/reg_issue5106/reg_issue5106.fz.expected_err
@@ -17,52 +17,52 @@ for value assigned  : '42'
 To solve this, you could change the type of the target 'x' to 'i32' or convert the type of the assigned value to 'String'.
 
 
---CURDIR--/reg_issue5106.fz:26:10: error 3: Public features must have explicit result type
+--CURDIR--/reg_issue5106.fz:26:10: error 3: Explicit type required
   public f1(x) =>        # 1. should flag an error: 2x feature/argument must have explicit type
 ---------^^
-Feature 'reg_issue5106.f1' is 'public' but has no explicit type specified
-Inferred type is 'unit'
+Feature 'reg_issue5106.f1' is 'public', but has no type specified.
+To solve this, please specify a type explicitly. Inferred type is 'unit'
 
 
---CURDIR--/reg_issue5106.fz:26:13: error 4: Arguments of public features must have explicit type
+--CURDIR--/reg_issue5106.fz:26:13: error 4: Explicit type required
   public f1(x) =>        # 1. should flag an error: 2x feature/argument must have explicit type
 ------------^
-Feature 'reg_issue5106.f1.x' is 'public' but has no explicit type specified
-No type could be inferred
+Feature 'reg_issue5106.f1.x' is argument of a 'public' feature, but has no type specified.
+To solve this, please specify a type explicitly.
 
 
---CURDIR--/reg_issue5106.fz:28:10: error 5: Public features must have explicit result type
+--CURDIR--/reg_issue5106.fz:28:10: error 5: Explicit type required
   public f2(x String) => # 2. should flag an error: feature must have explicit type
 ---------^^
-Feature 'reg_issue5106.f2' is 'public' but has no explicit type specified
-Inferred type is 'unit'
+Feature 'reg_issue5106.f2' is 'public', but has no type specified.
+To solve this, please specify a type explicitly. Inferred type is 'unit'
 
 
---CURDIR--/reg_issue5106.fz:31:10: error 6: Public features must have explicit result type
+--CURDIR--/reg_issue5106.fz:31:10: error 6: Explicit type required
   public f3(x) =>        # 4. should flag an error: 2x feature/argument must have explicit type
 ---------^^
-Feature 'reg_issue5106.f3' is 'public' but has no explicit type specified
-Inferred type is 'unit'
+Feature 'reg_issue5106.f3' is 'public', but has no type specified.
+To solve this, please specify a type explicitly. Inferred type is 'unit'
 
 
---CURDIR--/reg_issue5106.fz:31:13: error 7: Arguments of public features must have explicit type
+--CURDIR--/reg_issue5106.fz:31:13: error 7: Explicit type required
   public f3(x) =>        # 4. should flag an error: 2x feature/argument must have explicit type
 ------------^
-Feature 'reg_issue5106.f3.x' is 'public' but has no explicit type specified
-Inferred type is 'i32'
+Feature 'reg_issue5106.f3.x' is argument of a 'public' feature, but has no type specified.
+To solve this, please specify a type explicitly. Inferred type is 'i32'
 
 
---CURDIR--/reg_issue5106.fz:34:13: error 8: Arguments of public features must have explicit type
+--CURDIR--/reg_issue5106.fz:34:13: error 8: Explicit type required
   public f4(x) unit =>   # 5. should flag an error: feature must have explicit type
 ------------^
-Feature 'reg_issue5106.f4.x' is 'public' but has no explicit type specified
-Inferred type is 'i32'
+Feature 'reg_issue5106.f4.x' is argument of a 'public' feature, but has no type specified.
+To solve this, please specify a type explicitly. Inferred type is 'i32'
 
 
---CURDIR--/reg_issue5106.fz:47:13: error 9: Arguments of public features must have explicit type
+--CURDIR--/reg_issue5106.fz:47:13: error 9: Explicit type required
   public f9(x) is        # 6. should flag an error: argument must have explicit type
 ------------^
-Feature 'reg_issue5106.f9.x' is 'public' but has no explicit type specified
-Inferred type is 'i32'
+Feature 'reg_issue5106.f9.x' is argument of a 'public' feature, but has no type specified.
+To solve this, please specify a type explicitly. Inferred type is 'i32'
 
 9 errors.

--- a/tests/reg_issue7149/Makefile
+++ b/tests/reg_issue7149/Makefile
@@ -1,0 +1,25 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test Makefile
+#
+# -----------------------------------------------------------------------
+
+override NAME = reg_issue7149
+include ../simple.mk

--- a/tests/reg_issue7149/reg_issue7149.fz
+++ b/tests/reg_issue7149/reg_issue7149.fz
@@ -1,0 +1,26 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test reg_issue7149
+#
+# -----------------------------------------------------------------------
+
+reg_issue7149 is
+
+  x => native

--- a/tests/reg_issue7149/reg_issue7149.fz.expected_err
+++ b/tests/reg_issue7149/reg_issue7149.fz.expected_err
@@ -1,0 +1,7 @@
+
+--CURDIR--/reg_issue7149.fz:26:3: error 1: Failed to infer result type for feature 'reg_issue7149.x'.
+  x => native
+--^
+To solve this, please specify a result type explicitly.
+
+one error.

--- a/tests/reg_issue7149/reg_issue7149.fz.expected_err
+++ b/tests/reg_issue7149/reg_issue7149.fz.expected_err
@@ -1,7 +1,8 @@
 
---CURDIR--/reg_issue7149.fz:26:3: error 1: Failed to infer result type for feature 'reg_issue7149.x'.
+--CURDIR--/reg_issue7149.fz:26:3: error 1: Explicit type required
   x => native
 --^
-To solve this, please specify a result type explicitly.
+Feature 'reg_issue7149.x' is 'native', but has no type specified.
+To solve this, please specify a type explicitly.
 
 one error.


### PR DESCRIPTION
fix #7149
