### PR TITLE
base: Add features to obtain Fuzion version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,6 +127,8 @@ FUZION_FILES_RT       = $(shell find $(FZ_SRC_INCLUDE))
 FZ_SRC_EXAMPLES       = $(FZ_SRC)/examples
 FUZION_FILES_EXAMPLES = $(shell find $(FZ_SRC_EXAMPLES))
 
+FUZION_RUNTIME_VERSION    = $(BUILD_DIR)/modules/base/src/fuzion/runtime/version.fz
+FUZION_RUNTIME_VERSION_IN =    $(FZ_SRC)/modules/base/src/fuzion/runtime/version.fz.in
 MOD_BASE              = $(BUILD_DIR)/modules/base.fum
 MOD_TERMINAL          = $(BUILD_DIR)/modules/terminal.fum
 MOD_LOCK_FREE         = $(BUILD_DIR)/modules/lock_free.fum
@@ -257,18 +259,22 @@ $(FUZION_EBNF): $(FUZION_BASE) $(FZ_SRC)/bin/ebnf.fz
 	mkdir -p $(@D)
 	$(FZ) $(FZ_SRC)/bin/ebnf.fz $(JAVA_FILES_PARSER) > $@
 
-$(JAVA_FILE_UTIL_VERSION): $(FZ_SRC)/version.txt $(JAVA_FILE_UTIL_VERSION_IN)
-	mkdir -p $(@D)
-	cat $(JAVA_FILE_UTIL_VERSION_IN) \
-          | sed "s^@@VERSION@@^$(VERSION)^g" \
+ifeq ($(FUZION_REPRODUCIBLE_BUILD),true)
+SED_DATE_AND_BUILTBY = "s^@@DATE@@^^g;s^@@BUILTBY@@^^g"
+else
+SED_DATE_AND_BUILTBY = "s^@@DATE@@^`date +%Y-%m-%d\ %H:%M:%S`^g;s^@@BUILTBY@@^`printf $(USER)@; hostname`^g"
+endif
+
+PROCESS_VERSION_IN := \
+            sed "s^@@VERSION@@^$(VERSION)^g" \
           | sed "s^@@JAVA_VERSION@@^$(JAVA_VERSION)^g" \
           | sed "s^@@REPO_PATH@@^$(dir $(abspath $(lastword $(MAKEFILE_LIST))))^g" \
-          | sed "s^@@GIT_HASH@@^`cd $(FZ_SRC); printf \`git rev-parse HEAD\` \`git diff-index --quiet HEAD -- || echo with local changes\``^g" >$@
-ifeq ($(FUZION_REPRODUCIBLE_BUILD),true)
-	sed -i "s^@@DATE@@^^g;s^@@BUILTBY@@^^g" $@
-else
-	sed -i "s^@@DATE@@^`date +%Y-%m-%d\ %H:%M:%S`^g;s^@@BUILTBY@@^`printf $(USER)@; hostname`^g" $@
-endif
+          | sed "s^@@GIT_HASH@@^`cd $(FZ_SRC); printf \`git rev-parse HEAD\` \`git diff-index --quiet HEAD -- || echo with local changes\``^g" \
+          | sed $(SED_DATE_AND_BUILTBY)
+
+$(JAVA_FILE_UTIL_VERSION): $(FZ_SRC)/version.txt $(JAVA_FILE_UTIL_VERSION_IN)
+	mkdir -p $(@D)
+	cat $(JAVA_FILE_UTIL_VERSION_IN) | $(PROCESS_VERSION_IN) >$@
 
 $(CLASS_FILES_UTIL): $(JAVA_FILES_UTIL)
 	mkdir -p $(CLASSES_DIR)
@@ -421,10 +427,11 @@ $(FZ): $(FZ_SRC)/bin/fz | $(CLASS_FILES_TOOLS)
 	cp -rf $(FZ_SRC)/bin/fz $@
 	chmod +x $@
 
-$(MOD_BASE): $(FZ) $(shell find $(FZ_SRC)/modules/base/src -name "*.fz")
+$(MOD_BASE): $(FZ) $(shell find $(FZ_SRC)/modules/base/src -name "*.fz") $(FUZION_RUNTIME_VERSION_IN)
 	rm -rf $(@D)/base
 	mkdir -p $(@D)
 	cp -rf $(FZ_SRC)/modules/base $(@D)
+	cat $(FUZION_RUNTIME_VERSION_IN) | $(PROCESS_VERSION_IN) >$(FUZION_RUNTIME_VERSION)
 	$(FZ) -sourceDirs=$(BUILD_DIR)/modules/base/src -XloadBaseModule=off -saveModule=$@ -XenableSetKeyword
 	$(FZ) -XXcheckIntrinsics
 

--- a/modules/base/src/fuzion/runtime/version.fz.in
+++ b/modules/base/src/fuzion/runtime/version.fz.in
@@ -53,7 +53,7 @@ public build_date String => "@@DATE@@"
 #
 # In a reproducible build, this is an empty String.
 #
-public built_by String => "@@BUILTBY@@"
+public built_by String => "@@BUILTBY@@"
 
 
 # repo_path -- The repository path

--- a/modules/base/src/fuzion/runtime/version.fz.in
+++ b/modules/base/src/fuzion/runtime/version.fz.in
@@ -1,0 +1,61 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion standard library feature fuzion.runtime.version.fz.in
+#
+#  Author: Fridtjof Siebert (siebert@tokiwa.software)
+#
+# -----------------------------------------------------------------------
+
+# fuzion.runtime.version -- Fuzion version
+#
+# The version string, currently in the form &lt;major&gt;.&lt;minor&gt;["dev"].
+#
+public version String => "@@VERSION@@"
+
+
+# fuzion.runtime.java_version -- required OpenJDK version
+#
+# The required JDK version, e.g., "25".
+#
+public java_version String => "@@JAVA_VERSION@@"
+
+
+# git_hash -- The git hash code of the sources.
+#
+public git_hash String => "@@GIT_HASH@@"
+
+
+# build_date --The date and time of the build
+#
+# In a reproducible build, this is an empty String.
+#
+public build_date String => "@@DATE@@"
+
+
+# built_by --The user and machine of the build
+#
+# In a reproducible build, this is an empty String.
+#
+public built_by String => "@@BUILTBY@@"
+
+
+# repo_path -- The repository path
+#
+public repo_path String => "@@REPO_PATH@@"


### PR DESCRIPTION
New features `fuzion.runtime.version`, `fuzion.runtime.java_version`, `fuzion.runtime.git_hash`, `fuzion.runtime.build_date`, `fuzion.runtime.built_by` and `fuzion.runtime.repo_path` provide information on the source code this Fuzion release was built from.

This is useful to, e.g., check what version is used by fuzion-lang.dev using

    say fuzion.runtime.version
