### PR TITLE
merge `fzE_nanotime` and `fzE_posix_time`

### DIFF
--- a/include/fz.h
+++ b/include/fz.h
@@ -373,11 +373,6 @@ bool fzE_bitwise_compare_float(float f1, float f2);
 bool fzE_bitwise_compare_double(double d1, double d2);
 
 /**
- * @return a monotonically increasing timestamp.
- */
-uint64_t fzE_nanotime(void);
-
-/**
  * @return the time of the given posix clock
  */
 uint64_t fzE_posix_time(int clockid);

--- a/include/posix.c
+++ b/include/posix.c
@@ -406,21 +406,6 @@ int fzE_munmap(void * mapped_address, const int file_size){
 
 
 /**
- * returns a monotonically increasing timestamp.
- */
-uint64_t fzE_nanotime()
-{
-  struct timespec result;
-  if (clock_gettime(CLOCK_MONOTONIC,&result)!=0)
-  {
-    fprintf(stderr,"*** clock_gettime failed\012");
-    exit(EXIT_FAILURE);
-  }
-  return result.tv_sec*1000000000ULL+result.tv_nsec;
-}
-
-
-/**
  * @return the time of the given posix clock
  */
 uint64_t fzE_posix_time(int clockid)

--- a/include/win.c
+++ b/include/win.c
@@ -448,10 +448,11 @@ int fzE_munmap(void * mapped_address, const int file_size){
 
 
 /**
- * returns a monotonically increasing timestamp.
+ * @return the time of the given posix clock
  */
-uint64_t fzE_nanotime()
+uint64_t fzE_posix_time(int clockid)
 {
+  // NYI: BUG: clockid currently ignored
   static LARGE_INTEGER frequency = {0};
   if (frequency.QuadPart == 0) {
       if (!QueryPerformanceFrequency(&frequency)) {
@@ -475,11 +476,11 @@ uint64_t fzE_nanotime()
  */
 void fzE_nanosleep(uint64_t n)
 {
-  uint64_t start = fzE_nanotime();
+  uint64_t start = fzE_posix_time(-1);
   uint64_t end = start + n;
 
-  while (fzE_nanotime() < end) {
-    uint64_t remaining_ns = end - fzE_nanotime();
+  while (fzE_posix_time(-1) < end) {
+    uint64_t remaining_ns = end - fzE_posix_time(-1);
     if (remaining_ns > 1000000ULL) {
       Sleep((DWORD)(remaining_ns / 1000000ULL));
     } else if (remaining_ns > 0) {

--- a/modules/base/src/Random.fz
+++ b/modules/base/src/Random.fz
@@ -209,4 +209,4 @@ simple_random(seed1 u64, seed2 u64) : Random is
     #
     # NYI: BUG: we need ordering of default effects
     # simple_random (u64 77777777777777 ^ time.Nano.env.read.val) 98765432109876543
-    simple_random (u64 77777777777777 ^ fzE_nanotime) 98765432109876543
+    simple_random (u64 77777777777777 ^ (fzE_posix_time (id posix.clockid_t posix.clock_monotonic).val)) 98765432109876543

--- a/modules/base/src/native.fz
+++ b/modules/base/src/native.fz
@@ -191,9 +191,6 @@ module fzE_is_valid_mapped_memory(mm Mapped_Memory) bool =>
 module fzE_munmap(address Mapped_Memory, size i64) i32 => native
 
 
-# no guarantee can be given for precision nor resolution
-module fzE_nanotime u64 => native
-
 # read the current value of the given POSIX clockid
 #
 module fzE_posix_time(clockid i32) u64 => native

--- a/modules/base/src/time/Nano.fz
+++ b/modules/base/src/time/Nano.fz
@@ -54,7 +54,7 @@ public Nano ref : time.Clock is
 
       # no guarantee can be given for precision nor resolution
       #
-      public redef read time.instant => time.instant fzE_nanotime
+      public redef read time.instant => time.instant (fzE_posix_time (id posix.clockid_t posix.clock_monotonic).val)
 
       # no guarantee can be given for precision nor resolution
       #

--- a/tests/native/native.fz
+++ b/tests/native/native.fz
@@ -23,12 +23,12 @@
 
 test_native =>
 
-  fzE_nanotime u64 => native
+  fzE_posix_time(clockid i32) u64 => native
   fzE_nanosleep(arg1 u64) unit => native
 
-  start := fzE_nanotime
+  start := fzE_posix_time (id posix.clockid_t posix.clock_monotonic).val
   fzE_nanosleep 1E9
-  end := fzE_nanotime
+  end := fzE_posix_time (id posix.clockid_t posix.clock_monotonic).val
 
   say (end-start)>=1E9
 


### PR DESCRIPTION
this also fixes test failures on windows:
```
java.lang.UnsatisfiedLinkError: Unresolved symbol: fzE_posix_time
``