### PR TITLE
fuir: AbstractInterpreter, remove `nop`, mark `drop` as abstract

### DIFF
--- a/src/dev/flang/be/c/C.java
+++ b/src/dev/flang/be/c/C.java
@@ -122,10 +122,18 @@ public class C extends ANY
 
 
     /**
-     * no operation, like comment, but without giving any comment.
+     * drop a value, but process its side-effect.
+     *
+     * @param v an expression that calculates a value that is not needed, but
+     * where the calculation might have side-effects (like performing a call) that
+     * we do need.
+     *
+     * @param type clazz id for the type of the value
+     *
+     * @return code to perform the side effects of v and ignoring the produced value.
      */
     @Override
-    public CStmnt nop()
+    public CStmnt drop(CExpr v, int type)
     {
       return CStmnt.EMPTY;
     }

--- a/src/dev/flang/be/interpreter/Executor.java
+++ b/src/dev/flang/be/interpreter/Executor.java
@@ -202,7 +202,7 @@ public class Executor extends ProcessExpression<Value, Object>
   }
 
   @Override
-  public Object nop()
+  public Object drop(Value v, int type)
   {
     return null;
   }

--- a/src/dev/flang/be/jvm/CodeGen.java
+++ b/src/dev/flang/be/jvm/CodeGen.java
@@ -173,16 +173,6 @@ class CodeGen
 
 
   /**
-   * no operation, like comment, but without giving any comment.
-   */
-  @Override
-  public Expr nop()
-  {
-    return Expr.UNIT;
-  }
-
-
-  /**
    * drop a value, but process its side-effect.
    *
    * @param v an expression that calculates a value that is not needed, but

--- a/src/dev/flang/fuir/analysis/AbstractInterpreter.java
+++ b/src/dev/flang/fuir/analysis/AbstractInterpreter.java
@@ -97,29 +97,17 @@ public class AbstractInterpreter<VALUE, RESULT> extends ANY
     public abstract RESULT comment(String s);
 
     /**
-     * no operation, like comment, but without giving any comment.
-     */
-    public abstract RESULT nop();
-
-    /**
      * drop a value, but process its side-effect.
      *
      * @param v an expression that calculates a value that is not needed, but
      * where the calculation might have side-effects (like performing a call) that
      * we do need.
      *
-     * For backends that do not perform any side-effects in RESULT, this does
-     * not need to be redefined, the default implementation is nop() which is
-     * fine in this case.
-     *
      * @param type clazz id for the type of the value
      *
      * @return code to perform the side effects of v and ignoring the produced value.
      */
-    public RESULT drop(VALUE v, int type)
-    {
-      return nop(); // NYI: UNDER DEVELOPMENT: should be implemented by BEs.
-    }
+    public abstract RESULT drop(VALUE v, int type);
 
     /**
      * Perform an assignment val to field f in instance rt
@@ -632,10 +620,6 @@ public class AbstractInterpreter<VALUE, RESULT> extends ANY
           var constCl = _fuir.constClazz(s);
           var d = _fuir.constData(s);
           var r = _processor.constData(s, constCl, d);
-
-          if (CHECKS) check
-            // check that constant creation has no side effects.
-            (r.v1() == _processor.nop());
 
           push(stack, constCl, r.v0());
           res = r.v1();

--- a/src/dev/flang/fuir/analysis/AbstractInterpreter2.java.patch
+++ b/src/dev/flang/fuir/analysis/AbstractInterpreter2.java.patch
@@ -57,217 +57,205 @@
 <     public abstract RESULT comment(String s);
 ---
 >     public abstract void comment(String s);
-102c105
-<     public abstract RESULT nop();
----
->     public abstract void nop();
-116,117d118
+107,108d109
 <      *
 <      * @return code to perform the side effects of v and ignoring the produced value.
-119c120
-<     public RESULT drop(VALUE v, int type)
+110c111
+<     public abstract RESULT drop(VALUE v, int type);
 ---
->     public void drop(VALUE v, int type)
-121c122
-<       return nop(); // NYI: UNDER DEVELOPMENT: should be implemented by BEs.
----
->       nop(); // NYI: UNDER DEVELOPMENT: should be implemented by BEs.
-134,135d134
+>     public abstract void drop(VALUE v, int type);
+122,123d122
 <      *
 <      * @return resulting code of this assignment.
-137c136
+125c124
 <     public abstract RESULT assignStatic(int s, int f, VALUE tvalue, VALUE val);
 ---
 >     public abstract void assignStatic(int s, int f, VALUE tvalue, VALUE val);
-149c148
+137c136
 <     public abstract RESULT assign(int s, VALUE tvalue, VALUE avalue);
 ---
 >     public abstract void assign(int s, VALUE tvalue, VALUE avalue);
-165c164
+153c152
 <     public abstract Pair<VALUE, RESULT> call(int s, VALUE tvalue, List<VALUE> args);
 ---
 >     public abstract VALUE call(int s, VALUE tvalue, List<VALUE> args);
-176c175
+164c163
 <     public abstract Pair<VALUE, RESULT> box(int s, VALUE v, int vc, int rc);
 ---
 >     public abstract VALUE box(int s, VALUE v, int vc, int rc);
-183c182
+171c170
 <     public abstract Pair<VALUE, RESULT> current(int s);
 ---
 >     public abstract VALUE current(int s);
-190c189
+178c177
 <     public abstract Pair<VALUE, RESULT> outer(int s);
 ---
 >     public abstract VALUE outer(int s);
-210c209
+198c197
 <     public abstract Pair<VALUE, RESULT> constData(int s, int constCl, byte[] d);
 ---
 >     public abstract VALUE constData(int s, int constCl, byte[] d);
-221c220
+209c208
 <     public abstract RESULT match(int s, AbstractInterpreter<VALUE, RESULT> ai, VALUE subv);
 ---
 >     public abstract VALUE match(int s, AbstractInterpreter2<VALUE> ai, VALUE subv);
-235c234
+223c222
 <     public abstract Pair<VALUE, RESULT> tag(int s, VALUE value, int newcl, int tagNum);
 ---
 >     public abstract VALUE tag(int s, VALUE value, int newcl, int tagNum);
-242c241
+230c229
 <     public RESULT reportErrorInCode(String msg) { return comment(msg); }
 ---
 >     public void reportErrorInCode(String msg) { comment(msg); }
-301c300
+289c288
 <   public final ProcessExpression<VALUE, RESULT> _processor;
 ---
 >   public final ProcessExpression<VALUE> _processor;
-312c311
+300c299
 <   public AbstractInterpreter(FUIR fuir, ProcessExpression<VALUE, RESULT> processor)
 ---
 >   public AbstractInterpreter2(FUIR fuir, ProcessExpression<VALUE> processor)
-435,436d433
+423,424d421
 <    * @param l list that will receive the result
 <    *
-439c436
+427c424
 <   void assignOuterAndArgFields(List<RESULT> l, int s)
 ---
 >   void assignOuterAndArgFields(int s)
-449d445
+437d433
 <             l.add(cur.v1());
-451,452c447
+439,440c435
 <             l.add(out.v1());
 <             l.add(_processor.assignStatic(s, or, cur.v0(), out.v0()));
 ---
 >             _processor.assignStatic(s, or, cur, out);
-463d457
+451d445
 <             l.add(cur.v1());
-466c460
+454c448
 <             l.add(_processor.assignStatic(s, af, cur.v0(), ai));
 ---
 >             _processor.assignStatic(s, af, cur, ai);
-481c475
+469c463
 <   public Pair<VALUE,RESULT> processClazz(int cl)
 ---
 >   public VALUE processClazz(int cl)
-483d476
+471d464
 <     var l = new List<RESULT>();
-487c480
+475c468
 <         assignOuterAndArgFields(l, s);
 ---
 >         assignOuterAndArgFields(s);
-490,492c483,484
+478,480c471,472
 <     l.add(p.v1());
 <     var res = p.v0();
 <     return new Pair<>(res, _processor.sequence(l));
 ---
 >     var res = p;
 >     return res;
-505c497
+493c485
 <   public Pair<VALUE,RESULT> processCode(int s0)
 ---
 >   public VALUE processCode(int s0)
-508d499
+496d487
 <     var l = new List<RESULT>();
-512,513c503,504
+500,501c491,492
 <         l.add(_processor.expressionHeader(s));
 <         l.add(process(s, stack));
 ---
 >         _processor.expressionHeader(s);
 >         process(s, stack);
-522,523c513,514
+510,511c501,502
 <         l.add(_processor.reportErrorInCode("Severe compiler bug! This code should be unreachable:\n" +
 <                                            _fuir.siteAsString(last_s)));
 ---
 >         _processor.reportErrorInCode("Severe compiler bug! This code should be unreachable:\n" +
 >                                      _fuir.siteAsString(last_s));
-525a517
+513a505
 > 
-530c522
+518c510
 <     return new Pair<>(v, _processor.sequence(l));
 ---
 >     return v;
-540,542d531
+528,530d519
 <    *
 <    * @return the result of the abstract interpretation, e.g., the generated
 <    * code.
-544c533
+532c521
 <   public RESULT process(int s, Stack<VALUE> stack)
 ---
 >   public void process(int s, Stack<VALUE> stack)
-556d544
+544d532
 <     RESULT res;
-569c557
+557c545
 <               res = _processor.assign(s, tvalue, avalue);
 ---
 >               _processor.assign(s, tvalue, avalue);
-573,574c561,562
+561,562c549,550
 <               res = _processor.sequence(new List<>(_processor.drop(tvalue, tc),
 <                                                     _processor.drop(avalue, ft)));
 ---
 >               _processor.drop(tvalue, tc);
 >               _processor.drop(avalue, ft);
-585c573
+573c561
 <               res = _processor.comment("Box is a NOP, clazz is already a ref");
 ---
 >               _processor.comment("Box is a NOP, clazz is already a ref");
-591,592c579
+579,580c567
 <               push(stack, rc, r.v0());
 <               res = r.v1();
 ---
 >               push(stack, rc, r);
-603c590
+591c578
 <             ? new Pair<>(_processor.unitValue(), _processor.drop(tvalue, tc))
 ---
 >             ? _processor.unitValue()
-605c592
+593c580
 <           if (r.v0() == null)  // this may happen even if rt is not void (e.g., in case of tail recursion or error)
 ---
 >           if (r == null)  // this may happen even if rt is not void (e.g., in case of tail recursion or error)
-612c599
+600c587
 <               push(stack, rt, r.v0());
 ---
 >               push(stack, rt, r);
-614d600
+602d588
 <           res = r.v1();
-619c605
+607c593
 <           res = _processor.comment(_fuir.comment(s));
 ---
 >           _processor.comment(_fuir.comment(s));
-626,627c612
+614,615c600
 <           push(stack, cl, r.v0());
 <           res = r.v1();
 ---
 >           push(stack, cl, r);
-636,641c621
-<           if (CHECKS) check
-<             // check that constant creation has no side effects.
-<             (r.v1() == _processor.nop());
-< 
+624,625c609
 <           push(stack, constCl, r.v0());
 <           res = r.v1();
 ---
 >           push(stack, constCl, r);
-648,649c628,629
+632,633c616,617
 <           res = _processor.match(s, this, subv);
 <           if (_fuir.alwaysResultsInVoid(s))
 ---
 >           var r = _processor.match(s, this, subv);
 >           if (r == null)
-652a633,634
+636a621,622
 >           if (CHECKS) check
 >             (r == null || r == _processor.unitValue());
-664,665c646
+648,649c634
 <           push(stack, newcl, r.v0());
 <           res = r.v1();
 ---
 >           push(stack, newcl, r);
-679c660
+663c648
 <           res = _processor.drop(v, rt);
 ---
 >           _processor.drop(v, rt);
-685d665
+669d653
 <           res = null;
-694c674
+678c662
 <         say("process done: "+_fuir.siteAsString(s) + ":\t"+_fuir.codeAtAsString(s)+" stack is "+stack+" RES "+res);
 ---
 >         say("process done: "+_fuir.siteAsString(s) + ":\t"+_fuir.codeAtAsString(s)+" stack is "+stack);
-696d675
+680d663
 <     return res;

--- a/src/dev/flang/fuir/analysis/dfa/DFA.java
+++ b/src/dev/flang/fuir/analysis/dfa/DFA.java
@@ -153,10 +153,18 @@ public class DFA extends ANY
 
 
     /**
-     * no operation, like comment, but without giving any comment.
+     * drop a value, but process its side-effect.
+     *
+     * @param v an expression that calculates a value that is not needed, but
+     * where the calculation might have side-effects (like performing a call) that
+     * we do need.
+     *
+     * @param type clazz id for the type of the value
+     *
+     * @return code to perform the side effects of v and ignoring the produced value.
      */
     @Override
-    public void nop()
+    public void drop(Val v, int type)
     {
     }
 


### PR DESCRIPTION
`nop` feels useless to me and `drop` should be abstract anyway