### PR TITLE
ast: change logic in `AbstractCall.adjustResultType`

### DIFF
--- a/src/dev/flang/ast/AbstractCall.java
+++ b/src/dev/flang/ast/AbstractCall.java
@@ -285,7 +285,7 @@ public abstract class AbstractCall extends Expr
       (!frmlT.isOpenGeneric());
 
     return adjustResultType(res, context, target().type(), frmlT,
-                            (from,to) -> AstErrors.illegalOuterRefTypeInCall(this, true, arg, frmlT, from, to), true);
+                            (from,to) -> AstErrors.illegalOuterRefTypeInCall(this, true, arg, frmlT, from, to));
   }
 
 
@@ -308,20 +308,18 @@ public abstract class AbstractCall extends Expr
                                           Context context,
                                           AbstractType tt,
                                           AbstractType rt,
-                                          BiConsumer<AbstractType, AbstractType> foundRef,
-                                          boolean forArg /* NYI: UNDER DEVELOPMENT: try to remove this parameter */)
+                                          BiConsumer<AbstractType, AbstractType> foundRef)
   {
     var t0 = calledFeature() == Types.f_ERROR ? Types.t_ERROR : rt;
-    var t1 = t0 == Types.t_ERROR                           ? t0 : adjustThisTypeForTarget(context, t0, foundRef);
-    var t2 = t1 == Types.t_ERROR                           ? t1 : calledFeature().outer().handDownToType(t1, tt);  // NYI: CLEANUP: try to use handDownAndApply
+    var t1 = t0 == Types.t_ERROR                           ? t0 : calledFeature().outer().handDownToType(t0, tt);
+    var t2 = t1 == Types.t_ERROR                           ? t1 : adjustThisTypeForTarget(context, t1, foundRef);  // NYI: CLEANUP: try to use handDownAndApply
     var t3 = t2 == Types.t_ERROR                           ? t2 : t2.applyTypePars(tt);
     var t4 = t3 == Types.t_ERROR                           ? t3 : t3.applyTypePars(calledFeature(), actualTypeParameters());
     var t5 = t4 == Types.t_ERROR || tt.isGenericArgument() ? t4 : t4.resolve(res, tt.feature().context());
-    var t6 = t5 == Types.t_ERROR || forArg                 ? t5 : adjustThisTypeForTarget(context, t5, foundRef);
     if (POSTCONDITIONS) ensure
-      (t6 != null);
+      (t5 != null);
 
-    return t6;
+    return t5;
   }
 
 

--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -1469,7 +1469,7 @@ public class Call extends AbstractCall
     // / etc. in the same order and move them to a dedicated function).
     var t0 = tt == Types.t_ERROR ? tt : resolveSelect(res, rt, tt);
     var t4 = adjustResultType(res, context, tt, t0,
-                              (from,to) -> AstErrors.illegalOuterRefTypeInCall(this, false, calledFeature(), t0, from, to), false);
+                              (from,to) -> AstErrors.illegalOuterRefTypeInCall(this, false, calledFeature(), t0, from, to));
     // NYI: UNDER DEVELOPMENT: can we move more to previous call to adjustResultType()?
     var t5 = t4 == Types.t_ERROR ? t4 : resolveForCalledFeature(res, t4, tt, context);
     var t6 = t5 == Types.t_ERROR ? t5 : calledFeature().isCotype() ? t5 : t5.replace_type_parameters_of_cotype_origin(context.outerFeature());
@@ -3015,7 +3015,7 @@ public class Call extends AbstractCall
               _generics,
               _originalGenerics,
               pos(),
-              constraint -> adjustResultType(res, context, targetType(context), constraint, null, false));
+              constraint -> adjustResultType(res, context, targetType(context), constraint, null));
           }
       }
   }

--- a/tests/reg_issue7108/Makefile
+++ b/tests/reg_issue7108/Makefile
@@ -1,0 +1,25 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test Makefile
+#
+# -----------------------------------------------------------------------
+
+override NAME = reg_issue7108
+include ../simple.mk

--- a/tests/reg_issue7108/reg_issue7108.fz
+++ b/tests/reg_issue7108/reg_issue7108.fz
@@ -1,0 +1,34 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test reg_issue7108
+#
+# -----------------------------------------------------------------------
+
+rev(T type : property.orderable, val T) : property.orderable is
+
+  public redef type.lteq(a, b rev.this) bool
+  =>
+    b.val <= a.val
+
+property.orderable.rev1 => rev orderable.this
+
+s := ["A", "Q", "B", "C"]
+
+say <| s.map (.rev1) .sort

--- a/tests/reg_issue7108/reg_issue7108.fz.expected_out
+++ b/tests/reg_issue7108/reg_issue7108.fz.expected_out
@@ -1,0 +1,1 @@
+[instance[rev codepoint], instance[rev codepoint], instance[rev codepoint], instance[rev codepoint]]


### PR DESCRIPTION
fixes #7108

In the future we may need to clean this up further and integrate `adjustThisTypeForTarget` into `handDownAndApply`
