### PR TITLE
base: remove `String.type.from_mutable_array`

### DIFF
--- a/modules/base/src/String.fz
+++ b/modules/base/src/String.fz
@@ -970,33 +970,6 @@ public String ref : property.equatable, property.hashable, property.orderable is
     join elems "\n"
 
 
-  # create string by concatenating the results of $a[a.indices].
-  #
-  # This uses a growing array if further strings are appended using 'infix +',
-  # so it avoids quadratic runtime caused if each 'infix +' would create its
-  # own concatenation-string.
-  #
-  # The performance of creating a string a0+a1+a2+...+a<n> is in O(n) since the
-  # backing array is shared and doubled in size when full (so the final array size
-  # is less than 2n in size and the sum of all arrays is less than 4n = 2n + n +
-  # n/2+n/4+...).
-  #
-  # The performance of iterating the utf8 bytes of a string is O(l+n) for an
-  # array of length l created by concatenating n sub-strings.
-  #
-  public type.from_mutable_array(E type : mutate, a container.Mutable_Array Any E) String =>  # NYI: Remove?
-
-    _ : String is
-
-      public redef utf8 Sequence u8 =>
-        a.as_list.flat_map (.as_string.utf8)
-
-
-      public redef infix + (other Any) String =>
-        a.add other
-        from_mutable_array a
-
-
   # create string from the given utf8 bytes
   #
   module type.from_bytes(utf8_bytes Sequence u8) String =>

--- a/tests/lib_string/stringtest.fz
+++ b/tests/lib_string/stringtest.fz
@@ -44,6 +44,34 @@ stringtest is
 
   say (String.from "hell😀".codepoints)
 
+
+  # create string by concatenating the results of $a[a.indices].
+  #
+  # This uses a growing array if further strings are appended using 'infix +',
+  # so it avoids quadratic runtime caused if each 'infix +' would create its
+  # own concatenation-string.
+  #
+  # The performance of creating a string a0+a1+a2+...+a<n> is in O(n) since the
+  # backing array is shared and doubled in size when full (so the final array size
+  # is less than 2n in size and the sum of all arrays is less than 4n = 2n + n +
+  # n/2+n/4+...).
+  #
+  # The performance of iterating the utf8 bytes of a string is O(l+n) for an
+  # array of length l created by concatenating n sub-strings.
+  #
+  String.type.from_mutable_array(E type : mutate, a container.Mutable_Array Any E) String =>  # NYI: Remove?
+
+    _ : String is
+
+      public redef utf8 Sequence u8 =>
+        a.as_list.flat_map (.as_string.utf8)
+
+
+      public redef infix + (other Any) String =>
+        a.add other
+        from_mutable_array a
+
+
   mi : mutate is
   mi ! ()->
     say (String.from_mutable_array mi ((mi.array Any).new 1 nil))

--- a/tests/reg_issue1862/reg_issue1862.fz
+++ b/tests/reg_issue1862/reg_issue1862.fz
@@ -21,6 +21,33 @@
 #
 # -----------------------------------------------------------------------
 
+# create string by concatenating the results of $a[a.indices].
+#
+# This uses a growing array if further strings are appended using 'infix +',
+# so it avoids quadratic runtime caused if each 'infix +' would create its
+# own concatenation-string.
+#
+# The performance of creating a string a0+a1+a2+...+a<n> is in O(n) since the
+# backing array is shared and doubled in size when full (so the final array size
+# is less than 2n in size and the sum of all arrays is less than 4n = 2n + n +
+# n/2+n/4+...).
+#
+# The performance of iterating the utf8 bytes of a string is O(l+n) for an
+# array of length l created by concatenating n sub-strings.
+#
+String.type.from_mutable_array(E type : mutate, a container.Mutable_Array Any E) String =>  # NYI: Remove?
+
+  _ : String is
+
+    public redef utf8 Sequence u8 =>
+      a.as_list.flat_map (.as_string.utf8)
+
+
+    public redef infix + (other Any) String =>
+      a.add other
+      from_mutable_array a
+
+
 mi : mutate is
 mi ! ()->
   b := (String.type.from_mutable_array (mi.array Any .new 1 false))


### PR DESCRIPTION
We use `FingerTree` for string concat
