### PR TITLE
base: Add precondition to `concur.blocking_mutate.wakeup_next_in_waiting_list`

### DIFF
--- a/modules/base/src/concur/blocking_mutate.fz
+++ b/modules/base/src/concur/blocking_mutate.fz
@@ -93,7 +93,10 @@ public blocking_mutate : mutate is
   # of any waiting thread evaluates to true and, if so, wake up that
   # thread.
   #
-  wakeup_next_in_waiting_list =>
+  wakeup_next_in_waiting_list
+  pre
+    debug: is_exclusive
+  =>
     match waiting.first
       f concur.Thread =>
         for t := f, nxt


### PR DESCRIPTION
This is a private feature, but having this precondition helped me debug #7320 (by not causing a precondition fault).
