### PR TITLE
cleanup: rename internal THIS#TYPE as RELAY#TYPE

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -175,7 +175,7 @@ The available categories are
 
 Here is an example for a work-in-progress marker:
 
-    if (!f.typeParameter().isCotypesThisType())  // NYI: CLEANUP: #706: remove special handling for 'THIS_TYPE'
+    if (!f.typeParameter().isCotypesRelayType())  // NYI: CLEANUP: #706: remove special handling for 'RELAY_TYPE'
 
 ### Commit Messages
 

--- a/src/dev/flang/ast/AbstractCall.java
+++ b/src/dev/flang/ast/AbstractCall.java
@@ -226,7 +226,7 @@ public abstract class AbstractCall extends Expr
   Call cotypeInheritanceCall(Resolution res, AbstractFeature that)
   {
     var selfType = new ParsedType(pos(),
-                                  FuzionConstants.COTYPE_THIS_TYPE);
+                                  FuzionConstants.COTYPE_RELAY_TYPE);
     var typeParameters = new List<AbstractType>(selfType);
     if (this instanceof Call cpc && cpc.needsToInferTypeParametersFromArgs())
       {
@@ -309,7 +309,7 @@ public abstract class AbstractCall extends Expr
   {
     var t0 = calledFeature() == Types.f_ERROR ? Types.t_ERROR : rt;
     var t1 = t0 == Types.t_ERROR                           ? t0 : calledFeature().outer().handDownToType(t0, target().type().selfOrConstraint(context));
-    var t2 = t1 == Types.t_ERROR                           ? t1 : replace_type_parameter_used_for_this_type_in_cotype(t1, target());
+    var t2 = t1 == Types.t_ERROR                           ? t1 : replace_type_parameter_used_for_relay_type_in_cotype(t1, target());
     var t3 = t2 == Types.t_ERROR                           ? t2 : adjustThisTypeForTarget(context, t2, calledFeature(), target().type(), foundRef);  // NYI: CLEANUP: try to use handDownAndApply
     var t4 = t3 == Types.t_ERROR                           ? t3 : t3.applyTypePars(target().type());
     var t5 = t4 == Types.t_ERROR                           ? t4 : t4.applyTypePars(calledFeature(), actualTypeParameters());
@@ -343,11 +343,11 @@ public abstract class AbstractCall extends Expr
    * @param target the target of the call
    *
    */
-  private static AbstractType replace_type_parameter_used_for_this_type_in_cotype(AbstractType t, Expr target)
+  private static AbstractType replace_type_parameter_used_for_relay_type_in_cotype(AbstractType t, Expr target)
   {
     var tpt = target.asTypeParameterType();
     return tpt != null
-      ? t.replace_type_parameter_used_for_this_type_in_cotype(target.type().feature(), tpt)
+      ? t.replace_type_parameter_used_for_relay_type_in_cotype(target.type().feature(), tpt)
       : t;
   }
 

--- a/src/dev/flang/ast/AbstractFeature.java
+++ b/src/dev/flang/ast/AbstractFeature.java
@@ -545,7 +545,7 @@ public abstract class AbstractFeature extends Expr implements Comparable<Abstrac
   {
     var tfo = state().atLeast(State.FINDING_DECLARATIONS) && outer() != null && outer().isCotype() ? outer().cotypeOrigin() : null;
     return
-      isCoTypesThisType()
+      isCoTypesRelayTypeParameter()
         /* special type parameter used for this.type in type features */
         ? (tfo != null ? tfo.qualifiedName(context, human) : "null")
           + ".this.type"
@@ -863,9 +863,9 @@ public abstract class AbstractFeature extends Expr implements Comparable<Abstrac
 
 
   /**
-   * Is this the 'THIS_TYPE' type parameter in a cotype?
+   * Is this the 'RELAY_TYPE' type parameter in a cotype?
    */
-  public boolean isCoTypesThisType()
+  public boolean isCoTypesRelayTypeParameter()
   {
     return outer() != null
       && outer().isCotype()
@@ -2105,7 +2105,7 @@ public abstract class AbstractFeature extends Expr implements Comparable<Abstrac
 
     var result = this;
     var o = outer();
-    if (!isCoTypesThisType() && o.isCotype())
+    if (!isCoTypesRelayTypeParameter() && o.isCotype())
       {
         result = o.cotypeOrigin().typeArguments().get(typeParameterIndex()-1);
       }

--- a/src/dev/flang/ast/AbstractType.java
+++ b/src/dev/flang/ast/AbstractType.java
@@ -596,8 +596,8 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
       {
         assignableTo.add(actual);
       }
-    var target_type = this  .remove_type_parameter_used_for_this_type_in_cotype();
-    var actual_type = actual.remove_type_parameter_used_for_this_type_in_cotype();
+    var target_type = this  .remove_type_parameter_used_for_relay_type_in_cotype();
+    var actual_type = actual.remove_type_parameter_used_for_relay_type_in_cotype();
     var result = isArtificialType() || actual.isArtificialType()
         ? YesNo.dontKnow
         : YesNo.fromBool(target_type.compareTo(actual_type) == 0 || actual_type.isVoid());
@@ -618,7 +618,7 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
               }
           }
       }
-    if (result.no() && allowTagging && target_type.isChoice() && !isThisTypeInCotype())
+    if (result.no() && allowTagging && target_type.isChoice() && !isRelayTypeInCotype())
       {
         result = YesNo.fromBool(target_type.isChoiceMatch(actual_type, context));
       }
@@ -1287,10 +1287,10 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
             if (isCotypeType())
               {
                 /* A cotype has the actual underlying type as its first type parameter
-                 * {@code THIS_TYPE} in addition to the type parameters of the original type.
+                 * {@code RELAY_TYPE} in addition to the type parameters of the original type.
                  *
                  * In case this is a cotype, determine the actual types for the types in {@code g2}
-                 * by applying the actual type parameters passed to {@code THIS_TYPE}.
+                 * by applying the actual type parameters passed to {@code RELAY_TYPE}.
                  */
                 var this_type = g2.get(0);
                 g3 = g2.map(x -> x == this_type                ||        // leave first type parameter unchanged
@@ -1970,7 +1970,7 @@ there is no common super type of the two types (Types.t_ERROR)
   private boolean replacesThisType(AbstractType tt, Context context)
   {
     return
-      isThisTypeInCotype() && tt.isGenericArgument()   // we have a type parameter TT.THIS#TYPE, which is equal to TT
+      isRelayTypeInCotype() && tt.isGenericArgument()   // we have a type parameter TT.RELAY#TYPE, which is equal to TT
       ||
       isThisType() && (!tt.isGenericArgument() && tt.feature().inheritsFrom(feature())  // we have abc.this.type with tt inheriting from abc, so use tt
                        ||
@@ -2018,7 +2018,7 @@ there is no common super type of the two types (Types.t_ERROR)
 
   /**
    * Check this and, recursively, all types contained in this' type parameters
-   * and outer types if isThisTypeInCotype() is true and the surrounding
+   * and outer types if isRelayTypeInCotype() is true and the surrounding
    * type feature equals cotype.  Replace all matches by cotype's self
    * type.
    *
@@ -2032,11 +2032,11 @@ there is no common super type of the two types (Types.t_ERROR)
    *
    * @param cotype the type feature whose this.type we are replacing
    */
-  public AbstractType replace_this_type_in_cotype(AbstractFeature cotype)
+  public AbstractType replace_relay_type_in_cotype(AbstractFeature cotype)
   {
-    return isThisTypeInCotype() && cotype  == genericArgument().outer()
+    return isRelayTypeInCotype() && cotype  == genericArgument().outer()
       ? cotype.cotypeOrigin().selfTypeInCoType()
-      : applyToGenericsAndOuter(g -> g.replace_this_type_in_cotype(cotype));
+      : applyToGenericsAndOuter(g -> g.replace_relay_type_in_cotype(cotype));
   }
 
 
@@ -2170,7 +2170,7 @@ there is no common super type of the two types (Types.t_ERROR)
     else
       {
         var g = new List<AbstractType>(
-            // THIS#TYPE
+            // RELAY#TYPE
             this,
             // all other generics
             actualGenerics()
@@ -2230,7 +2230,7 @@ there is no common super type of the two types (Types.t_ERROR)
    *
    * @param tpt the type parameters type that is the target of the call ({@code T} in the example above).
    */
-  AbstractType replace_type_parameter_used_for_this_type_in_cotype(AbstractFeature tf, AbstractType tpt)
+  AbstractType replace_type_parameter_used_for_relay_type_in_cotype(AbstractFeature tf, AbstractType tpt)
   {
     if (PRECONDITIONS) require
       (tpt.isGenericArgument());
@@ -2247,7 +2247,7 @@ there is no common super type of the two types (Types.t_ERROR)
       }
     else
       {
-        result = applyToGenericsAndOuter(g -> g.replace_type_parameter_used_for_this_type_in_cotype(tf, tpt));
+        result = applyToGenericsAndOuter(g -> g.replace_type_parameter_used_for_relay_type_in_cotype(tf, tpt));
       }
     return result;
   }
@@ -2272,7 +2272,7 @@ there is no common super type of the two types (Types.t_ERROR)
    * replaced by the implicit first generic argument of {@code num.type}, but it needs
    * to be changed back to {@code num.this.type}.
    */
-  AbstractType remove_type_parameter_used_for_this_type_in_cotype()
+  AbstractType remove_type_parameter_used_for_relay_type_in_cotype()
   {
     var result = this;
     if (isGenericArgument())
@@ -2288,7 +2288,7 @@ there is no common super type of the two types (Types.t_ERROR)
       }
     else
       {
-        result = applyToGenericsAndOuter(g -> g.remove_type_parameter_used_for_this_type_in_cotype());
+        result = applyToGenericsAndOuter(g -> g.remove_type_parameter_used_for_relay_type_in_cotype());
       }
     return result;
   }
@@ -2383,11 +2383,11 @@ there is no common super type of the two types (Types.t_ERROR)
 
   /**
    * For a feature {@code f(A, B type)} the corresponding type feature has an implicit
-   * THIS#TYPE type parameter: {@code f.type(THIS#TYPE, A, B type)}.
+   * RELAY#TYPE type parameter: {@code f.type(RELAY#TYPE, A, B type)}.
    *
-   + This checks if this type is this implicit type parameter.
+   * This checks if this type is this implicit type parameter.
    */
-  public boolean isThisTypeInCotype()
+  public boolean isRelayTypeInCotype()
   {
     return isGenericArgument()
       && genericArgument().state().atLeast(State.FINDING_DECLARATIONS)
@@ -2480,7 +2480,7 @@ there is no common super type of the two types (Types.t_ERROR)
           {
             var ga = genericArgument();
             yield
-              (ga.isCoTypesThisType()
+              (ga.isCoTypesRelayTypeParameter()
                 ? ga.qualifiedName(context, humanReadable)
                 : ga.isTypeFeature()
                 ? ga.qualifiedName(humanReadable)
@@ -2498,7 +2498,7 @@ there is no common super type of the two types (Types.t_ERROR)
                   + (isRef() != feature().isRef() ? (isRef() ? "ref " : "value ") : "")
                   + featureName(humanReadable)
                   + (feature().isCotype() ? ".type" : "");
-            // skip first generic 'THIS#TYPE' for types of type features.
+            // skip first generic 'RELAY#TYPE' for types of type features.
             for (var g : generics().drop(feature().isCotype() ? 1 : 0))
               {
                 res = res + " " + g.toStringWrapped(humanReadable, context);
@@ -2637,7 +2637,7 @@ there is no common super type of the two types (Types.t_ERROR)
                                           // will be checked in SourceModule.checkTypes(Feature)
                 !c.constraintAssignableFrom(context, a))
               {
-                if (!f.isCoTypesThisType())
+                if (!f.isCoTypesRelayTypeParameter())
                   {
                     // In case of choice, error will be shown
                     // by SourceModule.checkTypes(): AstErrors.constraintMustNotBeChoice

--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -1572,7 +1572,7 @@ public class Call extends AbstractCall
       {
         t = _generics.get(0);
         // we are using `.this.type` inside a type feature, see #2295
-        if (t.isThisTypeInCotype())
+        if (t.isRelayTypeInCotype())
           {
             t = t.genericArgument().outer().thisType();
           }

--- a/src/dev/flang/ast/Feature.java
+++ b/src/dev/flang/ast/Feature.java
@@ -2178,7 +2178,7 @@ A pre-condition of a feature that does not redefine an inherited feature must st
       && !isUniverse()
       && (visibility().eraseTypeVisibility() == Visi.PUB
           || outer().visibility().eraseTypeVisibility() == Visi.PUB && isArgument())
-      && !(featureName().toString().startsWith(FuzionConstants.COTYPE_THIS_TYPE))
+      && !(featureName().toString().startsWith(FuzionConstants.COTYPE_RELAY_TYPE))
       && rt == NoType.INSTANCE;
   }
 
@@ -2774,14 +2774,14 @@ A pre-condition of a feature that does not redefine an inherited feature must st
 
 
   /**
-   * Is this the 'THIS_TYPE' type parameter in a type feature?
+   * Is this the 'RELAY_TYPE' type parameter in a type feature?
    *
    * Overriding since AbstractFeature.isCoTypesThisType needs outer to be
    * in state of at least FINDING_DECLARATIONS which is not always the case
    * when isCoTypesThisType is called.
    */
   @Override
-  public boolean isCoTypesThisType()
+  public boolean isCoTypesRelayTypeParameter()
   {
     return false;
   }

--- a/src/dev/flang/ast/Resolution.java
+++ b/src/dev/flang/ast/Resolution.java
@@ -623,12 +623,12 @@ public class Resolution extends ANY
                                       Visi.PRIV,
                                       0,
                                       af.selfType(),
-                                      FuzionConstants.COTYPE_THIS_TYPE,
+                                      FuzionConstants.COTYPE_RELAY_TYPE,
                                       Contract.EMPTY_CONTRACT,
                                       Impl.TYPE_PARAMETER)
               {
                 @Override
-                public boolean isCoTypesThisType()
+                public boolean isCoTypesRelayTypeParameter()
                 {
                   return true;
                 }

--- a/src/dev/flang/ast/ResolvedParametricType.java
+++ b/src/dev/flang/ast/ResolvedParametricType.java
@@ -105,7 +105,7 @@ class ResolvedParametricType extends ResolvedType
   @Override
   void usedFeatures(Set<AbstractFeature> s)
   {
-    if (!genericArgument().isCoTypesThisType() &&
+    if (!genericArgument().isCoTypesRelayTypeParameter() &&
         /**
          * Must not be recursive definition as in:
          *

--- a/src/dev/flang/ast/UnresolvedType.java
+++ b/src/dev/flang/ast/UnresolvedType.java
@@ -478,7 +478,7 @@ public abstract class UnresolvedType extends AbstractType implements HasSourcePo
           {
             var inCotype = of != originalOuterFeature(of);
             var mayBeFreeType = mayBeFreeType() && outer.isValueArgument();
-            var traverseOuter = outer() == null && _name != FuzionConstants.COTYPE_THIS_TYPE;
+            var traverseOuter = outer() == null && _name != FuzionConstants.COTYPE_RELAY_TYPE;
             var fo = res._module.lookupType(pos(), of, _name, traverseOuter,
                                             tolerant                                /* ignore ambiguous */,
                                             tolerant || mayBeFreeType || inCotype   /* ignore not found */);

--- a/src/dev/flang/fe/SourceModule.java
+++ b/src/dev/flang/fe/SourceModule.java
@@ -1612,7 +1612,7 @@ A post-condition of a feature that does not redefine an inherited feature must s
       fixed                                &&
       original    .outer().isCotype() &&
       redefinition.outer().isCotype() &&
-      to.replace_this_type_in_cotype(redefinition.outer())
+      to.replace_relay_type_in_cotype(redefinition.outer())
         .compareTo(tr) == 0                                                       ||
 
       /* avoid reporting errors in case of previous errors
@@ -1920,7 +1920,7 @@ A feature that is a constructor, choice or a type parameter may not redefine an 
    */
   private void checkRedefVisibility(Feature f)
   {
-    if (!f.isCoTypesThisType()
+    if (!f.isCoTypesRelayTypeParameter()
     // Function.call is public while actual lambdas-impl are not.
     // If lambda-impl were public then result-type and all arg-types
     // would have to be public as well. Hence this exception.

--- a/src/dev/flang/fuir/Clazz.java
+++ b/src/dev/flang/fuir/Clazz.java
@@ -329,7 +329,7 @@ class Clazz extends ANY implements Comparable<Clazz>
         !_type.feature().isTypeParameter() &&
         _type.outer().outer().feature() != _type.feature().outer().outer())
       {
-        var x = "IMPLEMENTATION RESTRICTION: illegal inheritance and usage of fixed feature: \n" +
+        var x = "IMPLEMENTATION RESTRICTION: illegal inheritance and usage of fixed feature:\n" +
         _type.toString() + "\n" + _type.outer().outer().feature().toString() + "\n" + _type.feature().outer().outer().toString();
         Errors.fatal(x);
       }
@@ -1299,7 +1299,7 @@ class Clazz extends ANY implements Comparable<Clazz>
         var skip = cotypeType;
         for (var g : actualTypeParameters())
           {
-            if (!skip) // skip first generic 'THIS#TYPE' for types of type features.
+            if (!skip) // skip first generic 'RELAY#TYPE' for types of cotype features.
               {
                 result = result + " " + StringHelpers.wrapInParentheses(g.toString(humanReadable));
               }

--- a/src/dev/flang/util/FuzionConstants.java
+++ b/src/dev/flang/util/FuzionConstants.java
@@ -333,7 +333,7 @@ public class FuzionConstants extends ANY
    * names with this prefix will be removed from .fum files which results in
    * this not being found in redefinitions.
    */
-  public static final String COTYPE_THIS_TYPE = "THIS" + INTERNAL_NAME_SYMBOL + "TYPE";
+  public static final String COTYPE_RELAY_TYPE = "RELAY" + INTERNAL_NAME_SYMBOL + "TYPE";
 
 
   /**

--- a/tests/covariance/test_covariance.fz
+++ b/tests/covariance/test_covariance.fz
@@ -225,7 +225,7 @@ test_this_type =>
 # This test creates nested features with inner type features that use outer features'
 # this.type in their signature.
 #
-test_this_type_in_cotype =>
+test_relay_type_in_cotype =>
 
   abc is
     def(s String) is
@@ -294,4 +294,4 @@ test_this_type_in_cotype =>
 
 run_test_covariance
 test_this_type
-test_this_type_in_cotype
+test_relay_type_in_cotype

--- a/tests/reg_issue5583/reg_issue5583.fz.expected_err
+++ b/tests/reg_issue5583/reg_issue5583.fz.expected_err
@@ -1,8 +1,8 @@
 
-error 1: IMPLEMENTATION RESTRICTION: illegal inheritance and usage of fixed feature: 
+error 1: IMPLEMENTATION RESTRICTION: illegal inheritance and usage of fixed feature:
 q.type.b.type.me
-private type.q(private fixed THIS#TYPE Type (type parameter)) q.type : a q.this.type is
-private type.a(private fixed THIS#TYPE Type (type parameter)) a.type : has_me a.this.type is
+private type.q(private fixed RELAY#TYPE Type (type parameter)) q.type : a q.this.type is
+private type.a(private fixed RELAY#TYPE Type (type parameter)) a.type : has_me a.this.type is
 
 *** fatal errors encountered, stopping.
 one error.

--- a/tests/reg_issue6957/reg_issue6957.fz.expected_err
+++ b/tests/reg_issue6957/reg_issue6957.fz.expected_err
@@ -1,8 +1,8 @@
 
-error 1: IMPLEMENTATION RESTRICTION: illegal inheritance and usage of fixed feature: 
+error 1: IMPLEMENTATION RESTRICTION: illegal inheritance and usage of fixed feature:
 f.type.stat.type.default_value
-private type.f(private fixed THIS#TYPE Type (type parameter)) f.type : (io f.this.type).file f.this.type is
-public type.file(private fixed THIS#TYPE Type (type parameter)) io.type.file.type : Any io.file.this.type is
+private type.f(private fixed RELAY#TYPE Type (type parameter)) f.type : (io f.this.type).file f.this.type is
+public type.file(private fixed RELAY#TYPE Type (type parameter)) io.type.file.type : Any io.file.this.type is
 
 *** fatal errors encountered, stopping.
 one error.


### PR DESCRIPTION
The terminology this-type for the first type parameter in a co-type was confusing, so I'm proposing to change to name to relay type. A type that is relayed/transported via the cotype.

