### PR TITLE
ai: mark drop as abstract

### DIFF
--- a/src/dev/flang/be/c/C.java
+++ b/src/dev/flang/be/c/C.java
@@ -43,6 +43,7 @@ import dev.flang.fuir.FUIR;
 import dev.flang.fuir.SpecialClazzes;
 import dev.flang.fuir.analysis.AbstractInterpreter;
 import dev.flang.fuir.analysis.TailCall;
+import dev.flang.fuir.analysis.dfa.Val;
 import dev.flang.ir.IR.FeatureKind;
 import dev.flang.util.ANY;
 import dev.flang.util.Errors;
@@ -126,6 +127,27 @@ public class C extends ANY
      */
     @Override
     public CStmnt nop()
+    {
+      return CStmnt.EMPTY;
+    }
+
+
+    /**
+     * drop a value, but process its side-effect.
+     *
+     * @param v an expression that calculates a value that is not needed, but
+     * where the calculation might have side-effects (like performing a call) that
+     * we do need.
+     *
+     * For backends that do not perform any side-effects in RESULT, this does
+     * not need to be redefined, the default implementation is nop() which is
+     * fine in this case.
+     *
+     * @param type clazz id for the type of the value
+     *
+     * @return code to perform the side effects of v and ignoring the produced value.
+     */
+    @Override public CStmnt drop(CExpr v, int type)
     {
       return CStmnt.EMPTY;
     }

--- a/src/dev/flang/be/interpreter/Executor.java
+++ b/src/dev/flang/be/interpreter/Executor.java
@@ -208,6 +208,12 @@ public class Executor extends ProcessExpression<Value, Object>
   }
 
   @Override
+  public Object drop(Value v, int type)
+  {
+    return null;
+  }
+
+  @Override
   public Object assignStatic(int s, int f, Value tvalue, Value val)
   {
     Interpreter.setField(f, _fuir.clazzAt(s), tvalue, val);

--- a/src/dev/flang/fuir/analysis/AbstractInterpreter.java
+++ b/src/dev/flang/fuir/analysis/AbstractInterpreter.java
@@ -116,10 +116,7 @@ public class AbstractInterpreter<VALUE, RESULT> extends ANY
      *
      * @return code to perform the side effects of v and ignoring the produced value.
      */
-    public RESULT drop(VALUE v, int type)
-    {
-      return nop(); // NYI: UNDER DEVELOPMENT: should be implemented by BEs.
-    }
+    public abstract RESULT drop(VALUE v, int type);
 
     /**
      * Perform an assignment val to field f in instance rt

--- a/src/dev/flang/fuir/analysis/AbstractInterpreter2.java.patch
+++ b/src/dev/flang/fuir/analysis/AbstractInterpreter2.java.patch
@@ -61,175 +61,177 @@
 <     public abstract RESULT nop();
 ---
 >     public abstract void nop();
-119c122
+117d119
+<      * @return code to perform the side effects of v and ignoring the produced value.
+119c121
 <     public abstract RESULT drop(VALUE v, int type);
 ---
 >     public abstract void drop(VALUE v, int type);
-131,132d133
+131,132d132
 <      *
 <      * @return resulting code of this assignment.
-134c135
+134c134
 <     public abstract RESULT assignStatic(int s, int f, VALUE tvalue, VALUE val);
 ---
 >     public abstract void assignStatic(int s, int f, VALUE tvalue, VALUE val);
-146c147
+146c146
 <     public abstract RESULT assign(int s, VALUE tvalue, VALUE avalue);
 ---
 >     public abstract void assign(int s, VALUE tvalue, VALUE avalue);
-162c163
+162c162
 <     public abstract Pair<VALUE, RESULT> call(int s, VALUE tvalue, List<VALUE> args);
 ---
 >     public abstract VALUE call(int s, VALUE tvalue, List<VALUE> args);
-173c174
+173c173
 <     public abstract Pair<VALUE, RESULT> box(int s, VALUE v, int vc, int rc);
 ---
 >     public abstract VALUE box(int s, VALUE v, int vc, int rc);
-180c181
+180c180
 <     public abstract Pair<VALUE, RESULT> current(int s);
 ---
 >     public abstract VALUE current(int s);
-187c188
+187c187
 <     public abstract Pair<VALUE, RESULT> outer(int s);
 ---
 >     public abstract VALUE outer(int s);
-207c208
+207c207
 <     public abstract Pair<VALUE, RESULT> constData(int s, int constCl, byte[] d);
 ---
 >     public abstract VALUE constData(int s, int constCl, byte[] d);
-218c219
+218c218
 <     public abstract RESULT match(int s, AbstractInterpreter<VALUE, RESULT> ai, VALUE subv);
 ---
 >     public abstract VALUE match(int s, AbstractInterpreter2<VALUE> ai, VALUE subv);
-232c233
+232c232
 <     public abstract Pair<VALUE, RESULT> tag(int s, VALUE value, int newcl, int tagNum);
 ---
 >     public abstract VALUE tag(int s, VALUE value, int newcl, int tagNum);
-239c240
+239c239
 <     public RESULT reportErrorInCode(String msg) { return comment(msg); }
 ---
 >     public void reportErrorInCode(String msg) { comment(msg); }
-298c299
+298c298
 <   public final ProcessExpression<VALUE, RESULT> _processor;
 ---
 >   public final ProcessExpression<VALUE> _processor;
-309c310
+309c309
 <   public AbstractInterpreter(FUIR fuir, ProcessExpression<VALUE, RESULT> processor)
 ---
 >   public AbstractInterpreter2(FUIR fuir, ProcessExpression<VALUE> processor)
-432,433d432
+432,433d431
 <    * @param l list that will receive the result
 <    *
-436c435
+436c434
 <   void assignOuterAndArgFields(List<RESULT> l, int s)
 ---
 >   void assignOuterAndArgFields(int s)
-446d444
+446d443
 <             l.add(cur.v1());
-448,449c446
+448,449c445
 <             l.add(out.v1());
 <             l.add(_processor.assignStatic(s, or, cur.v0(), out.v0()));
 ---
 >             _processor.assignStatic(s, or, cur, out);
-460d456
+460d455
 <             l.add(cur.v1());
-463c459
+463c458
 <             l.add(_processor.assignStatic(s, af, cur.v0(), ai));
 ---
 >             _processor.assignStatic(s, af, cur, ai);
-478c474
+478c473
 <   public Pair<VALUE,RESULT> processClazz(int cl)
 ---
 >   public VALUE processClazz(int cl)
-480d475
+480d474
 <     var l = new List<RESULT>();
-484c479
+484c478
 <         assignOuterAndArgFields(l, s);
 ---
 >         assignOuterAndArgFields(s);
-487,489c482,483
+487,489c481,482
 <     l.add(p.v1());
 <     var res = p.v0();
 <     return new Pair<>(res, _processor.sequence(l));
 ---
 >     var res = p;
 >     return res;
-502c496
+502c495
 <   public Pair<VALUE,RESULT> processCode(int s0)
 ---
 >   public VALUE processCode(int s0)
-505d498
+505d497
 <     var l = new List<RESULT>();
-509,510c502,503
+509,510c501,502
 <         l.add(_processor.expressionHeader(s));
 <         l.add(process(s, stack));
 ---
 >         _processor.expressionHeader(s);
 >         process(s, stack);
-519,520c512,513
+519,520c511,512
 <         l.add(_processor.reportErrorInCode("Severe compiler bug! This code should be unreachable:\n" +
 <                                            _fuir.siteAsString(last_s)));
 ---
 >         _processor.reportErrorInCode("Severe compiler bug! This code should be unreachable:\n" +
 >                                      _fuir.siteAsString(last_s));
-522a516
+522a515
 > 
-527c521
+527c520
 <     return new Pair<>(v, _processor.sequence(l));
 ---
 >     return v;
-537,539d530
+537,539d529
 <    *
 <    * @return the result of the abstract interpretation, e.g., the generated
 <    * code.
-541c532
+541c531
 <   public RESULT process(int s, Stack<VALUE> stack)
 ---
 >   public void process(int s, Stack<VALUE> stack)
-553d543
+553d542
 <     RESULT res;
-566c556
+566c555
 <               res = _processor.assign(s, tvalue, avalue);
 ---
 >               _processor.assign(s, tvalue, avalue);
-570,571c560,561
+570,571c559,560
 <               res = _processor.sequence(new List<>(_processor.drop(tvalue, tc),
 <                                                     _processor.drop(avalue, ft)));
 ---
 >               _processor.drop(tvalue, tc);
 >               _processor.drop(avalue, ft);
-582c572
+582c571
 <               res = _processor.comment("Box is a NOP, clazz is already a ref");
 ---
 >               _processor.comment("Box is a NOP, clazz is already a ref");
-588,589c578
+588,589c577
 <               push(stack, rc, r.v0());
 <               res = r.v1();
 ---
 >               push(stack, rc, r);
-600c589
+600c588
 <             ? new Pair<>(_processor.unitValue(), _processor.drop(tvalue, tc))
 ---
 >             ? _processor.unitValue()
-602c591
+602c590
 <           if (r.v0() == null)  // this may happen even if rt is not void (e.g., in case of tail recursion or error)
 ---
 >           if (r == null)  // this may happen even if rt is not void (e.g., in case of tail recursion or error)
-609c598
+609c597
 <               push(stack, rt, r.v0());
 ---
 >               push(stack, rt, r);
-611d599
+611d598
 <           res = r.v1();
-616c604
+616c603
 <           res = _processor.comment(_fuir.comment(s));
 ---
 >           _processor.comment(_fuir.comment(s));
-623,624c611
+623,624c610
 <           push(stack, cl, r.v0());
 <           res = r.v1();
 ---
 >           push(stack, cl, r);
-633,638c620
+633,638c619
 <           if (CHECKS) check
 <             // check that constant creation has no side effects.
 <             (r.v1() == _processor.nop());
@@ -238,29 +240,29 @@
 <           res = r.v1();
 ---
 >           push(stack, constCl, r);
-645,646c627,628
+645,646c626,627
 <           res = _processor.match(s, this, subv);
 <           if (_fuir.alwaysResultsInVoid(s))
 ---
 >           var r = _processor.match(s, this, subv);
 >           if (r == null)
-649a632,633
+649a631,632
 >           if (CHECKS) check
 >             (r == null || r == _processor.unitValue());
-661,662c645
+661,662c644
 <           push(stack, newcl, r.v0());
 <           res = r.v1();
 ---
 >           push(stack, newcl, r);
-676c659
+676c658
 <           res = _processor.drop(v, rt);
 ---
 >           _processor.drop(v, rt);
-682d664
+682d663
 <           res = null;
-691c673
+691c672
 <         say("process done: "+_fuir.siteAsString(s) + ":\t"+_fuir.codeAtAsString(s)+" stack is "+stack+" RES "+res);
 ---
 >         say("process done: "+_fuir.siteAsString(s) + ":\t"+_fuir.codeAtAsString(s)+" stack is "+stack);
-693d674
+693d673
 <     return res;

--- a/src/dev/flang/fuir/analysis/AbstractInterpreter2.java.patch
+++ b/src/dev/flang/fuir/analysis/AbstractInterpreter2.java.patch
@@ -61,182 +61,175 @@
 <     public abstract RESULT nop();
 ---
 >     public abstract void nop();
-116,117d118
-<      *
-<      * @return code to perform the side effects of v and ignoring the produced value.
-119c120
-<     public RESULT drop(VALUE v, int type)
+119c122
+<     public abstract RESULT drop(VALUE v, int type);
 ---
->     public void drop(VALUE v, int type)
-121c122
-<       return nop(); // NYI: UNDER DEVELOPMENT: should be implemented by BEs.
----
->       nop(); // NYI: UNDER DEVELOPMENT: should be implemented by BEs.
-134,135d134
+>     public abstract void drop(VALUE v, int type);
+131,132d133
 <      *
 <      * @return resulting code of this assignment.
-137c136
+134c135
 <     public abstract RESULT assignStatic(int s, int f, VALUE tvalue, VALUE val);
 ---
 >     public abstract void assignStatic(int s, int f, VALUE tvalue, VALUE val);
-149c148
+146c147
 <     public abstract RESULT assign(int s, VALUE tvalue, VALUE avalue);
 ---
 >     public abstract void assign(int s, VALUE tvalue, VALUE avalue);
-165c164
+162c163
 <     public abstract Pair<VALUE, RESULT> call(int s, VALUE tvalue, List<VALUE> args);
 ---
 >     public abstract VALUE call(int s, VALUE tvalue, List<VALUE> args);
-176c175
+173c174
 <     public abstract Pair<VALUE, RESULT> box(int s, VALUE v, int vc, int rc);
 ---
 >     public abstract VALUE box(int s, VALUE v, int vc, int rc);
-183c182
+180c181
 <     public abstract Pair<VALUE, RESULT> current(int s);
 ---
 >     public abstract VALUE current(int s);
-190c189
+187c188
 <     public abstract Pair<VALUE, RESULT> outer(int s);
 ---
 >     public abstract VALUE outer(int s);
-210c209
+207c208
 <     public abstract Pair<VALUE, RESULT> constData(int s, int constCl, byte[] d);
 ---
 >     public abstract VALUE constData(int s, int constCl, byte[] d);
-221c220
+218c219
 <     public abstract RESULT match(int s, AbstractInterpreter<VALUE, RESULT> ai, VALUE subv);
 ---
 >     public abstract VALUE match(int s, AbstractInterpreter2<VALUE> ai, VALUE subv);
-235c234
+232c233
 <     public abstract Pair<VALUE, RESULT> tag(int s, VALUE value, int newcl, int tagNum);
 ---
 >     public abstract VALUE tag(int s, VALUE value, int newcl, int tagNum);
-242c241
+239c240
 <     public RESULT reportErrorInCode(String msg) { return comment(msg); }
 ---
 >     public void reportErrorInCode(String msg) { comment(msg); }
-301c300
+298c299
 <   public final ProcessExpression<VALUE, RESULT> _processor;
 ---
 >   public final ProcessExpression<VALUE> _processor;
-312c311
+309c310
 <   public AbstractInterpreter(FUIR fuir, ProcessExpression<VALUE, RESULT> processor)
 ---
 >   public AbstractInterpreter2(FUIR fuir, ProcessExpression<VALUE> processor)
-435,436d433
+432,433d432
 <    * @param l list that will receive the result
 <    *
-439c436
+436c435
 <   void assignOuterAndArgFields(List<RESULT> l, int s)
 ---
 >   void assignOuterAndArgFields(int s)
-449d445
+446d444
 <             l.add(cur.v1());
-451,452c447
+448,449c446
 <             l.add(out.v1());
 <             l.add(_processor.assignStatic(s, or, cur.v0(), out.v0()));
 ---
 >             _processor.assignStatic(s, or, cur, out);
-463d457
+460d456
 <             l.add(cur.v1());
-466c460
+463c459
 <             l.add(_processor.assignStatic(s, af, cur.v0(), ai));
 ---
 >             _processor.assignStatic(s, af, cur, ai);
-481c475
+478c474
 <   public Pair<VALUE,RESULT> processClazz(int cl)
 ---
 >   public VALUE processClazz(int cl)
-483d476
+480d475
 <     var l = new List<RESULT>();
-487c480
+484c479
 <         assignOuterAndArgFields(l, s);
 ---
 >         assignOuterAndArgFields(s);
-490,492c483,484
+487,489c482,483
 <     l.add(p.v1());
 <     var res = p.v0();
 <     return new Pair<>(res, _processor.sequence(l));
 ---
 >     var res = p;
 >     return res;
-505c497
+502c496
 <   public Pair<VALUE,RESULT> processCode(int s0)
 ---
 >   public VALUE processCode(int s0)
-508d499
+505d498
 <     var l = new List<RESULT>();
-512,513c503,504
+509,510c502,503
 <         l.add(_processor.expressionHeader(s));
 <         l.add(process(s, stack));
 ---
 >         _processor.expressionHeader(s);
 >         process(s, stack);
-522,523c513,514
+519,520c512,513
 <         l.add(_processor.reportErrorInCode("Severe compiler bug! This code should be unreachable:\n" +
 <                                            _fuir.siteAsString(last_s)));
 ---
 >         _processor.reportErrorInCode("Severe compiler bug! This code should be unreachable:\n" +
 >                                      _fuir.siteAsString(last_s));
-525a517
+522a516
 > 
-530c522
+527c521
 <     return new Pair<>(v, _processor.sequence(l));
 ---
 >     return v;
-540,542d531
+537,539d530
 <    *
 <    * @return the result of the abstract interpretation, e.g., the generated
 <    * code.
-544c533
+541c532
 <   public RESULT process(int s, Stack<VALUE> stack)
 ---
 >   public void process(int s, Stack<VALUE> stack)
-556d544
+553d543
 <     RESULT res;
-569c557
+566c556
 <               res = _processor.assign(s, tvalue, avalue);
 ---
 >               _processor.assign(s, tvalue, avalue);
-573,574c561,562
+570,571c560,561
 <               res = _processor.sequence(new List<>(_processor.drop(tvalue, tc),
 <                                                     _processor.drop(avalue, ft)));
 ---
 >               _processor.drop(tvalue, tc);
 >               _processor.drop(avalue, ft);
-585c573
+582c572
 <               res = _processor.comment("Box is a NOP, clazz is already a ref");
 ---
 >               _processor.comment("Box is a NOP, clazz is already a ref");
-591,592c579
+588,589c578
 <               push(stack, rc, r.v0());
 <               res = r.v1();
 ---
 >               push(stack, rc, r);
-603c590
+600c589
 <             ? new Pair<>(_processor.unitValue(), _processor.drop(tvalue, tc))
 ---
 >             ? _processor.unitValue()
-605c592
+602c591
 <           if (r.v0() == null)  // this may happen even if rt is not void (e.g., in case of tail recursion or error)
 ---
 >           if (r == null)  // this may happen even if rt is not void (e.g., in case of tail recursion or error)
-612c599
+609c598
 <               push(stack, rt, r.v0());
 ---
 >               push(stack, rt, r);
-614d600
+611d599
 <           res = r.v1();
-619c605
+616c604
 <           res = _processor.comment(_fuir.comment(s));
 ---
 >           _processor.comment(_fuir.comment(s));
-626,627c612
+623,624c611
 <           push(stack, cl, r.v0());
 <           res = r.v1();
 ---
 >           push(stack, cl, r);
-636,641c621
+633,638c620
 <           if (CHECKS) check
 <             // check that constant creation has no side effects.
 <             (r.v1() == _processor.nop());
@@ -245,29 +238,29 @@
 <           res = r.v1();
 ---
 >           push(stack, constCl, r);
-648,649c628,629
+645,646c627,628
 <           res = _processor.match(s, this, subv);
 <           if (_fuir.alwaysResultsInVoid(s))
 ---
 >           var r = _processor.match(s, this, subv);
 >           if (r == null)
-652a633,634
+649a632,633
 >           if (CHECKS) check
 >             (r == null || r == _processor.unitValue());
-664,665c646
+661,662c645
 <           push(stack, newcl, r.v0());
 <           res = r.v1();
 ---
 >           push(stack, newcl, r);
-679c660
+676c659
 <           res = _processor.drop(v, rt);
 ---
 >           _processor.drop(v, rt);
-685d665
+682d664
 <           res = null;
-694c674
+691c673
 <         say("process done: "+_fuir.siteAsString(s) + ":\t"+_fuir.codeAtAsString(s)+" stack is "+stack+" RES "+res);
 ---
 >         say("process done: "+_fuir.siteAsString(s) + ":\t"+_fuir.codeAtAsString(s)+" stack is "+stack);
-696d675
+693d674
 <     return res;

--- a/src/dev/flang/fuir/analysis/dfa/DFA.java
+++ b/src/dev/flang/fuir/analysis/dfa/DFA.java
@@ -162,6 +162,27 @@ public class DFA extends ANY
 
 
     /**
+     * drop a value, but process its side-effect.
+     *
+     * @param v an expression that calculates a value that is not needed, but
+     * where the calculation might have side-effects (like performing a call) that
+     * we do need.
+     *
+     * For backends that do not perform any side-effects in RESULT, this does
+     * not need to be redefined, the default implementation is nop() which is
+     * fine in this case.
+     *
+     * @param type clazz id for the type of the value
+     *
+     * @return code to perform the side effects of v and ignoring the produced value.
+     */
+    @Override
+    public void drop(Val v, int type)
+    {
+    }
+
+
+    /**
      * Perform an assignment val to field f in instance rt
      *
      * @param s site of the expression causing this assignment


### PR DESCRIPTION
This seems cleaner than having a default implementation that just calls `nop`.


