### PR TITLE
runtime/jvm: more readable stack trace, fix most of #7169

### DIFF
--- a/src/dev/flang/be/jvm/runtime/Runtime.java
+++ b/src/dev/flang/be/jvm/runtime/Runtime.java
@@ -71,6 +71,7 @@ import dev.flang.util.Errors;
 import dev.flang.util.JavaInterface;
 import dev.flang.util.Pair;
 import dev.flang.util.StringHelpers;
+import dev.flang.util.Terminal;
 
 
 /**
@@ -683,8 +684,8 @@ public class Runtime extends ANY
 
     var stacktrace = new StringWriter();
     stacktrace.write("Call stack:\n");
-    String last = "";
-    int count = 0;
+    var allStartWithFuzionDot = true;
+    var strs = new dev.flang.util.List<String>();
     for (var s : t.getStackTrace())
       {
         var m = s.getMethodName();
@@ -713,24 +714,53 @@ public class Runtime extends ANY
                   }
                 str = cl.substring(start);
               }
-            if (str.equals(last))
+            // we try to remove all lines that are inner features of `fuzion` or `panic.type` up to and including
+            // a call to `fuzion...cause` or `panic.cause`.
+            //
+            // NYI: CLEANUP: This might remove user defined features with
+            // carefully chosen names as well. Once the code base is
+            // sufficiently stable, we could instead have a fixed list of
+            // features to suppress here.
+            allStartWithFuzionDot = allStartWithFuzionDot && (str.startsWith("fuzion.") ||
+                                                              str.startsWith("panic.type."));
+            if (allStartWithFuzionDot &&
+                str.matches("fuzion\\..*\\.cause.*") ||
+                str.matches("panic.cause.*"))
               {
-                count++;
+                while (strs.size() > 1)  // we leave the topmost feature in
+                                         // (usually `fuzion.sys.fatal_fault`).
+                  {
+                    strs.removeLast();
+                  }
+                strs.add("[..]");
               }
             else
               {
-                if (count > 1)
-                  {
-                    stacktrace.write("\n  " + StringHelpers.repeated(count));
-                  }
-                else if (count > 0)
-                  {
-                    stacktrace.write("\n");
-                  }
-                stacktrace.write(str + " at " + s.getFileName().replace(File.separator, "/") + ":" + s.getLineNumber());
-                last = str;
-                count = 1;
+                strs.add(str + " at " + Terminal.GREEN + s.getFileName().replace(File.separator, "/") + ":" + s.getLineNumber() + Terminal.REGULAR_COLOR);
               }
+          }
+      }
+    String last = "";
+    int count = 0;
+    for (var str : strs)
+      {
+        if (str.equals(last))
+          {
+            count++;
+          }
+        else
+          {
+            if (count > 1)
+              {
+                stacktrace.write("\n  " + StringHelpers.repeated(count) + "\n");
+              }
+            else if (count > 0)
+              {
+                stacktrace.write("\n");
+              }
+            stacktrace.write(str);
+            last = str;
+            count = 1;
           }
       }
     if (count > 1)

--- a/tests/catch_postcondition/catch_postcondition.fz.expected_err_jvm
+++ b/tests/catch_postcondition/catch_postcondition.fz.expected_err_jvm
@@ -2,12 +2,7 @@
 error 1: Postcondition `equals result-x x` does not hold after call
 Call stack:
 fuzion.sys.fatal_fault#2 at {base.fum}/fuzion/sys.fz:55
-fuzion.type.runtime.type.fault.type.default_value.(λkind_and_msg-> kind, msg := kind_and_m...).call#1 at {base.fum}/fuzion/runtime/fault.fz:63
-fuzion.runtime.fault.cause#1 at {base.fum}/eff/fallible.fz:35
-fuzion.type.runtime.type.contract_fault.type.default_value.(λkind_and_msg-> fuzion.runtime.fault.en...).call#1 at {base.fum}/fuzion/runtime/contract_fault.fz:42
-fuzion.runtime.contract_fault.cause#1 at {base.fum}/eff/fallible.fz:35
-fuzion.type.runtime.type.post_fault.type.default_value.(λmsg-> fuzion.runtime.contract_fault.en...).call#1 at {base.fum}/fuzion/runtime/post_fault.fz:42
-fuzion.runtime.post_fault.cause#1 at {base.fum}/eff/fallible.fz:35
+[..]
 fuzion.runtime.postcondition_fault#1 at {base.fum}/fuzion/runtime/post_fault.fz:56
 (catch_postcondition.test#1 i32).post double at --CURDIR--/catch_postcondition.fz:38
 (catch_postcondition.test#1 i32).double#1 at --CURDIR--/catch_postcondition.fz:37

--- a/tests/contracts_negative/SquareRoot.fz.expected_err_jvm
+++ b/tests/contracts_negative/SquareRoot.fz.expected_err_jvm
@@ -2,12 +2,7 @@
 error 1: FATAL FAULT `precondition`: a ≥ 0
 Call stack:
 fuzion.sys.fatal_fault#2 at {base.fum}/fuzion/sys.fz:55
-fuzion.type.runtime.type.fault.type.default_value.(λkind_and_msg-> kind, msg := kind_and_m...).call#1 at {base.fum}/fuzion/runtime/fault.fz:63
-fuzion.runtime.fault.cause#1 at {base.fum}/eff/fallible.fz:35
-fuzion.type.runtime.type.contract_fault.type.default_value.(λkind_and_msg-> fuzion.runtime.fault.en...).call#1 at {base.fum}/fuzion/runtime/contract_fault.fz:42
-fuzion.runtime.contract_fault.cause#1 at {base.fum}/eff/fallible.fz:35
-fuzion.type.runtime.type.pre_fault.type.default_value.(λmsg-> fuzion.runtime.contract_fault.en...).call#1 at {base.fum}/fuzion/runtime/pre_fault.fz:42
-fuzion.runtime.pre_fault.cause#1 at {base.fum}/eff/fallible.fz:35
+[..]
 fuzion.runtime.precondition_fault#1 at {base.fum}/fuzion/runtime/pre_fault.fz:56
 SquareRoot.pre sqrt at --CURDIR--/SquareRoot.fz:30
 SquareRoot.precall sqrt at --CURDIR--/SquareRoot.fz:29

--- a/tests/loop_invariant/loop_invariant.fz.expected_err_jvm
+++ b/tests/loop_invariant/loop_invariant.fz.expected_err_jvm
@@ -2,12 +2,7 @@
 error 1: FATAL FAULT `inv`: i < 1
 Call stack:
 fuzion.sys.fatal_fault#2 at {base.fum}/fuzion/sys.fz:55
-fuzion.type.runtime.type.fault.type.default_value.(λkind_and_msg-> kind, msg := kind_and_m...).call#1 at {base.fum}/fuzion/runtime/fault.fz:63
-fuzion.runtime.fault.cause#1 at {base.fum}/eff/fallible.fz:35
-fuzion.type.runtime.type.contract_fault.type.default_value.(λkind_and_msg-> fuzion.runtime.fault.en...).call#1 at {base.fum}/fuzion/runtime/contract_fault.fz:42
-fuzion.runtime.contract_fault.cause#1 at {base.fum}/eff/fallible.fz:35
-fuzion.type.runtime.type.invariant_fault.type.default_value.(λmsg-> fuzion.runtime.contract_fault.en...).call#1 at {base.fum}/fuzion/runtime/invariant_fault.fz:42
-fuzion.runtime.invariant_fault.cause#1 at {base.fum}/eff/fallible.fz:35
+[..]
 fuzion.runtime.invariantcondition_fault#1 at {base.fum}/fuzion/runtime/invariant_fault.fz:56
 loop_invariant.loop at --CURDIR--/loop_invariant.fz:32
 loop_invariant at --CURDIR--/loop_invariant.fz:31

--- a/tests/loop_variant_2/loop_variant_2.fz.expected_err_jvm
+++ b/tests/loop_variant_2/loop_variant_2.fz.expected_err_jvm
@@ -2,12 +2,7 @@
 error 1: FATAL FAULT `variant`: i64.min
 Call stack:
 fuzion.sys.fatal_fault#2 at {base.fum}/fuzion/sys.fz:55
-fuzion.type.runtime.type.fault.type.default_value.(λkind_and_msg-> kind, msg := kind_and_m...).call#1 at {base.fum}/fuzion/runtime/fault.fz:63
-fuzion.runtime.fault.cause#1 at {base.fum}/eff/fallible.fz:35
-fuzion.type.runtime.type.contract_fault.type.default_value.(λkind_and_msg-> fuzion.runtime.fault.en...).call#1 at {base.fum}/fuzion/runtime/contract_fault.fz:42
-fuzion.runtime.contract_fault.cause#1 at {base.fum}/eff/fallible.fz:35
-fuzion.type.runtime.type.variant_fault.type.default_value.(λmsg-> fuzion.runtime.contract_fault.en...).call#1 at {base.fum}/fuzion/runtime/variant_fault.fz:40
-fuzion.runtime.variant_fault.cause#1 at {base.fum}/eff/fallible.fz:35
+[..]
 fuzion.runtime.variantcondition_fault#1 at {base.fum}/fuzion/runtime/variant_fault.fz:55
 loop_variant_2.test_6.loop at --CURDIR--/loop_variant_2.fz:82
 loop_variant_2.test_6 at --CURDIR--/loop_variant_2.fz:81

--- a/tests/reg_issue1886_option_void/issue1886.fz.expected_err_jvm
+++ b/tests/reg_issue1886_option_void/issue1886.fz.expected_err_jvm
@@ -2,10 +2,7 @@
 error 1: FATAL FAULT `*** panic ***`: test
 Call stack:
 fuzion.sys.fatal_fault#2 at {base.fum}/fuzion/sys.fz:55
-fuzion.type.runtime.type.fault.type.default_value.(λkind_and_msg-> kind, msg := kind_and_m...).call#1 at {base.fum}/fuzion/runtime/fault.fz:63
-fuzion.runtime.fault.cause#1 at {base.fum}/eff/fallible.fz:35
-panic.type.default_value.(λ(msg->fuzion.runtime.fault.env.cause (...).call#1 at {base.fum}/panic.fz:39
-panic.cause#1 at {base.fum}/eff/fallible.fz:35
+[..]
 panic#1 at {base.fum}/panic.fz:59
 test_option_void at --CURDIR--/issue1886.fz:44
 

--- a/tests/reg_issue2194/reg_issue2194.fz.expected_err_jvm
+++ b/tests/reg_issue2194/reg_issue2194.fz.expected_err_jvm
@@ -2,12 +2,7 @@
 error 1: FATAL FAULT `precondition`: a < 3
 Call stack:
 fuzion.sys.fatal_fault#2 at {base.fum}/fuzion/sys.fz:55
-fuzion.type.runtime.type.fault.type.default_value.(λkind_and_msg-> kind, msg := kind_and_m...).call#1 at {base.fum}/fuzion/runtime/fault.fz:63
-fuzion.runtime.fault.cause#1 at {base.fum}/eff/fallible.fz:35
-fuzion.type.runtime.type.contract_fault.type.default_value.(λkind_and_msg-> fuzion.runtime.fault.en...).call#1 at {base.fum}/fuzion/runtime/contract_fault.fz:42
-fuzion.runtime.contract_fault.cause#1 at {base.fum}/eff/fallible.fz:35
-fuzion.type.runtime.type.pre_fault.type.default_value.(λmsg-> fuzion.runtime.contract_fault.en...).call#1 at {base.fum}/fuzion/runtime/pre_fault.fz:42
-fuzion.runtime.pre_fault.cause#1 at {base.fum}/eff/fallible.fz:35
+[..]
 fuzion.runtime.precondition_fault#1 at {base.fum}/fuzion/runtime/pre_fault.fz:56
 pre x at --CURDIR--/reg_issue2194.fz:25
 y#1 at --CURDIR--/reg_issue2194.fz:25

--- a/tests/reg_issue2231/reg_issue2231.fz.expected_err_jvm
+++ b/tests/reg_issue2231/reg_issue2231.fz.expected_err_jvm
@@ -2,14 +2,11 @@
 error 1: FATAL FAULT `*** panic ***`: unexpected abort in Type of 'reg_issue2231.ef'
 Call stack:
 fuzion.sys.fatal_fault#2 at {base.fum}/fuzion/sys.fz:55
-fuzion.type.runtime.type.fault.type.default_value.(λkind_and_msg-> kind, msg := kind_and_m...).call#1 at {base.fum}/fuzion/runtime/fault.fz:63
-fuzion.runtime.fault.cause#1 at {base.fum}/eff/fallible.fz:35
-panic.type.default_value.(λ(msg->fuzion.runtime.fault.env.cause (...).call#1 at {base.fum}/panic.fz:39
-panic.cause#1 at {base.fum}/eff/fallible.fz:35
+[..]
 panic#1 at {base.fum}/panic.fz:59
 (reg_issue2231.type.ef.type.instate#3 void).(λ(_ -> panic "unexpected abort in {effe...).call#1 at {base.fum}/effect.fz:191
-(instate_helper void reg_issue2231.ef).call_def.call#1 at {base.fum}/effect.fz:444
-instate_helper void reg_issue2231.ef at {base.fum}/effect.fz:434
+(instate_helper void reg_issue2231.ef).call_def.call#1 at {base.fum}/effect.fz:427
+instate_helper void reg_issue2231.ef at {base.fum}/effect.fz:417
 reg_issue2231.type.ef.type.instate#4 void at {base.fum}/effect.fz:170
 reg_issue2231.type.ef.type.instate#3 void at {base.fum}/effect.fz:191
 reg_issue2231.ef.instate_self#2 void at {base.fum}/effect.fz:212

--- a/tests/reg_issue2304/reg_issue2304.fz.expected_err_jvm
+++ b/tests/reg_issue2304/reg_issue2304.fz.expected_err_jvm
@@ -2,10 +2,7 @@
 error 1: FATAL FAULT `*** panic ***`: bah
 Call stack:
 fuzion.sys.fatal_fault#2 at {base.fum}/fuzion/sys.fz:55
-fuzion.type.runtime.type.fault.type.default_value.(λkind_and_msg-> kind, msg := kind_and_m...).call#1 at {base.fum}/fuzion/runtime/fault.fz:63
-fuzion.runtime.fault.cause#1 at {base.fum}/eff/fallible.fz:35
-panic.type.default_value.(λ(msg->fuzion.runtime.fault.env.cause (...).call#1 at {base.fum}/panic.fz:39
-panic.cause#1 at {base.fum}/eff/fallible.fz:35
+[..]
 panic#1 at {base.fum}/panic.fz:59
 p at --CURDIR--/reg_issue2304.fz:24
 (λx->p).call#1 at --CURDIR--/reg_issue2304.fz:25
@@ -13,7 +10,7 @@ p at --CURDIR--/reg_issue2304.fz:24
 (list i32).drop_while_list#2 ((list i32).filter_list#2 (Unary bool i32)).(λ(a -> !(p a))) at {base.fum}/list.fz:543
 (list i32).filter_list#2 (Unary bool i32) at {base.fum}/list.fz:564
 (list i32).filter#1 at {base.fum}/list.fz:555
-(array i32).filter#1 at {base.fum}/Sequence.fz:291
+(array i32).filter#1 at {base.fum}/Sequence.fz:294
 universe at --builtin--:25
 
 *** fatal errors encountered, stopping.

--- a/tests/reg_issue2325/reg_issue2325.fz.expected_err_jvm
+++ b/tests/reg_issue2325/reg_issue2325.fz.expected_err_jvm
@@ -2,19 +2,14 @@
 error 1: FATAL FAULT `precondition`: debug: (numeric.this +! other)
 Call stack:
 fuzion.sys.fatal_fault#2 at {base.fum}/fuzion/sys.fz:55
-fuzion.type.runtime.type.fault.type.default_value.(λkind_and_msg-> kind, msg := kind_and_m...).call#1 at {base.fum}/fuzion/runtime/fault.fz:63
-fuzion.runtime.fault.cause#1 at {base.fum}/eff/fallible.fz:35
-fuzion.type.runtime.type.contract_fault.type.default_value.(λkind_and_msg-> fuzion.runtime.fault.en...).call#1 at {base.fum}/fuzion/runtime/contract_fault.fz:42
-fuzion.runtime.contract_fault.cause#1 at {base.fum}/eff/fallible.fz:35
-fuzion.type.runtime.type.pre_fault.type.default_value.(λmsg-> fuzion.runtime.contract_fault.en...).call#1 at {base.fum}/fuzion/runtime/pre_fault.fz:42
-fuzion.runtime.pre_fault.cause#1 at {base.fum}/eff/fallible.fz:35
+[..]
 fuzion.runtime.precondition_fault#1 at {base.fum}/fuzion/runtime/pre_fault.fz:56
 i32.pre infix + at {base.fum}/numeric.fz:48
 i32.precall infix + at {base.fum}/numeric.fz:47
 i32.type.sum.anonymous.infix ∙#2 at {base.fum}/numeric.fz:222
 i32.type.sum.anonymous.op#2 at {base.fum}/Monoid.fz:60
 (list i32).fold#2 at {base.fum}/list.fz:274
-(interval i32).fold#1 at {base.fum}/Sequence.fz:612
+(interval i32).fold#1 at {base.fum}/Sequence.fz:611
 reg_issue2325 at --CURDIR--/reg_issue2325.fz:25
 
 *** fatal errors encountered, stopping.

--- a/tests/reg_issue270/issue270.fz.expected_err_jvm
+++ b/tests/reg_issue270/issue270.fz.expected_err_jvm
@@ -2,12 +2,7 @@
 error 1: FATAL FAULT `precondition`: false
 Call stack:
 fuzion.sys.fatal_fault#2 at {base.fum}/fuzion/sys.fz:55
-fuzion.type.runtime.type.fault.type.default_value.(λkind_and_msg-> kind, msg := kind_and_m...).call#1 at {base.fum}/fuzion/runtime/fault.fz:63
-fuzion.runtime.fault.cause#1 at {base.fum}/eff/fallible.fz:35
-fuzion.type.runtime.type.contract_fault.type.default_value.(λkind_and_msg-> fuzion.runtime.fault.en...).call#1 at {base.fum}/fuzion/runtime/contract_fault.fz:42
-fuzion.runtime.contract_fault.cause#1 at {base.fum}/eff/fallible.fz:35
-fuzion.type.runtime.type.pre_fault.type.default_value.(λmsg-> fuzion.runtime.contract_fault.en...).call#1 at {base.fum}/fuzion/runtime/pre_fault.fz:42
-fuzion.runtime.pre_fault.cause#1 at {base.fum}/eff/fallible.fz:35
+[..]
 fuzion.runtime.precondition_fault#1 at {base.fum}/fuzion/runtime/pre_fault.fz:56
 pre issue270 at --CURDIR--/issue270.fz:25
 precall issue270 at --CURDIR--/issue270.fz:25

--- a/tests/reg_issue3178/reg_issue3178.fz.expected_err_jvm
+++ b/tests/reg_issue3178/reg_issue3178.fz.expected_err_jvm
@@ -2,12 +2,7 @@
 error 1: FATAL FAULT `precondition`: debug: !(overflow_on_add other)
 Call stack:
 fuzion.sys.fatal_fault#2 at {base.fum}/fuzion/sys.fz:55
-fuzion.type.runtime.type.fault.type.default_value.(λkind_and_msg-> kind, msg := kind_and_m...).call#1 at {base.fum}/fuzion/runtime/fault.fz:63
-fuzion.runtime.fault.cause#1 at {base.fum}/eff/fallible.fz:35
-fuzion.type.runtime.type.contract_fault.type.default_value.(λkind_and_msg-> fuzion.runtime.fault.en...).call#1 at {base.fum}/fuzion/runtime/contract_fault.fz:42
-fuzion.runtime.contract_fault.cause#1 at {base.fum}/eff/fallible.fz:35
-fuzion.type.runtime.type.pre_fault.type.default_value.(λmsg-> fuzion.runtime.contract_fault.en...).call#1 at {base.fum}/fuzion/runtime/pre_fault.fz:42
-fuzion.runtime.pre_fault.cause#1 at {base.fum}/eff/fallible.fz:35
+[..]
 fuzion.runtime.precondition_fault#1 at {base.fum}/fuzion/runtime/pre_fault.fz:56
 i8.pre infix + at {base.fum}/num/wrap_around.fz:87
 i8.precall infix + at {base.fum}/num/wrap_around.fz:86

--- a/tests/reg_issue3352/reg_issue3352.fz.expected_err_jvm
+++ b/tests/reg_issue3352/reg_issue3352.fz.expected_err_jvm
@@ -2,14 +2,11 @@
 error 1: FATAL FAULT `*** panic ***`: *** invalid mutate for 'm'
 Call stack:
 fuzion.sys.fatal_fault#2 at {base.fum}/fuzion/sys.fz:55
-fuzion.type.runtime.type.fault.type.default_value.(λkind_and_msg-> kind, msg := kind_and_m...).call#1 at {base.fum}/fuzion/runtime/fault.fz:63
-fuzion.runtime.fault.cause#1 at {base.fum}/eff/fallible.fz:35
-panic.type.default_value.(λ(msg->fuzion.runtime.fault.env.cause (...).call#1 at {base.fum}/panic.fz:39
-panic.cause#1 at {base.fum}/eff/fallible.fz:35
+[..]
 panic#1 at {base.fum}/panic.fz:59
-m.mpanic#1 at {base.fum}/mutate.fz:103
-(m.new i32).check_and_replace at {base.fum}/mutate.fz:129
-(m.new i32).get at {base.fum}/mutate.fz:164
+m.mpanic#1 at {base.fum}/mutate.fz:118
+(m.new i32).check_and_replace at {base.fum}/mutate.fz:138
+(m.new i32).get at {base.fum}/mutate.fz:173
 universe at --builtin--:26
 
 *** fatal errors encountered, stopping.

--- a/tests/reg_issue4609/reg_issue4609.fz.expected_err_jvm
+++ b/tests/reg_issue4609/reg_issue4609.fz.expected_err_jvm
@@ -2,12 +2,7 @@
 error 1: FATAL FAULT `check`: false
 Call stack:
 fuzion.sys.fatal_fault#2 at {base.fum}/fuzion/sys.fz:55
-fuzion.type.runtime.type.fault.type.default_value.(λkind_and_msg-> kind, msg := kind_and_m...).call#1 at {base.fum}/fuzion/runtime/fault.fz:63
-fuzion.runtime.fault.cause#1 at {base.fum}/eff/fallible.fz:35
-fuzion.type.runtime.type.contract_fault.type.default_value.(λkind_and_msg-> fuzion.runtime.fault.en...).call#1 at {base.fum}/fuzion/runtime/contract_fault.fz:42
-fuzion.runtime.contract_fault.cause#1 at {base.fum}/eff/fallible.fz:35
-fuzion.type.runtime.type.check_fault.type.default_value.(λmsg-> fuzion.runtime.contract_fault.en...).call#1 at {base.fum}/fuzion/runtime/check_fault.fz:42
-fuzion.runtime.check_fault.cause#1 at {base.fum}/eff/fallible.fz:35
+[..]
 fuzion.runtime.checkcondition_fault#1 at {base.fum}/fuzion/runtime/check_fault.fz:56
 reg_issue4609.s.call at --CURDIR--/reg_issue4609.fz:33
 reg_issue4609.r#1 at --CURDIR--/reg_issue4609.fz:36

--- a/tests/reg_issue5064/reg_issue5064.fz.expected_err_jvm
+++ b/tests/reg_issue5064/reg_issue5064.fz.expected_err_jvm
@@ -2,12 +2,9 @@
 error 1: FATAL FAULT `*** panic ***`: --nil--
 Call stack:
 fuzion.sys.fatal_fault#2 at {base.fum}/fuzion/sys.fz:55
-fuzion.type.runtime.type.fault.type.default_value.(λkind_and_msg-> kind, msg := kind_and_m...).call#1 at {base.fum}/fuzion/runtime/fault.fz:63
-fuzion.runtime.fault.cause#1 at {base.fum}/eff/fallible.fz:35
-panic.type.default_value.(λ(msg->fuzion.runtime.fault.env.cause (...).call#1 at {base.fum}/panic.fz:39
-panic.cause#1 at {base.fum}/eff/fallible.fz:35
+[..]
 panic#1 at {base.fum}/panic.fz:59
-(option Stack.Node).or_panic at {base.fum}/switch.fz:175
+(option Stack.Node).or_panic at {base.fum}/switch.fz:165
 Stack.push#2 i32 at --CURDIR--/reg_issue5064.fz:46
 universe at --builtin--:48
 

--- a/tests/reg_issue5377/reg_issue5377.fz.expected_err_jvm
+++ b/tests/reg_issue5377/reg_issue5377.fz.expected_err_jvm
@@ -2,10 +2,7 @@
 error 1: FATAL FAULT `*** panic ***`: 
 Call stack:
 fuzion.sys.fatal_fault#2 at {base.fum}/fuzion/sys.fz:55
-fuzion.type.runtime.type.fault.type.default_value.(λkind_and_msg-> kind, msg := kind_and_m...).call#1 at {base.fum}/fuzion/runtime/fault.fz:63
-fuzion.runtime.fault.cause#1 at {base.fum}/eff/fallible.fz:35
-panic.type.default_value.(λ(msg->fuzion.runtime.fault.env.cause (...).call#1 at {base.fum}/panic.fz:39
-panic.cause#1 at {base.fum}/eff/fallible.fz:35
+[..]
 panic#1 at {base.fum}/panic.fz:59
 reg_issue5377.join at --CURDIR--/reg_issue5377.fz:31
 reg_issue5377 at --CURDIR--/reg_issue5377.fz:34

--- a/tests/reg_issue6074/reg_issue6074.fz.expected_err_jvm
+++ b/tests/reg_issue6074/reg_issue6074.fz.expected_err_jvm
@@ -2,15 +2,10 @@
 error 1: FATAL FAULT `precondition`: debug : to = 0 || (if is_array_backed || debug_level > 1 then is_valid_index to-1 else true)
 Call stack:
 fuzion.sys.fatal_fault#2 at {base.fum}/fuzion/sys.fz:55
-fuzion.type.runtime.type.fault.type.default_value.(λkind_and_msg-> kind, msg := kind_and_m...).call#1 at {base.fum}/fuzion/runtime/fault.fz:63
-fuzion.runtime.fault.cause#1 at {base.fum}/eff/fallible.fz:35
-fuzion.type.runtime.type.contract_fault.type.default_value.(λkind_and_msg-> fuzion.runtime.fault.en...).call#1 at {base.fum}/fuzion/runtime/contract_fault.fz:42
-fuzion.runtime.contract_fault.cause#1 at {base.fum}/eff/fallible.fz:35
-fuzion.type.runtime.type.pre_fault.type.default_value.(λmsg-> fuzion.runtime.contract_fault.en...).call#1 at {base.fum}/fuzion/runtime/pre_fault.fz:42
-fuzion.runtime.pre_fault.cause#1 at {base.fum}/eff/fallible.fz:35
+[..]
 fuzion.runtime.precondition_fault#1 at {base.fum}/fuzion/runtime/pre_fault.fz:56
-((array i32).slice#3 i32).array_slice.pre slice i32 at {base.fum}/Sequence.fz:350
-((array i32).slice#3 i32).array_slice.precall slice i32 at {base.fum}/Sequence.fz:348
+((array i32).slice#3 i32).array_slice.pre slice i32 at {base.fum}/Sequence.fz:353
+((array i32).slice#3 i32).array_slice.precall slice i32 at {base.fum}/Sequence.fz:351
 reg_issue6074 at --CURDIR--/reg_issue6074.fz:26
 
 *** fatal errors encountered, stopping.

--- a/tests/reg_issue7051/reg_issue7051.fz.expected_err_jvm
+++ b/tests/reg_issue7051/reg_issue7051.fz.expected_err_jvm
@@ -2,15 +2,11 @@
 error 1: Postcondition `result < 0` does not hold after call
 Call stack:
 fuzion.sys.fatal_fault#2 at {base.fum}/fuzion/sys.fz:55
-fuzion.type.runtime.type.fault.type.default_value.(λkind_and_msg-> kind, msg := kind_and_m...).call#1 at {base.fum}/fuzion/runtime/fault.fz:63
-fuzion.runtime.fault.cause#1 at {base.fum}/eff/fallible.fz:35
-fuzion.type.runtime.type.contract_fault.type.default_value.(λkind_and_msg-> fuzion.runtime.fault.en...).call#1 at {base.fum}/fuzion/runtime/contract_fault.fz:42
-fuzion.runtime.contract_fault.cause#1 at {base.fum}/eff/fallible.fz:35
-fuzion.type.runtime.type.post_fault.type.default_value.(λmsg-> fuzion.runtime.contract_fault.en...).call#1 at {base.fum}/fuzion/runtime/post_fault.fz:42
-fuzion.runtime.post_fault.cause#1 at {base.fum}/eff/fallible.fz:35
+[..]
 fuzion.runtime.postcondition_fault#1 at {base.fum}/fuzion/runtime/post_fault.fz:56
 reg_issue7051.outer2.post a i32 at --CURDIR--/reg_issue7051.fz:28
-  ... repeated twice ...reg_issue7051.outer2.a#2 i32 at --CURDIR--/reg_issue7051.fz:34
+reg_issue7051.outer2.post a i32 at --CURDIR--/reg_issue7051.fz:34
+reg_issue7051.outer2.a#2 i32 at --CURDIR--/reg_issue7051.fz:34
 reg_issue7051 at --CURDIR--/reg_issue7051.fz:37
 
 *** fatal errors encountered, stopping.

--- a/tests/sequence_sliding/sequence_sliding.fz.expected_err_jvm
+++ b/tests/sequence_sliding/sequence_sliding.fz.expected_err_jvm
@@ -2,12 +2,7 @@
 error 1: FATAL FAULT `precondition`: debug: size > 0
 Call stack:
 fuzion.sys.fatal_fault#2 at {base.fum}/fuzion/sys.fz:55
-fuzion.type.runtime.type.fault.type.default_value.(λkind_and_msg-> kind, msg := kind_and_m...).call#1 at {base.fum}/fuzion/runtime/fault.fz:63
-fuzion.runtime.fault.cause#1 at {base.fum}/eff/fallible.fz:35
-fuzion.type.runtime.type.contract_fault.type.default_value.(λkind_and_msg-> fuzion.runtime.fault.en...).call#1 at {base.fum}/fuzion/runtime/contract_fault.fz:42
-fuzion.runtime.contract_fault.cause#1 at {base.fum}/eff/fallible.fz:35
-fuzion.type.runtime.type.pre_fault.type.default_value.(λmsg-> fuzion.runtime.contract_fault.en...).call#1 at {base.fum}/fuzion/runtime/pre_fault.fz:42
-fuzion.runtime.pre_fault.cause#1 at {base.fum}/eff/fallible.fz:35
+[..]
 fuzion.runtime.precondition_fault#1 at {base.fum}/fuzion/runtime/pre_fault.fz:56
 (interval i32).pre sliding at {base.fum}/Sequence.fz:1160
 (interval i32).precall sliding at {base.fum}/Sequence.fz:1159


### PR DESCRIPTION
Before printing the stack trace, we try to remove all lines that are inner features of `fuzion` or `panic.type` up to and including a call to `fuzion...cause` or `panic.cause`.

Also, the reference to the source code is now presented in green if ANSI escapes are enabled.
