### PR TITLE
base: remove feature referencing DFA limitation

### DIFF
--- a/modules/base/src/fuzion/java.fz
+++ b/modules/base/src/fuzion/java.fz
@@ -33,11 +33,6 @@ public java is
   public Java_Object(public java_ref Java_Ref) ref
   is
 
-    # convenience feature to get JVM effect from current environment. This avoids DFA limitations
-    # that is currently not accurate enough to find the presence of the jvm effect for Strings
-    #
-    jvm => (fuzion.jvm.get_if_instated.or_else (panic "jvm effect required but not instated"))
-
     public is_null bool ! fuzion.jvm =>
       fuzion.jvm.env.is_null0 java_ref
 
@@ -111,4 +106,4 @@ public java is
   public Java_String(public redef java_ref Java_Ref) ref : String, fuzion.java.Java_Object java_ref
   is
     public redef utf8 Sequence u8 =>
-      (jvm.java_string_to_string java_ref).utf8
+      (fuzion.jvm.env.java_string_to_string java_ref).utf8


### PR DESCRIPTION
comment is seemingly outdated?
