### PR TITLE
Add method `as_string_decimals` to convert a float to a string with a custom number of decimals

### DIFF
--- a/modules/base/src/f32.fz
+++ b/modules/base/src/f32.fz
@@ -198,15 +198,22 @@ public f32(public val f32) : float, java_primitive is
 
 
   # convert this to a string with a fixed number of digits after the decimal point.
-  #
+  # If the given values are unusable, the result is the same as `as_string`.
+  # Overflows are technically possible, but floats become inaccurate long before that.
   public redef as_string_decimals(fraction_digits i32) String =>
-    if fraction_digits <= 0
+    if is_NaN
+      "NaN"
+    else if val = f32.positive_infinity
+      "Infinity"
+    else if val = f32.negative_infinity
+      "-Infinity"
+    else if fraction_digits <= 0
       f32.this.as_string
     else
       scale := 10.0 ** fraction_digits.as_f64
 
       rounded_scaled :=
-        if val >= 0.0
+        if val.as_f64 >= 0.0
           ((val.as_f64 * scale) + 0.5).as_i64_lax
         else
           ((val.as_f64 * scale) - 0.5).as_i64_lax

--- a/modules/base/src/f32.fz
+++ b/modules/base/src/f32.fz
@@ -203,7 +203,17 @@ public f32(public val f32) : float, java_primitive is
     if fraction_digits <= 0
       f32.this.as_string
     else
-      s String := (num.ryū f32).as_string val false (num.ryū f32).rounding_conservative
+      scale := 10.0 ** fraction_digits.as_f64
+
+      rounded_scaled :=
+        if val >= 0.0
+          ((val.as_f64 * scale) + 0.5).as_i64_lax
+        else
+          ((val.as_f64 * scale) - 0.5).as_i64_lax
+
+      rounded := rounded_scaled.as_f64 / scale
+
+      s String := (num.ryū f32).as_string rounded.as_f32 false (num.ryū f32).rounding_even
       match s.find "."
         i i32 =>
           digits := s.substring i+1

--- a/modules/base/src/f32.fz
+++ b/modules/base/src/f32.fz
@@ -197,6 +197,23 @@ public f32(public val f32) : float, java_primitive is
     (num.ryū f32).as_string val
 
 
+  # convert this to a string with a fixed number of digits after the decimal point.
+  #
+  public redef as_string(fraction_digits i32) String =>
+    if fraction_digits <= 0
+      f32.this.as_string
+    else
+      s String := (num.ryū f32).as_string val false (num.ryū f32).rounding_conservative
+      match s.find "."
+        i i32 =>
+          digits := s.substring i+1
+          if digits.byte_count > fraction_digits
+            "{s.substring 0 i}.{digits.substring 0 fraction_digits}"
+          else
+            "{s.substring 0 i}.{digits.pad "0" fraction_digits}"
+        nil => s
+
+
   # -----------------------------------------------------------------------
   #
   # type features:

--- a/modules/base/src/f32.fz
+++ b/modules/base/src/f32.fz
@@ -201,13 +201,7 @@ public f32(public val f32) : float, java_primitive is
   # If the given values are unusable, the result is the same as `as_string`.
   # Overflows are technically possible, but floats become inaccurate long before that.
   public redef as_string_decimals(fraction_digits i32) String =>
-    if is_NaN
-      "NaN"
-    else if val = f32.positive_infinity
-      "Infinity"
-    else if val = f32.negative_infinity
-      "-Infinity"
-    else if fraction_digits <= 0
+    if is_NaN || val.abs = f32.positive_infinity || fraction_digits <= 0
       f32.this.as_string
     else
       scale := 10.0 ** fraction_digits.as_f64

--- a/modules/base/src/f32.fz
+++ b/modules/base/src/f32.fz
@@ -199,7 +199,7 @@ public f32(public val f32) : float, java_primitive is
 
   # convert this to a string with a fixed number of digits after the decimal point.
   #
-  public redef as_string(fraction_digits i32) String =>
+  public redef as_string_decimals(fraction_digits i32) String =>
     if fraction_digits <= 0
       f32.this.as_string
     else

--- a/modules/base/src/f32.fz
+++ b/modules/base/src/f32.fz
@@ -200,6 +200,7 @@ public f32(public val f32) : float, java_primitive is
   # convert this to a string with a fixed number of digits after the decimal point.
   # If the given values are unusable, the result is the same as `as_string`.
   # Overflows are technically possible, but floats become inaccurate long before that.
+  #
   public redef as_string_decimals(fraction_digits i32) String =>
     if is_NaN || val.abs = f32.positive_infinity || fraction_digits <= 0
       f32.this.as_string

--- a/modules/base/src/f64.fz
+++ b/modules/base/src/f64.fz
@@ -209,13 +209,7 @@ public f64(public val f64) : float, java_primitive is
   # If the given values are unusable, the result is the same as `as_string`.
   # Overflows are technically possible, but floats become inaccurate long before that.
   public redef as_string_decimals(fraction_digits i32) String =>
-    if is_NaN
-      "NaN"
-    else if val = f64.positive_infinity
-      "Infinity"
-    else if val = f64.negative_infinity
-      "-Infinity"
-    else if fraction_digits <= 0
+    if is_NaN || val.abs = f64.positive_infinity || fraction_digits <= 0
       f64.this.as_string
     else
       scale := 10.0 ** fraction_digits.as_f64

--- a/modules/base/src/f64.fz
+++ b/modules/base/src/f64.fz
@@ -205,6 +205,23 @@ public f64(public val f64) : float, java_primitive is
     (num.ryū f64).as_string val
 
 
+  # convert this to a string with a fixed number of digits after the decimal point.
+  #
+  public redef as_string(fraction_digits i32) String =>
+    if fraction_digits <= 0
+      f64.this.as_string
+    else
+      s String := (num.ryū f64).as_string val false (num.ryū f64).rounding_conservative
+      match s.find "."
+        i i32 =>
+          digits := s.substring i+1
+          if digits.byte_count > fraction_digits
+            "{s.substring 0 i}.{digits.substring 0 fraction_digits}"
+          else
+            "{s.substring 0 i}.{digits.pad "0" fraction_digits}"
+        nil => s
+
+
   # -----------------------------------------------------------------------
   #
   # type features:

--- a/modules/base/src/f64.fz
+++ b/modules/base/src/f64.fz
@@ -211,7 +211,17 @@ public f64(public val f64) : float, java_primitive is
     if fraction_digits <= 0
       f64.this.as_string
     else
-      s String := (num.ryū f64).as_string val false (num.ryū f64).rounding_conservative
+      scale := 10.0 ** fraction_digits.as_f64
+
+      rounded_scaled :=
+        if val >= 0.0
+          ((val * scale) + 0.5).as_i64_lax
+        else
+          ((val * scale) - 0.5).as_i64_lax
+
+      rounded := rounded_scaled.as_f64 / scale
+
+      s String := (num.ryū f64).as_string rounded false (num.ryū f64).rounding_conservative
       match s.find "."
         i i32 =>
           digits := s.substring i+1

--- a/modules/base/src/f64.fz
+++ b/modules/base/src/f64.fz
@@ -206,9 +206,16 @@ public f64(public val f64) : float, java_primitive is
 
 
   # convert this to a string with a fixed number of digits after the decimal point.
-  #
+  # If the given values are unusable, the result is the same as `as_string`.
+  # Overflows are technically possible, but floats become inaccurate long before that.
   public redef as_string_decimals(fraction_digits i32) String =>
-    if fraction_digits <= 0
+    if is_NaN
+      "NaN"
+    else if val = f64.positive_infinity
+      "Infinity"
+    else if val = f64.negative_infinity
+      "-Infinity"
+    else if fraction_digits <= 0
       f64.this.as_string
     else
       scale := 10.0 ** fraction_digits.as_f64

--- a/modules/base/src/f64.fz
+++ b/modules/base/src/f64.fz
@@ -207,7 +207,7 @@ public f64(public val f64) : float, java_primitive is
 
   # convert this to a string with a fixed number of digits after the decimal point.
   #
-  public redef as_string(fraction_digits i32) String =>
+  public redef as_string_decimals(fraction_digits i32) String =>
     if fraction_digits <= 0
       f64.this.as_string
     else

--- a/modules/base/src/f64.fz
+++ b/modules/base/src/f64.fz
@@ -208,6 +208,7 @@ public f64(public val f64) : float, java_primitive is
   # convert this to a string with a fixed number of digits after the decimal point.
   # If the given values are unusable, the result is the same as `as_string`.
   # Overflows are technically possible, but floats become inaccurate long before that.
+  #
   public redef as_string_decimals(fraction_digits i32) String =>
     if is_NaN || val.abs = f64.positive_infinity || fraction_digits <= 0
       f64.this.as_string

--- a/modules/base/src/float.fz
+++ b/modules/base/src/float.fz
@@ -77,7 +77,7 @@ public float : numeric is
 
   # convert this float to a string with a fixed number of digits after the decimal point.
   #
-  public as_string(fraction_digits i32) String => abstract
+  public as_string_decimals(fraction_digits i32) String => abstract
 
 
   # floor: the greatest integer lower or equal to this

--- a/modules/base/src/float.fz
+++ b/modules/base/src/float.fz
@@ -76,7 +76,7 @@ public float : numeric is
 
 
   # convert this float to a string with a fixed number of digits after the decimal point.
-  # NYI : In the future, this should be replaced by a version of as_string with more formatting options,
+  # NYI: ENHANCEMENT: In the future, this should be replaced by a version of as_string with more formatting options,
   # as described here : https://github.com/tokiwa-software/fuzion/pull/7152#issuecomment-4613267795
   #
   public as_string_decimals(fraction_digits i32) String => abstract

--- a/modules/base/src/float.fz
+++ b/modules/base/src/float.fz
@@ -76,6 +76,8 @@ public float : numeric is
 
 
   # convert this float to a string with a fixed number of digits after the decimal point.
+  # NYI : In the future, this should be replaced by a version of as_string with more formatting options,
+  # as described here : https://github.com/tokiwa-software/fuzion/pull/7152#issuecomment-4613267795
   #
   public as_string_decimals(fraction_digits i32) String => abstract
 

--- a/modules/base/src/float.fz
+++ b/modules/base/src/float.fz
@@ -75,6 +75,11 @@ public float : numeric is
       (float.this + float.this.one/float.this.two).floor
 
 
+  # convert this float to a string with a fixed number of digits after the decimal point.
+  #
+  public as_string(fraction_digits i32) String => abstract
+
+
   # floor: the greatest integer lower or equal to this
   public floor float.this =>
     if fract < float.this.zero

--- a/modules/base/src/i32.fz
+++ b/modules/base/src/i32.fz
@@ -107,6 +107,7 @@ public i32(public val i32) : num.wrap_around, has_interval, java_primitive is
   public as_f32 f32 => as_f64.as_f32
 
   # Convert this to a string with a fixed number of digits after the decimal point.
+  #
   public as_string_decimals(fraction_digits i32) String =>
     as_f32.as_string_decimals fraction_digits
 

--- a/modules/base/src/i32.fz
+++ b/modules/base/src/i32.fz
@@ -106,6 +106,9 @@ public i32(public val i32) : num.wrap_around, has_interval, java_primitive is
   public as_f64 f64 => intrinsic
   public as_f32 f32 => as_f64.as_f32
 
+  # Convert this to a string with a fixed number of digits after the decimal point.
+  public as_string_decimals(fraction_digits i32) String =>
+    as_f32.as_string_decimals fraction_digits
 
   # create hash code from this number
   public redef type.hash_code(a i32.this) u64 =>

--- a/modules/base/src/i64.fz
+++ b/modules/base/src/i64.fz
@@ -126,6 +126,10 @@ public i64(public val i64) : num.wrap_around, has_interval, java_primitive is
   public as_int int =>
     int val
 
+  # Convert this to a string with a fixed number of digits after the decimal point.
+  public as_string_decimals(fraction_digits i32) String =>
+    as_f64.as_string_decimals fraction_digits
+
 
   # this i64 as an uint
   #

--- a/modules/base/src/i64.fz
+++ b/modules/base/src/i64.fz
@@ -127,6 +127,7 @@ public i64(public val i64) : num.wrap_around, has_interval, java_primitive is
     int val
 
   # Convert this to a string with a fixed number of digits after the decimal point.
+  #
   public as_string_decimals(fraction_digits i32) String =>
     as_f64.as_string_decimals fraction_digits
 

--- a/modules/base/src/int.fz
+++ b/modules/base/src/int.fz
@@ -144,7 +144,7 @@ is
     if ns then "$n" else "-$n"
 
   # Convert this to a string with a fixed number of digits after the decimal point.
-  
+    #
   public as_string_decimals(fraction_digits i32) String =>
     as_i64.as_f64.as_string_decimals fraction_digits
 

--- a/modules/base/src/int.fz
+++ b/modules/base/src/int.fz
@@ -143,6 +143,10 @@ is
   public redef as_string String =>
     if ns then "$n" else "-$n"
 
+  # Convert this to a string with a fixed number of digits after the decimal point.
+  
+  public as_string_decimals(fraction_digits i32) String =>
+    as_i64.as_f64.as_string_decimals fraction_digits
 
   # this int as an i32
   public redef as_i32 i32 =>


### PR DESCRIPTION
Solution to [this](https://github.com/tokiwa-software/fuzion-idioms/pull/396) discussion about [Idiom 23](https://fuzion-lang.dev/idioms/idiom23).
I will open a pull request for the related Idiom once this one is merged, to avoid causing issues.

Here's an usage example : 
```
y := 3.14563

say (y.as_string_decimals 2)  # Output: 3.14

x := 3.1

say (x.as_string_decimals 2)  # Output: 3.10

z := 3

say (z.as_string_decimals 2)  # Output: 3.00
```