### PR TITLE
base: add `codepoint.as_u8`, hide `String.type.minus_char` etc.

### DIFF
--- a/modules/base/src/String.fz
+++ b/modules/base/src/String.fz
@@ -1024,14 +1024,14 @@ public String ref : property.equatable, property.hashable, property.orderable is
 
   # NYI: remove the convenience functions when Fuzion supports char literals
   #
-  public type.minus_char  u8 => "-".utf8.first.or_panic
-  public type.plus_char   u8 => "+".utf8.first.or_panic
-  public type.zero_char   u8 => "0".utf8.first.or_panic
-  public type.nine_char   u8 => "9".utf8.first.or_panic
-  public type.a_char      u8 => "a".utf8.first.or_panic
-  public type.z_char      u8 => "z".utf8.first.or_panic
-  public type.cap_a_char  u8 => "A".utf8.first.or_panic
-  public type.cap_z_char  u8 => "Z".utf8.first.or_panic
+  module type.minus_char  u8 => "-".as_u8
+  module type.plus_char   u8 => "+".as_u8
+  module type.zero_char   u8 => "0".as_u8
+  module type.nine_char   u8 => "9".as_u8
+  module type.a_char      u8 => "a".as_u8
+  module type.z_char      u8 => "z".as_u8
+  module type.cap_a_char  u8 => "A".as_u8
+  module type.cap_z_char  u8 => "Z".as_u8
 
 
   # is byte a valid starting byte of a utf-8 string?

--- a/modules/base/src/codepoint.fz
+++ b/modules/base/src/codepoint.fz
@@ -86,7 +86,7 @@ is
 
   # shortcut to get this codepoint as a u8
   #
-  public as_u8
+  public as_u8 u8
     pre codepoint.utf8_encoded_in_one_byte.contains val
   => val.as_u8
 

--- a/modules/base/src/codepoint.fz
+++ b/modules/base/src/codepoint.fz
@@ -84,6 +84,12 @@ is
   #
   public is_not_a_character bool => codepoint.not_a_character.contains val
 
+  # shortcut to get this codepoint as a u8
+  #
+  public as_u8
+    pre codepoint.utf8_encoded_in_one_byte.contains val
+  => val.as_u8
+
 
   # range of permitted value for a codepoint
   #

--- a/tests/process/test_process.fz
+++ b/tests/process/test_process.fz
@@ -32,7 +32,7 @@ test_process =>
     _ : String is
       public redef utf8 Sequence u8 =>
         (1..byte_size)
-          .map u8 (x -> codepoint.type.zero_char)
+          .map u8 (x -> "0".as_u8)
 
 
   test(str String, f () -> outcome unit) =>

--- a/tests/process_utf8/process_utf8.fz
+++ b/tests/process_utf8/process_utf8.fz
@@ -32,7 +32,7 @@ process_utf8 =>
     _ : String is
       public redef utf8 Sequence u8 =>
         (1..byte_size)
-          .map u8 (x -> codepoint.type.zero_char)
+          .map u8 (x -> "0".as_u8)
 
 
   test(str String, f () -> outcome unit) =>


### PR DESCRIPTION
I think the convenience functions are better not exposed...