### PR TITLE
fe: add effect `native_access` to denote access of native code

### DIFF
--- a/modules/base/src/native_access.fz
+++ b/modules/base/src/native_access.fz
@@ -1,0 +1,34 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion standard library feature native_access
+#
+# -----------------------------------------------------------------------
+
+# native_access -- effect to denote access of native code
+#
+private:public native_access : effect is
+
+
+  # default implementation of native_access
+  #
+  # this will get instated automatically at startup
+  #
+  public redef fixed type.default_value option native_access =>
+    native_access

--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -2976,7 +2976,7 @@ public class Call extends AbstractCall
         context.outerFeature() != Types.resolved.f_effect_static_finally &&
         (_calledFeature == Types.resolved.f_effect_finally ||
          _calledFeature.redefinesFull().contains(Types.resolved.f_effect_finally)) &&
-        !res._module.name().equals(FuzionConstants.BASE_MODULE_NAME)
+        !res._module.isBaseModule()
        )
       {
         AstErrors.mustNotCallEffectFinally(this);
@@ -2986,7 +2986,7 @@ public class Call extends AbstractCall
     if (_calledFeature != null &&
         (_calledFeature == Types.resolved.f_effect_default_value ||
          _calledFeature.redefinesFull().contains(Types.resolved.f_effect_default_value)) &&
-        !res._module.name().equals(FuzionConstants.BASE_MODULE_NAME)
+        !res._module.isBaseModule()
        )
       {
         AstErrors.mustNotCallEffectDefaultValue(this);
@@ -3130,6 +3130,14 @@ public class Call extends AbstractCall
           {
             _calledFeature = cf.preAndCallFeature();
           }
+      }
+    if (_calledFeature != null && _calledFeature.isNative() && !res._module.isBaseModule())
+      {
+        var nativeAccessFromEnv = new ParsedCall(
+          Call.typeAsValue(SourcePosition.notAvailable, new ParsedType(SourcePosition.notAvailable, "native_access")),
+          new ParsedName(SourcePosition.notAvailable, "from_env"));
+        var replace = new ParsedCall(nativeAccessFromEnv, new ParsedName(SourcePosition.notAvailable, "replace"));
+        result = new Block(new List<>(replace.resolveTypes(res, context), result));
       }
     return result;
   }

--- a/src/dev/flang/ast/SrcModule.java
+++ b/src/dev/flang/ast/SrcModule.java
@@ -75,6 +75,7 @@ public interface SrcModule extends AbstractModule
                  Feature         innerType);
   void addTypeParameter(AbstractFeature outerType,
                         Feature         innerType);
+  boolean isBaseModule();
 
   /*----------------------  methods needed by AIR  ----------------------*/
 

--- a/src/dev/flang/fe/SourceModule.java
+++ b/src/dev/flang/fe/SourceModule.java
@@ -2163,6 +2163,13 @@ A feature that is a constructor, choice or a type parameter may not redefine an 
       }
   }
 
+
+  @Override
+  public boolean isBaseModule()
+  {
+    return !_options._loadBaseMod;
+  }
+
 }
 
 /* end of file */

--- a/tests/mod_sqlite/mod_sqlite.fz.effect
+++ b/tests/mod_sqlite/mod_sqlite.fz.effect
@@ -1,0 +1,11 @@
+concur.Threads
+fuzion.runtime.check_fault
+fuzion.runtime.contract_fault
+fuzion.runtime.fault
+fuzion.runtime.post_fault
+fuzion.runtime.pre_fault
+fuzion.runtime.stackoverflow
+io.Err
+io.Out
+native_access
+panic


### PR DESCRIPTION
Idea is that `fz -effects` shows if applications uses any native code.