### PR TITLE
base: make Nullary inherit from `auto_unwrap`

### DIFF
--- a/modules/base/src/Nullary.fz
+++ b/modules/base/src/Nullary.fz
@@ -25,4 +25,7 @@
 #
 # T is the result type of the function
 #
-public Nullary(public T type) ref : Function T is
+public Nullary(public T type) ref : Function T,
+                                    auto_unwrap T is
+
+  public redef unwrap T => call

--- a/modules/base/src/auto_unwrap.fz
+++ b/modules/base/src/auto_unwrap.fz
@@ -32,4 +32,10 @@
 #
 #
 public auto_unwrap(T type, E type... : effect) is
+
+  # the feature that is called to
+  # unwrap the value
+  #
+  # must be implemented by inheriting features
+  #
   public unwrap T => abstract

--- a/tests/reg_issue6634/reg_issue6634.fz.expected_err
+++ b/tests/reg_issue6634/reg_issue6634.fz.expected_err
@@ -3,7 +3,7 @@
       (()-> for i:=1E5,i-°1 while i>0 do)*1E5
 -----------------------------------------^
 Feature not found: 'infix/infix_right *' (one argument)
-Target feature: 'ex.(λ(()-> for i:=1E5,i-°1 while i>0 do))'
+Target feature: 'unit'
 In call: '(()-> for i:=1E5,i-°1 while i>0 do)*1E5'
 
 one error.


### PR DESCRIPTION
6634 needed to be rerecorded. It would be better if `mayUnwrapTarget` in `Call` would return false and to not unwrap the target if we can't find a feature for the calls name. Will create an issue for this.