### PR TITLE
base: cleanup and additional functions for `Channel`

### DIFF
--- a/modules/base/src/concur/Blocking_Queue.fz
+++ b/modules/base/src/concur/Blocking_Queue.fz
@@ -51,6 +51,13 @@ module Blocking_Queue(T type) ref is
       check cnd.broadcast
 
 
+  # has this queue been closed?
+  #
+  module is_closed =>
+    cnd.synchronized ()->
+      s.read.is_closed
+
+
   # enqueue an element
   # if queue is already closed, returns false
   # otherwise enqueues the element and returns true
@@ -95,4 +102,3 @@ module Blocking_Queue(T type) ref is
         depleted => nil
         t T => t
         retry => panic "Illegal state in Blocking_Queue, bug!"
-

--- a/modules/base/src/concur/Channel.fz
+++ b/modules/base/src/concur/Channel.fz
@@ -22,37 +22,101 @@
 # -----------------------------------------------------------------------
 
 
-# a Channel can be used to send values
-# to another thread
+# A Channel is a means to send values from one or several threads to one or several
+# receiver threads. Both, sender and receiver may block if the channel is full or
+# empty, respectively.
+#
+# A channel is originally open. It may be closed by a call to `Channel.close` to
+# close the channel. A closed channel may no longer be used to send data: An attempt
+# to send data to a closed channel will cause a fault (pre_fault if `safety` is enabled,
+# otherwise `panic`).
+#
+# A closed channel may still contain values that have not been received yet. These
+# values may still be received.  Any attempts to receive data from a closed empty
+# channel will return `nil`.
 #
 # NYI: UNDER DEVELOPMENT: max buf size
-public Channel(T type/*, buf_size i32*/) ref : Iterator T, Sending_Channel T, Receiving_Channel T is
+public Channel(public T type/*, buf_size i32*/) ref : Iterator T, Sending_Channel T, Receiving_Channel T is
 
   bq := Blocking_Queue T
 
 
-  # send a value to this Channel
-  # returns true if sending was successful,
-  # false if not
+  # send a value to this Channel.
   #
-  public redef infix <- (to T) bool ! atomic_access
+  # The channel must be open. Sending a value to a closed channel will cause a fault
+  # (pre_fault if `safety` is enabled, otherwise `panic`).
+  #
+  # In case the Channel is full, the attempt to send data will block until the Channel
+  # is no longer full or closed.
+  #
+  public redef infix <- (to T) unit ! atomic_access
   =>
-    bq.enqueue to
+    if ! bq.enqueue to then
+      panic "send to closed Channel $T"
 
 
-  # close the Channel
+  # receive the next value from this channel.  Return nil if
+  # the channel is empty and closed.
   #
-  # infix <- will now always return false
-  # next will return nil once Channel is empty
+  # If the channel is open and has no values available, this will
+  # block until values are available or the channel is closed.
   #
-  public redef close unit ! atomic_access =>
-    bq.close
-    # NYI: BUG: free/dispose cnd
+  public prefix <- option T => next
 
 
-  # returns nil when Channel is closed and empty
-  # otherwise returns the next received value
+  # receive the next value from this channel.  Return nil if
+  # the channel is empty and closed.
+  #
+  # If the channel is open and has no values available, this will
+  # block until values are available or the channel is closed.
+  #
+  # NYI: CLEANUP: Since this is a duplicate of `prefix <-`, we could
+  # remove it.
   #
   public redef next option T ! atomic_access =>
     bq.dequeue
 
+
+  # close this Channel
+  #
+  # Sending data via `infix <-` will no more be allowed and result in a fault.
+  #
+  # Receiving via `prefix <-` or `next` will return `nil` once Channel is empty
+  #
+  public redef close unit ! atomic_access
+  =>
+    bq.close
+    # NYI: BUG: free/dispose cnd
+
+
+  # Has this Channel been closed?
+  #
+  public redef is_closed bool
+  =>
+    bq.is_closed
+
+
+  # Create a lazy list of received values from a channel
+  #
+  # This can be used to process all the values of a channel, e.g., you can
+  #
+  #   sum_channel(ch Channel N : numeric) =>
+  #     ch.as_list.sum
+  #
+  # Note that in case of several concurrent readers, each value will end up
+  # with being seen by only one reader.
+  #
+  # Unless the Channel is closed, this will block to read at least one
+  # value from this Channel.
+  #
+  public as_list list T =>
+    match next
+      v T => v : as_list
+      nil => nil
+
+
+# create a Channel of the given type
+#
+public channel(T type) Channel T
+=>
+  Channel T

--- a/modules/base/src/concur/Sending_Channel.fz
+++ b/modules/base/src/concur/Sending_Channel.fz
@@ -25,6 +25,25 @@
 #
 public Sending_Channel(T type) ref is
 
-  public infix <- (to T) bool => abstract
+  # send a value to this Channel.
+  #
+  # The channel must be open. Sending a value to a closed channel will cause a fault
+  # (pre_fault if `safety` is enabled, otherwise `panic`).
+  #
+  # In case the Channel is full, the attempt to send data will block until the Channel
+  # is no longer full or closed.
+  #
+  public infix <- (to T) unit
+  pre
+    safety : !is_closed
+  =>
+    abstract
 
-  public close unit => abstract
+
+  public close unit
+  post
+    debug: is_closed
+  =>
+    abstract
+
+  public is_closed bool => abstract

--- a/tests/lib_concur_Channel/lib_concur_Channel.fz
+++ b/tests/lib_concur_Channel/lib_concur_Channel.fz
@@ -29,9 +29,9 @@ lib_concur_Channel =>
   concur.thread_pool _ 8 ()->
 
     check concur.thread_pool.env.submit ()->
-      check chan <- 1
-      check chan <- 2
-      check chan <- 3
+      chan <- 1
+      chan <- 2
+      chan <- 3
 
 
     time.nano.env.sleep (time.duration.ms 250)
@@ -48,5 +48,5 @@ lib_concur_Channel =>
 
 
     check concur.thread_pool.env.submit ()->
-      check chan <- 9
+      chan <- 9
       chan.close


### PR DESCRIPTION
I am trying to bring this closer to golang's channel functionality.

Apart from adding more detailed documentation, this adds the following features:

- added `Channel.prefix <-` as an alternative to `next`.

- added `Sending_Channel.is_closed`/`Channel.is_closed`

- added `Channel.as_list` that permits iteration of the elements

- added `channel(T type)` feature to create a channel. I would like to make `Channel` a template feature and return different implementations.

Also changed the following

- `Sending_Channel.infix <-`/`Channel.infix <-` no longer returns `bool`, but results in a precondition fault in case the Channel is closed.

What I would like to do next is marry this with `blocking_mutate`.
