### PR TITLE
fe: change outer in inherits call features visitation

### DIFF
--- a/src/dev/flang/ast/Feature.java
+++ b/src/dev/flang/ast/Feature.java
@@ -1285,7 +1285,7 @@ public class Feature extends AbstractFeature
   {
     for (var c: _inherits)
       {
-        Expr nc = c.visit(v, this);
+        Expr nc = c.visit(v, outer());
         if (CHECKS) check
           (Errors.any() || c == nc); // NYI: This will fail when doing funny stuff like inherit from bool.infix &&, need to check and handle explicitly
       }


### PR DESCRIPTION
It feels more correct for inherits calls to pass in the outer as the context instead of the feature itself.
This is since the inherits call happens before or rather during the construction of the feature so can not or even must not have knowledge about it.