### PR TITLE
base: remove some more `env` short-hands

### DIFF
--- a/modules/base/src/io/file.fz
+++ b/modules/base/src/io/file.fz
@@ -31,17 +31,3 @@ public file is
   # for reading/writing to file
   #
   module:public file_mutate : mutate is
-
-
-  # short hand to get the writer instance
-  # for the opened file of type file.this
-  #
-  public writer (io.buffered file_mutate).writer =>
-    (io.buffered file_mutate).writer.env
-
-
-  # short hand to get the reader instance
-  # for the opened file of type file.this
-  #
-  public reader (io.buffered file_mutate).reader =>
-    (io.buffered file_mutate).reader.env

--- a/modules/base/src/io/file/append.fz
+++ b/modules/base/src/io/file/append.fz
@@ -26,4 +26,4 @@
 #
 public append(p path, a Any) outcome unit =>
   use p mode.append ()->
-    writer.write $a
+    (io.buffered file_mutate).writer.env.write $a

--- a/modules/base/src/io/file/write.fz
+++ b/modules/base/src/io/file/write.fz
@@ -26,4 +26,4 @@
 #
 public write(p path, a Any) outcome unit =>
   use p mode.write ()->
-    writer.write $a
+    (io.buffered file_mutate).writer.env.write $a

--- a/modules/base/src/panic.fz
+++ b/modules/base/src/panic.fz
@@ -45,19 +45,13 @@ is
   => panic h unit
 
 
-# panic with no argument returns panic.env, the currently installed
-# panic handler.
-#
-public panic panic => panic.env
-
-
 # panic calls panic.cause msg, i.e., it uses the
 # current panic effect to panic with the given message.
 #
 public panic(c String|error) void =>
   match c
-    msg String => panic.cause msg
-    e error => panic.cause $e
+    msg String => panic.env.cause msg
+    e error => panic.env.cause $e
 
 
 # a variant of panic for code paths that are guaranteed to

--- a/modules/base/src/state.fz
+++ b/modules/base/src/state.fz
@@ -136,21 +136,16 @@ public state(S, R type, initial_value S, r ()->R) R =>
   res.or_panic
 
 
-# shorthand for accessing state monad for given type in current environment
-#
-public state_of(S type) state unit S => (state unit S).env
-
-
 # shorthand for getting state monad for given type in current environment
 #
-public state_get(S type) S => (state_of S).get
+public state_get(S type) S => (state unit S).env.get
 
 
 # shorthand for modifying state monad for given type in current environment
 #
-public state_modify(S type, f S->S) state unit S => (state_of S).modify f
+public state_modify(S type, f S->S) state unit S => (state unit S).env.modify f
 
 
 # shorthand for setting state monad for given type in current environment
 #
-public state_put(S type, new S) state unit S => (state_of S).put new
+public state_put(S type, new S) state unit S => (state unit S).env.put new

--- a/tests/lib_fileio_mmap/mmap_test.fz
+++ b/tests/lib_fileio_mmap/mmap_test.fz
@@ -30,11 +30,11 @@ mmap_test =>
 
   say <| io.file.use testfile io.file.mode.append ()->
 
-    io.file.writer.write (array u8 _ os.mmap_offset_multiple.as_i32 _->0)
+    (io.buffered io.file.file_mutate).writer.env.write (array u8 _ os.mmap_offset_multiple.as_i32 _->0)
       .or_panic
-    io.file.writer.write "hello!"
+    (io.buffered io.file.file_mutate).writer.env.write "hello!"
       .or_panic
-    io.file.writer.flush
+    (io.buffered io.file.file_mutate).writer.env.flush
       .or_panic
 
     offset := os.mmap_offset_multiple

--- a/tests/lib_io_dir/lib_io_dir.fz
+++ b/tests/lib_io_dir/lib_io_dir.fz
@@ -32,8 +32,8 @@ lib_io_dir =>
   _ := io.file.delete path
   say (io.dir.make path)
   say (io.dir.make path).err.msg
-  _ := io.file.use unit file1 io.file.mode.write (()-> io.file.writer.write "")
-  _ := io.file.use unit file2 io.file.mode.write (()-> io.file.writer.write "")
+  _ := io.file.use unit file1 io.file.mode.write (()-> (io.buffered io.file.file_mutate).writer.env.write "")
+  _ := io.file.use unit file2 io.file.mode.write (()-> (io.buffered io.file.file_mutate).writer.env.write "")
 
   res := io.dir.use (Sequence String) path ()->
     array 3 _->io.dir.open.env.read.as_string

--- a/tests/lib_io_file/fileiotests.fz
+++ b/tests/lib_io_file/fileiotests.fz
@@ -41,7 +41,7 @@ fileiotests =>
   say "$file exists: $(f.exists file)"
 
   _ := f
-    .use file f.mode.write (() -> f.writer.write content)
+    .use file f.mode.write (() -> (io.buffered f.file_mutate).writer.env.write content)
     .bind (_ -> say "$file was created")
   say "$file exists: $(f.exists file)"
 

--- a/tests/lib_io_utf8/lib_io_utf8.fz
+++ b/tests/lib_io_utf8/lib_io_utf8.fz
@@ -52,7 +52,7 @@ lib_io_utf8 =>
     say "$file exists: $(f.exists file)"
 
     _ := f
-      .use file f.mode.write ()->(f.writer.write content)
+      .use file f.mode.write ()->((io.buffered f.file_mutate).writer.env.write content)
       .bind (_ -> say "$file was created")
     say "$file exists: $(f.exists file)"
 
@@ -96,8 +96,8 @@ lib_io_utf8 =>
     _ := io.file.delete (path.of "⚗️🧫")
     say (io.dir.make (path.of "⚗️🧫"))
     say (io.dir.make (path.of "⚗️🧫")).err.msg
-    _ := io.file.use (path.of "⚗️🧫/1️⃣📜") io.file.mode.write ()->(io.file.writer.write "")
-    _ := io.file.use (path.of "⚗️🧫/2️⃣🗒️") io.file.mode.write ()->(io.file.writer.write "")
+    _ := io.file.use (path.of "⚗️🧫/1️⃣📜") io.file.mode.write ()->((io.buffered io.file.file_mutate).writer.env.write "")
+    _ := io.file.use (path.of "⚗️🧫/2️⃣🗒️") io.file.mode.write ()->((io.buffered io.file.file_mutate).writer.env.write "")
 
     res := io.dir.use (Sequence String) (path.of "⚗️🧫") ()->
       array 3 _->io.dir.open.env.read.as_string


### PR DESCRIPTION
It feels much cleaner to call effect features via `env` 
