### PR TITLE
fe: improve type inference for nested InlineArrays

### DIFF
--- a/modules/base/src/container/Mutable_Hash_Map.fz
+++ b/modules/base/src/container/Mutable_Hash_Map.fz
@@ -245,7 +245,7 @@ is
   public redef items Sequence (tuple HK V) =>
     LM.env.exclusive ()->
       contents.get.as_array
-        .flat_map (tuple HK V) (o -> o ? t tuple => [t] | * => [])
+        .flat_map (o -> o ? t tuple => [t] | * => [])
 
 
   # create an immutable map from this

--- a/modules/lock_free/src/lock_free/Map.fz
+++ b/modules/lock_free/src/lock_free/Map.fz
@@ -118,7 +118,7 @@ is
   public redef as_string String => "container_node[gen=$gen]($(array.as_string ", "))"
 
   as_list(f Indirection_Node CTK CTV -> Main_Node CTK CTV) =>
-    array.flat_map /* NYI: UNDER DEVELOPMENT: type inference */ (tuple CTK CTV) (.as_list f)
+    array.flat_map /* NYI: BUG: type inference */ (tuple CTK CTV) (.as_list f)
          .as_list
 
 

--- a/src/dev/flang/ast/AbstractType.java
+++ b/src/dev/flang/ast/AbstractType.java
@@ -392,7 +392,7 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
 
 
   /**
-   * Check if this or any of its generic arguments is Types.t_ERROR.
+   * Check if this or any of its generic arguments is or contains Types.t_ERROR.
    */
   public boolean containsError()
   {
@@ -414,6 +414,27 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
     if (POSTCONDITIONS) ensure
       (!result || Errors.any());
 
+    return result;
+  }
+
+
+  /**
+   * Check if this or any of its generic arguments contains an artificial type.
+   */
+  public boolean containsArtificialType()
+  {
+    boolean result = false;
+    if (isArtificialType())
+      {
+        result = true;
+      }
+    else if (isNormalType())
+      {
+        for (var t: generics())
+          {
+            result = result || t == null || t.containsArtificialType();
+          }
+      }
     return result;
   }
 

--- a/src/dev/flang/ast/InlineArray.java
+++ b/src/dev/flang/ast/InlineArray.java
@@ -176,7 +176,15 @@ public class InlineArray extends ExprWithPos
       {
         _type = super.type();
       }
-    return _type;
+
+    return _type == null || _type.isArtificialType() || !_type.containsArtificialType()
+      ? _type
+      : !urgent
+      ? null
+      : // possible propagation led to "better" element type in the mean time,
+        // we recreate the type.
+        ResolvedNormalType.create(_type.feature(),
+                                  new List<>(Expr.union(_elements, Context.NONE, urgent)));
   }
 
 
@@ -200,9 +208,12 @@ public class InlineArray extends ExprWithPos
   @Override
   Expr propagateExpectedType(Resolution res, Context context, AbstractType t, Supplier<String> from)
   {
+    var bt = t.isNormalType() && Types.resolved.f_array.inheritsFrom(t.feature()) && t.feature().typeArguments().size()==1
+      ? t.feature()
+      : Types.resolved.f_array;
     // if expected type is choice, examine if there is exactly one
     // array in choice generics, if so use this for further type propagation.
-    t = t.findInChoice(cg -> !cg.isParametricType() && cg.feature() == Types.resolved.f_array, context);
+    t = t.findInChoice(cg -> !cg.isParametricType() && cg.feature() == bt, context);
 
     var elementType = elementType(t);
     if (elementType != Types.t_ERROR
@@ -214,9 +225,8 @@ public class InlineArray extends ExprWithPos
           {
             li.set(li.next().propagateExpectedType(res, context, elementType, null));
           }
-        var arr = Types.resolved.f_array;
-        _type = arr.resultType()
-                    .applyTypePars(arr, new List<>(elementType));
+        _type = bt.resultType()
+                  .applyTypePars(bt, new List<>(elementType));
       }
     return this;
   }

--- a/src/dev/flang/ast/InlineArray.java
+++ b/src/dev/flang/ast/InlineArray.java
@@ -208,12 +208,12 @@ public class InlineArray extends ExprWithPos
   @Override
   Expr propagateExpectedType(Resolution res, Context context, AbstractType t, Supplier<String> from)
   {
-    var bt = t.isNormalType() && Types.resolved.f_array.inheritsFrom(t.feature()) && t.feature().typeArguments().size()==1
+    var arrayType = t.isNormalType() && Types.resolved.f_array.inheritsFrom(t.feature()) && t.feature().typeArguments().size()==1
       ? t.feature()
       : Types.resolved.f_array;
     // if expected type is choice, examine if there is exactly one
     // array in choice generics, if so use this for further type propagation.
-    t = t.findInChoice(cg -> !cg.isParametricType() && cg.feature() == bt, context);
+    t = t.findInChoice(cg -> !cg.isParametricType() && cg.feature() == arrayType, context);
 
     var elementType = elementType(t);
     if (elementType != Types.t_ERROR
@@ -225,8 +225,8 @@ public class InlineArray extends ExprWithPos
           {
             li.set(li.next().propagateExpectedType(res, context, elementType, null));
           }
-        _type = bt.resultType()
-                  .applyTypePars(bt, new List<>(elementType));
+        _type = arrayType.resultType()
+                  .applyTypePars(arrayType, new List<>(elementType));
       }
     return this;
   }

--- a/tests/type_inference_flat_map/type_inference_flat_map.fz
+++ b/tests/type_inference_flat_map/type_inference_flat_map.fz
@@ -26,8 +26,11 @@ type_inference_flat_map =>
   Sequence.flat_flat_map(B type, f T -> Sequence (Sequence B)) =>
     map (x->f x)
 
-  # NYI: BUG: does not work yet
-  # res := [1].flat_flat_map x->[[x]]
+  res0 := [1].flat_flat_map x->[[x]]
+  res1 => [1].flat_flat_map x->[[x]]
+
+  say <| type_of res0
+  say <| type_of res1
 
   res := [1].flat_flat_map x->
     y Sequence (Sequence i32) := [[x]]

--- a/tests/type_inference_flat_map/type_inference_flat_map.fz.expected_out
+++ b/tests/type_inference_flat_map/type_inference_flat_map.fz.expected_out
@@ -1,1 +1,3 @@
+Type of 'Sequence (Sequence (Sequence i32))'
+Type of 'Sequence (Sequence (Sequence i32))'
 [[[1]]]


### PR DESCRIPTION
the inner array may be a `Sequence` and not an `array`


