### PR TITLE
base: make `close` on mutable variable require `is_exclusive`

### DIFF
--- a/modules/base/src/mutate.fz
+++ b/modules/base/src/mutate.fz
@@ -146,7 +146,10 @@ public mutate : linear_effect is
 
     # stop any further mutations of this element
     #
-    public close unit =>
+    public close unit
+    pre
+      safety: is_exclusive
+    =>
       set open := false
 
 


### PR DESCRIPTION
Otherwise, we have racy accesses to the `open` flag when used with `blocking_mutate`.
