### PR TITLE
tokiwa: send kill signal to timed out process

### DIFF
--- a/modules/base/src/os/process.fz
+++ b/modules/base/src/os/process.fz
@@ -189,8 +189,20 @@ module:public process(public pid i64, module std_in, std_out, std_err i64, name 
 
   # send signal to process
   #
-  public send_signal(sig signal) outcome unit =>
+  public send_signal(sig os.signal) outcome unit =>
     fzE_send_signal pid sig.as_i32 = 0 ? unit : error "sending signal to process $pid" fzE_last_error
+
+
+  # send kill signal to process
+  #
+  public kill outcome unit =>
+    send_signal os.signals.kill
+
+
+  # send terminate signal to process
+  #
+  public terminate outcome unit =>
+    send_signal os.signals.terminate
 
 
   # start a process with name, arguments and environment variables

--- a/modules/tokiwa/src/tokiwa.fz
+++ b/modules/tokiwa/src/tokiwa.fz
@@ -87,6 +87,8 @@ public tokiwa is
                   (io.buffered lm).writer.env.write (io.slurp stdin_file).or_panic .or_panic).or_panic
 
         match p.wait (timeout.or_default time.duration.max)
-          e error => process_result "" "failed waiting for $cmd, error is: $e" 1
+          e error =>
+            _ := p.kill
+            process_result "" "failed waiting for $cmd, error is: $e" 1
           ec u32 => process_result fout.get ferr.get ec)
       .or_panic


### PR DESCRIPTION
record_process starts threads that read from out/err, if we don't kill the process the `read` may hang forever.
