### PR TITLE
tests: remove `time.nano.env.sleep` with arbitrary values

### DIFF
--- a/tests/lib_concur_Channel/lib_concur_Channel.fz
+++ b/tests/lib_concur_Channel/lib_concur_Channel.fz
@@ -25,6 +25,8 @@ lib_concur_Channel =>
 
   chan := concur.Channel u8
 
+  sent_items := concur.atomic bool .new false
+  received_item := concur.atomic bool .new false
 
   concur.thread_pool _ 8 ()->
 
@@ -32,9 +34,10 @@ lib_concur_Channel =>
       chan <- 1
       chan <- 2
       chan <- 3
+      sent_items.write true
 
 
-    time.nano.env.sleep (time.duration.ms 250)
+    while !sent_items.read
 
 
     check concur.thread_pool.env.submit ()->
@@ -42,9 +45,10 @@ lib_concur_Channel =>
         for n := chan.next
         while n.ok
           say "received $(n)"
+          received_item.write true
 
 
-    time.nano.env.sleep (time.duration.ms 250)
+    while !received_item.read
 
 
     check concur.thread_pool.env.submit ()->

--- a/tests/sockets/sockets_test.fz
+++ b/tests/sockets/sockets_test.fz
@@ -169,7 +169,6 @@ sockets_test is
 
   port(f net.family.val, p net.protocol.val) =>
     while servers.read[server_ident f p] = 0
-      time.nano.env.sleep (time.duration.s 1)
     servers.read[server_ident f p]
 
 ########### Tests ################

--- a/tests/sockets_thread_pool/sockets_test.fz
+++ b/tests/sockets_thread_pool/sockets_test.fz
@@ -172,7 +172,6 @@ sockets_thread_pool_test is
 
   port(f net.family.val, p net.protocol.val) =>
     while servers.read[server_ident f p] = 0
-      time.nano.env.sleep (time.duration.s 1)
     servers.read[server_ident f p]
 
 ########### Tests ################


### PR DESCRIPTION
- in sockets its just unnecessary
- the one in lib_channel is replaced by a busy loop

