### PR TITLE
base: add `atomic.update`

### DIFF
--- a/modules/base/src/concur/atomic.fz
+++ b/modules/base/src/concur/atomic.fz
@@ -166,7 +166,7 @@ is
   #
   # returns the (old_value, new_value)
   #
-  public update(compute_new T->T) (T,T) =>
+  public update(F type : T->T, compute_new F) (T,T) =>
     for current_value := read
         new_value     := compute_new current_value
     while !(compare_and_set current_value new_value)

--- a/modules/base/src/concur/atomic.fz
+++ b/modules/base/src/concur/atomic.fz
@@ -150,11 +150,7 @@ is
   public incr T ! atomic_access
     pre T : integer
   =>
-    for current_value := read
-        new_value := current_value+1
-    while !(compare_and_set current_value new_value)
-    else new_value
-
+    (update o->o+1).1
 
 
   # atomic decrement
@@ -162,10 +158,19 @@ is
   public decr T  ! atomic_access
     pre T : integer
   =>
+    (update o->o-1).1
+
+
+  # use `compute_new` to compute a new value of the atomic
+  # do this until a compare_and_set is successful.
+  #
+  # returns the (old_value, new_value)
+  #
+  public update(compute_new T->T) (T,T) =>
     for current_value := read
-        new_value := current_value-1
+        new_value     := compute_new current_value
     while !(compare_and_set current_value new_value)
-    else new_value
+    else (current_value, new_value)
 
 
   # create a new atomic of type T


### PR DESCRIPTION
to be able to update an atomic value a lambda that gets called with the respective old value until `compare_and_set` is successful
