### PR TITLE
base: improve consistency of error messages in `os.process`

### DIFF
--- a/modules/base/src/os/process.fz
+++ b/modules/base/src/os/process.fz
@@ -69,7 +69,7 @@ module:public process(public pid i64, module std_in, std_out, std_err i64, name 
       if res = -1
         # NYI: UNDER DEVELOPMENT: register failures
         _ := fzE_pipe_close desc
-        error "reading from {desc_name desc} of process {pid}." fzE_last_error
+        error "reading from {desc_name desc} of process {pid}" fzE_last_error
       else if res = 0
         # NYI: UNDER DEVELOPMENT: register failures
         _ := fzE_pipe_close desc
@@ -107,7 +107,7 @@ module:public process(public pid i64, module std_in, std_out, std_err i64, name 
         arr := t.as_array
         bw := fzE_pipe_write desc arr.internal_array.data arr.count
         if bw = -1
-          abort (outcome i32) (error "failed writing to stdin. wrote $r bytes already." fzE_last_error)
+          abort (outcome i32) (error "writing to {desc_name desc} of process {pid}. Wrote $r bytes already." fzE_last_error)
         else
           r+bw
 
@@ -167,7 +167,7 @@ module:public process(public pid i64, module std_in, std_out, std_err i64, name 
   #
   public close_in outcome unit =>
     if fzE_pipe_close std_in != 0
-      error "closing standard in was not successful" fzE_last_error
+      error "closing {desc_name std_in} of process {pid}" fzE_last_error
 
 
   # wait for this process
@@ -187,7 +187,7 @@ module:public process(public pid i64, module std_in, std_out, std_err i64, name 
   # send signal to process
   #
   public send_signal(sig signal) outcome unit =>
-    fzE_send_signal pid sig.as_i32 = 0 ? unit : error "failed sending signal to process $pid" fzE_last_error
+    fzE_send_signal pid sig.as_i32 = 0 ? unit : error "sending signal to process $pid" fzE_last_error
 
 
   # start a process with name, arguments and environment variables


### PR DESCRIPTION
fix #7142

Should the error messages only state where the error was or also that it failed? E.g.
* `error: closing stdin of process 123` or
  `error: closing stdin of process 123 was not successful`

* `error: reading from stdout of process 123.` or
  `error: failed reading from stdout of process 123.`
