### PR TITLE
base: add precondition to `Ring_Buffer` to ensure non negative size

### DIFF
--- a/modules/base/src/container/Ring_Buffer.fz
+++ b/modules/base/src/container/Ring_Buffer.fz
@@ -46,6 +46,7 @@ public Ring_Buffer(
   public size i64
 
 ) ref ! M
+  pre safety: size ≥ 0
 is
 
   # the elements in the ring buffer. Valid entries are at indices first..last-1 MOD size


### PR DESCRIPTION
fix #7183

Would it make sense to also forbid size 0?