### PR TITLE
fe: support auto_unwrap of match subjects and if conditions

### DIFF
--- a/src/dev/flang/ast/Expr.java
+++ b/src/dev/flang/ast/Expr.java
@@ -711,6 +711,33 @@ public abstract class Expr extends ANY implements HasSourcePosition
 
 
   /**
+   * Do automatic unwrapping of features inheriting {@code unwrap}
+   * if unwrapped type is a choice.
+   *
+   * @param res the resolution instance
+   *
+   * @param context the source code context where this Expr is used
+   *
+   * @return the unwrapped expression
+   */
+  Expr unwrapChoice(Resolution res, Context context)
+  {
+    var t = type();
+    return this != Call.ERROR && t != Types.t_ERROR
+      && !t.isChoice()
+      && !t.isGenericArgument()
+      && allInherited(t.feature())
+          .stream()
+          .anyMatch(c ->
+            c.calledFeature().equals(Types.resolved.f_auto_unwrap)
+            && !c.actualTypeParameters().isEmpty()
+                    && c.actualTypeParameters().get(0).applyTypePars(t).isChoice())
+      ? new ParsedCall(this, new ParsedName(pos(), FuzionConstants.UNWRAP)).resolveTypes(res, context)
+      : this;
+  }
+
+
+  /**
    * @param f
    *
    * @return the whole tree of inherited features flattened to a list.

--- a/src/dev/flang/ast/Match.java
+++ b/src/dev/flang/ast/Match.java
@@ -158,6 +158,13 @@ public class Match extends AbstractMatch
   void resolveTypes(Resolution res, Context context)
   {
     var st = _subject.typeForInferencing(context);
+
+    if (!subject().type().isChoice())
+      {
+        _subject = _subject.unwrapChoice(res, context);
+        st = _subject.typeForInferencing();
+      }
+
     if (st != null && st != Types.t_ERROR && !st.isGenericArgument())
       {
         res.resolveTypes(st.feature());

--- a/src/dev/flang/ast/Match.java
+++ b/src/dev/flang/ast/Match.java
@@ -159,7 +159,7 @@ public class Match extends AbstractMatch
   {
     var st = _subject.typeForInferencing(context);
 
-    if (!subject().type().isChoice())
+    if (st != null && !st.isChoice())
       {
         _subject = _subject.unwrapChoice(res, context);
         st = _subject.typeForInferencing();

--- a/tests/reg_issue7227/Makefile
+++ b/tests/reg_issue7227/Makefile
@@ -1,0 +1,25 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test Makefile
+#
+# -----------------------------------------------------------------------
+
+override NAME = reg_issue7227
+include ../simple.mk

--- a/tests/reg_issue7227/reg_issue7227.fz
+++ b/tests/reg_issue7227/reg_issue7227.fz
@@ -1,0 +1,33 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test reg_issue7227
+#
+# -----------------------------------------------------------------------
+
+reg_issue7227 =>
+
+  match mut (option String) nil
+    nil => say "nil"
+    String => say "string"
+
+  if mut bool false
+    say "true"
+  else
+    say "false"

--- a/tests/reg_issue7227/reg_issue7227.fz.expected_out
+++ b/tests/reg_issue7227/reg_issue7227.fz.expected_out
@@ -1,0 +1,2 @@
+nil
+false


### PR DESCRIPTION
fixes #7227

This allows to do a match on e.g. a mutable variable without the need for explicit unwrapping:
```fuzion
x := mut (option i32) nil

# some code that may compute a result
x <- 42

match x
  nil => say "no result found"
  n i32 => say n
```