### PR TITLE
fe: raise error if `outer` is called on this-type

### DIFF
--- a/src/dev/flang/ast/AbstractType.java
+++ b/src/dev/flang/ast/AbstractType.java
@@ -1873,7 +1873,7 @@ there is no common super type of the two types (Types.t_ERROR)
         tt = switch(tt.kind())
           {
             case GenericArgument, ThisType -> null;
-            case RefType,ValueType -> tt.outer();
+            case RefType, ValueType -> tt.outer();
           };
       }
     while (tt != null);

--- a/src/dev/flang/ast/AbstractType.java
+++ b/src/dev/flang/ast/AbstractType.java
@@ -2477,7 +2477,7 @@ there is no common super type of the two types (Types.t_ERROR)
   {
     String result = switch (kind())
       {
-        case GenericArgument :
+        case GenericArgument:
           {
             var ga = genericArgument();
             yield
@@ -2488,12 +2488,12 @@ there is no common super type of the two types (Types.t_ERROR)
                 : (humanReadable ? ga.baseNameHuman() : ga.baseName())) +
               (isRef() ? " (boxed)" : "");
           }
-        case ThisType :
+        case ThisType:
           {
             yield (feature().outer().isUniverse() ? "" : feature().outer().qualifiedName(humanReadable) + ".")
               + featureName(humanReadable) + ".this" + (feature().isCotype() ? ".type" : "");
           }
-        case RefType, ValueType :
+        case RefType, ValueType:
           {
             var res = outerToString(humanReadable)
                   + (isRef() != feature().isRef() ? (isRef() ? "ref " : "value ") : "")

--- a/src/dev/flang/ast/AbstractType.java
+++ b/src/dev/flang/ast/AbstractType.java
@@ -2478,17 +2478,21 @@ there is no common super type of the two types (Types.t_ERROR)
     String result = switch (kind())
       {
         case GenericArgument :
-         {
-          var ga = genericArgument();
-          yield
-            (ga.isCoTypesThisType()
-              ? ga.qualifiedName(context, humanReadable)
-              : ga.isTypeFeature()
-              ? ga.qualifiedName(humanReadable)
-              : (humanReadable ? ga.baseNameHuman() : ga.baseName())) +
-            (isRef() ? " (boxed)" : "");
-         }
-        case ThisType : { yield featureName(humanReadable) + ".this" + (feature().isCotype() ? ".type" : ""); }
+          {
+            var ga = genericArgument();
+            yield
+              (ga.isCoTypesThisType()
+                ? ga.qualifiedName(context, humanReadable)
+                : ga.isTypeFeature()
+                ? ga.qualifiedName(humanReadable)
+                : (humanReadable ? ga.baseNameHuman() : ga.baseName())) +
+              (isRef() ? " (boxed)" : "");
+          }
+        case ThisType :
+          {
+            yield (feature().outer().isUniverse() ? "" : feature().outer().qualifiedName(humanReadable) + ".")
+              + featureName(humanReadable) + ".this" + (feature().isCotype() ? ".type" : "");
+          }
         case RefType, ValueType :
           {
             var res = outerToString(humanReadable)
@@ -2517,9 +2521,7 @@ there is no common super type of the two types (Types.t_ERROR)
   protected String outerToString(boolean humanReadable)
   {
     var o = outer();
-    return isThisType()
-        ? (feature().outer().isUniverse() ? "" : feature().outer().qualifiedName(humanReadable) + ".")
-        : o != null && (o.isGenericArgument() || !o.feature().isUniverse())
+    return o != null && (o.isGenericArgument() || !o.feature().isUniverse())
         ? o.toStringWrapped(humanReadable) + "."
         : "";
   }

--- a/src/dev/flang/ast/AbstractType.java
+++ b/src/dev/flang/ast/AbstractType.java
@@ -108,7 +108,7 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
   /**
    * The outer of this type. May be null.
    *
-   * Requires that this is resolved and !isGenericArgument().
+   * Requires that this is resolved and isNormalType().
    */
   public abstract AbstractType outer();
 
@@ -728,7 +728,8 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
             case RefType, ValueType -> {
               yield actual.feature() == feature() &&
                 genericsAssignable(actual, context) &&
-                (outer() == null && actual.outer() == null || outer().isAssignableFromDirectly(actual.outer()).yes())
+                // NYI: BUG: isThisType logic certainly wrong...
+                (isThisType() || outer() == null && actual.outer() == null || outer().isAssignableFromDirectly(actual.outer()).yes())
               ||
                 constraintAssignableViaInherits(context, actual);
             }
@@ -1869,7 +1870,11 @@ there is no common super type of the two types (Types.t_ERROR)
     do
       {
         result = result.replace_this_type_by_actual_outer2(tt, foundRef, context);
-        tt = tt.isGenericArgument() ? null : tt.outer();
+        tt = switch(tt.kind())
+          {
+            case GenericArgument, ThisType -> null;
+            case RefType,ValueType -> tt.outer();
+          };
       }
     while (tt != null);
     return result;
@@ -2429,6 +2434,37 @@ there is no common super type of the two types (Types.t_ERROR)
 
 
   /**
+   * Helper function for toString
+   */
+  private String featureName(boolean humanReadable)
+  {
+    var f = feature();
+    var cotypeType = f.isCotype();
+    if (cotypeType)
+      {
+        f = f.cotypeOrigin();
+      }
+    var fn = f.featureName();
+    // for a feature that does not define a type itself, the name is not
+    // unique due to overloading with different argument counts. So we add
+    // the argument count to get a unique name.
+    var fname = (humanReadable ? f.baseNameHuman() : f.baseName())
+      +  (f.definesType() || fn.argCount() == 0 || fn.isInternal() || humanReadable
+            ? ""
+            : FuzionConstants.INTERNAL_NAME_SYMBOL + fn.argCount());
+
+    // NYI: would be good if postFeatures could be identified not be string comparison, but with something like
+    // `f.isPostFeature()`. Note that this would need to be saved in .fum file as well!
+    ///
+    return fname.startsWith(FuzionConstants.POSTCONDITION_FEATURE_PREFIX)
+      ? fname.substring(FuzionConstants.POSTCONDITION_FEATURE_PREFIX.length(),
+                                fname.lastIndexOf("_")) +
+          ".postcondition"
+      : fname;
+  }
+
+
+  /**
    * Get a String representation of this Type.
    *
    * Note that this does not work for instances of Type before they were
@@ -2439,70 +2475,34 @@ there is no common super type of the two types (Types.t_ERROR)
    */
   public String toString(boolean humanReadable, AbstractFeature context)
   {
-    String result;
-
-    if (isGenericArgument())
+    String result = switch (kind())
       {
-        var ga = genericArgument();
-        result =
-          (ga.isCoTypesThisType()
-            ? ga.qualifiedName(context, humanReadable)
-            : ga.isTypeFeature()
-            ? ga.qualifiedName(humanReadable)
-            : (humanReadable ? ga.baseNameHuman() : ga.baseName())) +
-          (isRef() ? " (boxed)" : "");
-      }
-    else
-      {
-        var f = feature();
-        var cotypeType = f.isCotype();
-        if (cotypeType)
+        case GenericArgument :
+         {
+          var ga = genericArgument();
+          yield
+            (ga.isCoTypesThisType()
+              ? ga.qualifiedName(context, humanReadable)
+              : ga.isTypeFeature()
+              ? ga.qualifiedName(humanReadable)
+              : (humanReadable ? ga.baseNameHuman() : ga.baseName())) +
+            (isRef() ? " (boxed)" : "");
+         }
+        case ThisType : { yield featureName(humanReadable) + ".this" + (feature().isCotype() ? ".type" : ""); }
+        case RefType, ValueType :
           {
-            f = f.cotypeOrigin();
-          }
-        var fn = f.featureName();
-        // for a feature that does not define a type itself, the name is not
-        // unique due to overloading with different argument counts. So we add
-        // the argument count to get a unique name.
-        var fname = (humanReadable ? f.baseNameHuman() : f.baseName())
-          +  (f.definesType() || fn.argCount() == 0 || fn.isInternal() || humanReadable
-                ? ""
-                : FuzionConstants.INTERNAL_NAME_SYMBOL + fn.argCount());
-
-        // NYI: would be good if postFeatures could be identified not be string comparison, but with something like
-        // `f.isPostFeature()`. Note that this would need to be saved in .fum file as well!
-        ///
-        if (fname.startsWith(FuzionConstants.POSTCONDITION_FEATURE_PREFIX))
-          {
-            fname = fname.substring(FuzionConstants.POSTCONDITION_FEATURE_PREFIX.length(),
-                                    fname.lastIndexOf("_")) +
-              ".postcondition";
-          }
-
-        result = outerToString(humanReadable)
-              + (isNormalType() && isRef() != feature().isRef() ? (isRef() ? "ref " : "value ") : "" )
-              + fname;
-        if (isThisType())
-          {
-            result = result + ".this";
-          }
-        if (cotypeType)
-          {
-            result = result + ".type";
-          }
-        if (isNormalType())
-          {
-            var skip = cotypeType;
-            for (var g : generics())
+            var res = outerToString(humanReadable)
+                  + (isRef() != feature().isRef() ? (isRef() ? "ref " : "value ") : "")
+                  + featureName(humanReadable)
+                  + (feature().isCotype() ? ".type" : "");
+            // skip first generic 'THIS#TYPE' for types of type features.
+            for (var g : generics().drop(feature().isCotype() ? 1 : 0))
               {
-                if (!skip) // skip first generic 'THIS#TYPE' for types of type features.
-                  {
-                    result = result + " " + g.toStringWrapped(humanReadable, context);
-                  }
-                skip = false;
+                res = res + " " + g.toStringWrapped(humanReadable, context);
               }
+            yield res;
           }
-      }
+      };
 
     if (POSTCONDITIONS) ensure
       (!humanReadable || !result.contains("#"));

--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -2237,11 +2237,14 @@ public class Call extends AbstractCall
                                  pos, conflict, foundAt);
                   }
               }
-            inferGeneric(res,
-                         context,
-                         formalType.outer(),
-                         actualType.outer(),
-                         pos, conflict, foundAt);
+            if (formalType.isNormalType() && actualType.isNormalType())
+              {
+                inferGeneric(res,
+                             context,
+                             formalType.outer(),
+                             actualType.outer(),
+                             pos, conflict, foundAt);
+              }
           }
         else if (formalType.isChoice())
           {

--- a/src/dev/flang/ast/ThisType.java
+++ b/src/dev/flang/ast/ThisType.java
@@ -82,7 +82,6 @@ class ThisType extends ResolvedType {
   @Override
   public List<AbstractType> generics()
   {
-    // TODO Auto-generated method stub
     throw new UnsupportedOperationException("Unimplemented method 'generics'");
   }
 
@@ -90,15 +89,12 @@ class ThisType extends ResolvedType {
   /**
    * The outer of this type. May be null.
    *
-   * Requires that this is resolved and !isGenericArgument().
+   * Requires that this is resolved and isNormalType().
    */
   @Override
   public AbstractType outer()
   {
-    // NYI: UNDER DEVELOPMENT: better null or not legal to call?
-    return Types.resolved == null
-      ? null
-      : Types.resolved.universe.selfType();
+    throw new UnsupportedOperationException("Unimplemented method 'outer'");
   }
 
 

--- a/src/dev/flang/fe/LibraryOut.java
+++ b/src/dev/flang/fe/LibraryOut.java
@@ -47,6 +47,7 @@ import dev.flang.ast.Feature;
 import dev.flang.ast.InlineArray;
 import dev.flang.ast.ResolvedType;
 import dev.flang.ast.State;
+import dev.flang.ast.Types;
 import dev.flang.ast.Universe;
 
 import dev.flang.util.ANY;
@@ -623,7 +624,8 @@ class LibraryOut extends ANY
                     type(gt);
                   }
               }
-            type(t.outer());
+            // NYI: CLEANUP: do not write outer for this types.
+            type(t.isThisType() ? Types.resolved.universe.selfType() : t.outer());
           }
       }
   }

--- a/src/dev/flang/fe/ThisType.java
+++ b/src/dev/flang/fe/ThisType.java
@@ -50,15 +50,13 @@ class ThisType extends LibraryType {
   @Override
   public List<AbstractType> generics()
   {
-    // TODO Auto-generated method stub
     throw new UnsupportedOperationException("Unimplemented method 'generics'");
   }
 
   @Override
   public AbstractType outer()
   {
-    // NYI: UNDER DEVELOPMENT: better null or not legal to call?
-    return _libModule.libraryUniverse().selfType();
+    throw new UnsupportedOperationException("Unimplemented method 'outer'");
   }
 
   @Override


### PR DESCRIPTION
If outer is called on a this-type this usually means the current logic is insufficiently well thought out, so I think its better to raise an error early when this happens.

