### PR TITLE
parser: use universe as target for call to tuple

### DIFF
--- a/src/dev/flang/parser/Parser.java
+++ b/src/dev/flang/parser/Parser.java
@@ -1934,7 +1934,7 @@ klammer     : LPAREN block RPAREN
           }
         else if (forked_t.size() != 1)
           {
-            res = new ParsedCall(null, new ParsedName(tokenSourceRange(), "tuple"), tuple());
+            res = new ParsedCall(Universe.instance, new ParsedName(tokenSourceRange(), "tuple"), tuple());
           }
         else
           {


### PR DESCRIPTION
Otherwise this might lead to problems if another feature named `tuple` is declared somewhere.