### PR TITLE
base: synchronize read access to `concur.Thread.park_condition`, fix #7320

### DIFF
--- a/modules/base/src/concur/Thread.fz
+++ b/modules/base/src/concur/Thread.fz
@@ -148,7 +148,7 @@ is
   =>
     cond.synchronized ()->
       code()
-      set park_condition := condition
+      set park_condition_var := condition
       set parked := true
       while parked   # perform this in a while to catch spurious wakeups
         cond.wait
@@ -173,9 +173,21 @@ is
 
 
   # for a parked `thread.this`, this holds a condition that must hold for the
-  # thread to be unparked.
+  # thread to be unparked.  All read- and write accesses to this are protected
+  # by `cond.synchronized`.
   #
-  module park_condition ()->bool := ()->true
+  park_condition_var ()->bool := ()->true
+
+
+  # for a parked `thread.this`, the condition that must hold for the thread to
+  # be unparked.
+  #
+  # This will synchronize the read of `park_condition_var` using
+  # `cond.synchronized`.
+  #
+  module park_condition ()->bool =>
+    cond.synchronized ()->
+      park_condition_var
 
 
   # String representation of thread


### PR DESCRIPTION
My understanding is that the missing synchronization here resulted in an outdated value being read by another thread and the parked thread either not being woken up at all or a runtime fault caused when checking a condition that comes from a different context accessing fields of a different instance of `blocking_mutate` (I say a mixture of `channel_mutate i32`'s and `channel_mutate (interval i32)`'s `park_condition`s in flang_dev's channel5.fz).
