### PR TITLE
base: rename `time.duration.times` to `time.duration.scale`

### DIFF
--- a/benchmarks/priority_queue_benchmark.fz
+++ b/benchmarks/priority_queue_benchmark.fz
@@ -121,14 +121,14 @@ priority_queue_benchmark =>
       say "average"
       enq_hist.for_each szh->(sz,h := szh; say "$(sz.as_string.pad_left 9): $(h.average.as_string_pad)")
       say "\naverage / log_2"
-      enq_hist.for_each szh->(sz,h := szh; say "$(sz.as_string.pad_left 9): $(h.average.times (f64.one / (sz.as_f64.log 2)) .as_string_pad)")
+      enq_hist.for_each szh->(sz,h := szh; say "$(sz.as_string.pad_left 9): $(h.average.scale (f64.one / (sz.as_f64.log 2)) .as_string_pad)")
       enq_hist.for_each szh->(_ ,h := szh; say h)
 
       say "\n\nDEQUEUE:\n"
       say "average"
       deq_hist.for_each szh->(sz,h := szh; say "$(sz.as_string.pad_left 9): $(h.average.as_string_pad)")
       say "\naverage / log_2"
-      deq_hist.for_each szh->(sz,h := szh; say "$(sz.as_string.pad_left 9): $(h.average.times (f64.one / (sz.as_f64.log 2)) .as_string_pad)")
+      deq_hist.for_each szh->(sz,h := szh; say "$(sz.as_string.pad_left 9): $(h.average.scale (f64.one / (sz.as_f64.log 2)) .as_string_pad)")
       deq_hist.for_each szh->(_ ,h := szh; say h)
 
 
@@ -208,7 +208,7 @@ priority_queue_benchmark =>
           hist_mk_heap.add (time.stopwatch ()->(q := container.Binary_Heap_Queue m T .from elements; _:=q))
 
       say """
-          $(hist_mk_heap.average.times (1.0 / elements.length.as_f64) .as_string_pad) \
+          $(hist_mk_heap.average.scale (1.0 / elements.length.as_f64) .as_string_pad) \
           per element for $(elements.length.as_string.pad_left (test_lengths.last.or_panic.as_string.byte_count)) \
           $elem_desc elements. Total time was $(hist_mk_heap.average.as_string_pad)"""
 

--- a/examples/jitter/jitter.fz
+++ b/examples/jitter/jitter.fz
@@ -142,7 +142,7 @@ jitter =>
 
     match flow.exception jitter_too_high .on ()->
 
-         for p := period_default, p.times 0.5 do
+         for p := period_default, p.scale 0.5 do
            run_for_period p
 
       e error => say $e

--- a/examples/jitter/jitter_threaded.fz
+++ b/examples/jitter/jitter_threaded.fz
@@ -135,7 +135,7 @@ jitter_threaded =>
 
       _ := match flow.exception jitter_too_high .on ()->
 
-           for p := period_default, p.times 0.5
+           for p := period_default, p.scale 0.5
            while p.as_duration >= time.duration.ms 1 do
              run_for_period p
 

--- a/modules/base/src/time/duration.fz
+++ b/modules/base/src/time/duration.fz
@@ -122,7 +122,7 @@ is
 
   # this duration multiplied by factor f
   #
-  public times(f f64) time.duration
+  public scale(f f64) time.duration
   =>
     time.duration (nanos.as_f64 * f).as_i64.as_u64
 

--- a/modules/base/src/time/duration.fz
+++ b/modules/base/src/time/duration.fz
@@ -122,6 +122,8 @@ is
 
   # this duration multiplied by factor f
   #
+  # NYI: HACK: only works for results < ~292.3 years due to usage of `.as_i64`
+  #
   public scale(f f64) time.duration
   =>
     time.duration (nanos.as_f64 * f).as_i64.as_u64

--- a/modules/base/src/time/histogram.fz
+++ b/modules/base/src/time/histogram.fz
@@ -137,7 +137,7 @@ is
     match max_recorded
       mr time.duration => n := num_buckets.as_i32
                           array n i->
-                            if i<(n-1) then mr.times ((i+1).as_f64 / (num_buckets.as_f64-1))
+                            if i<(n-1) then mr.scale ((i+1).as_f64 / (num_buckets.as_f64-1))
                                        else time.duration.max
       nil              => log_table
 
@@ -153,7 +153,7 @@ is
     debug: result.length = num_buckets
   =>
     step := 1.65  # step factor determined via trial and error
-    (1.0 :: *step).map f->(time.duration.ns 1 .times f)
+    (1.0 :: *step).map f->(time.duration.ns 1 .scale f)
                   .dedup     # some lower values might be duplicates like 1ns*1.65=1ns
                   .take num_buckets.as_i32-1
                   .concat [time.duration.max]
@@ -321,7 +321,7 @@ is
   public average time.duration
   =>
     if size.get > 0
-      sum.get.times 1.0/size.get.as_f64
+      sum.get.scale 1.0/size.get.as_f64
     else
       time.duration.zero
 


### PR DESCRIPTION
fix #5798