### PR TITLE
base: in `exclusive`, check wakeup-conditions while still holding mutex

### DIFF
--- a/modules/base/src/concur/blocking_mutate.fz
+++ b/modules/base/src/concur/blocking_mutate.fz
@@ -60,9 +60,8 @@ public blocking_mutate : mutate is
     mtx.synchronized ()->
       set exclusive_thread := concur.threads.env.current
       blocking_mutate.this.replace
+
       res := code()
-      set exclusive_thread := nil
-      blocking_mutate.this.replace
 
       match waiting.first
         f concur.Thread =>
@@ -75,6 +74,9 @@ public blocking_mutate : mutate is
             waiting.remove t
             t.unpark
         nil =>
+
+      set exclusive_thread := nil
+      blocking_mutate.this.replace
 
       res
 


### PR DESCRIPTION
This is required for other threads not to run off an invalidate the conditions.
