### PR TITLE
base: `Sending_Channel.infix <-` now panics if closed even in precondition.

### DIFF
--- a/modules/base/src/concur/Sending_Channel.fz
+++ b/modules/base/src/concur/Sending_Channel.fz
@@ -27,15 +27,15 @@ public Sending_Channel(T type) ref is
 
   # send a value to this Channel.
   #
-  # The channel must be open. Sending a value to a closed channel will cause a fault
-  # (pre_fault if `safety` is enabled, otherwise `panic`).
+  # The channel must be open. Sending a value to a closed channel will cause a panic,
+  # either immediately or if it closed while we block on a full channel.
   #
   # In case the Channel is full, the attempt to send data will block until the Channel
   # is no longer full or closed.
   #
   public infix <- (to T) unit
   pre
-    safety : !is_closed
+    (safety : !is_closed) || panic "send to closed Channel $T"
   =>
     abstract
 


### PR DESCRIPTION
I am trying a new mechanism to cause a fault other than pre_fault in a failing pre-condition.
