### PR TITLE
fe: fix type pars not handed down via targets of inheritance calls

### DIFF
--- a/src/dev/flang/ast/AbstractFeature.java
+++ b/src/dev/flang/ast/AbstractFeature.java
@@ -1484,6 +1484,7 @@ public abstract class AbstractFeature extends Expr implements Comparable<Abstrac
    */
   private static List<AbstractType> handDownListThroughInheritsCall(List<AbstractType> l, int select, AbstractCall c)
   {
+    // NYI: BUG: it is not really sufficient to only do this for targets that are calls
     return (c.target() instanceof AbstractCall ac
         ? handDownListThroughInheritsCall(l, ac.select(), ac)
         : l)

--- a/src/dev/flang/ast/AbstractFeature.java
+++ b/src/dev/flang/ast/AbstractFeature.java
@@ -1469,11 +1469,25 @@ public abstract class AbstractFeature extends Expr implements Comparable<Abstrac
 
     for (AbstractCall c : inh)
       {
-        var cf = c.calledFeature();
-        var actualTypes = c.actualTypeParameters();
-        l = l.flatMap(t -> t.applyTypeParsMaybeOpen(cf, actualTypes, select));
+        l = handDownListThroughInheritsCall(l, select, c);
       }
     return l;
+  }
+
+
+  /**
+   * Hand down l in the inheritance call c
+   *
+   * @param l the list of types to be handed down.
+   *
+   * @param c the inheritance call where l is supposed to be handed down
+   */
+  private static List<AbstractType> handDownListThroughInheritsCall(List<AbstractType> l, int select, AbstractCall c)
+  {
+    return (c.target() instanceof AbstractCall ac
+        ? handDownListThroughInheritsCall(l, ac.select(), ac)
+        : l)
+      .flatMap(t -> t.applyTypeParsMaybeOpen(c.calledFeature(), c.actualTypeParameters(), select));
   }
 
 

--- a/tests/reg_issue7436/Makefile
+++ b/tests/reg_issue7436/Makefile
@@ -1,0 +1,25 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test Makefile
+#
+# -----------------------------------------------------------------------
+
+override NAME = reg_issue7436
+include ../simple.mk

--- a/tests/reg_issue7436/reg_issue7436.fz
+++ b/tests/reg_issue7436/reg_issue7436.fz
@@ -1,0 +1,40 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test reg_issue7436
+#
+# -----------------------------------------------------------------------
+
+buffered_ (LM type : mutate) is
+  Writer_ ref : effect is
+    buffer := container.Ring_Buffer u8 LM 10
+    a =>
+      say buffer
+
+lm : mutate is
+
+std_in_writer(LM type : mutate) : (buffered_ LM).Writer_ is
+
+b (LM type : mutate) =>
+
+  (buffered_ LM).Writer_.instate _ (std_in_writer LM) ()->
+    (buffered_ LM).Writer_.env.a
+
+lm ! ()->
+  b lm

--- a/tests/reg_issue7436/reg_issue7436.fz.expected_out
+++ b/tests/reg_issue7436/reg_issue7436.fz.expected_out
@@ -1,0 +1,1 @@
+instance[container.Ring_Buffer u8 lm]


### PR DESCRIPTION
This is/was an issue that came up in #7355, where type pars where not handed down properly like in:
`writer (desc File_Descriptor) : io.buffered file_mutate .Writer is`

fixes #7436
