### PR TITLE
base: add wrapper type `uid` to be used by `unique_id` effect

### DIFF
--- a/modules/base/src/concur/thread.fz
+++ b/modules/base/src/concur/thread.fz
@@ -28,7 +28,7 @@
 module:public Thread(thrd Internal_Thread,
 
                      # NYI: CLEANUP: use thread id
-                     id u64
+                     id uid
                      ) ref
   : property.equatable
 is

--- a/modules/base/src/concur/threads.fz
+++ b/modules/base/src/concur/threads.fz
@@ -79,7 +79,7 @@ is
   # with given tid.
   #
   public spawn_without_inherited_effects(# NYI: CLEANUP: remove this argument and use system thread id
-                                         tid u64,
+                                         tid uid,
 
                                          # code ot run int he new thread without an new, empty effect environment
                                          code ()->unit
@@ -122,7 +122,7 @@ default_thread_handler : Thread_Handler is
   # spawn a new thread using given code
   #
   redef spawn(# NYI: CLEANUP: remove this argument and use system thread id
-              tid u64,
+              tid uid,
               code ()->unit)
   =>
     concur.Thread (fuzion.sys.thread.spawn code) tid
@@ -134,7 +134,7 @@ private:public Thread_Handler ref is
   # spawn a new thread using given code
   #
   spawn(# NYI: CLEANUP: remove this argument and use system thread id
-        tid u64,
+        tid uid,
         code ()->unit) concur.Thread
   =>
     abstract

--- a/modules/base/src/concur/threads.fz
+++ b/modules/base/src/concur/threads.fz
@@ -111,7 +111,7 @@ is
   #
   public redef fixed type.default_value option concur.threads
   =>
-    initial := concur.Thread fuzion.sys.thread.current 0
+    initial := concur.Thread fuzion.sys.thread.current (uid 0)
     concur.threads concur.default_thread_handler [initial] initial
 
 

--- a/modules/base/src/uid.fz
+++ b/modules/base/src/uid.fz
@@ -1,0 +1,42 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion standard library feature uid
+#
+# -----------------------------------------------------------------------
+
+# uid -- unique identifier type
+#
+# Wraps a u64 in a dedicated type to prevent accidental mixing
+# with other numeric values while preserving ordering semantics.
+#
+# Instances are typically created by the unique_id effect.
+#
+public uid(val u64) : property.orderable is
+
+
+  # Returns the identifier as its decimal string representation.
+  #
+  public redef as_string String => val.as_string
+
+
+  # Defines a total ordering for uid values based on their
+  # underlying numeric representation.
+  #
+  public redef type.lteq(a, b uid.this) bool => a.val <= b.val

--- a/modules/base/src/uid.fz
+++ b/modules/base/src/uid.fz
@@ -39,4 +39,4 @@ public uid(val u64) : property.orderable is
   # Defines a total ordering for uid values based on their
   # underlying numeric representation.
   #
-  public redef type.lteq(a, b uid.this) bool => a.val <= b.val
+  public fixed redef type.lteq(a, b uid.this) bool => a.val <= b.val

--- a/modules/base/src/unique_id.fz
+++ b/modules/base/src/unique_id.fz
@@ -26,7 +26,7 @@
 public unique_id (p Unique_Id_Handler) : effect
 is
 
-  public get u64 => {replace; p.get}
+  public get uid => {replace; p.get}
 
 
   # default implementation of fuzion.runtime.unique_id
@@ -35,12 +35,12 @@ is
   #
   public redef fixed type.default_value option unique_id =>
     unique_id (_ : Unique_Id_Handler is
-                 public redef get u64 => fzE_unique_id
+                 public redef get uid => uid fzE_unique_id
               )
 
 
 public Unique_Id_Handler ref is
-  public get u64 => abstract
+  public get uid => abstract
 
 
 # get a unique id > 0
@@ -52,5 +52,5 @@ public Unique_Id_Handler ref is
 # would take more than 500 years before we run out of values
 # (2^64/10^9/3600/24/365.25).
 #
-public unique_id u64 ! unique_id =>
+public unique_id uid ! unique_id =>
   unique_id.env.get

--- a/modules/lock_free/src/lock_free/Map.fz
+++ b/modules/lock_free/src/lock_free/Map.fz
@@ -89,19 +89,19 @@ branch(CTK type : property.hashable, CTV type) : choice (Indirection_Node CTK CT
 
 # a container node
 # consists of a bitmap of filled spaces and an array of child nodes
-container_node(CTK type : property.hashable, CTV type, bmp u32, array array (branch CTK CTV), gen u64)
+container_node(CTK type : property.hashable, CTV type, bmp u32, array array (branch CTK CTV), gen uid)
 is
 
   # update a child node and return a new container_node
-  update(pos u32, node branch CTK CTV, g u64) =>
+  update(pos u32, node branch CTK CTV, g uid) =>
     container_node bmp (array.put pos.as_i32 node) g
 
   # add a child node and return a new container_node
-  put(sn singleton_node CTK CTV, pos, flag u32, g u64) =>
+  put(sn singleton_node CTK CTV, pos, flag u32, g uid) =>
     container_node (bmp | flag) (array.insert pos.as_i32 sn).as_array g
 
   # remove a child node and return a new container_node
-  remove(pos, flag u32, g u64)
+  remove(pos, flag u32, g uid)
     pre
       debug: array.indices.contains pos.as_i32
     post
@@ -187,12 +187,12 @@ failed_node(CTK type : property.hashable, CTV type, prev Main_Node CTK CTV) is
 
 
 # shorthand for creating a new indirection node from Main_Node and gen
-indirection_node(CTK type : property.hashable, CTV type, data Main_Node CTK CTV, gen u64) =>
+indirection_node(CTK type : property.hashable, CTV type, data Main_Node CTK CTV, gen uid) =>
   Indirection_Node (concur.atomic (Main_Node CTK CTV) .new data) gen
 
 
 # an indirection node
-Indirection_Node(CTK type : property.hashable, CTV type, data concur.atomic (Main_Node CTK CTV), gen u64) ref : property.equatable is
+Indirection_Node(CTK type : property.hashable, CTV type, data concur.atomic (Main_Node CTK CTV), gen uid) ref : property.equatable is
 
   id := unique_id
 
@@ -293,7 +293,7 @@ is
   # 1) taking a snapshot and the root node needs to be copied to a new generation
   # 2) copying a container node to a new generation
   #
-  copy_to_gen(i Indirection_Node CTK CTV, new_gen u64)
+  copy_to_gen(i Indirection_Node CTK CTV, new_gen uid)
     post
       debug: result.data.read.prev.read.is_nil
   =>
@@ -301,7 +301,7 @@ is
 
 
   # copy this container_node to new generation
-  renew(cn container_node CTK CTV, new_gen u64) =>
+  renew(cn container_node CTK CTV, new_gen uid) =>
     copy => cn
       .array
       .map (branch CTK CTV) x->
@@ -438,7 +438,7 @@ is
 
 
   # compress a container node
-  compress(cn container_node CTK CTV, lev u32, g u64) =>
+  compress(cn container_node CTK CTV, lev u32, g uid) =>
     narr => cn.array.map_to_array (branch CTK CTV) n->
       match n
         i Indirection_Node =>
@@ -474,7 +474,7 @@ is
 
   # turns this: container_node -> Indirection_Node -> tomb_node -> singleton_node
   # into  this: container_node -> singleton_node
-  clean_parent(parent option (Indirection_Node CTK CTV), i Indirection_Node CTK CTV, hash, lev u32, gen u64) unit =>
+  clean_parent(parent option (Indirection_Node CTK CTV), i Indirection_Node CTK CTV, hash, lev u32, gen uid) unit =>
     _ := parent >>= p->
       m := gcas_read p
       match m.data
@@ -504,7 +504,7 @@ is
   # Main_Node -> list_node -> singleton_nodes
   # or recurse
   # Main_Node -> container_node -> Indirection_Node -> dual x y
-  dual(x, y singleton_node CTK CTV, lev u32, gen u64) =>
+  dual(x, y singleton_node CTK CTV, lev u32, gen uid) =>
     d choice (container_node CTK CTV) (tomb_node CTK CTV) (list_node CTK CTV) =>
       # NYI: UNDER DEVELOPMENT: why 35??
       if lev < 35
@@ -540,7 +540,7 @@ is
 
   # try lookup key in ctrie
   # may fail and result in a restart
-  lookup(i Indirection_Node CTK CTV, k CTK, lev u32, parent option (Indirection_Node CTK CTV), gen u64) choice restart not_found CTV
+  lookup(i Indirection_Node CTK CTV, k CTK, lev u32, parent option (Indirection_Node CTK CTV), gen uid) choice restart not_found CTV
   =>
     m := gcas_read i
     match m.data
@@ -578,7 +578,7 @@ is
 
   # try adding an element to the ctrie
   # may fail and result in a restart
-  put(i Indirection_Node CTK CTV, k CTK, v CTV, lev u32, parent option (Indirection_Node CTK CTV), gen u64) choice restart ctrie_ok
+  put(i Indirection_Node CTK CTV, k CTK, v CTV, lev u32, parent option (Indirection_Node CTK CTV), gen uid) choice restart ctrie_ok
   =>
     m := gcas_read i
     match m.data
@@ -621,7 +621,7 @@ is
 
   # try remove an element from the ctrie
   # may fail and result in a restart
-  remove(i Indirection_Node CTK CTV, k CTK, lev u32, parent option (Indirection_Node CTK CTV), gen u64) choice restart not_found CTV
+  remove(i Indirection_Node CTK CTV, k CTK, lev u32, parent option (Indirection_Node CTK CTV), gen uid) choice restart not_found CTV
   =>
     m := gcas_read i
     match m.data


### PR DESCRIPTION
fix #6405

@michaellilltokiwa is this what you were thinking?

What's the preferred way to create new instances? Provide a type feature `type.new` or make the constructor public?