### PR TITLE
fe: make type parameters with unspecified visibility inherit type visibility of outer

### DIFF
--- a/src/dev/flang/ast/Feature.java
+++ b/src/dev/flang/ast/Feature.java
@@ -108,7 +108,9 @@ public class Feature extends AbstractFeature
   public Visi visibility()
   {
     return _visibility == Visi.UNSPECIFIED
-      ? Visi.PRIV
+      ? (isTypeParameter()
+          ? outer().visibility().typeVisibility()
+          : Visi.PRIV)
       : _visibility;
   }
 

--- a/src/dev/flang/fe/SourceModule.java
+++ b/src/dev/flang/fe/SourceModule.java
@@ -1971,7 +1971,7 @@ A feature that is a constructor, choice or a type parameter may not redefine an 
    */
   private void checkLegalTypeVisibility(Feature f)
   {
-    if (!f.definesType() && f.visibility().definesTypeVisibility())
+    if (!f.definesType() && !f.isTypeParameter() && f.visibility().definesTypeVisibility())
       {
         AstErrors.illegalTypeVisibilityModifier(f);
       }

--- a/tests/choice_constraints/choice_constraints.fz
+++ b/tests/choice_constraints/choice_constraints.fz
@@ -84,12 +84,10 @@ choice_constraints =>
   say <| (id (option String) nil).test (option String) nil
 
 
-  # NYI: BUG: Type 'A' was not found, no corresponding feature nor formal type parameter exists
+  switch.test2(X type : switch.this, x X) =>
+    match x
+      a A => say a
+      b B => say b
 
-  # switch.test2(X type : switch.this, x X) =>
-  #   match x
-  #     a A => say a
-  #     b B => say b
-
-  # (id (option String) nil).test2 (option String) nil
+  (id (option String) nil).test2 (option String) nil
 

--- a/tests/choice_constraints/choice_constraints.fz.expected_out
+++ b/tests/choice_constraints/choice_constraints.fz.expected_out
@@ -5,3 +5,4 @@ hello
 --nil--
 --nil--
 --nil--
+--nil--


### PR DESCRIPTION
fixes bug in test choice constraints

@tokiwa-software/developers Do you agree with this change in semantics for default visibility of type parameters?