### PR TITLE
Improved error messages to better point to source

### DIFF
--- a/src/dev/flang/fuir/FuirErrors.java
+++ b/src/dev/flang/fuir/FuirErrors.java
@@ -116,10 +116,42 @@ public class FuirErrors extends AstErrors
   }
 
 
-  public static void unmetTypeContraint(SourcePosition pos, AbstractType tp, Clazz constraint)
-  {
-    error(pos, "Actual type parameter " + s(tp) + " does not satisfy constraint " + s(constraint._type), "");
-  }
+    public static void unmetTypeContraint(SourcePosition pos, AbstractType tp, Clazz constraint)
+    {
+        // Build the error message
+        StringBuilder fullMsg = new StringBuilder();
+        fullMsg.append("Actual type parameter '").append(s(tp)).append("' does not satisfy constraint '")
+            .append(s(constraint._type)).append("'");
+        
+        // Show the source code with underlining at the error position
+        if (!pos.isBuiltIn())
+        {
+            // Underline the source code at the error position
+            fullMsg.append("\n").append(pos.showInSource());
+        }
+        
+        // Add information about where the type parameter is defined
+        SourcePosition defPos = tp.declarationPos();
+        if (defPos != null && !defPos.isBuiltIn())
+        {
+            fullMsg.append("\nConstraint defined at: ").append(defPos.fileNameWithPosition());
+        }
+        
+        error(pos, fullMsg.toString(), "");
+    }
+
+    // Helper to get source line
+    private static String getSourceLine(SourcePosition pos)
+    {
+        if (pos.isBuiltIn() || pos._sourceFile == null)
+            return "";
+        
+        int line = pos.line();
+        if (line <= 0 || line > pos._sourceFile.numLines())
+            return "";
+        
+        return pos._sourceFile.line(line);
+    }
 
 }
 

--- a/src/dev/flang/fuir/FuirErrors.java
+++ b/src/dev/flang/fuir/FuirErrors.java
@@ -120,21 +120,28 @@ public class FuirErrors extends AstErrors
     {
         // Build the error message
         StringBuilder fullMsg = new StringBuilder();
-        fullMsg.append("Actual type parameter '").append(s(tp)).append("' does not satisfy constraint '")
-            .append(s(constraint._type)).append("'");
+        fullMsg.append("Actual type parameter ").append(s(tp)).append(" does not satisfy constraint ")
+              .append(s(constraint._type));
         
         // Show the source code with underlining at the error position
         if (!pos.isBuiltIn())
         {
-            // Underline the source code at the error position
             fullMsg.append("\n").append(pos.showInSource());
         }
         
         // Add information about where the type parameter is defined
+        // Only show this if it's different from the error position
         SourcePosition defPos = tp.declarationPos();
-        if (defPos != null && !defPos.isBuiltIn())
+        if (defPos != null && !defPos.isBuiltIn() && !defPos.equals(pos))
         {
             fullMsg.append("\nConstraint defined at: ").append(defPos.fileNameWithPosition());
+            // Show the constraint definition too
+            fullMsg.append("\n").append(defPos.showInSource());
+        }
+        else if (defPos != null && !defPos.isBuiltIn())
+        {
+            // If it's the same position, just mention it briefly
+            fullMsg.append("\nConstraint defined at this location");
         }
         
         error(pos, fullMsg.toString(), "");

--- a/src/dev/flang/fuir/FuirErrors.java
+++ b/src/dev/flang/fuir/FuirErrors.java
@@ -147,19 +147,6 @@ public class FuirErrors extends AstErrors
         error(pos, fullMsg.toString(), "");
     }
 
-    // Helper to get source line
-    private static String getSourceLine(SourcePosition pos)
-    {
-        if (pos.isBuiltIn() || pos._sourceFile == null)
-            return "";
-        
-        int line = pos.line();
-        if (line <= 0 || line > pos._sourceFile.numLines())
-            return "";
-        
-        return pos._sourceFile.line(line);
-    }
-
 }
 
 /* end of file */

--- a/src/dev/flang/fuir/GeneratingFUIR.java
+++ b/src/dev/flang/fuir/GeneratingFUIR.java
@@ -2495,12 +2495,20 @@ public class GeneratingFUIR extends FUIR
         if (c.calledFeature() == Types.resolved.f_Type_infix_colon)
           {
             var T = innerClazz.actualTypeParameters()[0];
-            if (!T._type.constraintAssignableFrom(tclazz._type.generics().get(0))
-            // NYI: CLEANUP: need to detect pre condition feature properly!
-             && outerClazz.feature().featureName().isInternal())
-              {
-                FuirErrors.unmetTypeContraint(c.pos(), tclazz._type.generics().get(0), T);
-              }
+            if (!T._type.constraintAssignableFrom(tclazz._type.generics().get(0)))
+            {
+                // Get the position of the actual type parameter usage
+                AbstractType actualType = tclazz._type.generics().get(0);
+                SourcePosition errorPos = actualType.declarationPos(); // Position of the type parameter in the source
+                
+                // If declarationPos is null or built-in, use the call position as fallback
+                if (errorPos == null || errorPos.isBuiltIn())
+                {
+                    errorPos = c.pos();
+                }
+                
+                FuirErrors.unmetTypeContraint(errorPos, actualType, T);
+            }
             cf = T._type.constraintAssignableFrom(tclazz._type.generics().get(0))
               ? Types.resolved.f_Type_infix_colon_true
               : Types.resolved.f_Type_infix_colon_false;

--- a/src/dev/flang/fuir/GeneratingFUIR.java
+++ b/src/dev/flang/fuir/GeneratingFUIR.java
@@ -2497,11 +2497,28 @@ public class GeneratingFUIR extends FUIR
             var T = innerClazz.actualTypeParameters()[0];
             if (!T._type.constraintAssignableFrom(tclazz._type.generics().get(0)))
             {
-                // Get the position of the actual type parameter usage
                 AbstractType actualType = tclazz._type.generics().get(0);
-                SourcePosition errorPos = actualType.declarationPos(); // Position of the type parameter in the source
                 
-                // If declarationPos is null or built-in, use the call position as fallback
+                // Get the position where this type is actually used
+                SourcePosition errorPos = null;
+                
+                // If we have the actual expression that provides this type parameter
+                // we can get its position from the AST
+                if (c.actuals() != null && c.actuals().size() > 0)
+                {
+                    // Find the actual expression that corresponds to this type parameter
+                    for (Expr actual : c.actuals())
+                    {
+                        // Check if this corresponds to the type parameter
+                        if (actual.type() != null && actual.type().equals(actualType))
+                        {
+                            errorPos = actual.pos();
+                            break;
+                        }
+                    }
+                }
+                
+                // Fallback to call position if it couldn't find a better one
                 if (errorPos == null || errorPos.isBuiltIn())
                 {
                     errorPos = c.pos();


### PR DESCRIPTION
Second attempt at solving issue #7187.

For comparison with fz -e 'say [unit].sum' : 
Before : 
```

{base.fum}/Sequence/statistic.fz:97:5: error 1: Actual type parameter 'unit' does not satisfy constraint 'numeric'
    T : numeric


one error.
```


After : 
```

{base.fum}/Sequence/statistic.fz:97:5: error 1: Actual type parameter 'unit' does not satisfy constraint 'numeric'
    T : numeric

Constraint defined at: {base.fum}/unit.fz:84:8:
public unit : property.orderable, property.hashable is

    T : numeric


one error.
```