### PR TITLE
be/jvm: callNative, store result of arguments expressions in locals

### DIFF
--- a/src/dev/flang/be/jvm/CodeGen.java
+++ b/src/dev/flang/be/jvm/CodeGen.java
@@ -668,15 +668,18 @@ class CodeGen
       + ")"
       + nativeResultTypeDescriptor(rt).descriptor();
 
+    var argSlots = new List<Integer>();
     var localSlotsOfMemorySegments = new List<Integer>();
-    return Expr
-          .getstatic(_names.javaClass(cc),
-                     Names.METHOD_HANDLE_FIELD_NAME,
-                     Names.CT_JAVA_LANG_INVOKE_METHODHANDLE)                                   // MethodHandle
-          .andThen(convertArgumentsToMemorySegments(si, args, localSlotsOfMemorySegments, cc)) // MethodHandle, args...
+    return assignArgsToLocals(si, args, argSlots, cc)
+          .andThen(Expr
+            .getstatic(_names.javaClass(cc),
+                       Names.METHOD_HANDLE_FIELD_NAME,
+                       Names.CT_JAVA_LANG_INVOKE_METHODHANDLE)                                   // MethodHandle
+          )
+          .andThen(convertArgumentsToMemorySegments(si, argSlots, localSlotsOfMemorySegments, cc)) // MethodHandle, args...
           .andThen(invokeMethodHandle(rt, invokeDescr))                                        // rt
           .andThen(copyValueResultToFuzion(rt))                                                // rt
-          .andThen(copyMemorySegmentsToArrays(cc, args, localSlotsOfMemorySegments))           // rt
+          .andThen(copyMemorySegmentsToArrays(cc, argSlots, localSlotsOfMemorySegments))           // rt
           .is(_types.javaType(rt));
   }
 
@@ -761,17 +764,17 @@ class CodeGen
   /**
    * invoke memorySegment2Obj for any of the args that are not primitives
    */
-  private Expr copyMemorySegmentsToArrays(int cc, List<Expr> args, List<Integer> slotsOfMemorySegments)
+  private Expr copyMemorySegmentsToArrays(int cc, List<Integer> argsSlots, List<Integer> slotsOfMemorySegments)
   {
     var result = Expr.UNIT;
     var slot = 0;
-    for (int i = 0; i < args.size(); i++)
+    for (int i = 0; i < argsSlots.size(); i++)
       {
         var at = _fuir.clazzArgClazz(cc, i);
         if (_fuir.clazzIsArray(at) || _fuir.clazzIsMutateArray(at) || _fuir.clazzIsRef(at))
           {
             result = result
-                .andThen(args.get(i))
+                .andThen(_types.javaType(at).load(argsSlots.get(i)))
                 .andThen(_fuir.clazzIsArray(at) || _fuir.clazzIsMutateArray(at) ? getArrayDataField(at) : Expr.NOP)
                 .andThen(Expr.aload(slotsOfMemorySegments.get(slot), Names.CT_JAVA_LANG_FOREIGN_MEMORYSEGMENT))
                 .andThen(invokeMemorySegment2Obj());
@@ -803,29 +806,29 @@ class CodeGen
    * the created MemorySegments are stored in locals and
    * the slot index is added to the slots list.
    */
-  private Expr convertArgumentsToMemorySegments(int si, List<Expr> args, List<Integer> slots, int cc)
+  private Expr convertArgumentsToMemorySegments(int si, List<Integer> argsSlots, List<Integer> slots, int cc)
   {
     var result = Expr.UNIT;
-    for (int i = 0; i < args.size(); i++)
+    for (int i = 0; i < argsSlots.size(); i++)
       {
         var at = _fuir.clazzArgClazz(cc, i);
         var call = _fuir.lookupCall(at);
         if (call != NO_CLAZZ)
           {
             result = result
-              .andThen(upcall(_fuir.clazzOuterRef(call) != NO_CLAZZ ? args.get(i) : Expr.ACONST_NULL, call));
+              .andThen(upcall(_fuir.clazzOuterRef(call) != NO_CLAZZ ? _types.javaType(at).load(argsSlots.get(i)) : Expr.ACONST_NULL, call));
           }
-        else if (args.get(i).type().isPrimitive())
+        else if (_types.javaType(at).isPrimitive())
           {
             result = result
-              .andThen(args.get(i));
+              .andThen(_types.javaType(at).load(argsSlots.get(i)));
           }
         else if (_fuir.clazzIsArray(at) || _fuir.clazzIsMutateArray(at) || _fuir.clazzIsRef(at) /* this may mean: internal_array.data */)
           {
             var slot = _jvm.allocLocal(si, 1);
             slots.addLast(slot);
             result = result
-                .andThen(args.get(i))
+                .andThen(_types.javaType(at).load(argsSlots.get(i)))
                 .andThen(_fuir.clazzIsArray(at) || _fuir.clazzIsMutateArray(at) ? getArrayDataField(at) : Expr.NOP)
                 .andThen(invokeObj2MemorySegment())
                 .andThen(Expr.astore(slot, Names.CT_JAVA_LANG_FOREIGN_MEMORYSEGMENT.vti()))
@@ -834,9 +837,35 @@ class CodeGen
         else
           {
             result = result
-                .andThen(args.get(i))
+                .andThen(_types.javaType(at).load(argsSlots.get(i)))
                 .andThen(invokeObj2MemorySegment());
           }
+      }
+    return result;
+  }
+
+
+  /**
+   * Assign the list of argument expressions to locals
+   *
+   * @param si
+   * @param args
+   * @param slots
+   * @param cc
+   * @return
+   */
+  private Expr assignArgsToLocals(int si, List<Expr> args, List<Integer> slots, int cc)
+  {
+    var result = Expr.UNIT;
+    for (int i = 0; i < args.size(); i++)
+      {
+        var at = _fuir.clazzArgClazz(cc, i);
+        var jt = _types.javaType(at);
+        var slot = _jvm.allocLocal(si, jt.stackSlots());
+        slots.addLast(slot);
+        result = result
+          .andThen(args.get(i))
+          .andThen(jt.store(slot));
       }
     return result;
   }


### PR DESCRIPTION
fixes the bug that came up in:
https://github.com/tokiwa-software/fuzion/actions/runs/29237320990/job/86774908481

`fzE_dir_read io.dir.open.env.dd internal_array.data`

Specifically the expression `io.dir.open.env.dd` triggered the problem since a Labels positions was found to be already set when it was expected to not yet be set.

fixes #7387
