### PR TITLE
base: move has_interval to `property.interval`

### DIFF
--- a/modules/base/src/Sequence.fz
+++ b/modules/base/src/Sequence.fz
@@ -850,7 +850,7 @@ is
   # adds an index to every element
   # in the sequence starting at start_idx
   #
-  public indexed(I type : has_interval, start_idx I) Sequence (tuple I T) =>
+  public indexed(I type : property.interval, start_idx I) Sequence (tuple I T) =>
     zip (start_idx..) (a,b -> (b, a))
 
 

--- a/modules/base/src/i128.fz
+++ b/modules/base/src/i128.fz
@@ -25,7 +25,7 @@
 
 # i128 -- 128-bit signed integer values
 #
-public i128(public hi i64, public lo u64) : num.wrap_around, has_interval is
+public i128(public hi i64, public lo u64) : num.wrap_around, property.interval is
 
   # overflow checking
 

--- a/modules/base/src/i16.fz
+++ b/modules/base/src/i16.fz
@@ -25,7 +25,7 @@
 
 # i16 -- 16-bit signed integer values
 #
-public i16(public val i16) : num.wrap_around, has_interval, java_primitive is
+public i16(public val i16) : num.wrap_around, property.interval, java_primitive is
 
   # overflow checking
 

--- a/modules/base/src/i32.fz
+++ b/modules/base/src/i32.fz
@@ -25,7 +25,7 @@
 
 # i32 -- 32-bit signed integer values
 #
-public i32(public val i32) : num.wrap_around, has_interval, java_primitive is
+public i32(public val i32) : num.wrap_around, property.interval, java_primitive is
 
   # overflow checking
 

--- a/modules/base/src/i64.fz
+++ b/modules/base/src/i64.fz
@@ -25,7 +25,7 @@
 
 # i64 -- 64-bit signed integer values
 #
-public i64(public val i64) : num.wrap_around, has_interval, java_primitive is
+public i64(public val i64) : num.wrap_around, property.interval, java_primitive is
 
   # overflow checking
 

--- a/modules/base/src/i8.fz
+++ b/modules/base/src/i8.fz
@@ -25,7 +25,7 @@
 
 # i8 -- 8-bit signed integer values
 #
-public i8(public val i8) : num.wrap_around, has_interval, java_primitive is
+public i8(public val i8) : num.wrap_around, property.interval, java_primitive is
 
   # overflow checking
 

--- a/modules/base/src/int.fz
+++ b/modules/base/src/int.fz
@@ -25,7 +25,7 @@
 
 # int -- signed integer values of arbitrary size
 #
-module:public int (is_positive bool, n uint) : has_interval
+module:public int (is_positive bool, n uint) : property.interval
 is
 
   # normalize the sign => no minus zero

--- a/modules/base/src/interval.fz
+++ b/modules/base/src/interval.fz
@@ -124,37 +124,3 @@ is
   #
   public redef finite trit =>
     if through.exists then trit.yes else trit.no
-
-
-
-# has_interval -- feature for integers that can define an interval
-#
-public has_interval : integer is
-
-
-  # defining an integer interval from this to other, both inclusive
-  #
-  # special cases of interval a..b:
-  #
-  #     a <  b: the interval from a to b, both inclusive
-  #     a == b: the interval containing only one element, a
-  #     a >  b: an empty interval
-  public infix .. (through has_interval.this) interval has_interval.this =>
-    interval has_interval.this through has_interval.this.one
-
-
-  # an infinite integer Sequence starting from this up to the maximum value
-  # has_interval.this.max
-  #
-  public postfix .. interval has_interval.this =>
-    interval has_interval.this nil has_interval.this.one
-
-
-  # an infinite integer Sequence starting from this up to the maximum value
-  # has_interval.this.max
-  #
-  # NYI: CLEANUP: Eventually remove `postfix ..` or `postfix ..∞` in favor of the
-  # other one, for now this is here to show that `∞` is a legal symbol in an operator.
-  #
-  public postfix ..∞ interval has_interval.this =>
-    postfix ..

--- a/modules/base/src/property/interval.fz
+++ b/modules/base/src/property/interval.fz
@@ -1,0 +1,57 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion standard library feature interval
+#
+# -----------------------------------------------------------------------
+
+
+# interval -- feature for integers that can define an interval
+#
+public interval : /* NYI: UNDER DEVELOPMENT: inherit privately */ integer is
+
+
+  # defining an integer interval from this to other, both inclusive
+  #
+  # special cases of interval a..b:
+  #
+  #     a <  b: the interval from a to b, both inclusive
+  #     a == b: the interval containing only one element, a
+  #     a >  b: an empty interval
+  public infix .. (through property.interval.this) universe.interval property.interval.this =>
+    # NYI: BUG: why is .type necessary here?
+    interval interval.this through property.interval.this.type.one
+
+
+  # an infinite integer Sequence starting from this up to the maximum value
+  # interval.this.max
+  #
+  public postfix .. universe.interval property.interval.this =>
+    # NYI: BUG: why is .type necessary here?
+    interval interval.this nil property.interval.this.type.one
+
+
+  # an infinite integer Sequence starting from this up to the maximum value
+  # interval.this.max
+  #
+  # NYI: CLEANUP: Eventually remove `postfix ..` or `postfix ..∞` in favor of the
+  # other one, for now this is here to show that `∞` is a legal symbol in an operator.
+  #
+  public postfix ..∞ universe.interval property.interval.this =>
+    postfix ..

--- a/modules/base/src/u128.fz
+++ b/modules/base/src/u128.fz
@@ -25,7 +25,7 @@
 
 # u128 -- 128-bit unsigned integer values
 #
-public u128(public hi u64, public lo u64) : num.wrap_around, has_interval is
+public u128(public hi u64, public lo u64) : num.wrap_around, property.interval is
 
   # overflow checking
 

--- a/modules/base/src/u16.fz
+++ b/modules/base/src/u16.fz
@@ -25,7 +25,7 @@
 
 # u16 -- 16-bit unsigned integer values
 #
-public u16(public val u16) : num.wrap_around, has_interval, java_primitive is
+public u16(public val u16) : num.wrap_around, property.interval, java_primitive is
 
   # overflow checking
 

--- a/modules/base/src/u32.fz
+++ b/modules/base/src/u32.fz
@@ -25,7 +25,7 @@
 
 # u32 -- 32-bit unsigned integer values
 #
-public u32(public val u32) : num.wrap_around, has_interval is
+public u32(public val u32) : num.wrap_around, property.interval is
 
   # overflow checking
 

--- a/modules/base/src/u64.fz
+++ b/modules/base/src/u64.fz
@@ -25,7 +25,7 @@
 
 # u64 -- 64-bit unsigned integer values
 #
-public u64(public val u64) : num.wrap_around, has_interval is
+public u64(public val u64) : num.wrap_around, property.interval is
 
   # overflow checking
 

--- a/modules/base/src/u8.fz
+++ b/modules/base/src/u8.fz
@@ -25,7 +25,7 @@
 
 # u8 -- 8-bit unsigned integer values
 #
-public u8(public val u8) : num.wrap_around, has_interval is
+public u8(public val u8) : num.wrap_around, property.interval is
 
   # overflow checking
 

--- a/modules/base/src/uint.fz
+++ b/modules/base/src/uint.fz
@@ -26,7 +26,7 @@
 # unsigned integer of arbitrary size, including zero
 # represented by its bit sequence
 #
-module:public uint (module b Sequence u32, _ unit) : has_interval
+module:public uint (module b Sequence u32, _ unit) : property.interval
 is
 
   # the actually relevant data of this uint.

--- a/src/dev/flang/ast/AstErrors.java
+++ b/src/dev/flang/ast/AstErrors.java
@@ -893,7 +893,7 @@ public class AstErrors extends ANY
             processed.add(ep);
             if (earlierPosString.length() > 0)
               {
-                earlierPosString.append(", and at \n");
+                earlierPosString.append(", and at\n");
               }
             earlierPosString.append(ep.show());
           }
@@ -1454,7 +1454,7 @@ public class AstErrors extends ANY
           "Ambiguous type",
           "For a type used in a declaration, overloading results in an ambiguity that cannot be resolved by the compiler.\n" +
           "Type that is ambiguous: " + st(t) + "\n" +
-          "Possible features that match this type: \n" +
+          "Possible features that match this type:\n" +
           featureList(possibilities) + "\n" +
           "To solve this, rename these features such that each one has a unique name.");
   }
@@ -1700,7 +1700,7 @@ public class AstErrors extends ANY
       {
         error(pos,
               "Target type of a lambda expression must be a plain type whose feature inherits " + sqn("fuzion.lambda_target") + ", e.g., " + sqn("Function") + ".",
-              "A lambda expression can only be used if assigned to a field or argument whose type contains an abstract lambda target feature \n" +
+              "A lambda expression can only be used if assigned to a field or argument whose type contains an abstract lambda target feature\n" +
               "with argument count of the lambda expression equal to the effective argument count of the lambda target.\n" +
               "Target type: " + s(t) + (from == null ? "" : " from " + from.get()) + "\n" +
               "To solve this, assign the lambda expression to a type that is a lambda target, e.g., " + ss("f (i32, i32) -> bool := x, y -> x > y") + ".");
@@ -1747,7 +1747,7 @@ public class AstErrors extends ANY
   {
     error(pos,
           "Choice type must not access features of surrounding scope.",
-          "A closure cannot be built for a choice type. Forbidden accesses occur at \n" +
+          "A closure cannot be built for a choice type. Forbidden accesses occur at\n" +
           accesses + "\n" +
           "To solve this, you might move the accessed features outside of the common outer feature.");
   }

--- a/src/dev/flang/fe/FeErrors.java
+++ b/src/dev/flang/fe/FeErrors.java
@@ -101,7 +101,7 @@ public class FeErrors extends AstErrors
     var afn = sqn(mir.featureAsString(af));
     error(pos, "Field may not have been initialized",
           "Some execution paths to the use of field " + afn + " must "+
-          "assign a value to this field. \n"+
+          "assign a value to this field.\n"+
           "Uninitialized field: " + afn + "\n"+
           "To solve this, make sure a value is assigned to the field before it is used and "+
           "there are no calls to features that end up reading this field before it is "+

--- a/src/dev/flang/fuir/analysis/dfa/Call.java
+++ b/src/dev/flang/fuir/analysis/dfa/Call.java
@@ -684,7 +684,7 @@ public class Call extends ANY implements Comparable<Call>, Context
           {
             // NYI: Make this a normal error similar to DfaErrors.usedEffectnotinstalled:
             Errors.fatal("Trying to replace effect " + Errors.code(_dfa._fuir.clazzName(ecl))
-                         + " that is not yet installed: \n" + toString(false) + "\n" + toString(true));
+                         + " that is not yet installed:\n" + toString(false) + "\n" + toString(true));
           }
       }
     if (_env != null)

--- a/src/dev/flang/parser/OpExpr.java
+++ b/src/dev/flang/parser/OpExpr.java
@@ -212,8 +212,8 @@ class OpExpr extends ANY
                 var p = op._pos;
                 Errors.error(p,
                              "Syntax error: infix operator "+Errors.code(op._text)+" appears to be "+(op._whiteSpaceAfter ? "postfix" : "prefix")+" operator.",
-                             "Whitespace "+(op._whiteSpaceBefore?"before":"after")+ " this operator suggests that \n" +
-                             "it was not intended as an infix operator. \n"+
+                             "Whitespace "+(op._whiteSpaceBefore?"before":"after")+ " this operator suggests that\n" +
+                             "it was not intended as an infix operator.\n"+
                              "To fix this, you may try to insert white space "+(op._whiteSpaceBefore?"after":"before")+" the operator at "+
                              (op._whiteSpaceAfter ? p.startPos()
                                                   : p.endPos()).show() + "\n" +

--- a/src/dev/flang/tools/fzjava/ForClass.java
+++ b/src/dev/flang/tools/fzjava/ForClass.java
@@ -424,7 +424,7 @@ class ForClass extends ANY
       "#\n" +
       "# !!!!!!  DO NOT EDIT, GENERATED CODE !!!!!!\n" +
       "#\n" +
-      "# This code was generated automatically using the " + FZJava.FZJAVA_TOOL + " tool V" + fzj.version() + " called \n" +
+      "# This code was generated automatically using the " + FZJava.FZJAVA_TOOL + " tool V" + fzj.version() + " called\n" +
       "# as follows:\n" +
       "#\n" +
       "#   " + fzj.command() + "\n" +

--- a/tests/choice_negative/choice_negative.fz.expected_err
+++ b/tests/choice_negative/choice_negative.fz.expected_err
@@ -220,7 +220,7 @@ The following types have overlapping values:
 --CURDIR--/choice_negative.fz:126:5: error 30: Choice type must not access features of surrounding scope.
     A : choice i64 f32 is
 ----^
-A closure cannot be built for a choice type. Forbidden accesses occur at 
+A closure cannot be built for a choice type. Forbidden accesses occur at
 --CURDIR--/choice_negative.fz:128:14:
         _ := x # 25. should flag an error: access to closure not permitted in choice
 -------------^
@@ -231,7 +231,7 @@ To solve this, you might move the accessed features outside of the common outer 
 --CURDIR--/choice_negative.fz:134:9: error 31: Choice type must not access features of surrounding scope.
     B : A, choice i64 f32 is
 --------^
-A closure cannot be built for a choice type. Forbidden accesses occur at 
+A closure cannot be built for a choice type. Forbidden accesses occur at
 --CURDIR--/choice_negative.fz:133:14:
         _ := x # 26. should flag an error: access to closure not permitted in choice
 -------------^

--- a/tests/generics_negative/generics_negative.fz.expected_err
+++ b/tests/generics_negative/generics_negative.fz.expected_err
@@ -138,7 +138,7 @@ Type inference failed for one type parameter 'T'
 ---------------------^
 For a type used in a declaration, overloading results in an ambiguity that cannot be resolved by the compiler.
 Type that is ambiguous: 'X'
-Possible features that match this type: 
+Possible features that match this type:
 'generics_negative.ambiguousTypeParameterName.outer.inner.X' defined at --CURDIR--/generics_negative.fz:191:13:
       inner(X type, Y2 type, Z type)
 ------------^
@@ -154,7 +154,7 @@ To solve this, rename these features such that each one has a unique name.
 ---------------------^
 For a type used in a declaration, overloading results in an ambiguity that cannot be resolved by the compiler.
 Type that is ambiguous: 'Z'
-Possible features that match this type: 
+Possible features that match this type:
 'generics_negative.ambiguousTypeParameterName.outer.inner.Z' defined at --CURDIR--/generics_negative.fz:191:30:
       inner(X type, Y2 type, Z type)
 -----------------------------^

--- a/tests/outerNormalization/outerNormalization.fz
+++ b/tests/outerNormalization/outerNormalization.fz
@@ -127,7 +127,7 @@ outerNormalization is
   testNormalize2
 
 
-  # An (open) interval such as '0..' is of type '(has_interval i32).infix ..', but
+  # An (open) interval such as '0..' is of type '(property.interval i32).infix ..', but
   # that should be converted to 'i32.infix ..' in FUIR:
   #
   testInterval =>

--- a/tests/overloading_negative/overloading_negative.fz.expected_err
+++ b/tests/overloading_negative/overloading_negative.fz.expected_err
@@ -4,7 +4,7 @@
 -------^
 For a type used in a declaration, overloading results in an ambiguity that cannot be resolved by the compiler.
 Type that is ambiguous: 'a'
-Possible features that match this type: 
+Possible features that match this type:
 'overloading_negative.test1.a' defined at --CURDIR--/overloading_negative.fz:37:5:
     a is
 ----^
@@ -23,7 +23,7 @@ To solve this, rename these features such that each one has a unique name.
 -------^
 For a type used in a declaration, overloading results in an ambiguity that cannot be resolved by the compiler.
 Type that is ambiguous: 'a'
-Possible features that match this type: 
+Possible features that match this type:
 'overloading_negative.test1.a' defined at --CURDIR--/overloading_negative.fz:37:5:
     a is
 ----^
@@ -42,7 +42,7 @@ To solve this, rename these features such that each one has a unique name.
 -------^
 For a type used in a declaration, overloading results in an ambiguity that cannot be resolved by the compiler.
 Type that is ambiguous: 'a'
-Possible features that match this type: 
+Possible features that match this type:
 'overloading_negative.test1.a' defined at --CURDIR--/overloading_negative.fz:37:5:
     a is
 ----^

--- a/tests/reg_issue3337/reg_issue3337.fz.expected_err
+++ b/tests/reg_issue3337/reg_issue3337.fz.expected_err
@@ -4,7 +4,7 @@
 -----------------------^^^^^^
 For a type used in a declaration, overloading results in an ambiguity that cannot be resolved by the compiler.
 Type that is ambiguous: 'String'
-Possible features that match this type: 
+Possible features that match this type:
 'reg_issue3337.test1.String' defined at --CURDIR--/reg_issue3337.fz:28:9:
   test1(String type, h String) is                #  1. should flag an error: `h String` ambiguous
 --------^^^^^^
@@ -20,7 +20,7 @@ To solve this, rename these features such that each one has a unique name.
 -----------------------^^^^^^
 For a type used in a declaration, overloading results in an ambiguity that cannot be resolved by the compiler.
 Type that is ambiguous: 'String'
-Possible features that match this type: 
+Possible features that match this type:
 'reg_issue3337.test2.String' defined at --CURDIR--/reg_issue3337.fz:29:9:
   test2(String type, h String) =>                #  2. should flag an error: `h String` ambiguous
 --------^^^^^^
@@ -36,7 +36,7 @@ To solve this, rename these features such that each one has a unique name.
 ---------------------^^^^^^
 For a type used in a declaration, overloading results in an ambiguity that cannot be resolved by the compiler.
 Type that is ambiguous: 'String'
-Possible features that match this type: 
+Possible features that match this type:
 'reg_issue3337.test7.String' defined at --CURDIR--/reg_issue3337.fz:34:9:
   test7(String type) String =>                   #  7. should flag an error: `String` ambiguous
 --------^^^^^^
@@ -52,7 +52,7 @@ To solve this, rename these features such that each one has a unique name.
 ----------------------------^^^^^^
 For a type used in a declaration, overloading results in an ambiguity that cannot be resolved by the compiler.
 Type that is ambiguous: 'String'
-Possible features that match this type: 
+Possible features that match this type:
 'reg_issue3337.test8.String' defined at --CURDIR--/reg_issue3337.fz:35:9:
   test8(String type) option String =>            #  8. should flag an error: `option String` ambiguous
 --------^^^^^^
@@ -68,7 +68,7 @@ To solve this, rename these features such that each one has a unique name.
 -----------------------------------^^^^^^
 For a type used in a declaration, overloading results in an ambiguity that cannot be resolved by the compiler.
 Type that is ambiguous: 'String'
-Possible features that match this type: 
+Possible features that match this type:
 'reg_issue3337.test3.String' defined at --CURDIR--/reg_issue3337.fz:30:9:
   test3(String type, h type : list String) is    #  3. should flag an error: `list  String` ambiguous
 --------^^^^^^
@@ -84,7 +84,7 @@ To solve this, rename these features such that each one has a unique name.
 -----------------------------------^^^^^^
 For a type used in a declaration, overloading results in an ambiguity that cannot be resolved by the compiler.
 Type that is ambiguous: 'String'
-Possible features that match this type: 
+Possible features that match this type:
 'reg_issue3337.test4.String' defined at --CURDIR--/reg_issue3337.fz:31:9:
   test4(String type, h type : list String) =>    #  4. should flag an error: `list String` ambiguous
 --------^^^^^^
@@ -100,7 +100,7 @@ To solve this, rename these features such that each one has a unique name.
 ----------------------^^^^^^
 For a type used in a declaration, overloading results in an ambiguity that cannot be resolved by the compiler.
 Type that is ambiguous: 'String'
-Possible features that match this type: 
+Possible features that match this type:
 'reg_issue3337.test5.String' defined at --CURDIR--/reg_issue3337.fz:32:31:
   test5(h type : list String, String type) is    #  5. should flag an error: `list String` ambiguous
 ------------------------------^^^^^^
@@ -116,7 +116,7 @@ To solve this, rename these features such that each one has a unique name.
 ----------------------^^^^^^
 For a type used in a declaration, overloading results in an ambiguity that cannot be resolved by the compiler.
 Type that is ambiguous: 'String'
-Possible features that match this type: 
+Possible features that match this type:
 'reg_issue3337.test6.String' defined at --CURDIR--/reg_issue3337.fz:33:31:
   test6(h type : list String, String type) =>    #  6. should flag an error: `list String` ambiguous
 ------------------------------^^^^^^
@@ -132,7 +132,7 @@ To solve this, rename these features such that each one has a unique name.
 ------------------------------------^^^^^^
 For a type used in a declaration, overloading results in an ambiguity that cannot be resolved by the compiler.
 Type that is ambiguous: 'String'
-Possible features that match this type: 
+Possible features that match this type:
 'reg_issue3337.test9.String' defined at --CURDIR--/reg_issue3337.fz:36:9:
   test9(String type) is _ := option String nil   #  9. should flag an error: `option String` ambiguous
 --------^^^^^^
@@ -148,7 +148,7 @@ To solve this, rename these features such that each one has a unique name.
 -------------------------------------^^^^^^
 For a type used in a declaration, overloading results in an ambiguity that cannot be resolved by the compiler.
 Type that is ambiguous: 'String'
-Possible features that match this type: 
+Possible features that match this type:
 'reg_issue3337.test10.String' defined at --CURDIR--/reg_issue3337.fz:37:10:
   test10(String type) => _ := option String nil  # 10. should flag an error: `option String` ambiguous
 ---------^^^^^^

--- a/tests/reg_issue4592/reg_issue4592.fz.expected_err
+++ b/tests/reg_issue4592/reg_issue4592.fz.expected_err
@@ -1,9 +1,9 @@
 
-error 1: Trying to replace effect 'reg_issue4592.My_Eff2' that is not yet installed: 
-call 'reg_issue4592.type.My_Eff2.type.set0#1' at {base.fum}/effect.fz:304:5:
+error 1: Trying to replace effect 'reg_issue4592.My_Eff2' that is not yet installed:
+call 'reg_issue4592.type.My_Eff2.type.set0#1' at {base.fum}/effect.fz:298:5:
     set0 e
 ----^^^^^^
-effect environment 'reg_issue4592.My_Eff' for call to 'reg_issue4592.type.My_Eff2.type.set0#1' at {base.fum}/effect.fz:304:5:
+effect environment 'reg_issue4592.My_Eff' for call to 'reg_issue4592.type.My_Eff2.type.set0#1' at {base.fum}/effect.fz:298:5:
     set0 e
 ----^^^^^^
 

--- a/tests/reg_issue5243/reg_issue5243.fz.expected_err
+++ b/tests/reg_issue5243/reg_issue5243.fz.expected_err
@@ -2,16 +2,16 @@
 --CURDIR--/reg_issue5243.fz:39:13: error 1: Target type of a lambda expression must be a plain type whose feature inherits 'fuzion.lambda_target', e.g., 'Function'.
   say (1 .. .filter %%2)  # should fail
 ------------^^^^^^^^^^^
-A lambda expression can only be used if assigned to a field or argument whose type contains an abstract lambda target feature 
+A lambda expression can only be used if assigned to a field or argument whose type contains an abstract lambda target feature
 with argument count of the lambda expression equal to the effective argument count of the lambda target.
-Target type: 'i32' from formal argument type in call to 'has_interval.infix ..'
+Target type: 'i32' from formal argument type in call to 'property.interval.infix ..'
 To solve this, assign the lambda expression to a type that is a lambda target, e.g., 'f (i32, i32) -> bool := x, y -> x > y'.
 
 
 --CURDIR--/reg_issue5243.fz:40:13: error 2: Target type of a lambda expression must be a plain type whose feature inherits 'fuzion.lambda_target', e.g., 'Function'.
   say (1 +  .filter %%2)  # should fail
 ------------^^^^^^^^^^^
-A lambda expression can only be used if assigned to a field or argument whose type contains an abstract lambda target feature 
+A lambda expression can only be used if assigned to a field or argument whose type contains an abstract lambda target feature
 with argument count of the lambda expression equal to the effective argument count of the lambda target.
 Target type: 'i32' from formal argument type in call to 'num.wrap_around.precall infix +'
 To solve this, assign the lambda expression to a type that is a lambda target, e.g., 'f (i32, i32) -> bool := x, y -> x > y'.

--- a/tests/reg_issue5417/reg_issue5417.fz.expected_err
+++ b/tests/reg_issue5417/reg_issue5417.fz.expected_err
@@ -4,7 +4,7 @@
 --------------^^
 For a type used in a declaration, overloading results in an ambiguity that cannot be resolved by the compiler.
 Type that is ambiguous: 'ex'
-Possible features that match this type: 
+Possible features that match this type:
 'ex.ex.ex' defined at --CURDIR--/reg_issue5417.fz:28:5:
     ex is
 ----^^
@@ -23,7 +23,7 @@ To solve this, rename these features such that each one has a unique name.
 --------------^^^^^
 For a type used in a declaration, overloading results in an ambiguity that cannot be resolved by the compiler.
 Type that is ambiguous: 'ex'
-Possible features that match this type: 
+Possible features that match this type:
 'ex.ex.ex' defined at --CURDIR--/reg_issue5417.fz:28:5:
     ex is
 ----^^

--- a/tests/reg_issue6709_unbalanced_infix/reg_issue6709_unbalanced_infix.fz.expected_err
+++ b/tests/reg_issue6709_unbalanced_infix/reg_issue6709_unbalanced_infix.fz.expected_err
@@ -2,8 +2,8 @@
 --CURDIR--/reg_issue6709_unbalanced_infix.fz:37:18: error 1: Syntax error: infix operator '+' appears to be prefix operator.
   test001 := (a) +b   # 1. should flag an error: unbalanced infix `+`
 -----------------^
-Whitespace before this operator suggests that 
-it was not intended as an infix operator. 
+Whitespace before this operator suggests that
+it was not intended as an infix operator.
 To fix this, you may try to insert white space after the operator at --CURDIR--/reg_issue6709_unbalanced_infix.fz:37:19:
   test001 := (a) +b   # 1. should flag an error: unbalanced infix `+`
 ------------------^
@@ -13,8 +13,8 @@ Parse stack: opsTail, opExpr, operatorExpr, implFldInit, implFldOrRout, routOrFi
 --CURDIR--/reg_issue6709_unbalanced_infix.fz:38:15: error 2: Syntax error: infix operator '+' appears to be postfix operator.
   test002 := a+ b     # 2. should flag an error: unbalanced infix `+`
 --------------^
-Whitespace after this operator suggests that 
-it was not intended as an infix operator. 
+Whitespace after this operator suggests that
+it was not intended as an infix operator.
 To fix this, you may try to insert white space before the operator at --CURDIR--/reg_issue6709_unbalanced_infix.fz:38:15:
   test002 := a+ b     # 2. should flag an error: unbalanced infix `+`
 --------------^
@@ -24,8 +24,8 @@ Parse stack: opsTail, opExpr, operatorExpr, implFldInit, implFldOrRout, routOrFi
 --CURDIR--/reg_issue6709_unbalanced_infix.fz:48:17: error 3: Syntax error: infix operator '+' appears to be postfix operator.
   test008 := (a)+ b                # 3. should flag an error: unbalanced infix `+`
 ----------------^
-Whitespace after this operator suggests that 
-it was not intended as an infix operator. 
+Whitespace after this operator suggests that
+it was not intended as an infix operator.
 To fix this, you may try to insert white space before the operator at --CURDIR--/reg_issue6709_unbalanced_infix.fz:48:17:
   test008 := (a)+ b                # 3. should flag an error: unbalanced infix `+`
 ----------------^
@@ -35,8 +35,8 @@ Parse stack: opsTail, opExpr, operatorExpr, implFldInit, implFldOrRout, routOrFi
 --CURDIR--/reg_issue6709_unbalanced_infix.fz:49:18: error 4: Syntax error: infix operator '+' appears to be prefix operator.
   test009 := (a) +b                # 4. should flag an error: unbalanced infix `+`
 -----------------^
-Whitespace before this operator suggests that 
-it was not intended as an infix operator. 
+Whitespace before this operator suggests that
+it was not intended as an infix operator.
 To fix this, you may try to insert white space after the operator at --CURDIR--/reg_issue6709_unbalanced_infix.fz:49:19:
   test009 := (a) +b                # 4. should flag an error: unbalanced infix `+`
 ------------------^
@@ -46,8 +46,8 @@ Parse stack: opsTail, opExpr, operatorExpr, implFldInit, implFldOrRout, routOrFi
 --CURDIR--/reg_issue6709_unbalanced_infix.fz:51:15: error 5: Syntax error: infix operator '+' appears to be postfix operator.
   test011 := a+ (b)                # 5. should flag an error: unbalanced infix `+`
 --------------^
-Whitespace after this operator suggests that 
-it was not intended as an infix operator. 
+Whitespace after this operator suggests that
+it was not intended as an infix operator.
 To fix this, you may try to insert white space before the operator at --CURDIR--/reg_issue6709_unbalanced_infix.fz:51:15:
   test011 := a+ (b)                # 5. should flag an error: unbalanced infix `+`
 --------------^
@@ -57,8 +57,8 @@ Parse stack: opsTail, opExpr, operatorExpr, implFldInit, implFldOrRout, routOrFi
 --CURDIR--/reg_issue6709_unbalanced_infix.fz:61:14: error 6: Syntax error: infix operator '..' appears to be postfix operator.
       i in -4.. +4                # 6. should flag an error: unbalanced infix `..`
 -------------^^
-Whitespace after this operator suggests that 
-it was not intended as an infix operator. 
+Whitespace after this operator suggests that
+it was not intended as an infix operator.
 To fix this, you may try to insert white space before the operator at --CURDIR--/reg_issue6709_unbalanced_infix.fz:61:14:
       i in -4.. +4                # 6. should flag an error: unbalanced infix `..`
 -------------^
@@ -68,8 +68,8 @@ Parse stack: opsTail, opExpr, operatorExpr, exprInLine, indexVar, indexVars, loo
 --CURDIR--/reg_issue6709_unbalanced_infix.fz:69:24: error 7: Syntax error: infix operator '-' appears to be postfix operator.
     for j in low..(high- 1) do    # 7. should flag an error: unbalanced infix `-`
 -----------------------^
-Whitespace after this operator suggests that 
-it was not intended as an infix operator. 
+Whitespace after this operator suggests that
+it was not intended as an infix operator.
 To fix this, you may try to insert white space before the operator at --CURDIR--/reg_issue6709_unbalanced_infix.fz:69:24:
     for j in low..(high- 1) do    # 7. should flag an error: unbalanced infix `-`
 -----------------------^
@@ -79,8 +79,8 @@ Parse stack: opsTail, opExpr, operatorExpr, actualCommas, tuple, klammer, bracke
 --CURDIR--/reg_issue6709_unbalanced_infix.fz:74:27: error 8: Syntax error: infix operator '|>' appears to be postfix operator.
     x3 => 42 |> .as_string|> say  # 8. should flag an error: unbalanced infix `|>`
 --------------------------^^
-Whitespace after this operator suggests that 
-it was not intended as an infix operator. 
+Whitespace after this operator suggests that
+it was not intended as an infix operator.
 To fix this, you may try to insert white space before the operator at --CURDIR--/reg_issue6709_unbalanced_infix.fz:74:27:
     x3 => 42 |> .as_string|> say  # 8. should flag an error: unbalanced infix `|>`
 --------------------------^
@@ -90,8 +90,8 @@ Parse stack: opsTail, opExpr, operatorExpr, expr, exprs, block (twice), implRout
 --CURDIR--/reg_issue6709_unbalanced_infix.fz:75:28: error 9: Syntax error: infix operator '|>' appears to be postfix operator.
     x4 => 42 |>(.as_string)|> say # 9.+10. 2x should flag an error: unbalanced infix `|>`
 ---------------------------^^
-Whitespace after this operator suggests that 
-it was not intended as an infix operator. 
+Whitespace after this operator suggests that
+it was not intended as an infix operator.
 To fix this, you may try to insert white space before the operator at --CURDIR--/reg_issue6709_unbalanced_infix.fz:75:28:
     x4 => 42 |>(.as_string)|> say # 9.+10. 2x should flag an error: unbalanced infix `|>`
 ---------------------------^
@@ -101,8 +101,8 @@ Parse stack: opsTail, opExpr, operatorExpr, expr, exprs, block (twice), implRout
 --CURDIR--/reg_issue6709_unbalanced_infix.fz:75:14: error 10: Syntax error: infix operator '|>' appears to be prefix operator.
     x4 => 42 |>(.as_string)|> say # 9.+10. 2x should flag an error: unbalanced infix `|>`
 -------------^^
-Whitespace before this operator suggests that 
-it was not intended as an infix operator. 
+Whitespace before this operator suggests that
+it was not intended as an infix operator.
 To fix this, you may try to insert white space after the operator at --CURDIR--/reg_issue6709_unbalanced_infix.fz:75:16:
     x4 => 42 |>(.as_string)|> say # 9.+10. 2x should flag an error: unbalanced infix `|>`
 ---------------^
@@ -112,8 +112,8 @@ Parse stack: opsTail, opExpr, operatorExpr, expr, exprs, block (twice), implRout
 --CURDIR--/reg_issue6709_unbalanced_infix.fz:80:15: error 11: Syntax error: infix operator '+' appears to be postfix operator.
     say (123.0+ 456)              # 11. should flag an error: unbalanced infix `+`
 --------------^
-Whitespace after this operator suggests that 
-it was not intended as an infix operator. 
+Whitespace after this operator suggests that
+it was not intended as an infix operator.
 To fix this, you may try to insert white space before the operator at --CURDIR--/reg_issue6709_unbalanced_infix.fz:80:15:
     say (123.0+ 456)              # 11. should flag an error: unbalanced infix `+`
 --------------^
@@ -123,8 +123,8 @@ Parse stack: opsTail, opExpr, operatorExpr, actualCommas, tuple, klammer, bracke
 --CURDIR--/reg_issue6709_unbalanced_infix.fz:81:16: error 12: Syntax error: infix operator '+' appears to be prefix operator.
     say (123.0 +456)              # 12. should flag an error: unbalanced infix `+`
 ---------------^
-Whitespace before this operator suggests that 
-it was not intended as an infix operator. 
+Whitespace before this operator suggests that
+it was not intended as an infix operator.
 To fix this, you may try to insert white space after the operator at --CURDIR--/reg_issue6709_unbalanced_infix.fz:81:17:
     say (123.0 +456)              # 12. should flag an error: unbalanced infix `+`
 ----------------^
@@ -134,8 +134,8 @@ Parse stack: opsTail, opExpr, operatorExpr, actualCommas, tuple, klammer, bracke
 --CURDIR--/reg_issue6709_unbalanced_infix.fz:82:11: error 13: Syntax error: infix operator '-' appears to be postfix operator.
     say (a- b)                    # 13. should flag an error: unbalanced infix `-`
 ----------^
-Whitespace after this operator suggests that 
-it was not intended as an infix operator. 
+Whitespace after this operator suggests that
+it was not intended as an infix operator.
 To fix this, you may try to insert white space before the operator at --CURDIR--/reg_issue6709_unbalanced_infix.fz:82:11:
     say (a- b)                    # 13. should flag an error: unbalanced infix `-`
 ----------^
@@ -145,8 +145,8 @@ Parse stack: opsTail, opExpr, operatorExpr, actualCommas, tuple, klammer, bracke
 --CURDIR--/reg_issue6709_unbalanced_infix.fz:83:11: error 14: Syntax error: infix operator '--' appears to be postfix operator.
     say (a-- b)                   # 14. should flag an error: unbalanced infix `--`
 ----------^^
-Whitespace after this operator suggests that 
-it was not intended as an infix operator. 
+Whitespace after this operator suggests that
+it was not intended as an infix operator.
 To fix this, you may try to insert white space before the operator at --CURDIR--/reg_issue6709_unbalanced_infix.fz:83:11:
     say (a-- b)                   # 14. should flag an error: unbalanced infix `--`
 ----------^
@@ -156,8 +156,8 @@ Parse stack: opsTail, opExpr, operatorExpr, actualCommas, tuple, klammer, bracke
 --CURDIR--/reg_issue6709_unbalanced_infix.fz:90:18: error 15: Syntax error: infix operator '||' appears to be postfix operator.
     chck ($x2="6"|| $x1="6")      # 15. should flag an error: unbalanced infix `||`
 -----------------^^
-Whitespace after this operator suggests that 
-it was not intended as an infix operator. 
+Whitespace after this operator suggests that
+it was not intended as an infix operator.
 To fix this, you may try to insert white space before the operator at --CURDIR--/reg_issue6709_unbalanced_infix.fz:90:18:
     chck ($x2="6"|| $x1="6")      # 15. should flag an error: unbalanced infix `||`
 -----------------^
@@ -167,8 +167,8 @@ Parse stack: opsTail, opExpr, operatorExpr, actualCommas, tuple, klammer, bracke
 --CURDIR--/reg_issue6709_unbalanced_infix.fz:98:98: error 16: Syntax error: infix operator '-' appears to be postfix operator.
                                                                   : ignore_last_buffer_index.get)- 1     # 16. should flag an error: unbalanced infix `-`
 -------------------------------------------------------------------------------------------------^
-Whitespace after this operator suggests that 
-it was not intended as an infix operator. 
+Whitespace after this operator suggests that
+it was not intended as an infix operator.
 To fix this, you may try to insert white space before the operator at --CURDIR--/reg_issue6709_unbalanced_infix.fz:98:98:
                                                                   : ignore_last_buffer_index.get)- 1     # 16. should flag an error: unbalanced infix `-`
 -------------------------------------------------------------------------------------------------^
@@ -178,8 +178,8 @@ Parse stack: opsTail, opExpr, operatorExpr, expr, exprs, block (twice), implRout
 --CURDIR--/reg_issue6709_unbalanced_infix.fz:104:20: error 17: Syntax error: infix operator '+' appears to be postfix operator.
      "  count  |\n"+              # 17. should flag an error: unbalanced infix `+`
 -------------------^
-Whitespace after this operator suggests that 
-it was not intended as an infix operator. 
+Whitespace after this operator suggests that
+it was not intended as an infix operator.
 To fix this, you may try to insert white space before the operator at --CURDIR--/reg_issue6709_unbalanced_infix.fz:104:20:
      "  count  |\n"+              # 17. should flag an error: unbalanced infix `+`
 -------------------^

--- a/tests/reg_issue698_np_excep_in_choice_with_call_to_outer_ref/issue698.fz.expected_err
+++ b/tests/reg_issue698_np_excep_in_choice_with_call_to_outer_ref/issue698.fz.expected_err
@@ -2,7 +2,7 @@
 --CURDIR--/issue698.fz:31:3: error 1: Choice type must not access features of surrounding scope.
   tree(A type : property.orderable) : choice nil (Node A (tree A) (tree A)) is
 --^^^^
-A closure cannot be built for a choice type. Forbidden accesses occur at 
+A closure cannot be built for a choice type. Forbidden accesses occur at
 --CURDIR--/issue698.fz:38:11:
       _ : Node A (tree A) (tree A) is
 ----------^^^^


### PR DESCRIPTION
failing due to merge incongruence