### PR TITLE
fe: `handDownListThroughInheritsCall` use target-type for applying type pars

### DIFF
--- a/src/dev/flang/ast/AbstractCall.java
+++ b/src/dev/flang/ast/AbstractCall.java
@@ -554,6 +554,15 @@ public abstract class AbstractCall extends Expr
   }
 
 
+  // need to overrid this here since this is not visible for LibraryCall
+  // and we want LibraryCall.typeForInferencing to not return null...
+  @Override
+  AbstractType typeForInferencing()
+  {
+    return type();
+  }
+
+
   /**
    * This call as a human readable string
    */

--- a/src/dev/flang/ast/AbstractFeature.java
+++ b/src/dev/flang/ast/AbstractFeature.java
@@ -1484,11 +1484,15 @@ public abstract class AbstractFeature extends Expr implements Comparable<Abstrac
    */
   private static List<AbstractType> handDownListThroughInheritsCall(List<AbstractType> l, int select, AbstractCall c)
   {
-    // NYI: BUG: it is not really sufficient to only do this for targets that are calls
-    return (c.target() instanceof AbstractCall ac
-              ? handDownListThroughInheritsCall(l, ac.select(), ac)
-              : l)
-      .flatMap(t -> t.applyTypeParsMaybeOpen(c.calledFeature(), c.actualTypeParameters(), select));
+    return l
+      .flatMap(t ->
+          // first, apply type pars using target type
+          (t.isOpenGeneric() || c.target().typeForInferencing() == null
+             ? t
+             : t.applyTypePars(c.target().type()))
+          // then apply type pars using the call
+          .applyTypeParsMaybeOpen(c.calledFeature(), c.actualTypeParameters(), select)
+        );
   }
 
 

--- a/src/dev/flang/ast/AbstractType.java
+++ b/src/dev/flang/ast/AbstractType.java
@@ -877,7 +877,7 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
 
 
   /**
-   * Convenience wrapper for applyTypeParsmaybeOpen for a given target type
+   * Convenience wrapper for applyTypeParsMaybeOpen for a given target type
    * t. If t is a plain type, apply t's feature and type parameters to this.
    *
    * @param t the type describing the feature and actual type parameters to applay.


### PR DESCRIPTION
instead of this `instanceof` hack

