### PR TITLE
run_tests: fix `test_duration` sort order

### DIFF
--- a/bin/run_tests.fz
+++ b/bin/run_tests.fz
@@ -259,7 +259,7 @@ main =>
 
   test_durations
     .items
-    .sort_by (.1)
+    .sort_by (t -> property.reverse_order t.1)
     .take num_slowest
     .for_each (td -> say "$(td.1.as_string_pad) $(td.0)")
 


### PR DESCRIPTION
fixes #7241


