### PR TITLE
title change wording from _type argument_ to _type parameter_ as according to ref manual

### DIFF
--- a/modules/base/src/Function.fz
+++ b/modules/base/src/Function.fz
@@ -58,5 +58,5 @@ public Function(public R type,
 #
 #     curry(x A.0) R->A.1... is x,a... -> call x a...
 #
-# where A.1... is the tail of type argument A (might be empty), and A.0 is the first element,
+# where A.1... is the tail of type parameter A (might be empty), and A.0 is the first element,
 # void (or unit?) if it does not exist.

--- a/modules/base/src/choice.fz
+++ b/modules/base/src/choice.fz
@@ -43,7 +43,7 @@
 # with actual generics.
 #
 # A field of choice type can be assigned a value of the same choice type
-# or of any of the actual generic type arguments provided to the choice
+# or of any of the actual generic type parameters provided to the choice
 # feature.
 #
 # Two choice types choice A B and choice B A that differ only in the order

--- a/modules/base/src/void.fz
+++ b/modules/base/src/void.fz
@@ -55,7 +55,7 @@
 # Since no value of type void can ever be produced, the assignment is dead code that
 # will be removed by the fuzion implementation.
 #
-# Type void may be used as an actual type argument for a type parameter.  If this
+# Type void may be used as an actual type parameter for a type parameter.  If this
 # is done, it will turn all features that have arguments of that type into absurd
 # features.  Also, this will ensure that any feature that produces a result of that
 # type to never return a result (typically to not be callable in the first place as

--- a/src/dev/flang/ast/AbstractFeature.java
+++ b/src/dev/flang/ast/AbstractFeature.java
@@ -268,7 +268,7 @@ public abstract class AbstractFeature extends Expr implements Comparable<Abstrac
 
 
   /**
-   * All arguments of this feature. This includes type arguments.
+   * All arguments of this feature. This includes type parameters.
    */
   public abstract List<AbstractFeature> arguments();
 
@@ -1700,7 +1700,7 @@ public abstract class AbstractFeature extends Expr implements Comparable<Abstrac
 
 
   /**
-   * Is this feature an argument of its outer feature, but not a type argument?
+   * Is this feature an argument of its outer feature, but not a type parameter?
    */
   boolean isValueArgument()
   {
@@ -1788,7 +1788,7 @@ public abstract class AbstractFeature extends Expr implements Comparable<Abstrac
 
 
   /**
-   * Return the index of this type parameter within the type arguments of its
+   * Return the index of this type parameter within the type parameters of its
    * outer feature.
    *
    * @return the index such that formalGenerics.get(result)) this

--- a/src/dev/flang/ast/AstErrors.java
+++ b/src/dev/flang/ast/AstErrors.java
@@ -249,7 +249,7 @@ public class AstErrors extends ANY
           : ", you must provide "
             + StringHelpers.singularOrPlural(f.arguments().size(), "argument") + "."
             + (f.typeArguments().size() > 0
-                ? " The type arguments may be omitted or `_` may be used in place of a type argument if they can be inferred from the value arguments.."
+                ? " The type parameters may be omitted or `_` may be used in place of a type parameter if they can be inferred from the value arguments.."
                 : ""));
   }
 
@@ -1662,7 +1662,7 @@ public class AstErrors extends ANY
     var ns = ss(names.toString("", ",", ""));
     var expected_args =
       ntypes  == 0 ? StringHelpers.singularOrPlural(nvalues, "argument"     )
-                   : StringHelpers.singularOrPlural(ntypes , "type argument") + " and " +
+                   : StringHelpers.singularOrPlural(ntypes , "type parameter") + " and " +
                      StringHelpers.singularOrPlural(nvalues, "value argument");
     error(pos,
           "Wrong number of arguments in lambda expression",

--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -2321,9 +2321,9 @@ public class Call extends AbstractCall
 
 
   /**
-   * Is it allowed to change/infer actual type argument with index i?
+   * Is it allowed to change/infer actual type parameter with index i?
    *
-   * @param i the index of the actual type argument
+   * @param i the index of the actual type parameter
    *
    * @return
    */

--- a/src/dev/flang/ast/Function.java
+++ b/src/dev/flang/ast/Function.java
@@ -138,7 +138,7 @@ public class Function extends AbstractLambda
    *
    * @param names the names of the arguments, "x", "y". The are parsed as
    * expressions and these might end up being turned into types by asParsedType
-   * if this lambda ends up used as an actual type argument.
+   * if this lambda ends up used as an actual type parameter.
    *
    * @param e the code on the right hand side of '->'.
    */

--- a/src/dev/flang/ast/ParsedCall.java
+++ b/src/dev/flang/ast/ParsedCall.java
@@ -685,7 +685,7 @@ A `_` may be used as placeholder for a xref:fuzion_actual_typeparameter[actual t
                   {
                     firstValueIndex = tn;
                   }
-                else if (_actuals.size() == vn)  // value args are present, type args are inferred
+                else if (_actuals.size() == vn)  // value args are present, type parameters are inferred
                   {
                     firstValueIndex = 0;
                   }

--- a/src/dev/flang/ast/QualThisType.java
+++ b/src/dev/flang/ast/QualThisType.java
@@ -65,7 +65,7 @@ public class QualThisType extends UnresolvedType
 
   /**
    * resolve this type, i.e., find or create the corresponding instance of
-   * ResolvedType of this and all outer types and type arguments this depends on.
+   * ResolvedType of this and all outer types and type parameters this depends on.
    *
    * @param res this is called during type resolution, res gives the resolution
    * instance.

--- a/src/dev/flang/ast/UnresolvedType.java
+++ b/src/dev/flang/ast/UnresolvedType.java
@@ -417,7 +417,7 @@ public abstract class UnresolvedType extends AbstractType implements HasSourcePo
 
   /**
    * resolve this type, i.e., find or create the corresponding instance of
-   * ResolvedType of this and all outer types and type arguments this depends on.
+   * ResolvedType of this and all outer types and type parameters this depends on.
    *
    * @param res this is called during type resolution, res gives the resolution
    * instance.
@@ -433,7 +433,7 @@ public abstract class UnresolvedType extends AbstractType implements HasSourcePo
 
   /**
    * resolve this type, i.e., find or create the corresponding instance of
-   * ResolvedType of this and all outer types and type arguments this depends on.
+   * ResolvedType of this and all outer types and type parameters this depends on.
    *
    * @param res this is called during type resolution, res gives the resolution
    * instance.

--- a/src/dev/flang/fe/FeErrors.java
+++ b/src/dev/flang/fe/FeErrors.java
@@ -63,8 +63,8 @@ public class FeErrors extends AstErrors
   {
     var g = m.generics();
     error(m.pos(),
-          "Main feature must not have type arguments",
-          "Main feature has " + StringHelpers.singularOrPlural(m.typeArguments().size(),"type argument") + " " + g + ", but should have no arguments to be used as main feature in an application\n" +
+          "Main feature must not have type parameters",
+          "Main feature has " + StringHelpers.singularOrPlural(m.typeArguments().size(),"type parameter") + " " + g + ", but should have no arguments to be used as main feature in an application\n" +
           "To solve this, remove the arguments from feature " + s(m) + "\n");
   }
 

--- a/src/dev/flang/lsp/feature/Diagnostics.java
+++ b/src/dev/flang/lsp/feature/Diagnostics.java
@@ -59,7 +59,7 @@ public enum Diagnostics
 
   public static Stream<Diagnostic> getDiagnostics(URI uri)
   {
-    // NYI: UNDER DEVELOPMENT: check names of type arguments
+    // NYI: UNDER DEVELOPMENT: check names of type parameters
     return Util.concatStreams(
       errors(uri),
       warnings(uri),

--- a/src/dev/flang/tools/docs/Html.java
+++ b/src/dev/flang/tools/docs/Html.java
@@ -544,7 +544,7 @@ public class Html extends ANY
         universeFunctions.addAll(allUniverseFeat.getOrDefault(AbstractFeature.Kind.Intrinsic, new TreeSet<AbstractFeature>()));
         universeFunctions.addAll(allUniverseFeat.getOrDefault(AbstractFeature.Kind.Native, new TreeSet<AbstractFeature>()));
 
-        // only keep features that have a matching type argument with a type other than Any
+        // only keep features that have a matching type parameter with a type other than Any
         universeFunctions.removeIf(
           af->af.typeArguments().isEmpty()
           || af.typeArguments().stream().noneMatch(typeParam->typeParam.constraint().compareTo(Types.resolved.t_Any ) != 0

--- a/src/dev/flang/util/StringHelpers.java
+++ b/src/dev/flang/util/StringHelpers.java
@@ -131,11 +131,11 @@ public class StringHelpers extends ANY
 
 
   /**
-   * Create a string representation for a type argument count.
+   * Create a string representation for a type parameter count.
    *
-   * @param count the number of type arguments
+   * @param count the number of type parameters
    *
-   * @return a string like "no type arguments", "one type argument", "2 type
+   * @return a string like "no type parameters", "one type parameter", "2 type
    * arguments"
    */
   public static String typeParametersString(int count)

--- a/tests/asParsedType/test_asParsedType.fz
+++ b/tests/asParsedType/test_asParsedType.fz
@@ -43,7 +43,7 @@ x(T type) => say "GOT: x $T"
 y(T type, v T) => say "GOT: y $T"
 
 
-# ------  tests using actual type arguments  ------
+# ------  tests using actual type parameters  ------
 
 
 say "EXP: x Type of 'i32'"

--- a/tests/asParsedType_negative/test_asParsedType_negative.fz
+++ b/tests/asParsedType_negative/test_asParsedType_negative.fz
@@ -42,7 +42,7 @@ test_asParsedType_negative is
   y(T type, v T) => say "GOT: y $T"
 
 
-  # ------  tests using actual type arguments  ------
+  # ------  tests using actual type parameters  ------
 
 
   say "EXP: x Type of 'i32'"

--- a/tests/free_types_negative/test_free_types_negative.fz
+++ b/tests/free_types_negative/test_free_types_negative.fz
@@ -88,7 +88,7 @@ test_free_type_negative is
   ga3 f64    | String := 3.14
   g ga1
   g ga2
-  g ga3              # 6. should flag an error since type arguments are in the wrong order such that constraint is not matched
+  g ga3              # 6. should flag an error since type parameters are in the wrong order such that constraint is not matched
 
   # mixture of explicit and free type parameters
   #

--- a/tests/free_types_negative/test_free_types_negative.fz.expected_err
+++ b/tests/free_types_negative/test_free_types_negative.fz.expected_err
@@ -92,7 +92,7 @@ To solve this, you could change the type of the target 'v' to 'f64' or convert t
 
 
 --CURDIR--/test_free_types_negative.fz:91:3: error 10: Incompatible type parameter
-  g ga3              # 6. should flag an error since type arguments are in the wrong order such that constraint is not matched
+  g ga3              # 6. should flag an error since type parameters are in the wrong order such that constraint is not matched
 --^
 formal type parameter 'B : numeric'
 actual type parameter 'String'

--- a/tests/partial_application_negative/partial_application_negative.fz.expected_err
+++ b/tests/partial_application_negative/partial_application_negative.fz.expected_err
@@ -89,7 +89,7 @@ In call: 'map'
 To solve this, you might change the actual number of arguments to match the feature 'map' (one type parameter B, one value argument f) at {base.fum}/Sequence.fz:553:10:
   public map(B type, f T->B) Sequence B
 ---------^^^
-To call 'map', you must provide 2 arguments. The type arguments may be omitted or `_` may be used in place of a type argument if they can be inferred from the value arguments..
+To call 'map', you must provide 2 arguments. The type parameters may be omitted or `_` may be used in place of a type parameter if they can be inferred from the value arguments..
 
 
 

--- a/tests/reg_issue3507/reg_issue3507.fz.expected_err
+++ b/tests/reg_issue3507/reg_issue3507.fz.expected_err
@@ -6,10 +6,10 @@ Main feature has one value argument ('x.v'), but should have no arguments to be 
 To solve this, remove the arguments from feature 'x'
 
 
---CURDIR--/reg_issue3507.fz:24:1: error 2: Main feature must not have type arguments
+--CURDIR--/reg_issue3507.fz:24:1: error 2: Main feature must not have type parameters
 x(v T) => _ := T
 ^
-Main feature has one type argument T, but should have no arguments to be used as main feature in an application
+Main feature has one type parameter T, but should have no arguments to be used as main feature in an application
 To solve this, remove the arguments from feature 'x'
 
 2 errors.

--- a/tests/reg_issue5818_calling_with_open_type/reg_issue5818_calling_with_open_type.fz
+++ b/tests/reg_issue5818_calling_with_open_type/reg_issue5818_calling_with_open_type.fz
@@ -78,7 +78,7 @@ reg_issue5818_calling_with_open_type =>
 
   # ------------------------------
 
-  # Now an open type argument that is used as the type of a value arguemnt.
+  # Now an open type parameter that is used as the type of a value arguemnt.
   #
   # if open type parameters are used as type of value arguments, the types must be inferred:
   #

--- a/tests/reg_issue5818_calling_with_open_type_negative/reg_issue5818_calling_with_open_type.fz
+++ b/tests/reg_issue5818_calling_with_open_type_negative/reg_issue5818_calling_with_open_type.fz
@@ -76,7 +76,7 @@ reg_issue5818_calling_with_open_type =>
 
   # ------------------------------
 
-  # Now an open type argument that is used as the type of a value arguemnt.
+  # Now an open type parameter that is used as the type of a value arguemnt.
   #
   # if open type parameters are used as type of value arguments, the types must be inferred:
   #

--- a/tests/reg_issue5818_calling_with_open_type_negative/reg_issue5818_calling_with_open_type.fz.expected_err
+++ b/tests/reg_issue5818_calling_with_open_type_negative/reg_issue5818_calling_with_open_type.fz.expected_err
@@ -93,7 +93,7 @@ In call: '(array String)'
 To solve this, you might change the actual number of arguments to match the feature 'array' (2 type parameters T I, 2 value arguments length init) at {base.fum}/array.fz:195:8:
 public array(T type, I type : integer, length I, init I -> T) array T =>
 -------^^^^^
-To call 'array', you must provide 4 arguments. The type arguments may be omitted or `_` may be used in place of a type argument if they can be inferred from the value arguments..
+To call 'array', you must provide 4 arguments. The type parameters may be omitted or `_` may be used in place of a type parameter if they can be inferred from the value arguments..
 
 
 
@@ -119,7 +119,7 @@ In call: '(array String)'
 To solve this, you might change the actual number of arguments to match the feature 'array' (2 type parameters T I, 2 value arguments length init) at {base.fum}/array.fz:195:8:
 public array(T type, I type : integer, length I, init I -> T) array T =>
 -------^^^^^
-To call 'array', you must provide 4 arguments. The type arguments may be omitted or `_` may be used in place of a type argument if they can be inferred from the value arguments..
+To call 'array', you must provide 4 arguments. The type parameters may be omitted or `_` may be used in place of a type parameter if they can be inferred from the value arguments..
 
 
 
@@ -390,7 +390,7 @@ In call: 'g _'
 To solve this, you might change the actual number of arguments to match the feature 'g' (2 type parameters T U, one open type parameter A (no arguments)) at --CURDIR--/reg_issue5818_calling_with_open_type.fz:59:3:
   g(T,U type, A type ...) =>
 --^
-To call 'g', you must provide 3 arguments. The type arguments may be omitted or `_` may be used in place of a type argument if they can be inferred from the value arguments..
+To call 'g', you must provide 3 arguments. The type parameters may be omitted or `_` may be used in place of a type parameter if they can be inferred from the value arguments..
 
 
 
@@ -403,7 +403,7 @@ In call: 'g _'
 To solve this, you might change the actual number of arguments to match the feature 'g' (2 type parameters T U, one open type parameter A (no arguments)) at --CURDIR--/reg_issue5818_calling_with_open_type.fz:59:3:
   g(T,U type, A type ...) =>
 --^
-To call 'g', you must provide 3 arguments. The type arguments may be omitted or `_` may be used in place of a type argument if they can be inferred from the value arguments..
+To call 'g', you must provide 3 arguments. The type parameters may be omitted or `_` may be used in place of a type parameter if they can be inferred from the value arguments..
 
 
 

--- a/tests/reg_issue6092/reg_issue6092.fz.expected_err
+++ b/tests/reg_issue6092/reg_issue6092.fz.expected_err
@@ -8,7 +8,7 @@ In call: 'r u8 2'
 To solve this, you might change the actual number of arguments to match the feature 'r' (2 type parameters A C, one value argument c) at --CURDIR--/reg_issue6092.fz:24:1:
 r(A type, c C) =>
 ^
-To call 'r', you must provide 3 arguments. The type arguments may be omitted or `_` may be used in place of a type argument if they can be inferred from the value arguments..
+To call 'r', you must provide 3 arguments. The type parameters may be omitted or `_` may be used in place of a type parameter if they can be inferred from the value arguments..
 
 
 one error.

--- a/tests/reg_issue6379/reg_issue6379.fz.expected_err
+++ b/tests/reg_issue6379/reg_issue6379.fz.expected_err
@@ -8,7 +8,7 @@ In call: 'ignore unit (array 3 _->1) _->'
 To solve this, you might change the actual number of arguments to match the feature 'ignore' (one type parameter T, one value argument x) at {base.fum}/ignore.fz:50:8:
 public ignore(T type, x T) unit =>
 -------^^^^^^
-To call 'ignore', you must provide 2 arguments. The type arguments may be omitted or `_` may be used in place of a type argument if they can be inferred from the value arguments..
+To call 'ignore', you must provide 2 arguments. The type parameters may be omitted or `_` may be used in place of a type parameter if they can be inferred from the value arguments..
 
 
 one error.

--- a/tests/reg_issue7_genericConstraint/checkGenericConstraint.fz
+++ b/tests/reg_issue7_genericConstraint/checkGenericConstraint.fz
@@ -25,7 +25,7 @@
 
 # Regression test for issue #7: https://github.com/tokiwa-software/fuzion/issues/7
 #
-# A simple negative test using incompatible actual type argument
+# A simple negative test using incompatible actual type parameter
 #
 checkGenericConstraint is
 


### PR DESCRIPTION
This is to have more consistency in our texts.
