### PR TITLE
os: add basic support for creating pipes

### DIFF
--- a/include/fz.h
+++ b/include/fz.h
@@ -474,6 +474,16 @@ int fzE_process_create(char * args[], size_t argsLen, char * env[], size_t envLe
 int64_t fzE_process_poll(int64_t p);
 
 /**
+ * open a new pipe, put read and write end into array passed here
+ *
+ * @param fds array to be filled with pipe's file descriptors
+ *
+ * @return non-zero error number, or 0 on success
+ *
+ */
+int fzE_pipe_create(int64_t * fds);
+
+/**
  * read nbytes bytes into `buf` from pipe `desc`.
  *
  * @return -1 error, bytes read on success

--- a/include/posix.c
+++ b/include/posix.c
@@ -797,6 +797,26 @@ int64_t fzE_process_poll(int64_t p){
 }
 
 
+// open a new pipe
+//
+int fzE_pipe_create(int64_t * fds)
+{
+  int pipefd[2];
+
+  if (pipe(pipefd) == -1)
+  {
+    return errno; 
+  }
+  else
+  {
+    fds[0] = (int64_t) pipefd[0];
+    fds[1] = (int64_t) pipefd[1];
+  }
+
+  return 0;
+}
+
+
 // returns -1 on error, 0 on pipe exhausted/closed
 // otherwise the number of bytes read
 int fzE_pipe_read(int64_t desc, char * buf, size_t nbytes){

--- a/include/win.c
+++ b/include/win.c
@@ -951,6 +951,15 @@ int64_t fzE_process_poll(int64_t p){
 }
 
 
+// always return 38, pipe creation not yet implemented
+//
+// NYI: ENHANCEMENT: support pipe creation on Windows
+//
+int fzE_pipe_create(int64_t *fds)
+{
+  return 38; // ENOSYS on Linux
+}
+
 // returns -1 on error, 0 on pipe exhausted/closed
 // otherwise the number of bytes read
 int fzE_pipe_read(int64_t desc, char * buf, size_t nbytes){

--- a/modules/base/src/native.fz
+++ b/modules/base/src/native.fz
@@ -253,6 +253,11 @@ module fzE_process_create(
 module fzE_process_poll(process i64) i64 => native
 
 
+# returns error code on error or zero on success
+#
+module fzE_pipe_create(pipefd Array i64) i32 => native
+
+
 # returns -1 on error, 0 on end_of_file, number of read bytes otherwise.
 #
 module fzE_pipe_read(

--- a/modules/base/src/os/pipe.fz
+++ b/modules/base/src/os/pipe.fz
@@ -1,0 +1,132 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion standard library feature os.pipe
+#
+# -----------------------------------------------------------------------
+
+
+# effect for creating pipes
+#
+private:public pipe : effect is
+
+  # the underlying pipe's file descriptors
+  #
+  pipefd array i64 := [0, 0]
+
+
+  # create the pipe
+  #
+  check debug: pipefd.count = 2
+  status := fzE_pipe_create pipefd.internal_array.data
+
+
+  # has this pipe been used already?
+  #
+  public used concur.atomic bool := concur.atomic bool .new false
+
+
+  # write bytes to a write end
+  #
+  write_handler (desc i64) : io.Write_Handler is
+    public redef write (bytes Sequence u8) outcome unit =>
+      if fzE_pipe_write desc bytes.as_array.internal_array.data bytes.count = -1
+        error "failed writing to $(desc)" fzE_last_error
+      else
+        unit
+
+
+  # read bytes from a read end
+  #
+  read_handler (desc i64) : io.Read_Handler is
+    public redef read (max_count i32) choice (Sequence u8) io.end_of_file error =>
+      pipe_buffer_size := io.buffer_size.as_i32
+      arr := array u8 _ pipe_buffer_size _->0
+      res := fzE_pipe_read desc arr.internal_array.data arr.count
+      if res = -1
+        _ := fzE_pipe_close desc
+        error "failed reading from $(desc)" fzE_last_error
+      else if res = 0
+        _ := fzE_pipe_close desc
+        io.end_of_file
+      else
+        arr.slice 0 res
+
+
+  # with writer for one pipe
+  #
+  with_writer(T type, LM type : mutate, w () -> outcome unit, r i64 -> T) outcome T ! concur.atomic_access
+  pre
+    debug: !used.read
+  =>
+    if status != 0
+      error "creating pipe" status.as_i64
+    else
+      used.write true
+      read_desc, write_desc := (pipefd[0], pipefd[1])
+
+      match (io.buffered LM).writer (write_handler write_desc) ! w
+        unit =>
+          _ := fzE_pipe_close write_desc
+          r read_desc
+        e error => e
+
+
+  # instate a pipe for writing and run code
+  #
+  public type.for_writing(T type, LM type : mutate, w () -> outcome unit, r i64 -> T) outcome T =>
+    os.pipe ! ()->
+      os.pipe.env.with_writer T LM w r
+
+
+  # with reader for one pipe
+  #
+  with_reader(T type, LM type : mutate, r () -> outcome unit, w i64 -> T) outcome T ! concur.atomic_access
+  pre
+    debug: !used.read
+  =>
+    if status != 0
+      error "creating pipe" status.as_i64
+    else
+      used.write true
+      read_desc, write_desc := (pipefd[0], pipefd[1])
+
+      match (io.buffered LM).reader (read_handler read_desc) ! r
+        unit =>
+          _ := fzE_pipe_close read_desc
+          w write_desc
+        e error => e
+
+
+  # instate a pipe for reading and run code
+  #
+  public type.for_reading(T type, LM type : mutate, r () -> outcome unit, w i64 -> T) outcome T =>
+    os.pipe ! ()->
+      os.pipe.env.with_reader T LM r w
+
+
+  # close all remaining pipes
+  #
+  public redef finally unit =>
+    for fd in pipefd
+    do
+      if fd != 0
+        _ := fzE_pipe_close fd
+      else
+        unit # ignore


### PR DESCRIPTION
A small example for this:

```
$ cat ex_pipe.fz 
max_test_time := time.duration.s 10

envir_vars := envir.vars.env.map_of [ "PATH", "LANG" ]

Sequence.prefix ! outcome tokiwa.process_result =>
  seq := map x->x.as_string
  os.process.start seq.first.or_panic (seq.drop 1) envir_vars
            .bind (p -> tokiwa.record_process p Sequence.this.as_string max_test_time nil)

ex_pipe =>
  os.pipe ! ()->
    lm : mutate is
    _ := lm ! ()->
      os.pipe.env.with_writer _ lm (()->
          (io.buffered lm).writer.env.write "hello, world!\n" .or_panic
          (io.buffered lm).writer.env.flush.or_panic
          say "written") (r->
          x := !["/usr/bin/cat", "/dev/fd/{r}"]
          say x)

_ := ex_pipe

$ fz -modules=tokiwa ex_pipe.fz
written
0: hello, world!
```