### PR TITLE
base: better error for failing `switch.or_panic`

### DIFF
--- a/modules/base/src/switch.fz
+++ b/modules/base/src/switch.fz
@@ -160,7 +160,7 @@ is
   # get A or panic with `B.as_string`
   #
   public or_panic A =>
-    or_panic ($)
+    or_panic b->"'switch.or_panic' called on '$(switch.this.type.name)' that is '$b'"
 
 
   # get A or panic with result of `msg`

--- a/tests/reg_issue5064/reg_issue5064.fz.expected_err_c
+++ b/tests/reg_issue5064/reg_issue5064.fz.expected_err_c
@@ -1,1 +1,1 @@
-*** failed *** panic ***: `--nil--`
+*** failed *** panic ***: `'switch.or_panic' called on 'option Stack.Node' that is '--nil--'`

--- a/tests/reg_issue5064/reg_issue5064.fz.expected_err_int
+++ b/tests/reg_issue5064/reg_issue5064.fz.expected_err_int
@@ -1,5 +1,5 @@
 
-error 1: FATAL FAULT `*** panic ***`: --nil--
+error 1: FATAL FAULT `*** panic ***`: 'switch.or_panic' called on 'option Stack.Node' that is '--nil--'
 Call stack:
 fuzion.type.runtime.type.fault.type.default_value.(λkind_and_msg-> kind, msg := kind_and_m...).call#1: {base.fum}/fuzion/runtime/fault.fz:63:7:
       fuzion.sys.fatal_fault kind msg
@@ -20,8 +20,8 @@ panic#1: {base.fum}/panic.fz:53:19:
       b B => panic (msg b)
 -------------^^^^^^^^^^^^^
 (option Stack.Node).or_panic: {base.fum}/switch.fz:163:5:
-    or_panic ($)
-----^^^^^^^^^^^^
+    or_panic b->"'switch.or_panic' called on '$(switch.this.type.name)' that is '$b'"
+----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Stack.push#2 i32: --CURDIR--/reg_issue5064.fz:46:10:
     _ := top.or_panic
 ---------^^^^^^^^^^^^

--- a/tests/reg_issue5064/reg_issue5064.fz.expected_err_jvm
+++ b/tests/reg_issue5064/reg_issue5064.fz.expected_err_jvm
@@ -1,9 +1,9 @@
 
-error 1: FATAL FAULT `*** panic ***`: --nil--
+error 1: FATAL FAULT `*** panic ***`: 'switch.or_panic' called on 'option Stack.Node' that is '--nil--'
 Call stack:
 fuzion.sys.fatal_fault#2 at {base.fum}/fuzion/sys.fz:55
 [..]
-panic#1 at {base.fum}/panic.fz:59
+panic#1 at {base.fum}/panic.fz:53
 (option Stack.Node).or_panic#1 at {base.fum}/switch.fz:171
 (option Stack.Node).or_panic at {base.fum}/switch.fz:163
 Stack.push#2 i32 at --CURDIR--/reg_issue5064.fz:46


### PR DESCRIPTION
The error before looked like this

     > ./build/bin/fz -modules=base -e '_ := option i32 nil .or_panic'

    error 1: FATAL FAULT `*** panic ***`: --nil--
    Call stack:
    [...]

Now we we get

     > ./build/bin/fz -modules=base -e '_ := option i32 nil .or_panic'

    error 1: FATAL FAULT `*** panic ***`: 'switch.or_panic' called on 'option i32' that is '--nil--'
    Call stack:
    [...]
