### PR TITLE
parser: more sourceRange uses instead of sourcePos

### DIFF
--- a/src/dev/flang/parser/Lexer.java
+++ b/src/dev/flang/parser/Lexer.java
@@ -2624,10 +2624,10 @@ Fuzion xref:input_source[input sources] must match the Fuzion grammar defined in
                                                                       sourcePos(_minIndentStartPos),
                                                                       detail);
       case t_lineLimit        -> Errors.lineBreakNotAllowedHere (sourcePos(lineEndPos(_sameLine)), detail);
-      case t_spaceOrSemiLimit -> Errors.whiteSpaceNotAllowedHere(sourcePos(tokenPos()), detail);
-      case t_commaLimit       -> Errors.commaNotAllowedHere     (sourcePos(tokenPos()), detail);
-      case t_colonLimit       -> Errors.colonPartOfTernary      (sourcePos(tokenPos()), detail);
-      case t_barLimit         -> Errors.barPartOfCase           (sourcePos(tokenPos()), detail);
+      case t_spaceOrSemiLimit -> Errors.whiteSpaceNotAllowedHere(tokenSourceRange(), detail);
+      case t_commaLimit       -> Errors.commaNotAllowedHere     (tokenSourceRange(), detail);
+      case t_colonLimit       -> Errors.colonPartOfTernary      (tokenSourceRange(), detail);
+      case t_barLimit         -> Errors.barPartOfCase           (tokenSourceRange(), detail);
       case t_ambiguousSemi    -> Errors.ambiguousSemicolon(sourcePos(pos));
       default                 -> Errors.syntax(sourcePos(pos), expected, currentAsString(), detail);
       }

--- a/src/dev/flang/parser/Parser.java
+++ b/src/dev/flang/parser/Parser.java
@@ -484,12 +484,12 @@ namequal    : name dot qual
       {
         if (skip(mayBeAtMinIndent, Token.t_type))
           {
-            result.add(new ParsedName(tokenSourcePos(), FuzionConstants.TYPE_NAME));
+            result.add(new ParsedName(tokenSourceRange(), FuzionConstants.TYPE_NAME));
             dot();
           }
         else if (skip(mayBeAtMinIndent, Token.t_universe))
           {
-            result.add(new ParsedName(tokenSourcePos(), FuzionConstants.UNIVERSE_NAME));
+            result.add(new ParsedName(tokenSourceRange(), FuzionConstants.UNIVERSE_NAME));
             dot();
           }
         result.add(name(mayBeAtMinIndent, false));
@@ -1345,7 +1345,7 @@ indexTail   : ":=" exprInLine
     Call result;
     do
       {
-        SourcePosition pos = tokenSourcePos();
+        SourcePosition pos = tokenSourceRange();
         var l = bracketTermWithNLs(BRACKETS, "indexCall", () -> actualCommas(true));
         String n = FuzionConstants.FEATURE_NAME_INDEX;
         if (skip(":="))
@@ -1934,7 +1934,7 @@ klammer     : LPAREN block RPAREN
           }
         else if (forked_t.size() != 1)
           {
-            res = new ParsedCall(null, new ParsedName(tokenSourcePos(), "tuple"), tuple());
+            res = new ParsedCall(null, new ParsedName(tokenSourceRange(), "tuple"), tuple());
           }
         else
           {


### PR DESCRIPTION
No tests, needed to be changed since a lot of the error cases are not covered yet.