### PR TITLE
fe: add (workaround) assignabilty rule `a.type.T` assignable to `a.T`

### DIFF
--- a/modules/base/src/container/Mutable_Map.fz
+++ b/modules/base/src/container/Mutable_Map.fz
@@ -123,11 +123,6 @@ public Mutable_Map(public K type : property.equatable, public V type) ref is
   public type.empty Mutable_Map.this => abstract
 
 
-/*
-
-  NYI: BUG?: To solve this, you could change the type of the target 'k' to 'container.Mutable_Map.type.K' or convert the type of the assigned value to 'container.Mutable_Map.K'.
-
-
   # from_entries -- routine to initialize a Mutable_Map from
   # a sequence of key value tuples
   #
@@ -137,4 +132,3 @@ public Mutable_Map(public K type : property.equatable, public V type) ref is
       m.put kv.0 kv.1
     m
 
-*/

--- a/modules/lock_free/src/lock_free/Map.fz
+++ b/modules/lock_free/src/lock_free/Map.fz
@@ -714,14 +714,3 @@ is
 
     lock_free.Map (concur.atomic (lock_free.root_node CTK CTV) .new initial_root_node) false
 
-
-  # lock_free.Map.from_entries -- routine to initialize a ctrie from a sequence of key value tuples
-  #
-  # This feature creates an instance of a ctrie.
-  #
-  # example: lock_free.Map.from_entries [(key1, value1), (key2, value2)]
-  #
-  public type.from_entries(kvs Sequence (tuple CTK CTV)) lock_free.Map CTK CTV =>
-    m := (lock_free.Map CTK CTV).empty
-    kvs.for_each (kv -> m.put kv.0 kv.1)
-    m

--- a/src/dev/flang/ast/AbstractType.java
+++ b/src/dev/flang/ast/AbstractType.java
@@ -654,6 +654,19 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
       {
         result = isAssignableFrom(actual.selfOrConstraint(context).asRef(true), context, allowBoxing, allowTagging, assignableTo);
       }
+    // NYI: CLEANUP: the bug is probably that target type in a type feature
+    // is considered to be container.Mutable_Map.K
+    // once this is fixed this assignability rule could be removed again...
+    //
+    // in Mutable_Map.type.from_entries we have e.g.:
+    // target_type: container.Mutable_Map.K
+    // actual_type: container.Mutable_Map.type.K
+    // these should be assignable
+    //
+    if (result.no() && target_type.isParametricType() && target_type.typeParameter().cotypeGeneric().asParametricType().compareTo(actual_type) == 0)
+      {
+        result = YesNo.yes;
+      }
     return result;
   }
 


### PR DESCRIPTION
I'm not 100% sure but the rule is probably unnecessary if replace type pars in type features by there cotype counter parts. 
I added an NYI  CLEANUP comment for this.

This allows implementing `Mutable_Map.type.from_entries`

