### PR TITLE
base: date_time, fix milli_second bug

### DIFF
--- a/modules/base/src/time/date_time.fz
+++ b/modules/base/src/time/date_time.fz
@@ -19,7 +19,7 @@
 #
 #  Source code of Fuzion standard library feature time.date_time
 #
-#  Authors: 
+#  Authors:
 #  - Michael Lill (michael.lill@tokiwa.software)
 #  - Yann Glady (yann.glady@tokiwa.software)
 #
@@ -31,24 +31,33 @@
 #
 
 
-public date_time(public year, month, day, hour, minute, second, nano_second i32) : property.orderable
+public date_time(public year, month, day, hour, minute, second i32, nano_second_ i32) : property.orderable
 pre
   debug: 1 ≤ month ≤ 12
   debug: is_valid_date year month day
   debug: 0 ≤ hour ≤ 23
   debug: 0 ≤ minute ≤ 59
   debug: 0 ≤ second ≤ 60 # possible leap seconds
-  debug: 0 ≤ nano_second ≤ 1E9
+  debug: 0 ≤ nano_second_ ≤ 1E9
 is
 
   # the millisecond of this datetime
   #
   public milli_second i32
-  post
-    debug: result ≥ 0 & result ≤ 999
+    post
+      debug: result ≥ 0 & result < 1E3
   =>
-    # NYI: BUG: wrong! we should then not expose nano_second
-    nano_second / 1E6
+    nano_second_ / 1E6
+
+
+  # the nanosecond of this datetime
+  #
+  public nano_second i32
+    post
+      debug: result ≥ 0 & result < 1E6
+  =>
+    nano_second_ % 1E6
+
 
 
   year_as_string => year.as_string 4 10
@@ -58,7 +67,7 @@ is
   minute_as_string => minute.as_string 2 10
   second_as_string => second.as_string 2 10
   milli_second_as_string => milli_second.as_string 3 10
-  nano_second_as_string => nano_second.as_string 9 10
+  nano_second_as_string => nano_second.as_string 6 10
 
 
   # ISO 8601 string for this datetime
@@ -87,14 +96,14 @@ is
       time.pmilli_second => ("$year_as_string-$month_as_string-$day_as_string" +
                               "T$hour_as_string:$minute_as_string:$second_as_string.$milli_second_as_string")
       time.pnano_second  => ("$year_as_string-$month_as_string-$day_as_string" +
-                              "T$hour_as_string:$minute_as_string:$second_as_string.$nano_second_as_string")
+                              "T$hour_as_string:$minute_as_string:$second_as_string.$milli_second_as_string$nano_second_as_string")
 
 
   # internal helper: total nanoseconds since unix epoch
   #
   nanos i64
   =>
-    unix_time_stamp_i64 * 1000000000 + nano_second.as_i64
+    unix_time_stamp_i64 * 1000000000 + nano_second_.as_i64
 
 
   # add a duration to this date time
@@ -119,16 +128,13 @@ is
     date_time base.year base.month base.day base.hour base.minute base.second new_nano.as_i32
 
 
-  # as_string(f date_time_format, local/time_zone) String is
-  # ...
-
 
   # returns an array containing the year, the day in the year, hour, minute,
   # second, and nano_second of this date time
   #
   # internal helper feature
   #
-  args_in_order => [year, month, day, hour, minute, second, nano_second]
+  args_in_order => [year, month, day, hour, minute, second, nano_second_]
 
 
   # 0 = Sunday, 1 = Monday, etc.
@@ -226,11 +232,11 @@ is
     total_seconds := n
     days_since_1970 := total_seconds / seconds_in_day # number of days since 1970-01-01 (can be negative for dates before 1970)
     leftover_seconds := total_seconds % seconds_in_day # leftover seconds after previous calculation
-    # add one day if leftover_seconds is negative, 
+    # add one day if leftover_seconds is negative,
     # because in that case we are actually in the previous day
-    days := days_since_1970 - (if leftover_seconds < 0 then 1 else 0) 
+    days := days_since_1970 - (if leftover_seconds < 0 then 1 else 0)
     # add 24 hours to leftover_seconds if it is negative, to get a value in the range of 0..86399 representing the time of day
-    time_seconds := leftover_seconds + (if leftover_seconds < 0 then seconds_in_day else 0) 
+    time_seconds := leftover_seconds + (if leftover_seconds < 0 then seconds_in_day else 0)
 
     year, month, day :=
       if days >= 0 # after 1970
@@ -267,7 +273,7 @@ is
             # for dates before 1970, the day is calculated as the number of days in the month minus the leftover days,
             # because we calculated backwards
             days_in_month_local := time.days_in_month yy mm
-            (yy, mm, days_in_month_local.as_i32 - remaining.as_i32 + 1) 
+            (yy, mm, days_in_month_local.as_i32 - remaining.as_i32 + 1)
 
 
 
@@ -283,7 +289,7 @@ is
   # defines an equality relation for date time
   #
   public redef type.equality(a, b date_time.this) bool =>
-    a.nano_second = b.nano_second &
+    a.nano_second_ = b.nano_second_ &
      a.year = b.year &
      a.month = b.month &
      a.day = b.day &
@@ -312,7 +318,7 @@ public fixed supported_year(y i32) bool =>
   # Dates too far away from the unix epoch (1970-01-01) would cause an overflow in the unix_time_stamp calculation,
   # which is currently implemented using a 64-bit integer counting nanoseconds since the epoch.
   1650 <= y <= 2260
-  
+
 
 # is the given year a leap year?
 #


### PR DESCRIPTION
date_time just divided nano_second by one million and returned this as the result but this was then not subtracted from nano_second.

