### PR TITLE
Move helper features `String`/`Sequence.execute` from scripts to module `tokiwa`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -257,7 +257,7 @@ $(BUILD_DIR)/%.md: $(FZ_SRC)/%.md
 
 $(FUZION_EBNF): $(FUZION_BASE) $(FZ_SRC)/bin/ebnf.fz
 	mkdir -p $(@D)
-	$(FZ) $(FZ_SRC)/bin/ebnf.fz $(JAVA_FILES_PARSER) > $@
+	$(FZ) -modules=tokiwa $(FZ_SRC)/bin/ebnf.fz $(JAVA_FILES_PARSER) > $@
 
 ifeq ($(FUZION_REPRODUCIBLE_BUILD),true)
 SED_DATE_AND_BUILTBY = "s^@@DATE@@^^g;s^@@BUILTBY@@^^g"

--- a/bin/check_simple_example.fz
+++ b/bin/check_simple_example.fz
@@ -23,10 +23,6 @@
 
 ########### Extensions ###############
 
-# used for protecting spaces when splitting command string
-#
-protected_space := codepoint codepoint.utf8_encoded_in_four_bytes.as_list.last.or_panic
-
 is_windows =>
   os.platform.or_panic ? os.windows => true | os.posix => false
 
@@ -90,37 +86,6 @@ envir_vars :=
       .as_array))
   .add "FUZION_DISABLE_ANSI_ESCAPES" "true"
 
-# execute this Sequence of process+args
-#
-Sequence.execute(
-  # feed .stdin file to executed process?
-  feed_stdin bool
-) =>
-  seq := map (.as_string)
-  match os.process.start seq.first.or_panic (seq.drop 1) envir_vars
-    e error => panic "failed executing $(Sequence.this), error is $e"
-    p os.process =>
-      feed option io.path :=
-        if feed_stdin
-          io.path.of "$file.stdin"
-        else
-          nil
-      tokiwa.record_process p Sequence.this.as_string cpu_time_limit feed
-
-# execute this string by splitting at all whitespaces
-#
-String.execute(
-  # feed .stdin file to executed process?
-  feed_stdin bool
-) =>
-  split_if (=" ")
-    .map (.replace protected_space " ")
-    .execute feed_stdin
-
-# execute this string by splitting at all whitespaces
-#
-String.execute =>
-  String.this.execute false
 
 
 ############################################################################
@@ -153,22 +118,18 @@ check_exit_code(run tokiwa.process_result) =>
 #
 clean_err(f io.path) =>
 
-  tokiwa.process_result.or_panic =>
-    if !ok
-      panic "one of the sed executions failed"
-
   if is_windows
-    "sed -i s|/|#|g $f".execute .or_panic
+    "sed -i s|/|#|g $f".execute envir_vars nil cpu_time_limit .or_panic.panic_on_error
     # 8 slashes here intentional, unclear why so many are needed though...
-    "sed -i s|\\\\\\\\|#|g $f".execute .or_panic
-    "sed -i s|$(os.cwd.or_panic.as_string.replace "\\" "#" .replace "/" "#")|--CURDIR--| $f".execute .or_panic
-    "sed -i s|$(("$(os.cwd.or_panic.as_string.substring 1 2):$(os.cwd.or_panic.as_string.substring 2)").replace "\\" "#" .replace "/" "#")|--CURDIR--| $f".execute .or_panic
-  "sed -i s#$(os.cwd.or_panic.as_string)#--CURDIR--# $f".execute .or_panic
+    "sed -i s|\\\\\\\\|#|g $f".execute envir_vars nil cpu_time_limit .or_panic.panic_on_error
+    "sed -i s|$(os.cwd.or_panic.as_string.replace "\\" "#" .replace "/" "#")|--CURDIR--| $f".execute envir_vars nil cpu_time_limit .or_panic.panic_on_error
+    "sed -i s|$(("$(os.cwd.or_panic.as_string.substring 1 2):$(os.cwd.or_panic.as_string.substring 2)").replace "\\" "#" .replace "/" "#")|--CURDIR--| $f".execute envir_vars nil cpu_time_limit .or_panic.panic_on_error
+  _ := "sed -i s#$(os.cwd.or_panic.as_string)#--CURDIR--# $f".execute .or_panic
   # line numbers
-  "sed -E -i s/\\.fz:[0-9]+:[0-9]+:/\\.fz:n:n:/g $f".execute .or_panic
-  "sed -E -i s/\\.(fz|java):[0-9]+/\\.\\1:n/g $f".execute .or_panic
+  "sed -E -i s/\\.fz:[0-9]+:[0-9]+:/\\.fz:n:n:/g $f".execute envir_vars nil cpu_time_limit .or_panic.panic_on_error
+  "sed -E -i s/\\.(fz|java):[0-9]+/\\.\\1:n/g $f".execute envir_vars nil cpu_time_limit .or_panic.panic_on_error
   # replace CLASS_PREFIX_WITH_ID
-  "sed -E -i s/fzC__L[0-9]+/fzC_LXXX/g $f".execute .or_panic
+  "sed -E -i s/fzC__L[0-9]+/fzC_LXXX/g $f".execute envir_vars nil cpu_time_limit .or_panic.panic_on_error
 
 
 # delete temporary files
@@ -192,6 +153,7 @@ be     := envir.Args.env[1]
 # can not execute bash script fz on windows with CreateProcess
 fz_run := envir.Args.env[2].replace "../../bin/fz" "java $(is_windows ? "-Dsun.stdout.encoding=UTF-8 -Dsun.stderr.encoding=UTF-8" : "") --enable-preview --enable-native-access=ALL-UNNAMED --class-path ../../classes $(envir.Vars.env["FUZION_JAVA_OPTIONS"].or_else "") -Xss5m -Dline.separator=\n -Dfile.encoding=UTF-8 -Dfuzion.home=../../ -Dfuzion.command=fz dev.flang.tools.Fuzion"
 file   := envir.Args.env[3]
+input  := io.path.of "$file.stdin"
 exp_out := if be = "effect"
              io.path.of "$file.effect"
            else
@@ -213,7 +175,7 @@ else
 
     bt := concur.Threads.env.spawn ()->
       time.Nano.env.sleep cpu_time_limit
-      say "$("*** CANCELLED:".bold.red) test $file exceeded cpu time limit of $cpu_time_limit s"
+      say "$("*** CANCELLED:".bold.red) test $file exceeded cpu time limit of $cpu_time_limit"
       Exit.env.exit 1
 
     concur.Threads.env.detach bt
@@ -222,14 +184,14 @@ else
       s := envir.Vars.env
                 .get x
                 .or_default ""
-                .replace " " protected_space
+                .replace " " tokiwa.protected_space
                 .split "|"
       String.join s " "
 
     if be = "c"
-      compile := "$fz_run -XmaxErrors=-1 -c $(backend_options "FUZION_C_BACKEND_OPTIONS") $file -o=testbin".execute
+      compile := "$fz_run -XmaxErrors=-1 -c $(backend_options "FUZION_C_BACKEND_OPTIONS") $file -o=testbin".execute envir_vars nil cpu_time_limit .or_panic
       if compile.ok
-        run := "./testbin".execute true
+        run := "./testbin".execute envir_vars input cpu_time_limit .or_panic
 
         check_exit_code run
 
@@ -239,21 +201,21 @@ else
         io.write (io.path.of "tmp_out.txt") compile.out .or_panic
         io.write (io.path.of "tmp_err.txt") compile.err .or_panic
     else if be = "jvm"
-      run := "$fz_run -XmaxErrors=-1 -jvm $(backend_options "FUZION_JVM_BACKEND_OPTIONS") $file".execute true
+      run := "$fz_run -XmaxErrors=-1 -jvm $(backend_options "FUZION_JVM_BACKEND_OPTIONS") $file".execute envir_vars input cpu_time_limit .or_panic
 
       check_exit_code run
 
       io.write (io.path.of "tmp_out.txt") run.out .or_panic
       io.write (io.path.of "tmp_err.txt") run.err .or_panic
     else if be = "int"
-      run := "$fz_run -XmaxErrors=-1 -interpreter $file".execute true
+      run := "$fz_run -XmaxErrors=-1 -interpreter $file".execute envir_vars input cpu_time_limit .or_panic
 
       check_exit_code run
 
       io.write (io.path.of "tmp_out.txt") run.out .or_panic
       io.write (io.path.of "tmp_err.txt") run.err .or_panic
     else if be = "effect"
-      run := "$fz_run -XmaxErrors=-1 -effects $file".execute
+      run := "$fz_run -XmaxErrors=-1 -effects $file".execute envir_vars nil cpu_time_limit .or_panic
 
       check_exit_code run
 
@@ -261,14 +223,14 @@ else
     else
       panic "backend unknown: $be"
 
-    out := "diff --strip-trailing-cr $(exp_out) tmp_out.txt".execute
+    out := "diff --strip-trailing-cr $(exp_out) tmp_out.txt".execute envir_vars nil cpu_time_limit .or_panic
 
     err :=
       if be != "effect"
         io.copy exp_err exp_err_cleaned .or_panic
         clean_err (io.path.of "tmp_err.txt")
         clean_err exp_err_cleaned
-        "diff --strip-trailing-cr $(exp_err_cleaned) tmp_err.txt".execute
+        "diff --strip-trailing-cr $(exp_err_cleaned) tmp_err.txt".execute envir_vars nil cpu_time_limit .or_panic
       else
         tokiwa.process_result.empty_success
 

--- a/bin/ebnf.fz
+++ b/bin/ebnf.fz
@@ -29,59 +29,6 @@ main =>
 
   ########### Extensions ###############
 
-  # execute this Sequence of process+args
-  # return what we read from stdout as the result
-  #
-  Sequence.prefix ! String =>
-
-    lm : mutate is
-
-    lm ! ()->
-      seq := map (.as_string)
-      match os.process.start seq.first.or_panic (seq.drop 1)
-        e error => panic "failed executing $(Sequence.this), error is $e"
-        p os.process =>
-          res :=
-            match p.with_out String lm (()->String.from (io.buffered lm).read_fully)
-              e error => panic "failed reading stdout from $(Sequence.this), error is: $e"
-              s String => s.trim_end
-          err :=
-            match p.with_err String lm (()->String.from (io.buffered lm).read_fully)
-              e error => panic "failed reading stderr from $(Sequence.this), error is: $e"
-              s String => s.trim_end
-          ec := p.wait.or_default 1
-          if ec != 0
-            panic "error $ec when executing $seq, stderr: $err"
-          res
-
-
-  # feed this string to a new process
-  # return what we read from stdout as the result
-  #
-  String.infix | (seq Sequence String) String =>
-
-    lm : mutate is
-
-    lm ! ()->
-      match os.process.start seq.first.or_panic (seq.drop 1)
-        e error => panic "failed executing $seq, error is $e"
-        p os.process =>
-          _ := p.with_in unit lm ()->
-            _ := (io.buffered lm).Writer.env.write String.this
-            _ := (io.buffered lm).Writer.env.flush
-            _ := p.wait # close stdin
-          match p.with_out String lm (()->String.from (io.buffered lm).read_fully)
-            e error => panic "failed reading stdout from $seq, error is: $e"
-            s String => s
-
-
-  # execute this string by splitting at all whitespaces
-  # return what we read from stdout as the result
-  #
-  String.prefix !! String =>
-    !split
-
-
   # check if exe is installed by trying
   # to execute it once
   #
@@ -179,10 +126,10 @@ main =>
     say ebnf
 
     # test grammar with antlr4
-    tmp := !!"mktemp --directory"
-    _ := !!"mkdir $tmp/fuzion_grammar"
+    tmp := "mktemp --directory".execute.or_panic.out_or_panic.trim_end (id (Unary bool codepoint) (="\n"))
+    "mkdir $tmp/fuzion_grammar".execute.or_panic.panic_on_error
     _ := io.write (io.path.of "$tmp/fuzion_grammar/Fuzion.g4") ebnf
     antlr := if (os.process.start "antlr4").bind u32 p->p.wait = 0 then "antlr4" else "antlr"
     # NYI: UNDER DEVELOPMENT: add option -Werror
-    _ := !!"$antlr -long-messages -o $tmp/fuzion_grammar $tmp/fuzion_grammar/Fuzion.g4"
-    _ := !!"rm -Rf $tmp"
+    "$antlr -long-messages -o $tmp/fuzion_grammar $tmp/fuzion_grammar/Fuzion.g4".execute.or_panic.panic_on_error
+    "rm -Rf $tmp".execute.or_panic.panic_on_error

--- a/bin/record_simple_example.fz
+++ b/bin/record_simple_example.fz
@@ -24,10 +24,6 @@
 
 ########### Extensions ###############
 
-# used for protecting spaces when splitting command string
-#
-protected_space := codepoint codepoint.utf8_encoded_in_four_bytes.as_list.last.or_panic
-
 # envir vars as map
 #
 envir_vars := container.map_of ((envir.Vars.env.map_of [
@@ -56,38 +52,6 @@ envir_vars := container.map_of ((envir.Vars.env.map_of [
     "LANGUAGE"
   ]).items ++ [("FUZION_DISABLE_ANSI_ESCAPES", "true")])
 
-# execute this Sequence of process+args
-#
-Sequence.execute(
-  # feed .stdin file to executed process?
-  feed_stdin bool
-) =>
-  seq := map (.as_string)
-  match os.process.start seq.first.or_panic (seq.drop 1) envir_vars
-    e error => panic "failed executing $(Sequence.this), error is $e"
-    p os.process =>
-      feed option io.path :=
-        if feed_stdin
-          io.path.of "$file.stdin"
-        else
-          nil
-      tokiwa.record_process p Sequence.this.as_string nil feed
-
-# execute this string by splitting at all whitespaces
-#
-String.execute(
-  # feed .stdin file to executed process?
-  feed_stdin bool
-) =>
-  split_if (=" ")
-    .map (.replace protected_space " ")
-    .execute feed_stdin
-
-# execute this string by splitting at all whitespaces
-#
-String.execute =>
-  String.this.execute false
-
 
 ####### record_simple_example ########
 
@@ -103,22 +67,23 @@ if envir.Args.env.count != 4
 type_    := envir.Args.env[1]
 fz_run   := envir.Args.env[2] # NYI: UNDER DEVELOPMENT: code should be same as check_simple_example.fz
 file     := envir.Args.env[3]
+input    := io.path.of "$file.stdin"
 
-res :=
+res tokiwa.process_result :=
   if type_ = "jvm" || type_ = "any"
-    "$fz_run -XmaxErrors=-1 -jvm $(envir.Vars.env["FUZION_JVM_BACKEND_OPTIONS"].or_default "") $file".execute true
+    "$fz_run -XmaxErrors=-1 -jvm $(envir.Vars.env["FUZION_JVM_BACKEND_OPTIONS"].or_default "") $file".execute envir_vars input nil .or_panic
   else if type_ = "c"
-    c := "$fz_run -XmaxErrors=-1 -c $(envir.Vars.env["FUZION_C_BACKEND_OPTIONS"].or_default "") -o=testbin $file".execute true
+    c := "$fz_run -XmaxErrors=-1 -c $(envir.Vars.env["FUZION_C_BACKEND_OPTIONS"].or_default "") -o=testbin $file".execute envir_vars input nil .or_panic
     if (c.exit_code = 0)
-      e := "./testbin".execute
+      e := "./testbin".execute envir_vars nil nil .or_panic
       _ := io.file.delete (io.path.of "testbin")
       tokiwa.process_result c.out+e.out c.err+e.err e.exit_code
     else
       c
   else if type_ = "int"
-    "$fz_run -XmaxErrors=-1 -interpreter $file".execute true
+    "$fz_run -XmaxErrors=-1 -interpreter $file".execute envir_vars input nil .or_panic
   else if type_ = "effect"
-    "$fz_run -XmaxErrors=-1 -effects $file".execute
+    "$fz_run -XmaxErrors=-1 -effects $file".execute envir_vars nil nil .or_panic
   else
     panic "not supported"
 

--- a/bin/run_tests.fz
+++ b/bin/run_tests.fz
@@ -45,37 +45,6 @@ envir_vars := envir.Vars.env.map_of [
 #
 max_test_time := (time.duration.min 10)
 
-# execute this Sequence of process+args
-#
-Sequence.prefix ! =>
-  seq := map (.as_string)
-  os.process.start seq.first.or_panic (seq.drop 1) envir_vars
-            .bind (p -> tokiwa.record_process p Sequence.this.as_string max_test_time nil)
-
-
-# feed this string to a new process
-#
-String.infix | (seq Sequence String) =>
-
-  lm : mutate is
-  lm ! ()->
-    match os.process.start seq.first.or_panic (seq.drop 1) envir_vars
-      e error => panic "failed executing $seq, error is $e"
-      p os.process =>
-        _ := p.with_in unit lm ()->
-          # NYI: ambiguous result type:
-          # _ := write_to lm
-          _ := (io.buffered lm).Writer.env.write String.this
-          _ := (io.buffered lm).Writer.env.flush
-          _ := p.close_in
-        tokiwa.record_process p seq.as_string max_test_time nil
-
-
-# execute this string by splitting at all whitespaces
-#
-String.prefix !! =>
-  !split
-
 
 append_line(mtx concur.sync.mutex, dest io.path, str String) =>
   mtx.synchronized ()->
@@ -131,9 +100,9 @@ main =>
   # first, try third arg then try a few executables, if everything fails use default value
   thread_count :=
       envir.Vars.env["FUZION_RUN_TESTS_PARALLELISM"]  .flat_map (    .trim.parse_i32) .first
-        .or_else (     (!!"nproc --all"              ).flat_map (.out.trim.parse_i32) .first
-          .or_else (   (!!"getconf _NPROCESSORS_ONLN").flat_map (.out.trim.parse_i32) .first
-            .or_else ( (!!"sysctl -n hw.ncpu"        ).flat_map (.out.trim.parse_i32) .first
+        .or_else (    "nproc --all"              .execute.flat_map (.out.trim.parse_i32) .first
+          .or_else (  "getconf _NPROCESSORS_ONLN".execute.flat_map (.out.trim.parse_i32) .first
+            .or_else ("sysctl -n hw.ncpu"        .execute.flat_map (.out.trim.parse_i32) .first
               .or_else 4)))
 
   tests := find_tests (build_dir.resolve "tests")
@@ -160,7 +129,7 @@ main =>
     else
 
       opt_res, elapsed_time := time.stopwatch _ ()->
-            !!"make $target --environment-overrides --directory=$test"
+            "make $target --environment-overrides --directory=$test".execute envir_vars nil max_test_time
 
       test_durations.put test elapsed_time
 

--- a/modules/tokiwa/src/tokiwa.fz
+++ b/modules/tokiwa/src/tokiwa.fz
@@ -26,6 +26,62 @@
 #
 public tokiwa is
 
+  # used for protecting spaces when splitting command string
+  #
+  public protected_space codepoint =>
+    codepoint 0x10ffff # last Unicode codepoint, a noncharacter reserved for internal use
+
+
+  # execute this Sequence of process+args
+  #
+  public Sequence.execute(
+    # environment variables
+    env_vars option (container.Map String String),
+
+    # feed .stdin file to executed process?
+    feed_stdin option io.path,
+
+    # maximum time to wait for the execution to finish
+    timeout option time.duration
+  ) outcome tokiwa.process_result =>
+    seq := map (.as_string)
+    ( if env_vars.ok
+        os.process.start seq.first.or_panic (seq.drop 1) env_vars.or_panic
+      else
+        os.process.start seq.first.or_panic (seq.drop 1)
+    ).bind p->
+      tokiwa.record_process p Sequence.this.as_string timeout feed_stdin
+
+  # execute this string by splitting at all whitespaces
+  #
+  public String.execute(
+    # environment variables
+    env_vars option (container.Map String String),
+
+    # feed .stdin file to executed process?
+    feed_stdin option io.path,
+
+    # maximum time to wait for the execution to finish
+    timeout option time.duration
+  ) outcome tokiwa.process_result =>
+    split_if (=" ")
+      .map (.replace tokiwa.protected_space " ")
+      .execute env_vars feed_stdin timeout
+
+  # execute this string by splitting at all whitespaces
+  #
+  public String.execute(
+    # environment variables
+    env_vars option (container.Map String String)
+  ) outcome tokiwa.process_result =>
+    String.this.execute env_vars nil nil
+
+  # execute this string by splitting at all whitespaces
+  #
+  public String.execute outcome tokiwa.process_result =>
+    String.this.execute nil nil nil
+
+
   #
   # send something to our influx database
   #
@@ -45,6 +101,12 @@ public tokiwa is
   public process_result(public out, err String, public exit_code u32) is
 
     public ok bool => exit_code = 0
+
+    public panic_on_error unit =>
+      if !ok then panic "$(exit_code): $(err)"
+
+    public out_or_panic String =>
+      if ok then out else panic "$(exit_code): $(err)"
 
 
     public type.empty_success tokiwa.process_result =>

--- a/tests/lsp/lsp.fz
+++ b/tests/lsp/lsp.fz
@@ -23,10 +23,6 @@
 
 ########### Extensions ###############
 
-# used for protecting spaces when splitting command string
-#
-protected_space := codepoint codepoint.utf8_encoded_in_four_bytes.as_list.last.or_panic
-
 # envir vars as map
 #
 envir_vars := container.map_of ((envir.Vars.env.map_of [
@@ -99,27 +95,6 @@ record_process(
       tokiwa.process_result (String.join_lines fout.get) "" 1
     ec u32 =>
       tokiwa.process_result (String.join_lines fout.get) "" ec
-
-# execute this Sequence of process+args
-#
-Sequence.execute(
-  # feed .stdin file to executed process?
-  feed_stdin Sequence (String, i32)
-) =>
-  seq := map (.as_string)
-  match os.process.start seq.first.or_panic (seq.drop 1) envir_vars
-    e error => panic "failed executing $(Sequence.this), error is $e"
-    p os.process => record_process p Sequence.this.as_string feed_stdin
-
-# execute this string by splitting at all whitespaces
-#
-String.execute(
-  # feed .stdin file to executed process?
-  feed_stdin Sequence (String, i32)
-) =>
-  split_if (=" ")
-    .map (.replace protected_space " ")
-    .execute feed_stdin
 
 
 ############################################################################


### PR DESCRIPTION
fix #7348

`check_simple_example` got extremely slow. Running `make -C build/tests/hello` (witch check_simple_example already compiled) takes 15 MINUTES instead of like 12 seconds. But it seems to work.

Running it in jvm got also slower, though I think not that extreme.
```
fz -debug=0 -modules=terminal,tokiwa bin/check_simple_example.fz jvm "fz" tests/hello/HelloWorld.fz
```