### PR TITLE
base: change precondition `codepoint.as_u8` as according to review of #7247

### DIFF
--- a/modules/base/src/codepoint.fz
+++ b/modules/base/src/codepoint.fz
@@ -87,7 +87,7 @@ is
   # shortcut to get this codepoint as a u8
   #
   public as_u8 u8
-    pre codepoint.utf8_encoded_in_one_byte.contains val
+    pre debug: val.fits_in_u8
   => val.as_u8
 
 


### PR DESCRIPTION
> Since codepoints 128 through 255 are not encoded in one byte.

_Originally posted by @fridis in https://github.com/tokiwa-software/fuzion/pull/7247#discussion_r3473273179_
            