### PR TITLE
realtime/task: allow setting last time a task runs

### DIFF
--- a/modules/base/src/concur/task_pool.fz
+++ b/modules/base/src/concur/task_pool.fz
@@ -34,9 +34,9 @@ is
   public redef submit(P type : time.period, t realtime.task P) unit ! atomic_access =>
 
     nt := concur.Threads.env.spawn ()->
+      actual_last := t.last_start.or_default (time.instant u64.max)
       now := time.Nano.env.read
-      end_of_time := time.instant u64.max
-      _ := time.Nano.env.run_periodic now t.period end_of_time t.code
+      _ := time.Nano.env.run_periodic now t.period actual_last t.code
 
     thrds.write (list nt thrds)
 

--- a/modules/base/src/realtime/task.fz
+++ b/modules/base/src/realtime/task.fz
@@ -26,4 +26,5 @@
 #
 public task(P type : time.period,
             module code Function unit,
-            module period P) is
+            module period P,
+            module last_start option time.instant) is


### PR DESCRIPTION
I'd love feedback on the API design here. This is good for now, but with tasks having more and more parameters I feel like this could become very problematic in the near future.