### PR TITLE
cleanup: rename, `isGenericArgument` -> `isParametricType`, etc.

### DIFF
--- a/bin/aspell.dict
+++ b/bin/aspell.dict
@@ -535,7 +535,6 @@ fzP
 fzT
 fzTag
 fzThrd
-genericArgument
 genericsToReplace
 GenericType
 getAll
@@ -687,7 +686,7 @@ isExpr
 isFiel
 isField
 isFrozen
-isGenericArgument
+isParametricType
 isI
 isInstantiated
 isIntrinsc
@@ -1307,7 +1306,7 @@ checkIndentation
 clangVersion
 cloneValue
 codePointIndentation
-constraintMustNotBeGenericArgument
+constraintMustNotBeParametricType
 curPos
 datagram
 debugLevel

--- a/src/dev/flang/ast/AbstractCall.java
+++ b/src/dev/flang/ast/AbstractCall.java
@@ -376,7 +376,7 @@ public abstract class AbstractCall extends Expr
     if (!cf.isOuterRef())
       {
         var declF = cf.outer();
-        if (!tt.isGenericArgument() && declF != tt.feature())
+        if (!tt.isParametricType() && declF != tt.feature())
           {
             var heir = tt.feature();
             t = t.replace_inherited_this_type(declF, heir, foundRef);
@@ -445,7 +445,7 @@ public abstract class AbstractCall extends Expr
    */
   private List<AbstractType> openGenericsFor(Resolution res, Context context, AbstractType ft)
   {
-    var f = ft.genericArgument().outer();
+    var f = ft.typeParameter().outer();
     return
       calledFeature() == f ? ft.applyTypeParsMaybeOpen(f, actualTypeParameters(), NO_SELECT)
                            : openGenericsFor(res, context, ft, target().type());
@@ -472,7 +472,7 @@ public abstract class AbstractCall extends Expr
       (tt != null);
 
     var x = res == null ? tt.selfOrConstraint(context) : tt.selfOrConstraint(res, context);
-    var f = ft.genericArgument().outer();
+    var f = ft.typeParameter().outer();
 
     if (CHECKS) check
       (x.isPlainType() || Errors.any());

--- a/src/dev/flang/ast/AbstractFeature.java
+++ b/src/dev/flang/ast/AbstractFeature.java
@@ -701,7 +701,7 @@ public abstract class AbstractFeature extends Expr implements Comparable<Abstrac
                       {
                         t = a.resultType();
                       }
-                    result = result || t.isGenericArgument() && t.genericArgument() == g;
+                    result = result || t.isParametricType() && t.typeParameter() == g;
                   }
               }
           }
@@ -744,7 +744,7 @@ public abstract class AbstractFeature extends Expr implements Comparable<Abstrac
               {
                 t = a.resultType();
               }
-            return t.isGenericArgument() && t.genericArgument() == g;
+            return t.isParametricType() && t.typeParameter() == g;
           })
          );
   }
@@ -1957,7 +1957,7 @@ public abstract class AbstractFeature extends Expr implements Comparable<Abstrac
         .allMatch(rt ->
              Types.resolved.numericTypes.contains(rt)
              || Types.resolved.legalNativeResultTypes.contains(rt)
-             || !rt.isGenericArgument() && rt.feature().mayBeNativeValue());
+             || !rt.isParametricType() && rt.feature().mayBeNativeValue());
   }
 
   /**

--- a/src/dev/flang/ast/AbstractMatch.java
+++ b/src/dev/flang/ast/AbstractMatch.java
@@ -166,7 +166,7 @@ public abstract class AbstractMatch extends ExprWithPos
   void checkTypes(Context context)
   {
     var st = subject().type();
-    if (st.isGenericArgument())
+    if (st.isParametricType())
       {
         AstErrors.matchSubjectMustNotBeTypeParameter(subject().pos(), st);
       }

--- a/src/dev/flang/ast/AbstractType.java
+++ b/src/dev/flang/ast/AbstractType.java
@@ -114,7 +114,7 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
 
 
   /**
-   * The mode of the type: GenericArgument, ThisType, RefType or ValueType.
+   * The mode of the type: ParametricType, ThisType, RefType or ValueType.
    */
   public abstract TypeKind kind();
 
@@ -152,7 +152,7 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
   /**
    * This type as a reference.
    *
-   * Requires that this is resolved, !isGenericArgument().
+   * Requires that this is resolved, !isParametricType().
    */
   public AbstractType asRef()
   {
@@ -165,17 +165,17 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
    *
    * @param allowForThisType allow this-types to be turned in to a ref-type
    *
-   * Requires that this is resolved, !isGenericArgument().
+   * Requires that this is resolved, !isParametricType().
    */
   public AbstractType asRef(boolean allowForThisType)
   {
     if (PRECONDITIONS) require
       (!(this instanceof UnresolvedType),
-       !isGenericArgument(),
+       !isParametricType(),
        allowForThisType || !isThisType());
 
     return switch (kind()) {
-      case GenericArgument -> throw new Error("asValue not legal for genericArgument");
+      case ParametricType -> throw new Error("asValue not legal for ParametricType");
       case ThisType -> allowForThisType
         ? ResolvedNormalType.create(
             feature().genericsAsActuals(),
@@ -195,16 +195,16 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
    * Return this type as a this-type, a type denoting the
    * instance of this type in the current context.
    *
-   * Requires that this is resolved and !isGenericArgument().
+   * Requires that this is resolved and !isParametricType().
    */
   public AbstractType asThis()
   {
     if (PRECONDITIONS) require
       (!(this instanceof UnresolvedType),
-       !isGenericArgument());
+       !isParametricType());
 
     return switch (kind()) {
-      case GenericArgument -> throw new Error("asThis not legal for genericArgument");
+      case ParametricType -> throw new Error("asThis not legal for ParametricType");
       case ThisType -> this;
       case RefType, ValueType ->
         feature().isUniverse()
@@ -227,7 +227,7 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
   /**
    * For a resolved normal type, return the underlying feature.
    *
-   * Requires that this is resolved and !isGenericArgument().
+   * Requires that this is resolved and !isParametricType().
    *
    * @return the underlying feature.
    */
@@ -235,7 +235,7 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
   {
     if (PRECONDITIONS) require
       (!(this instanceof UnresolvedType),
-       !isGenericArgument());
+       !isParametricType());
 
     var result = backingFeature();
 
@@ -249,13 +249,13 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
   /**
    * For a resolved parametric type return the generic.
    *
-   * Requires that this is resolved and isGenericArgument().
+   * Requires that this is resolved and isParametricType().
    */
-  public AbstractFeature genericArgument()
+  public AbstractFeature typeParameter()
   {
     if (PRECONDITIONS) require
       (!(this instanceof UnresolvedType),
-       isGenericArgument());
+       isParametricType());
 
     var result = backingFeature();
 
@@ -295,7 +295,7 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
    */
   public boolean isOpenGeneric()
   {
-    return isGenericArgument() && genericArgument().isOpenTypeParameter();
+    return isParametricType() && typeParameter().isOpenTypeParameter();
   }
 
 
@@ -304,18 +304,18 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
    */
   public boolean isChoice()
   {
-    return !isGenericArgument() && feature().isChoice();
+    return !isParametricType() && feature().isChoice();
   }
 
 
   // cache field
-  private final boolean _isGenericArgument = kind() == TypeKind.GenericArgument;
+  private final boolean _isParametricType = kind() == TypeKind.ParametricType;
   /**
    * Is this type a generic argument (true) or false backed by a feature (false)?
    */
-  public boolean isGenericArgument()
+  public boolean isParametricType()
   {
-    return _isGenericArgument;
+    return _isParametricType;
   }
 
 
@@ -356,7 +356,7 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
       switch (kind())
       {
         case RefType, ValueType        -> true;
-        case ThisType, GenericArgument -> false;
+        case ThisType, ParametricType -> false;
       };
   }
 
@@ -583,8 +583,8 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
   YesNo isAssignableFrom(AbstractType actual, Context context, boolean allowBoxing, boolean allowTagging, Set<AbstractType> assignableTo)
   {
     if (PRECONDITIONS) require
-      (this  .isGenericArgument() || this  .feature() != null || Errors.any(),
-       actual.isGenericArgument() || actual.feature() != null || Errors.any());
+      (this  .isParametricType() || this  .feature() != null || Errors.any(),
+       actual.isParametricType() || actual.feature() != null || Errors.any());
 
         /*
     // tag::fuzion_rule_TYPE_SYSTEM_ASSIGNABLE_FROM[]
@@ -601,11 +601,11 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
     var result = isArtificialType() || actual.isArtificialType()
         ? YesNo.dontKnow
         : YesNo.fromBool(target_type.compareTo(actual_type) == 0 || actual_type.isVoid());
-    if (result.no() && !target_type.isGenericArgument() && isRef() && actual_type.isRef())
+    if (result.no() && !target_type.isParametricType() && isRef() && actual_type.isRef())
       {
-        if (actual_type.isGenericArgument())
+        if (actual_type.isParametricType())
           {
-            result = isAssignableFrom(actual_type.genericArgument().constraint(context).asRef(true), context, allowBoxing, allowTagging, assignableTo);
+            result = isAssignableFrom(actual_type.typeParameter().constraint(context).asRef(true), context, allowBoxing, allowTagging, assignableTo);
           }
         else
           {
@@ -629,9 +629,9 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
       }
     if (result.no() && allowBoxing)
       {
-        if (actual.isGenericArgument())
+        if (actual.isParametricType())
           {
-            result = isAssignableFrom(actual.genericArgument().constraint(context).asRef(true), context, allowBoxing, allowTagging, assignableTo);
+            result = isAssignableFrom(actual.typeParameter().constraint(context).asRef(true), context, allowBoxing, allowTagging, assignableTo);
           }
         else if (!actual.isRef())
           {
@@ -687,8 +687,8 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
   private boolean constraintAssignableFrom(Context context, AbstractType actual)
   {
     if (PRECONDITIONS) require
-      (this  .isGenericArgument() || this  .feature() != null || Errors.any(),
-       actual.isGenericArgument() || actual.feature() != null || Errors.any(),
+      (this  .isParametricType() || this  .feature() != null || Errors.any(),
+       actual.isParametricType() || actual.feature() != null || Errors.any(),
        Errors.any() || this != Types.t_ERROR && actual != Types.t_ERROR);
 
     var result = containsError()                   ||
@@ -696,7 +696,7 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
       this  .compareTo(actual               ) == 0 ||
       this  .compareTo(Types.resolved.t_Any ) == 0;
 
-    if (!result && !isGenericArgument())
+    if (!result && !isParametricType())
       {
         // NYI: BUG: #4756, #5002, likely unsound
         result = switch (actual.kind())
@@ -707,7 +707,7 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
              * this: 'T : property.orderable'
              * actual: 'I : integer'
              */
-            case GenericArgument -> constraintAssignableFrom(context, actual.genericArgument().constraint(context));
+            case ParametricType -> constraintAssignableFrom(context, actual.typeParameter().constraint(context));
             /**
              * e.g.:
              *
@@ -786,8 +786,8 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
   private boolean genericsAssignable(AbstractType actual, Context context)
   {
     if (PRECONDITIONS) require
-      (!this.isGenericArgument(),
-       !actual.isGenericArgument());
+      (!this.isParametricType(),
+       !actual.isParametricType());
 
     var ogs = actual.generics();
     var i1 = actualGenerics().iterator();
@@ -803,7 +803,7 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
         if (
           switch (g.kind())
             {
-              case GenericArgument ->
+              case ParametricType ->
                                       // NYI: BUG: #5002: check recursive type, e.g.:
                                       // this  = monad monad.A monad.MA
                                       // other = monad option.T (option option.T)
@@ -875,8 +875,8 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
                                                    List<AbstractType> actualTypes,
                                                    int select)
   {
-    return isOpenGeneric() && genericArgument().outer() == f && select == NO_SELECT
-      ? genericArgument().replaceOpen(actualTypes)
+    return isOpenGeneric() && typeParameter().outer() == f && select == NO_SELECT
+      ? typeParameter().replaceOpen(actualTypes)
       : new List<>(applyTypePars(f, actualTypes, select));
   }
 
@@ -926,7 +926,7 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
   public boolean dependsOnGenericsNoOuter()
   {
     boolean result = false;
-    if (isGenericArgument())
+    if (isParametricType())
       {
         result = true;
       }
@@ -956,7 +956,7 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
     YesNo result = _dependsOnGenerics;
     if (result == YesNo.dontKnow)
       {
-        if (isGenericArgument())
+        if (isParametricType())
           {
             result = YesNo.yes;
           }
@@ -1005,7 +1005,7 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
     if (PRECONDITIONS) require
       (target != null,
        Errors.any() || !isOpenGeneric(),
-       Errors.any() || target.isGenericArgument() || target.isThisType() || target.feature().generics().sizeMatches(target.generics()));
+       Errors.any() || target.isParametricType() || target.isThisType() || target.feature().generics().sizeMatches(target.generics()));
 
     AbstractType result;
     if (typeParCachingEnabled && _appliedTypeParsCachedFor1 == target)
@@ -1051,7 +1051,7 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
         var effectiveTargetType = tt.selfOrConstraint(Context.NONE);
         result = switch(effectiveTargetType.kind())
           {
-            case GenericArgument -> throw new Error("unexpected case in applyTypePars_");
+            case ParametricType -> throw new Error("unexpected case in applyTypePars_");
             case ThisType -> applyTypePars(effectiveTargetType.feature(), effectiveTargetType.feature().genericsAsActuals());
             case ValueType, RefType ->
               {
@@ -1121,7 +1121,7 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
    */
   boolean isCotypeType()
   {
-    return !isGenericArgument() && feature().isCotype();
+    return !isParametricType() && feature().isCotype();
   }
 
 
@@ -1187,9 +1187,9 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
   {
     AbstractFeature res = null;
 
-    if (isGenericArgument())
+    if (isParametricType())
       {
-        res = genericArgument();
+        res = typeParameter();
         if (res.outer().generics() != f.generics())  // if g is not formal generic of f, and g is a type feature generic, try g's origin:
           {
              res = f.isCotype() ? res.cotypeGeneric()
@@ -1236,7 +1236,7 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
 
     return switch (kind())
       {
-        case GenericArgument ->
+        case ParametricType ->
           {
             var result = this;
             var g = matchingTypeParameter(f);
@@ -1264,7 +1264,7 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
                   {
                     result = g.replace(actualGenerics);
                   }
-                while (result != Types.t_ERROR && forOuter != null && !result.isGenericArgument() && !result.feature().inheritsFrom(forOuter))
+                while (result != Types.t_ERROR && forOuter != null && !result.isParametricType() && !result.feature().inheritsFrom(forOuter))
                   {
                     result = result.outer();
                     if (CHECKS) check
@@ -1294,7 +1294,7 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
                  */
                 var this_type = g2.get(0);
                 g3 = g2.map(x -> x == this_type                ||        // leave first type parameter unchanged
-                                 this_type.isGenericArgument()    ? x    // no actuals to apply in a generic arg
+                                 this_type.isParametricType()    ? x    // no actuals to apply in a generic arg
                                                                   : x.applyTypePars(this_type)
                                                                      .replace_this_type_by_actual_outer(this_type, Context.NONE));
               }
@@ -1359,7 +1359,7 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
   AbstractType actualType(AbstractType t, Context context)
   {
     if (PRECONDITIONS) require
-      (!isGenericArgument(),
+      (!isParametricType(),
        !t.isOpenGeneric());
 
     return t.applyTypePars(this)
@@ -1644,9 +1644,9 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
     var g = soc.replaceGenericsAndOuter(f.genericsAsActuals(), soc.outer())
       .lambdaTargetResultType(res);
 
-    if (g.isGenericArgument() && g.genericArgument().outer() == f)
+    if (g.isParametricType() && g.typeParameter().outer() == f)
       {
-        result = g.genericArgument();
+        result = g.typeParameter();
       }
     return result;
   }
@@ -1871,7 +1871,7 @@ there is no common super type of the two types (Types.t_ERROR)
         result = result.replace_this_type_by_actual_outer2(tt, foundRef, context);
         tt = switch(tt.kind())
           {
-            case GenericArgument, ThisType -> null;
+            case ParametricType, ThisType -> null;
             case RefType, ValueType -> tt.outer();
           };
       }
@@ -1916,7 +1916,7 @@ there is no common super type of the two types (Types.t_ERROR)
   int whichOuterInheritsFrom(AbstractFeature f)
   {
     if (PRECONDITIONS) require
-      (!isGenericArgument());
+      (!isParametricType());
 
     var result = 0;
     var tf = feature();
@@ -1970,9 +1970,9 @@ there is no common super type of the two types (Types.t_ERROR)
   private boolean replacesThisType(AbstractType tt, Context context)
   {
     return
-      isThisTypeInCotype() && tt.isGenericArgument()   // we have a type parameter TT.THIS#TYPE, which is equal to TT
+      isThisTypeInCotype() && tt.isParametricType()   // we have a type parameter TT.THIS#TYPE, which is equal to TT
       ||
-      isThisType() && (!tt.isGenericArgument() && tt.feature().inheritsFrom(feature())  // we have abc.this.type with tt inheriting from abc, so use tt
+      isThisType() && (!tt.isParametricType() && tt.feature().inheritsFrom(feature())  // we have abc.this.type with tt inheriting from abc, so use tt
                        ||
                        // we have a,b,c.this.type and tt is type parameter with constraint x.y.z: So replace it if
                        // any of `a.b.c`, `a.b`, or `a` inherits from this. During monomorphization, when the type
@@ -1981,7 +1981,7 @@ there is no common super type of the two types (Types.t_ERROR)
                        // NYI: CLEANUP: instead of returning `tt` here, we might create a new type that refers to the n`th outer type
                        // of the actual type parameter, i.e., `Outer(1,tt)` in case `a.b` inherits from this, and `Outer(2,tt)` and in
                        // case `a` inherits from this.
-                       tt.isGenericArgument() && tt.genericArgument().constraint(context).whichOuterInheritsFrom(feature()) >= 0
+                       tt.isParametricType() && tt.typeParameter().constraint(context).whichOuterInheritsFrom(feature()) >= 0
                        );
   }
 
@@ -2034,7 +2034,7 @@ there is no common super type of the two types (Types.t_ERROR)
    */
   public AbstractType replace_this_type_in_cotype(AbstractFeature cotype)
   {
-    return isThisTypeInCotype() && cotype  == genericArgument().outer()
+    return isThisTypeInCotype() && cotype  == typeParameter().outer()
       ? cotype.cotypeOrigin().selfTypeInCoType()
       : applyToGenericsAndOuter(g -> g.replace_this_type_in_cotype(cotype));
   }
@@ -2140,7 +2140,7 @@ there is no common super type of the two types (Types.t_ERROR)
   public AbstractType cotypeType()
   {
     if (PRECONDITIONS) require
-      (!isGenericArgument(),
+      (!isParametricType(),
        feature().state().atLeast(State.RESOLVED));
 
     return cotypeType(null);
@@ -2163,7 +2163,7 @@ there is no common super type of the two types (Types.t_ERROR)
 
     AbstractType result = null;
     var fot = backingFeature();
-    if (fot.isUniverse() || this == Types.t_ERROR || fot.isCotype() || isGenericArgument())
+    if (fot.isUniverse() || this == Types.t_ERROR || fot.isCotype() || isParametricType())
       {
         result = this;
       }
@@ -2233,12 +2233,12 @@ there is no common super type of the two types (Types.t_ERROR)
   AbstractType replace_type_parameter_used_for_this_type_in_cotype(AbstractFeature tf, AbstractType tpt)
   {
     if (PRECONDITIONS) require
-      (tpt.isGenericArgument());
+      (tpt.isParametricType());
 
     var result = this;
-    if (isGenericArgument() && tf.isCotype())
+    if (isParametricType() && tf.isCotype())
       {
-        if (genericArgument() == tf.arguments().get(0))
+        if (typeParameter() == tf.arguments().get(0))
           { // a call of the form `T.f x` where `f` is declared as
             // `abc.type.f(arg abc.this.type)`, so replace
             // `abc.this.type` by `T`.
@@ -2275,9 +2275,9 @@ there is no common super type of the two types (Types.t_ERROR)
   AbstractType remove_type_parameter_used_for_this_type_in_cotype()
   {
     var result = this;
-    if (isGenericArgument())
+    if (isParametricType())
       {
-        var tp = genericArgument();
+        var tp = typeParameter();
         var tf = tp.outer();
         if (tf.isCotype() && tp == tf.arguments().get(0))
           { // generic used for `abc.this.type` in `abc.type` by `abc.this.type`.
@@ -2332,11 +2332,11 @@ there is no common super type of the two types (Types.t_ERROR)
       (outerCotype.isCotype());
 
     AbstractType result;
-    if (isGenericArgument())
+    if (isParametricType())
       {
-        if (genericArgument().outer() == outerCotype.cotypeOrigin())
+        if (typeParameter().outer() == outerCotype.cotypeOrigin())
           {
-            result = outerCotype.typeArguments().get(genericArgument().typeParameterIndex() + 1).asGenericType();
+            result = outerCotype.typeArguments().get(typeParameter().typeParameterIndex() + 1).asGenericType();
           }
         else
           {
@@ -2389,10 +2389,10 @@ there is no common super type of the two types (Types.t_ERROR)
    */
   public boolean isThisTypeInCotype()
   {
-    return isGenericArgument()
-      && genericArgument().state().atLeast(State.FINDING_DECLARATIONS)
-      && genericArgument().outer().isCotype()
-      && genericArgument().typeParameterIndex() == 0;
+    return isParametricType()
+      && typeParameter().state().atLeast(State.FINDING_DECLARATIONS)
+      && typeParameter().outer().isCotype()
+      && typeParameter().typeParameterIndex() == 0;
   }
 
 
@@ -2407,7 +2407,7 @@ there is no common super type of the two types (Types.t_ERROR)
   {
     return
       isThisType() ||
-      !isGenericArgument() && (generics().stream().anyMatch(g -> g.containsThisType()) ||
+      !isParametricType() && (generics().stream().anyMatch(g -> g.containsThisType()) ||
                                outer() != null && outer().containsThisType());
   }
 
@@ -2476,9 +2476,9 @@ there is no common super type of the two types (Types.t_ERROR)
   {
     String result = switch (kind())
       {
-        case GenericArgument:
+        case ParametricType:
           {
-            var ga = genericArgument();
+            var ga = typeParameter();
             yield
               (ga.isCoTypesThisType()
                 ? ga.qualifiedName(context, humanReadable)
@@ -2520,7 +2520,7 @@ there is no common super type of the two types (Types.t_ERROR)
   protected String outerToString(boolean humanReadable)
   {
     var o = outer();
-    return o != null && (o.isGenericArgument() || !o.feature().isUniverse())
+    return o != null && (o.isParametricType() || !o.feature().isUniverse())
         ? o.toStringWrapped(humanReadable) + "."
         : "";
   }
@@ -2633,7 +2633,7 @@ there is no common super type of the two types (Types.t_ERROR)
           {
             a.checkLegalThisType(p, context);
             a.checkChoice(p, context);
-            if (!c.isGenericArgument() && // See AstErrors.constraintMustNotBeGenericArgument,
+            if (!c.isParametricType() && // See AstErrors.constraintMustNotBeParametricType,
                                           // will be checked in SourceModule.checkTypes(Feature)
                 !c.constraintAssignableFrom(context, a))
               {
@@ -2761,7 +2761,7 @@ there is no common super type of the two types (Types.t_ERROR)
    */
   public AbstractType selfOrConstraint()
   {
-    return (isGenericArgument() ? genericArgument().constraint(Context.NONE) : this);
+    return (isParametricType() ? typeParameter().constraint(Context.NONE) : this);
   }
 
 
@@ -2772,7 +2772,7 @@ there is no common super type of the two types (Types.t_ERROR)
    */
   AbstractType selfOrConstraint(Context context)
   {
-    return (isGenericArgument() ? genericArgument().constraint(context) : this);
+    return (isParametricType() ? typeParameter().constraint(context) : this);
   }
 
 
@@ -2784,7 +2784,7 @@ there is no common super type of the two types (Types.t_ERROR)
    */
   AbstractType selfOrConstraint(Resolution res, Context context)
   {
-    return (isGenericArgument() ? genericArgument().constraint(res, context) : this);
+    return (isParametricType() ? typeParameter().constraint(res, context) : this);
   }
 
 
@@ -2877,9 +2877,9 @@ there is no common super type of the two types (Types.t_ERROR)
    */
   AbstractType replaceTypeParameters(Feature postFeature)
   {
-    return isGenericArgument()
-      ? genericArgument().outer() == postFeature.origin()
-          ? postFeature.typeArguments().get(genericArgument().typeParameterIndex()).asGenericType()
+    return isParametricType()
+      ? typeParameter().outer() == postFeature.origin()
+          ? postFeature.typeArguments().get(typeParameter().typeParameterIndex()).asGenericType()
           : this
       : applyToGenericsAndOuter(x -> x.replaceTypeParameters(postFeature));
   }

--- a/src/dev/flang/ast/AstErrors.java
+++ b/src/dev/flang/ast/AstErrors.java
@@ -405,7 +405,7 @@ public class AstErrors extends ANY
                   .append(st(ts.toString(true)));
               }
           }
-        if (remedy == null && !frmlT.isGenericArgument() && frmlT.asRef(true).isAssignableFromWithoutBoxing(actlT, context).yes())
+        if (remedy == null && !frmlT.isParametricType() && frmlT.asRef(true).isAssignableFromWithoutBoxing(actlT, context).yes())
           {
             remedy = "To solve this, you could change the type of " + target + " to a " + st("ref")+ " type like " + s(frmlT.asRef(true)) + ".\n";
           }
@@ -428,7 +428,7 @@ public class AstErrors extends ANY
           }
         else
           {
-            remedy = frmlT.isValue() && !actlT.isGenericArgument() && !frmlT.isGenericArgument() && actlT.feature().inheritsFrom(frmlT.feature()) ?
+            remedy = frmlT.isValue() && !actlT.isParametricType() && !frmlT.isParametricType() && actlT.feature().inheritsFrom(frmlT.feature()) ?
                         "To solve this you could:\n" + //
                             (frmlT.isChoice() ? "" : "  • make  " + s(frmlT) + " a reference by adding the " + st("ref")+ " keyword, so all its heirs can be used in place of it,\n") +
                             "  • change the type of the target " + target + " to " + s(actlT) + ", or\n" +
@@ -655,7 +655,7 @@ public class AstErrors extends ANY
    * @param detail2 optional extra lines of detail message giving further
    * information, like "Calling feature: xyz.f\n" or "Type: Stack bool int\n".
    */
-  static void wrongNumberOfGenericArguments(FormalGenerics fg,
+  static void wrongNumberOfTypeArguments(FormalGenerics fg,
                                             List<AbstractType> actualGenerics,
                                             SourcePosition pos,
                                             String detail1,
@@ -716,7 +716,7 @@ public class AstErrors extends ANY
   {
     return t.compareTo(from) == 0
       ? s(t)
-      : s(t) + " (from " + (from.isGenericArgument() ? s(from.genericArgument()) : s(from)) + ")";
+      : s(t) + " (from " + (from.isParametricType() ? s(from.typeParameter()) : s(from)) + ")";
   }
 
   public static void argumentTypeMismatchInRedefinition(AbstractFeature originalFeature, AbstractFeature originalArg, AbstractType originalArgType,
@@ -1370,8 +1370,8 @@ public class AstErrors extends ANY
     if (target            instanceof Call    c                                  &&
         c.calledFeature() instanceof Feature cf                                 &&
         cf.state().atLeast(State.RESOLVED_TYPES)                                &&
-        cf.resultType().isGenericArgument()                                     &&
-        cf.resultType().genericArgument() instanceof Feature tp                 &&
+        cf.resultType().isParametricType()                                     &&
+        cf.resultType().typeParameter() instanceof Feature tp                 &&
         tp.isFreeType()                                                         &&
         tp.constraint().compareTo(Types.resolved.t_Any) == 0)
       {
@@ -1555,7 +1555,7 @@ public class AstErrors extends ANY
       }
   }
 
-  public static void constraintMustNotBeGenericArgument(AbstractFeature tp)
+  public static void constraintMustNotBeParametricType(AbstractFeature tp)
   {
     error(tp.pos(),
           "Constraint for type parameter must not be a type parameter",
@@ -1582,14 +1582,14 @@ public class AstErrors extends ANY
           "The else block of this loop is declared at " + elseBlock.pos().show());
   }
 
-  static void formalGenericWithGenericArgs(SourcePosition pos, UnresolvedType t, AbstractFeature generic)
+  static void formalGenericWithTypeParameters(SourcePosition pos, UnresolvedType t, AbstractFeature tp)
   {
     error(pos,
           "Formal type parameter must not have type parameters",
           "In a type with type parameters >>A B<<, the base type >>A<< must not be a formal type parameter.\n" +
           "Type used: " + s(t) + "\n" +
-          "Formal type parameter used " + sbnf(generic) + "\n" +
-          "Formal type parameter declared in " + generic.pos().show() + "\n");
+          "Formal type parameter used " + sbnf(tp) + "\n" +
+          "Formal type parameter declared in " + tp.pos().show() + "\n");
   }
 
   static void genericsMustBeDisjoint(SourcePosition pos, AbstractType t1, AbstractType t2)
@@ -1897,7 +1897,7 @@ public class AstErrors extends ANY
           "Actual type parameters: " + (sz == 0 ? "none" : s(types)) + "\n");
   }
 
-  static void failedToInferOpenGenericArg(SourcePosition pos, int count, Expr actual)
+  static void failedToInferOpenTypeParameterType(SourcePosition pos, int count, Expr actual)
   {
     error(pos,
           "Failed to infer open type parameter type from actual argument.",
@@ -2398,7 +2398,7 @@ public class AstErrors extends ANY
   {
     var t = e.type();
     error(e.pos(), "Expression produces result of type " + s(t) +  " but result is not used.",
-        (!t.isGenericArgument() && t.feature().isConstructor()
+        (!t.isParametricType() && t.feature().isConstructor()
           ? "To solve this, use the result, explicitly ignore the result " + st("_ := <expression>") + " or change " + s(t.feature()) + " from constructor to routine by replacing " + skw("is") + " by " + skw("=>") + "."
           : "To solve this, use the result or explicitly ignore the result " + st("_ := <expression>") + "."));
   }
@@ -2482,7 +2482,7 @@ public class AstErrors extends ANY
 
   public static void notAnEffect(AbstractType t, SourcePosition pos)
   {
-    var f = t.isGenericArgument() ? t.genericArgument().outer() : t.feature();
+    var f = t.isParametricType() ? t.typeParameter().outer() : t.feature();
     error(pos,
           "Feature " + sbnf(f) + " is not an effect.",
           "Effects required by a feature are specified with " + skw("!") + " in the signature. " +
@@ -2656,7 +2656,7 @@ public class AstErrors extends ANY
      );
   }
 
-  public static void lamdaOuterMustNotBeGenericArgument(SourcePosition pos, AbstractType tt)
+  public static void lamdaOuterMustNotBeTypeParameter(SourcePosition pos, AbstractType tt)
   {
     error(pos, "Can not create lambda since an outer of its type is a generic argument.",
       "The generic argument used in lambdas type " + s(tt) + "."

--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -452,7 +452,7 @@ public class Call extends AbstractCall
       }
 
     if (POSTCONDITIONS) ensure
-      (result == null || !result.isGenericArgument());
+      (result == null || !result.isParametricType());
     return result;
   }
 
@@ -743,7 +743,7 @@ public class Call extends AbstractCall
    */
   private boolean mayUnwrapTarget()
   {
-    return _target != null && _target.typeForInferencing() != null && !_target.typeForInferencing().isGenericArgument() && _target.typeForInferencing().feature().inheritsFrom(Types.resolved.f_auto_unwrap);
+    return _target != null && _target.typeForInferencing() != null && !_target.typeForInferencing().isParametricType() && _target.typeForInferencing().feature().inheritsFrom(Types.resolved.f_auto_unwrap);
   }
 
 
@@ -1143,9 +1143,9 @@ public class Call extends AbstractCall
   AbstractType typeForInferencing(Context context)
   {
     var result = typeForInferencing();
-    if (result != null && result.isGenericArgument())
+    if (result != null && result.isParametricType())
       {
-        result = result.genericArgument().constraint(context);
+        result = result.typeParameter().constraint(context);
         if (result.compareTo(Types.resolved.t_Any) != 0)
           {
             _type = result;
@@ -1380,7 +1380,7 @@ public class Call extends AbstractCall
       {
         _target = res.resolveType(_target, context);
         var tt = target().type();
-        if (urgent && !tt.isGenericArgument())
+        if (urgent && !tt.isParametricType())
           {
             res.resolveTypes(tt.feature());
           }
@@ -1506,7 +1506,7 @@ public class Call extends AbstractCall
           }
         else if (_select >= 0)
           {
-            var types = t.genericArgument().replaceOpen(tt.generics());
+            var types = t.typeParameter().replaceOpen(tt.generics());
             int sz = types.size();
             if (_select >= sz)
               {
@@ -1564,8 +1564,8 @@ public class Call extends AbstractCall
               yield tf.selfType().applyTypePars(tf, tg);
             }
           case ThisType -> t;
-          // See AstErrors.constraintMustNotBeGenericArgument
-          case GenericArgument -> t;
+          // See AstErrors.constraintMustNotBeParametricType
+          case ParametricType -> t;
         };
       }
     else if (isTypeAsValueCall())
@@ -1574,9 +1574,9 @@ public class Call extends AbstractCall
         // we are using `.this.type` inside a type feature, see #2295
         if (t.isThisTypeInCotype())
           {
-            t = t.genericArgument().outer().thisType();
+            t = t.typeParameter().outer().thisType();
           }
-        else if (!t.isGenericArgument())
+        else if (!t.isParametricType())
           {
             t = t.cotypeType(res);
           }
@@ -1629,12 +1629,12 @@ public class Call extends AbstractCall
       { // a NumLiteral in first pass, no type provided
         actual = null;
       }
-    else if (formalTypeForPropagation.isGenericArgument() &&
-             formalTypeForPropagation.genericArgument().outer() == _calledFeature)
+    else if (formalTypeForPropagation.isParametricType() &&
+             formalTypeForPropagation.typeParameter().outer() == _calledFeature)
       { // a NumLiteral in second pass and type is a type parameter, e.g., `T`
         // in `f(T type, a,b T)` in a call `f 12 x` where x returns `f64`, so we
         // propagate this to NumLiteral `12`:
-        var t = _generics.get(formalTypeForPropagation.genericArgument().typeParameterIndex());
+        var t = _generics.get(formalTypeForPropagation.typeParameter().typeParameterIndex());
         actual = actual.propagateExpectedType(res, context, t, null);
         _actuals.set(argnum, actual);
       }
@@ -1720,8 +1720,8 @@ public class Call extends AbstractCall
   private boolean mustReportMissingImmediately(AbstractType rt, boolean[] conflict)
   {
     var x = (rt == null ||
-        !rt.isGenericArgument() ||
-         rt.genericArgument().outer().outer() != _calledFeature.outer()) ||
+        !rt.isParametricType() ||
+         rt.typeParameter().outer().outer() != _calledFeature.outer()) ||
          // NYI: CLEANUP: why true, i.e., must report errors, in case of previous errors in the actuals?
          _actuals.stream().anyMatch(a -> a.typeForInferencing() == Types.t_ERROR);
 
@@ -1926,7 +1926,7 @@ public class Call extends AbstractCall
             if (!checked[vai])
               {
                 var t = frml.resultTypeIfPresent(res);
-                var g = t.isGenericArgument() ? t.genericArgument() : null;
+                var g = t.isParametricType() ? t.typeParameter() : null;
                 if (t.isOpenGeneric() && g.outer() == _calledFeature)
                   { // open type that must be inferred as in `tuple 42 "x"`
                     if (pass == 1)
@@ -1940,7 +1940,7 @@ public class Call extends AbstractCall
                             if (actualType == null)
                               {
                                 actualType = Types.t_ERROR;
-                                AstErrors.failedToInferOpenGenericArg(pos(), argnum+1, actual);
+                                AstErrors.failedToInferOpenTypeParameterType(pos(), argnum+1, actual);
                               }
                             _generics.add(actualType);
                             argnum++;
@@ -1964,7 +1964,7 @@ public class Call extends AbstractCall
                     if (t.dependsOnGenerics())
                       {
                         var actualType = typeFromActual(res, context, actual, false);
-                        if (t.isGenericArgument())
+                        if (t.isParametricType())
                           {
                             res.resolveTypes(g);
                             var c = g.constraint();
@@ -2096,7 +2096,7 @@ public class Call extends AbstractCall
     if (actualType != null)
       {
         actualType = actualType.replace_type_parameters_of_cotype_origin(context.outerFeature());
-        if (!actualType.isGenericArgument() && actualType.feature().isCotype())
+        if (!actualType.isParametricType() && actualType.feature().isCotype())
           {
             actualType = actual instanceof Call c && c.calledFeature().isOpenTypeParameter()
               ? Types.resolved.f_Open_Types.selfType()
@@ -2200,9 +2200,9 @@ public class Call extends AbstractCall
       {
         inferGeneric(res, context, formalType.generics().get(0), actualType, pos, conflict, foundAt);
       }
-    else if (formalType.isGenericArgument())
+    else if (formalType.isParametricType())
       {
-        var g = formalType.genericArgument();
+        var g = formalType.typeParameter();
         if (g.outer() == _calledFeature)
           { // we found a use of a generic type, so record it:
             var i = g.typeParameterIndex();
@@ -2223,7 +2223,7 @@ public class Call extends AbstractCall
       {
         var fft = formalType.feature();
         res.resolveTypes(fft);
-        var aft = actualType.isGenericArgument() ? null : actualType.feature();
+        var aft = actualType.isParametricType() ? null : actualType.feature();
         if (fft == aft)
           {
             for (int i=0; i < formalType.actualGenerics().size(); i++)
@@ -2279,8 +2279,8 @@ public class Call extends AbstractCall
                   .choiceGenerics(context)
                   .stream()
                   .filter(x -> x.dependsOnGenerics()
-                           && !x.isGenericArgument()
-                           && !actualType.isGenericArgument()
+                           && !x.isParametricType()
+                           && !actualType.isParametricType()
                            && x.feature() == actualType.feature())
                   .toList();
                 for (var ct : matchingFeature)
@@ -2410,13 +2410,13 @@ public class Call extends AbstractCall
       .stream()
       .map(g -> {
         var result = false;
-        if (!g.isGenericArgument())
+        if (!g.isParametricType())
           {
             result = inferGenericLambdaResult(res, context, al, pos, conflict, foundAt, lambdaResultType, g.generics(), argumentType);
           }
         else
           {
-            var rg = g.genericArgument();
+            var rg = g.typeParameter();
             var ri = rg.typeParameterIndex();
             if (rg.outer() == _calledFeature && foundAt.get(ri) == null)
               {

--- a/src/dev/flang/ast/Case.java
+++ b/src/dev/flang/ast/Case.java
@@ -294,7 +294,7 @@ public class Case extends AbstractCase
     List<AbstractType> matches = new List<>();
     int i = 0;
     t = t.resolve(res, context);
-    var inferGenerics = !t.isGenericArgument() && (t.isThisType() || t.generics().isEmpty()) && !t.feature().typeArguments().isEmpty();
+    var inferGenerics = !t.isParametricType() && (t.isThisType() || t.generics().isEmpty()) && !t.feature().typeArguments().isEmpty();
     var hasErrors = t.containsError();
     check
       (!hasErrors || Errors.any());
@@ -303,7 +303,7 @@ public class Case extends AbstractCase
         if (CHECKS) check
           (Errors.any() || cg != null);
         if (cg != null &&
-            (inferGenerics  && !cg.isGenericArgument() && t.feature() == cg.feature() /* match feature, take generics from cg */ ||
+            (inferGenerics  && !cg.isParametricType() && t.feature() == cg.feature() /* match feature, take generics from cg */ ||
              !inferGenerics && t.compareTo(cg) == 0                    /* match exactly */ ))
           {
             t = cg;

--- a/src/dev/flang/ast/Context.java
+++ b/src/dev/flang/ast/Context.java
@@ -142,8 +142,8 @@ abstract class Context extends ANY
                               .typeArguments()
                               .stream()
                               .filter(y ->
-                                  y.outer().origin() == rpt.genericArgument().outer().origin() &&
-                                  y.baseName().toString().equals(rpt.genericArgument().baseName())
+                                  y.outer().origin() == rpt.typeParameter().outer().origin() &&
+                                  y.baseName().toString().equals(rpt.typeParameter().baseName())
                                 )
                               .findFirst()
                               .get()

--- a/src/dev/flang/ast/Expr.java
+++ b/src/dev/flang/ast/Expr.java
@@ -698,7 +698,7 @@ public abstract class Expr extends ANY implements HasSourcePosition
     return this != Call.ERROR && t != Types.t_ERROR
       && expectedType.isAssignableFromWithoutBoxing(t, context).no()
       && expectedType.compareTo(Types.resolved.t_Any) != 0
-      && !t.isGenericArgument()
+      && !t.isParametricType()
       && allInherited(t.feature())
           .stream()
           .anyMatch(c ->
@@ -725,7 +725,7 @@ public abstract class Expr extends ANY implements HasSourcePosition
     var t = type();
     return this != Call.ERROR && t != Types.t_ERROR
       && !t.isChoice()
-      && !t.isGenericArgument()
+      && !t.isParametricType()
       && allInherited(t.feature())
           .stream()
           .anyMatch(c ->
@@ -832,7 +832,7 @@ public abstract class Expr extends ANY implements HasSourcePosition
       {
         return null;
       }
-    else if (frmlT.isRef() || frmlT.isGenericArgument() || frmlT.isThisType() && !frmlT.isChoice())
+    else if (frmlT.isRef() || frmlT.isParametricType() || frmlT.isThisType() && !frmlT.isChoice())
       {
         /* Boxing needed when we assign to generic argument (so it
          * could be a ref) or frmlT is this type and the underlying feature is by

--- a/src/dev/flang/ast/Feature.java
+++ b/src/dev/flang/ast/Feature.java
@@ -2209,9 +2209,9 @@ A pre-condition of a feature that does not redefine an inherited feature must st
           || Types.resolved.legalNativeArgumentTypes.contains(at)
           || at.selfOrConstraint(Context.NONE).isLambdaTargetButNotLazy(res)
           // NYI: BUG: check if array element type is valid
-          || !at.isGenericArgument() && at.feature() == Types.resolved.f_mutate_array
-          || !at.isGenericArgument() && at.feature().mayBeNativeValue()
-          || !at.isGenericArgument() && Types.resolved.f_fuzion_sys_array_data.resultType().feature() == at.feature()
+          || !at.isParametricType() && at.feature() == Types.resolved.f_mutate_array
+          || !at.isParametricType() && at.feature().mayBeNativeValue()
+          || !at.isParametricType() && Types.resolved.f_fuzion_sys_array_data.resultType().feature() == at.feature()
           )
         )
       {
@@ -2223,7 +2223,7 @@ A pre-condition of a feature that does not redefine an inherited feature must st
   private void checkLegalNativeResultType(Resolution res, SourcePosition pos, AbstractType rt)
   {
     ensureTypeSetsInitialized(res);
-    if (!(Types.resolved.legalNativeResultTypes.contains(rt) || !rt.isGenericArgument() && rt.feature().mayBeNativeValue())
+    if (!(Types.resolved.legalNativeResultTypes.contains(rt) || !rt.isParametricType() && rt.feature().mayBeNativeValue())
         && !(Errors.any() && rt == Types.t_ERROR))
       {
         AstErrors.illegalNativeType(pos, "Result type", rt);

--- a/src/dev/flang/ast/FormalGenerics.java
+++ b/src/dev/flang/ast/FormalGenerics.java
@@ -142,11 +142,11 @@ public class FormalGenerics extends ANY
     var result = sizeMatches(actualGenerics) || actualGenerics.contains(Types.t_ERROR);
     if (!result)
       {
-        AstErrors.wrongNumberOfGenericArguments(this,
-                                                actualGenerics,
-                                                pos,
-                                                detail1,
-                                                detail2);
+        AstErrors.wrongNumberOfTypeArguments(this,
+                                             actualGenerics,
+                                             pos,
+                                             detail1,
+                                             detail2);
       }
     return result;
   }

--- a/src/dev/flang/ast/Function.java
+++ b/src/dev/flang/ast/Function.java
@@ -447,8 +447,8 @@ public class Function extends AbstractLambda
     return switch(tt.kind())
       {
         case TypeKind.ThisType -> new Current(pos(), tt.feature());
-        case TypeKind.GenericArgument -> {
-          AstErrors.lamdaOuterMustNotBeGenericArgument(pos(), tt);
+        case TypeKind.ParametricType -> {
+          AstErrors.lamdaOuterMustNotBeTypeParameter(pos(), tt);
           yield Call.ERROR;
         }
         default -> {
@@ -488,7 +488,7 @@ public class Function extends AbstractLambda
   private AbstractType refineResultType(Resolution res, Context context, AbstractType frmlRt, AbstractType lmbdRt)
   {
     var result = lmbdRt;
-    if (!frmlRt.isGenericArgument())
+    if (!frmlRt.isParametricType())
       {
         if (frmlRt.isChoice()
             // NYI: UNDER DEVELOPMENT: We may want to go further here and support more than
@@ -504,7 +504,7 @@ public class Function extends AbstractLambda
                   }
               }
           }
-        else if (!lmbdRt.isGenericArgument()
+        else if (!lmbdRt.isParametricType()
                  && lmbdRt.feature() != frmlRt.feature()
                  && lmbdRt.feature().inheritsFrom(frmlRt.feature()))
           {

--- a/src/dev/flang/ast/InlineArray.java
+++ b/src/dev/flang/ast/InlineArray.java
@@ -202,7 +202,7 @@ public class InlineArray extends ExprWithPos
   {
     // if expected type is choice, examine if there is exactly one
     // array in choice generics, if so use this for further type propagation.
-    t = t.findInChoice(cg -> !cg.isGenericArgument() && cg.feature() == Types.resolved.f_array, context);
+    t = t.findInChoice(cg -> !cg.isParametricType() && cg.feature() == Types.resolved.f_array, context);
 
     var elementType = elementType(t);
     if (elementType != Types.t_ERROR

--- a/src/dev/flang/ast/Match.java
+++ b/src/dev/flang/ast/Match.java
@@ -165,7 +165,7 @@ public class Match extends AbstractMatch
         st = _subject.typeForInferencing();
       }
 
-    if (st != null && st != Types.t_ERROR && !st.isGenericArgument())
+    if (st != null && st != Types.t_ERROR && !st.isParametricType())
       {
         res.resolveTypes(st.feature());
       }

--- a/src/dev/flang/ast/NumLiteral.java
+++ b/src/dev/flang/ast/NumLiteral.java
@@ -772,7 +772,7 @@ public class NumLiteral extends Constant
     else if (t.compareTo(Types.resolved.t_u64) == 0) { return ConstantType.ct_u64; }
     else if (t.compareTo(Types.resolved.t_f32) == 0) { return ConstantType.ct_f32; }
     else if (t.compareTo(Types.resolved.t_f64) == 0) { return ConstantType.ct_f64; }
-    else                                             { return t.isGenericArgument() ? ConstantType.ct_numeric : null; }
+    else                                             { return t.isParametricType() ? ConstantType.ct_numeric : null; }
   }
 
 
@@ -838,7 +838,7 @@ public class NumLiteral extends Constant
     // if expected type is choice, examine if there is exactly one numeric
     // constant type in choice generics, if so use that for further type
     // propagation.
-    t = t.findInChoice(cg -> !cg.isGenericArgument() && findConstantType(cg) != null, context);
+    t = t.findInChoice(cg -> !cg.isParametricType() && findConstantType(cg) != null, context);
     if (_propagatedType == null && findConstantType(t) != null)
       {
         _propagatedType = t;
@@ -912,28 +912,28 @@ public class NumLiteral extends Constant
   @Override
   protected Expr resolveSyntacticSugar2(Resolution res, Context _context)
   {
-    if (_propagatedType != null && _propagatedType.isGenericArgument())
+    if (_propagatedType != null && _propagatedType.isParametricType())
       {
         Call result;
 
         if (_originalString.equals("0"))
           {
             result = new ParsedCall(
-                          new ParsedCall(new ParsedName(pos(), _propagatedType.genericArgument().baseName())),
+                          new ParsedCall(new ParsedName(pos(), _propagatedType.typeParameter().baseName())),
                           new ParsedName(pos(), "zero"))
                   .resolveTypes(res, _context);
           }
         else if (_originalString.equals("1"))
           {
             result = new ParsedCall(
-                          new ParsedCall(new ParsedName(pos(), _propagatedType.genericArgument().baseName())),
+                          new ParsedCall(new ParsedName(pos(), _propagatedType.typeParameter().baseName())),
                           new ParsedName(pos(), "one"))
                   .resolveTypes(res, _context);
           }
         else
           {
             result = new ParsedCall(
-                      new ParsedCall(new ParsedName(pos(), _propagatedType.genericArgument().baseName())),
+                      new ParsedCall(new ParsedName(pos(), _propagatedType.typeParameter().baseName())),
                       new ParsedName(pos(), "from_u32"),
                       new List<>(this))
               {

--- a/src/dev/flang/ast/ResolvedNormalType.java
+++ b/src/dev/flang/ast/ResolvedNormalType.java
@@ -254,7 +254,7 @@ public class ResolvedNormalType extends ResolvedType
 
 
   /**
-   * The mode of the type: GenericArgument, ThisType, RefType or ValueType.
+   * The mode of the type: ParametricType, ThisType, RefType or ValueType.
    */
   @Override
   public TypeKind kind()
@@ -268,7 +268,7 @@ public class ResolvedNormalType extends ResolvedType
    *
    * @return the underlying feature.
    *
-   * @throws Error if this is not resolved or isGenericArgument().
+   * @throws Error if this is not resolved or isParametricType().
    */
   @Override
   protected AbstractFeature backingFeature()

--- a/src/dev/flang/ast/ResolvedParametricType.java
+++ b/src/dev/flang/ast/ResolvedParametricType.java
@@ -78,7 +78,7 @@ class ResolvedParametricType extends ResolvedType
 
 
   /**
-   * genericArgument gives the Generic instance of a type defined by a generic
+   * typeParameter gives the Generic instance of a type defined by a generic
    * argument.
    *
    * @return the Generic instance, never null.
@@ -105,7 +105,7 @@ class ResolvedParametricType extends ResolvedType
   @Override
   void usedFeatures(Set<AbstractFeature> s)
   {
-    if (!genericArgument().isCoTypesThisType() &&
+    if (!typeParameter().isCoTypesThisType() &&
         /**
          * Must not be recursive definition as in:
          *
@@ -113,20 +113,20 @@ class ResolvedParametricType extends ResolvedType
          *   fs(F type : F) =>
          * scenario1
          */
-        this != genericArgument().resultType())
+        this != typeParameter().resultType())
       {
-        genericArgument().resultType().usedFeatures(s);
+        typeParameter().resultType().usedFeatures(s);
       }
   }
 
 
   /**
-   * The mode of the type: GenericArgument, ThisType, RefType or ValueType.
+   * The mode of the type: ParametricType, ThisType, RefType or ValueType.
    */
   @Override
   public TypeKind kind()
   {
-    return TypeKind.GenericArgument;
+    return TypeKind.ParametricType;
   }
 
 

--- a/src/dev/flang/ast/ThisType.java
+++ b/src/dev/flang/ast/ThisType.java
@@ -99,7 +99,7 @@ class ThisType extends ResolvedType {
 
 
   /**
-   * The mode of the type: GenericArgument, ThisType, RefType or ValueType.
+   * The mode of the type: ParametricType, ThisType, RefType or ValueType.
    */
   @Override
   public TypeKind kind()

--- a/src/dev/flang/ast/TypeKind.java
+++ b/src/dev/flang/ast/TypeKind.java
@@ -29,11 +29,11 @@ package dev.flang.ast;
 
 /**
  * For specifying the kind of a type.
- * May be one of "GenericArgument", "ValueType", "RefType" or "ThisType".
+ * May be one of "ParametricType", "ValueType", "RefType" or "ThisType".
  */
 public enum TypeKind {
 
-  GenericArgument(0x00),
+  ParametricType(0x00),
   ValueType(0x01),
   RefType(0x02),
   ThisType(0x03);
@@ -47,7 +47,7 @@ public enum TypeKind {
   public static TypeKind fromInt(int num)
   {
     return switch (num) {
-      case 0x00 -> TypeKind.GenericArgument;
+      case 0x00 -> TypeKind.ParametricType;
       case 0x01 -> TypeKind.ValueType;
       case 0x02 -> TypeKind.RefType;
       case 0x03 -> TypeKind.ThisType;

--- a/src/dev/flang/ast/UnresolvedType.java
+++ b/src/dev/flang/ast/UnresolvedType.java
@@ -208,7 +208,7 @@ public abstract class UnresolvedType extends AbstractType implements HasSourcePo
     this._generics = (((g == null) || g.isEmpty()) ? NONE : g).freeze();
     this._outer    = o;
     this._typeKind = typeKind;
-    // to make caching of _isGenericArgument work
+    // to make caching of _isParametricType work
     // we call constructor after _typeKind is set
     super();
   }
@@ -260,7 +260,7 @@ public abstract class UnresolvedType extends AbstractType implements HasSourcePo
 
     this._pos               = original._pos;
     this._typeKind          = Optional.of(typeKind);
-    // to make caching of _isGenericArgument work
+    // to make caching of _isParametricType work
     // we call constructor after _typeKind is set
     super();
     this._name              = original._name;
@@ -282,7 +282,7 @@ public abstract class UnresolvedType extends AbstractType implements HasSourcePo
   {
     this._pos               = original._pos;
     this._typeKind          = original._typeKind;
-    // to make caching of _isGenericArgument work
+    // to make caching of _isParametricType work
     // we call constructor after _typeKind is set
     super();
     this._name              = original._name;
@@ -524,7 +524,7 @@ public abstract class UnresolvedType extends AbstractType implements HasSourcePo
                           {
                             if (!tolerant)
                               {
-                                AstErrors.formalGenericWithGenericArgs(pos(), this, f);
+                                AstErrors.formalGenericWithTypeParameters(pos(), this, f);
                                 _resolved = Types.t_ERROR;
                               }
                           }
@@ -535,7 +535,7 @@ public abstract class UnresolvedType extends AbstractType implements HasSourcePo
                               {
                                 if (!tolerant)
                                   {
-                                    AstErrors.illegalUseOfOpenFormalGeneric(pos(), gt.genericArgument());
+                                    AstErrors.illegalUseOfOpenFormalGeneric(pos(), gt.typeParameter());
                                     _resolved = Types.t_ERROR;
                                   }
                               }
@@ -923,7 +923,7 @@ public abstract class UnresolvedType extends AbstractType implements HasSourcePo
 
 
   /**
-   * The mode of the type: GenericArgument, ThisType, RefType or ValueType.
+   * The mode of the type: ParametricType, ThisType, RefType or ValueType.
    */
   @Override
   public TypeKind kind()

--- a/src/dev/flang/fe/GenericType.java
+++ b/src/dev/flang/fe/GenericType.java
@@ -83,7 +83,7 @@ class GenericType extends LibraryType
 
 
   /**
-   * genericArgument gives the Generic instance of a type defined by a generic
+   * typeParameter gives the Generic instance of a type defined by a generic
    * argument.
    *
    * @return the Generic instance, never null.
@@ -104,12 +104,12 @@ class GenericType extends LibraryType
 
 
   /**
-   * The mode of the type: GenericArgument, ThisType, RefType or ValueType.
+   * The mode of the type: ParametricType, ThisType, RefType or ValueType.
    */
   @Override
   public TypeKind kind()
   {
-    return TypeKind.GenericArgument;
+    return TypeKind.ParametricType;
   }
 
 }

--- a/src/dev/flang/fe/LibraryModule.java
+++ b/src/dev/flang/fe/LibraryModule.java
@@ -488,7 +488,7 @@ public class LibraryModule extends Module implements MirModule
    *
    * @param offset the offset of the Generic
    */
-  AbstractFeature genericArgument(int offset)
+  AbstractFeature typeParameter(int offset)
   {
     var tp = feature(offset);
     var o = tp.outer();
@@ -529,7 +529,7 @@ public class LibraryModule extends Module implements MirModule
           }
         else if (k == -1)
           {
-            result = new GenericType(this, at, genericArgument(typeTypeParameter(at)));
+            result = new GenericType(this, at, typeParameter(typeTypeParameter(at)));
           }
         else
           {

--- a/src/dev/flang/fe/LibraryOut.java
+++ b/src/dev/flang/fe/LibraryOut.java
@@ -600,17 +600,17 @@ class LibraryOut extends ANY
         _data.writeInt(-2);     // NYI: optimization: maybe write just one integer, e.g., -index-2
         _data.writeInt(off);
       }
-    else if (!t.isGenericArgument() && t.feature().isUniverse())
+    else if (!t.isParametricType() && t.feature().isUniverse())
       {
         _data.writeInt(-3);
       }
     else
       {
         _data.addOffset(t, _data.offset());
-        if (t.isGenericArgument())
+        if (t.isParametricType())
           {
             _data.writeInt(-1);
-            _data.writeOffset(t.genericArgument());
+            _data.writeOffset(t.typeParameter());
           }
         else
           {

--- a/src/dev/flang/fe/NormalType.java
+++ b/src/dev/flang/fe/NormalType.java
@@ -142,7 +142,7 @@ class NormalType extends LibraryType
    *
    * @return the underlying feature.
    *
-   * @throws Error if this is not resolved or isGenericArgument().
+   * @throws Error if this is not resolved or isParametricType().
    */
   @Override
   protected AbstractFeature backingFeature()
@@ -162,7 +162,7 @@ class NormalType extends LibraryType
 
 
   /**
-   * The mode of the type: GenericArgument, ThisType, RefType or ValueType.
+   * The mode of the type: ParametricType, ThisType, RefType or ValueType.
    */
   @Override
   public TypeKind kind()

--- a/src/dev/flang/fe/SourceModule.java
+++ b/src/dev/flang/fe/SourceModule.java
@@ -1788,9 +1788,9 @@ A feature that is a constructor, choice or a type parameter may not redefine an 
     if (f.isTypeParameter() &&
         !f.outer().isCotype()) // reg_issue1932 shows error twice without this)
       {
-        if (f.constraint().isGenericArgument())
+        if (f.constraint().isParametricType())
           {
-            AstErrors.constraintMustNotBeGenericArgument(f);
+            AstErrors.constraintMustNotBeParametricType(f);
           }
         if (f.constraint().isChoice())
           {

--- a/src/dev/flang/fuir/Clazz.java
+++ b/src/dev/flang/fuir/Clazz.java
@@ -670,8 +670,8 @@ class Clazz extends ANY implements Comparable<Clazz>
       // clazz actually describes a cotype
       feature().isCotype() &&
       // NYI: UNDER DEVELOPMENT: can this logic be simplified?
-         (t.isGenericArgument() && t.genericArgument().outer().isCotype() ||
-         !t.isGenericArgument() && t.feature() == _type.generics().get(0).actualType(t).feature()))
+         (t.isParametricType() && t.typeParameter().outer().isCotype() ||
+         !t.isParametricType() && t.feature() == _type.generics().get(0).actualType(t).feature()))
       {
         t = _type.generics().get(0).actualType(t);
       }
@@ -749,7 +749,7 @@ class Clazz extends ANY implements Comparable<Clazz>
       {
       case RefType -> true;
       case ValueType -> false;
-      case GenericArgument -> throw new Error("unexpected generic argument type: " + _type);
+      case ParametricType -> throw new Error("unexpected generic argument type: " + _type);
       case ThisType        -> throw new Error("unexpected this type: " + _type);
       default              -> throw new Error("unexpected type kind: " + _type.kind() + " type: " + _type);
       };
@@ -1785,11 +1785,11 @@ class Clazz extends ANY implements Comparable<Clazz>
   Clazz typeClazz()
   {
     if (PRECONDITIONS)
-      require(Errors.any() || !_type.isGenericArgument());
+      require(Errors.any() || !_type.isParametricType());
 
     if (_typeClazz == null)
       {
-        if (_type.isGenericArgument())
+        if (_type.isParametricType())
           {
             _typeClazz = _fuir.error();
           }
@@ -1994,7 +1994,7 @@ class Clazz extends ANY implements Comparable<Clazz>
 
     List<AbstractType> types;
     var inh = _outer == null ? null : _outer.feature().tryFindInheritanceChain(fouter.outer());
-    var declaredIn = ft.genericArgument().outer();
+    var declaredIn = ft.typeParameter().outer();
     if (inh != null &&
         inh.stream().anyMatch(c -> c.calledFeature() == declaredIn))
       {
@@ -2002,7 +2002,7 @@ class Clazz extends ANY implements Comparable<Clazz>
       }
     else if (feature() == declaredIn)
       {
-        types = ft.genericArgument().replaceOpen(_type.generics());
+        types = ft.typeParameter().replaceOpen(_type.generics());
       }
     else if (_outer != null)
       {

--- a/src/dev/flang/ir/Box.java
+++ b/src/dev/flang/ir/Box.java
@@ -73,7 +73,7 @@ public class Box extends Expr
     if (PRECONDITIONS) require
       (value != null,
        !frmlT.containsUndefined(),
-       frmlT.isGenericArgument() || frmlT.isThisType() || !value.type().isRef(),
+       frmlT.isParametricType() || frmlT.isThisType() || !value.type().isRef(),
        !(value instanceof Box));
 
     this._value = value;

--- a/src/dev/flang/ir/IR.java
+++ b/src/dev/flang/ir/IR.java
@@ -387,7 +387,7 @@ public abstract class IR extends ANY
      */
     // NYI: ugly special case: currently needed for code like
     // because isAssignableFrom does not return yes without correct Context...
-    else if (t.isGenericArgument() && frmlT.isRef())
+    else if (t.isParametricType() && frmlT.isRef())
       {
         var rt = expr.needsBoxing(frmlT);
         if (rt != null)
@@ -399,7 +399,7 @@ public abstract class IR extends ANY
     if (POSTCONDITIONS) ensure
       (Errors.any()
         || t.isVoid()
-        || frmlT.isGenericArgument()
+        || frmlT.isParametricType()
         || frmlT.isThisType()
         || result.needsBoxing(frmlT) == null
         || frmlT.isAssignableFrom(t).no());

--- a/src/dev/flang/lsp/feature/Rename.java
+++ b/src/dev/flang/lsp/feature/Rename.java
@@ -129,7 +129,7 @@ public class Rename extends ANY
     var typePositions = FeatureTool.selfAndDescendants(ParserTool.universe(Util.toURI(params.getTextDocument().getUri())))
       .filter(f ->
         !f.equals(featureToRename)
-        && !f.resultType().isGenericArgument()
+        && !f.resultType().isParametricType()
         && f.resultType().outer() != null
         && f.resultType().outer().equals(featureToRename)
       )

--- a/src/dev/flang/lsp/shared/TypeTool.java
+++ b/src/dev/flang/lsp/shared/TypeTool.java
@@ -70,7 +70,7 @@ public class TypeTool extends ANY
     if (PRECONDITIONS)
       require(!containsError(type), !type.containsUndefined());
 
-    if (type.isGenericArgument())
+    if (type.isParametricType())
       {
         return baseName(type) + (type.isRef() ? " (boxed)": "");
       }
@@ -99,8 +99,8 @@ public class TypeTool extends ANY
    */
   public static String baseName(AbstractType t)
   {
-    return (t.isGenericArgument()
-              ? t.genericArgument()
+    return (t.isParametricType()
+              ? t.typeParameter()
               : t.feature())
       .featureName()
       .baseName();

--- a/src/dev/flang/tools/docs/Html.java
+++ b/src/dev/flang/tools/docs/Html.java
@@ -164,7 +164,7 @@ public class Html extends ANY
   private String anchorType(AbstractFeature af, AbstractFeature context, AbstractFeature relativeTo)
   {
     var at = af.resultType();
-    if (at.isGenericArgument())
+    if (at.isParametricType())
       {
         return htmlEncodeNbsp(at.toString(false, context))
                + (at.isOpenGeneric() ? "..." : "");


### PR DESCRIPTION
Basically replace generic argument by parametric type. Goal is to have more consistency in the language we use in the codebase.


