### PR TITLE
base: allow repeated calls of `os.process.wait` while process is running

### DIFF
--- a/include/fz.h
+++ b/include/fz.h
@@ -471,7 +471,7 @@ int fzE_process_create(char * args[], size_t argsLen, char * env[], size_t envLe
  *
  * @return -1 error, >=0 exit code
  */
-int64_t fzE_process_wait(int64_t p);
+int64_t fzE_process_poll(int64_t p);
 
 /**
  * read nbytes bytes into `buf` from pipe `desc`.

--- a/include/posix.c
+++ b/include/posix.c
@@ -765,7 +765,7 @@ int fzE_process_create(char * args[], size_t argsLen, char * env[], size_t envLe
 //   -2  : an error occurred when calling waitpid, check errno
 //  <-100: process was terminated by a signal
 //         -100-SIG, e.g., -109 for 9 (SIGKILL)
-int64_t fzE_process_wait(int64_t p){
+int64_t fzE_process_poll(int64_t p){
 
   assert(p>0);
 

--- a/include/posix.c
+++ b/include/posix.c
@@ -789,7 +789,8 @@ int64_t fzE_process_poll(int64_t p){
   else if (WIFSIGNALED(status)) {
       // process was terminated by a signal
       res = -100 - WTERMSIG(status);
-  } else {
+  }
+  else {
     assert(false);
   }
   return res;

--- a/include/posix.c
+++ b/include/posix.c
@@ -757,19 +757,40 @@ int fzE_process_create(char * args[], size_t argsLen, char * env[], size_t envLe
 }
 
 
-// wait for process to finish
-// returns exit code or -1 on wait-failure.
+// check the process status, does not wait for process to finish
+//
+// result
+//   >=0 : the process exit code
+//   -1  : process is still running
+//   -2  : an error occurred when calling waitpid, check errno
+//  <-100: process was terminated by a signal
+//         -100-SIG, e.g., -109 for 9 (SIGKILL)
 int64_t fzE_process_wait(int64_t p){
 
   assert(p>0);
 
   int status;
-  int ret = waitpid(p, &status, WNOHANG);
+  pid_t ret = waitpid(p, &status, WNOHANG);
 
-  return ret > 0 && WIFEXITED(status)
-    // man waitpid: "This macro should be employed only if WIFEXITED returned true."
-    ? WEXITSTATUS(status)
-    : -1;
+  int res = 0;
+
+  if (ret == 0) {
+      // Child is still running.
+      res = -1;
+  }
+  else if (ret == -1) {
+      // Error. Check errno.
+      res = -2;
+  }
+  else if (WIFEXITED(status)) {
+      // process exited
+      res = WEXITSTATUS(status);
+  }
+  else if (WIFSIGNALED(status)) {
+      // process was terminated by a signal
+      res = -100 - WTERMSIG(status);
+  }
+  return res;
 }
 
 

--- a/include/posix.c
+++ b/include/posix.c
@@ -789,6 +789,8 @@ int64_t fzE_process_wait(int64_t p){
   else if (WIFSIGNALED(status)) {
       // process was terminated by a signal
       res = -100 - WTERMSIG(status);
+  } else {
+    assert(false);
   }
   return res;
 }

--- a/include/win.c
+++ b/include/win.c
@@ -923,20 +923,31 @@ int fzE_process_create(char *args[], size_t argsLen, char *env[], size_t envLen,
 }
 
 
-// wait for process to finish
-// returns exit code or -1 on wait-failure.
-int64_t fzE_process_wait(int64_t p){
-  DWORD status = 0;
-  if (GetExitCodeProcess((HANDLE)p, &status)){
-    if (status == STILL_ACTIVE){
-      return -1;
+// check the process status, does not wait for process to finish
+//
+// result
+//   >=0 : the process exit code (including exception/termination codes)
+//   -1  : process is still running
+//   -2  : an error occurred when calling waitpid, check errno
+int64_t fzE_process_poll(int64_t p){
+
+    assert(p != 0);
+
+    DWORD status;
+
+    if (!GetExitCodeProcess((HANDLE)p, &status)) {
+        // Error calling GetExitCodeProcess()
+        return -2;
     }
-    else {
-      CloseHandle((HANDLE)p);
-      return (int64_t)status;
+
+    if (status == STILL_ACTIVE) {
+        // Process is still running.
+        return -1;
     }
-  }
-  return 255;
+
+    // Process has exited.
+    CloseHandle((HANDLE)p);
+    return (int64_t)status;
 }
 
 

--- a/modules/base/src/native.fz
+++ b/modules/base/src/native.fz
@@ -250,7 +250,7 @@ module fzE_process_create(
 
 # wait for process to exit
 #
-module fzE_process_wait(process i64) i64 => native
+module fzE_process_poll(process i64) i64 => native
 
 
 # returns -1 on error, 0 on end_of_file, number of read bytes otherwise.

--- a/modules/base/src/os/processes.fz
+++ b/modules/base/src/os/processes.fz
@@ -60,10 +60,6 @@ public processes (ph os.Process_Handler, public running_processes container.Set 
     #
     upper_bound_poll_time := time.duration.s 1
 
-    os.processes ph (running_processes ∖ (container.set_of_ordered [p]))
-      .replace
-    # NYI: UNDER DEVELOPMENT: register errors in runtime_errors_effect
-    _ := fzE_pipe_close p.std_in = 0
 
     for
       r := fzE_process_wait p.pid
@@ -71,14 +67,23 @@ public processes (ph os.Process_Handler, public running_processes container.Set 
       # NYI: UNDER DEVELOPMENT: replace polling by signaled waits (POSIX) / events (WIN) or similar.
       # 1ms, 2ms, 4ms, 8ms, 16ms, 32ms, ..., 1s
       polling_time := time.duration.ms 1, min upper_bound_poll_time polling_time*2
-    while r < 0 && elapsed_time <= timeout
+    while r = -1 && elapsed_time <= timeout
       time.nano.env.sleep (min timeout-elapsed_time polling_time)
     else
       if r >= 0
-        r.as_u32
+        res := outcome r.as_u32
+        os.processes ph (running_processes ∖ (container.set_of_ordered [p]))
+          .replace
+        # NYI: UNDER DEVELOPMENT: register errors in runtime_errors_effect
+        _ := fzE_pipe_close p.std_in = 0
+        res
       else
-        if elapsed_time > timeout
+        if r = -1 && elapsed_time > timeout
           error "Waiting for process with id $(p.pid) timed out."
+        else if r < -100
+          sig := (r.abs - 100).as_i32
+          sig_name := os.signal.from_number sig .bind s->" ($(s.as_string))" .or_default ""
+          error "Process $(p.pid) was terminated by signal $sig$sig_name"
         else
           error "Waiting for process with id $(p.pid) was unsuccessful" fzE_last_error
 

--- a/modules/base/src/os/processes.fz
+++ b/modules/base/src/os/processes.fz
@@ -60,7 +60,6 @@ public processes (ph os.Process_Handler, public running_processes container.Set 
     #
     upper_bound_poll_time := time.duration.s 1
 
-
     for
       r := fzE_process_wait p.pid
       elapsed_time := time.nano.env.read-start
@@ -71,12 +70,9 @@ public processes (ph os.Process_Handler, public running_processes container.Set 
       time.nano.env.sleep (min timeout-elapsed_time polling_time)
     else
       if r >= 0
-        res := outcome r.as_u32
         os.processes ph (running_processes ∖ (container.set_of_ordered [p]))
           .replace
-        # NYI: UNDER DEVELOPMENT: register errors in runtime_errors_effect
-        _ := fzE_pipe_close p.std_in = 0
-        res
+        outcome r.as_u32
       else
         if r = -1 && elapsed_time > timeout
           error "Waiting for process with id $(p.pid) timed out."

--- a/modules/base/src/os/processes.fz
+++ b/modules/base/src/os/processes.fz
@@ -61,7 +61,7 @@ public processes (ph os.Process_Handler, public running_processes container.Set 
     upper_bound_poll_time := time.duration.s 1
 
     for
-      r := fzE_process_wait p.pid
+      r := fzE_process_poll p.pid
       elapsed_time := time.nano.env.read-start
       # NYI: UNDER DEVELOPMENT: replace polling by signaled waits (POSIX) / events (WIN) or similar.
       # 1ms, 2ms, 4ms, 8ms, 16ms, 32ms, ..., 1s

--- a/modules/base/src/os/signal.fz
+++ b/modules/base/src/os/signal.fz
@@ -54,3 +54,37 @@ is
       signals.broken_pipe => 13
       signals.alarm => 14
       signals.terminate => 15
+
+
+  public redef as_string String =>
+    match signal.this
+      s signals.hangup                   => s.as_string
+      s signals.interrupt                => s.as_string
+      s signals.quit                     => s.as_string
+      s signals.illegal_instruction      => s.as_string
+      s signals.trap                     => s.as_string
+      s signals.abort                    => s.as_string
+      s signals.arithmetic_error         => s.as_string
+      s signals.kill                     => s.as_string
+      s signals.invalid_memory_reference => s.as_string
+      s signals.broken_pipe              => s.as_string
+      s signals.alarm                    => s.as_string
+      s signals.terminate                => s.as_string
+
+
+  module type.from_number(I type : integer, n I) option os.signal =>
+
+    if !n.fits_in_i32                                                            then nil
+    else if n.as_i32 = (id os.signal os.signals.hangup).as_i32                   then option (id os.signal os.signals.hangup)
+    else if n.as_i32 = (id os.signal os.signals.interrupt).as_i32                then option (id os.signal os.signals.interrupt)
+    else if n.as_i32 = (id os.signal os.signals.quit).as_i32                     then option (id os.signal os.signals.quit)
+    else if n.as_i32 = (id os.signal os.signals.illegal_instruction).as_i32      then option (id os.signal os.signals.illegal_instruction)
+    else if n.as_i32 = (id os.signal os.signals.trap).as_i32                     then option (id os.signal os.signals.trap)
+    else if n.as_i32 = (id os.signal os.signals.abort).as_i32                    then option (id os.signal os.signals.abort)
+    else if n.as_i32 = (id os.signal os.signals.arithmetic_error).as_i32         then option (id os.signal os.signals.arithmetic_error)
+    else if n.as_i32 = (id os.signal os.signals.kill).as_i32                     then option (id os.signal os.signals.kill)
+    else if n.as_i32 = (id os.signal os.signals.invalid_memory_reference).as_i32 then option (id os.signal os.signals.invalid_memory_reference)
+    else if n.as_i32 = (id os.signal os.signals.broken_pipe).as_i32              then option (id os.signal os.signals.broken_pipe)
+    else if n.as_i32 = (id os.signal os.signals.alarm).as_i32                    then option (id os.signal os.signals.alarm)
+    else if n.as_i32 = (id os.signal os.signals.terminate).as_i32                then option (id os.signal os.signals.terminate)
+    else nil

--- a/modules/base/src/os/signal.fz
+++ b/modules/base/src/os/signal.fz
@@ -72,19 +72,18 @@ is
       s signals.terminate                => s.as_string
 
 
-  module type.from_number(I type : integer, n I) option os.signal =>
+  module type.from_number(n i32) option os.signal =>
 
-    if !n.fits_in_i32                                                            then nil
-    else if n.as_i32 = (id os.signal os.signals.hangup).as_i32                   then option (id os.signal os.signals.hangup)
-    else if n.as_i32 = (id os.signal os.signals.interrupt).as_i32                then option (id os.signal os.signals.interrupt)
-    else if n.as_i32 = (id os.signal os.signals.quit).as_i32                     then option (id os.signal os.signals.quit)
-    else if n.as_i32 = (id os.signal os.signals.illegal_instruction).as_i32      then option (id os.signal os.signals.illegal_instruction)
-    else if n.as_i32 = (id os.signal os.signals.trap).as_i32                     then option (id os.signal os.signals.trap)
-    else if n.as_i32 = (id os.signal os.signals.abort).as_i32                    then option (id os.signal os.signals.abort)
-    else if n.as_i32 = (id os.signal os.signals.arithmetic_error).as_i32         then option (id os.signal os.signals.arithmetic_error)
-    else if n.as_i32 = (id os.signal os.signals.kill).as_i32                     then option (id os.signal os.signals.kill)
-    else if n.as_i32 = (id os.signal os.signals.invalid_memory_reference).as_i32 then option (id os.signal os.signals.invalid_memory_reference)
-    else if n.as_i32 = (id os.signal os.signals.broken_pipe).as_i32              then option (id os.signal os.signals.broken_pipe)
-    else if n.as_i32 = (id os.signal os.signals.alarm).as_i32                    then option (id os.signal os.signals.alarm)
-    else if n.as_i32 = (id os.signal os.signals.terminate).as_i32                then option (id os.signal os.signals.terminate)
+    if      n = (id os.signal os.signals.hangup).as_i32                   then option (id os.signal os.signals.hangup)
+    else if n = (id os.signal os.signals.interrupt).as_i32                then option (id os.signal os.signals.interrupt)
+    else if n = (id os.signal os.signals.quit).as_i32                     then option (id os.signal os.signals.quit)
+    else if n = (id os.signal os.signals.illegal_instruction).as_i32      then option (id os.signal os.signals.illegal_instruction)
+    else if n = (id os.signal os.signals.trap).as_i32                     then option (id os.signal os.signals.trap)
+    else if n = (id os.signal os.signals.abort).as_i32                    then option (id os.signal os.signals.abort)
+    else if n = (id os.signal os.signals.arithmetic_error).as_i32         then option (id os.signal os.signals.arithmetic_error)
+    else if n = (id os.signal os.signals.kill).as_i32                     then option (id os.signal os.signals.kill)
+    else if n = (id os.signal os.signals.invalid_memory_reference).as_i32 then option (id os.signal os.signals.invalid_memory_reference)
+    else if n = (id os.signal os.signals.broken_pipe).as_i32              then option (id os.signal os.signals.broken_pipe)
+    else if n = (id os.signal os.signals.alarm).as_i32                    then option (id os.signal os.signals.alarm)
+    else if n = (id os.signal os.signals.terminate).as_i32                then option (id os.signal os.signals.terminate)
     else nil

--- a/modules/base/src/os/signals.fz
+++ b/modules/base/src/os/signals.fz
@@ -28,47 +28,59 @@ public signals is
   # hangup detected
   #
   public hangup is
+    public redef as_string String => "SIGHUP"
 
   # interrupt
   #
   public interrupt is
+    public redef as_string String => "SIGINT"
 
   # quit
   #
   public quit is
+    public redef as_string String => "SIGQUIT"
 
   # illegal instruction
   #
   public illegal_instruction is
+    public redef as_string String => "SIGILL"
 
   # trace/breakpoint trap
   #
   public trap is
+    public redef as_string String => "SIGTRAP"
 
   # abort
   #
   public abort is
+    public redef as_string String => "SIGABRT"
 
   # arithmetic error (fpe)
   #
   public arithmetic_error is
+    public redef as_string String => "SIGFPE"
 
   # kill
   #
   public kill is
+    public redef as_string String => "SIGKILL"
 
   # invalid memory reference (segv)
   #
   public invalid_memory_reference is
+    public redef as_string String => "SIGSEGV"
 
   # broken pipe
   #
   public broken_pipe is
+    public redef as_string String => "SIGPIPE"
 
   # alarm, timer signal
   #
   public alarm is
+    public redef as_string String => "SIGALRM"
 
   # terminate (term)
   #
   public terminate is
+    public redef as_string String => "SIGTERM"

--- a/modules/tokiwa/src/tokiwa.fz
+++ b/modules/tokiwa/src/tokiwa.fz
@@ -85,6 +85,7 @@ public tokiwa is
               lm ! ()->
                 (p.with_in unit lm ()->
                   (io.buffered lm).writer.env.write (io.slurp stdin_file).or_panic .or_panic).or_panic
+              _ := p.close_in
 
         match p.wait (timeout.or_default time.duration.max)
           e error =>

--- a/tests/process/test_process.fz
+++ b/tests/process/test_process.fz
@@ -47,7 +47,7 @@ test_process =>
     (os.process.start "cat").bind p->
       _ := p.write_string "Hello from the other side."
       # closing input so cat knows we are done and must write to standard out
-      say p.wait
+      say p.close_in
       _ := lm ! ()->
         _ := p.with_out unit lm ()->
           say ((io.buffered lm).read_string 1E9).or_panic

--- a/tests/process/test_process.fz.expected_out
+++ b/tests/process/test_process.fz.expected_out
@@ -1,5 +1,5 @@
 ===  Test: write to stdin of process  ===
-0
+unit
 Hello from the other side.
 ===  Test: read stdout of process  ===
 eecchhoo

--- a/tests/process_buffered_writer/test_process.fz
+++ b/tests/process_buffered_writer/test_process.fz
@@ -37,6 +37,7 @@ process_buffered_writer =>
       _ := lm ! ()->
         _ := p.with_in unit lm ()->
           _ := (io.buffered lm).writer.env.write "Hello, World!\n"
-        say p.wait
+        # closing input so cat knows we are done and must write to standard out
+        say p.close_in
         _ := p.with_out unit lm ()->
           say ((io.buffered lm).read_string 1E9).or_panic

--- a/tests/process_buffered_writer/test_process.fz.expected_out
+++ b/tests/process_buffered_writer/test_process.fz.expected_out
@@ -1,4 +1,4 @@
 ===  Test: write to stdin of process (new)  ===
-0
+unit
 Hello, World!
 


### PR DESCRIPTION
Also distinguish termination by signal from timeout.

#### Examples

Process gets terminated
```
say "starting process"
p := os.process.start "sleep" ["10m"] .or_panic
say <| p.wait (time.duration.s 1)
say <| p.wait (time.duration.s 1)

yap "send KILL: "
say <| p.kill

say <| p.wait (time.duration.s 1)
```
```
❯ fz /tmp/process_test.fz             
starting process
--error: Waiting for process with id 518483 timed out.--
--error: Waiting for process with id 518483 timed out.--
send KILL: unit
--error: Process 518483 was terminated by signal 9 (SIGKILL)--
```

Process exits normally
```
say "starting process"
p := os.process.start "sleep" ["5s"] .or_panic
say <| p.wait (time.duration.s 1)
say <| p.wait (time.duration.s 1)

yap "sleeping 5s ..."
time.nano.env.sleep (time.duration.s 5)
say " [done]"

say <| p.wait (time.duration.s 1)
```
```
❯ fz /tmp/process_test.fz
starting process
--error: Waiting for process with id 518616 timed out.--
--error: Waiting for process with id 518616 timed out.--
sleeping 5s ... [done]
0

```