### PR TITLE
base: remove confusing effect instatement feature `infix <-`

### DIFF
--- a/modules/base/src/effect.fz
+++ b/modules/base/src/effect.fz
@@ -243,17 +243,6 @@ public effect is
     code -> instate_self code
 
 
-  # infix variant of effect.instate
-  #
-  # use it like this:
-  #
-  #     effect_type <- effect_instance ! code
-  #
-  public type.infix <- (E type : effect, e E) effect_to_be_instated E =>
-    effect_to_be_instated e
-
-
-
   # has an effect of this type been instated?
   #
   public type.is_instated bool => is_instated0
@@ -421,27 +410,3 @@ instate_helper(# result type
       set res := def cur_e
 
 
-
-# a constructor for holding an effect type and instance that is to be instated
-#
-# this allows defining operators to instate effects like
-#
-#     effect_type <- effect_instance ! code
-#
-private:public effect_to_be_instated(E type : effect, e E) is
-
-
-  # infix variant of effect.instate
-  #
-  # use it like this:
-  #
-  #     effect_type <- effect_instance ! code
-  #
-  public infix !(# result type
-                 R type,
-
-                 # the code to execute with `e` instated.
-                 code () -> R
-  ) R
-  =>
-    E.instate R e code

--- a/modules/base/src/state.fz
+++ b/modules/base/src/state.fz
@@ -132,7 +132,7 @@ public state(S type, initial_value S) state unit S => state unit initial_value o
 #
 public state(S, R type, initial_value S, r ()->R) R =>
   res option R := nil
-  (state unit S) <- (state unit S unit initial_value oneway_monad_mode.inst) ! (()->set res := r.call)
+  (state unit S).instate _ (state unit S unit initial_value oneway_monad_mode.inst) (()->set res := r.call)
   res.or_panic
 
 


### PR DESCRIPTION
fix #6713
