### PR TITLE
parser: fix require condition when `operatorExpr` returns `Call.ERROR`

### DIFF
--- a/src/dev/flang/parser/Parser.java
+++ b/src/dev/flang/parser/Parser.java
@@ -1820,7 +1820,7 @@ exprNoColon : operatorExpr          // may not contain {@code :} unless enclosed
             matchOperator(":", "expr of the form >>a ? b : c<<");
             Expr g = operatorExpr();
             i.end();
-            result = new ParsedCall(result, new ParsedName(result.pos().rangeTo(g.pos().byteEndPos()), "ternary ? :"), new List<>(f, g));
+            result = f == Call.ERROR || g == Call.ERROR ? Call.ERROR : new ParsedCall(result, new ParsedName(result.pos().rangeTo(g.pos().byteEndPos()), "ternary ? :"), new List<>(f, g));
           }
       }
     return result;

--- a/tests/reg_issue7338/Makefile
+++ b/tests/reg_issue7338/Makefile
@@ -1,0 +1,25 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test Makefile
+#
+# -----------------------------------------------------------------------
+
+override NAME = reg_issue7338
+include ../simple.mk

--- a/tests/reg_issue7338/reg_issue7338.fz
+++ b/tests/reg_issue7338/reg_issue7338.fz
@@ -1,0 +1,32 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test reg_issue7338
+#
+# -----------------------------------------------------------------------
+
+
+print_if_present(s String, o option i32) option unit =>
+  say o?       # NYI postfix ? operator not supported yet
+
+v := 10000
+_ := print_if_present "v = "  (v)
+_ := print_if_present "v² = " (v *? v)
+_ := print_if_present "v³ = " (v *? v *? v)
+_ := print_if_present "v⁴ = " (v *? v *? v *? v)

--- a/tests/reg_issue7338/reg_issue7338.fz.expected_err
+++ b/tests/reg_issue7338/reg_issue7338.fz.expected_err
@@ -1,0 +1,9 @@
+
+--CURDIR--/reg_issue7338.fz:26:58: error 1: No line break may occur at this position
+  say o?       # NYI postfix ? operator not supported yet
+---------------------------------------------------------^
+This code is part of an expression that must reside within a single line.
+While parsing: term, parse stack: term, opExpr, operatorExpr (twice), actualSpace, actualSpaces, actualArgs, call, call0, callOrFeatOrThis, term, opExpr, operatorExpr, expr, exprs, block (twice), implRout, routOrField, feature, expr, exprs, block (twice), unit
+To solve this, enclose the expression in parentheses '(' and ')'.
+
+one error.


### PR DESCRIPTION
fixes #7338
