### PR TITLE
base: rename `net.channel` to `net.endpoint`

### DIFF
--- a/modules/base/src/net/client.fz
+++ b/modules/base/src/net/client.fz
@@ -32,7 +32,7 @@
 #       _ := net.client net.family.ipv4 net.protocol.tcp "tokiwa.software" 80
 #         .bind c->
 #           c.with _ mutate ()->
-#             say net.channel.env.get_peer_address
+#             say net.endpoint.env.get_peer_address
 #             say <| (io.buffered mutate).Writer.env.write [0,1,2]
 #
 # Blocks until connection is established.

--- a/modules/base/src/net/connection.fz
+++ b/modules/base/src/net/connection.fz
@@ -31,7 +31,7 @@ module:public connection(desc i32) is
     fuzion.sys.net.close desc
 
 
-  # this installs reader, writer and channel for the given connection
+  # this installs reader, writer and endpoint for the given connection
   #
   public with(T type, LM type : mutate, fn ()->T) T
   =>
@@ -58,21 +58,21 @@ module:public connection(desc i32) is
           fuzion.sys.net.write desc data.as_array
 
 
-    channel_ =>
+    endpoint_ =>
       net
-        .channel desc
+        .endpoint desc
 
     # NYI: CLEANUP: can we still have fluent
     # interface here?
     (io.buffered LM).Writer.instate writer ()->
       reader
-        .and T _ channel_
+        .and T _ endpoint_
         .call fn
 
 
 
 
-  # this installs reader, writer and channel for the given connection
+  # this installs reader, writer and endpoint for the given connection
   #
   # NYI: DOCUMENTATION: see tests/sockets_thread_pool for now
   #

--- a/modules/base/src/net/endpoint.fz
+++ b/modules/base/src/net/endpoint.fz
@@ -22,18 +22,7 @@
 # -----------------------------------------------------------------------
 
 
-# a endpoint encapsulates an open network resource
-# that can be read from and written to.
-# endpoints are usually installed by a successfully connected client
-# or a by a newly accepted server connection.
-#
-# Note that even though UDP is a connection-less protocol its
-# usage in fuzion does not differ from TCP except for the following
-# caveats.
-# 1) Reading a Datagram with a buffer not large enough to hold
-# all data will lead to the rest of the datagram being dropped.
-# 2) writing to a endpoint installed by `server.accept` will result in an error.
-# 3) reading from a endpoint installed by `client ...` will block indefinitely.
+# an endpoint provides access to the peers address and port
 #
 module:public endpoint(desc i32) : effect
 is

--- a/modules/base/src/net/endpoint.fz
+++ b/modules/base/src/net/endpoint.fz
@@ -17,14 +17,14 @@
 #
 #  Tokiwa Software GmbH, Germany
 #
-#  Source code of Fuzion standard library feature net.channel
+#  Source code of Fuzion standard library feature net.endpoint
 #
 # -----------------------------------------------------------------------
 
 
-# a channel encapsulates an open network resource
+# a endpoint encapsulates an open network resource
 # that can be read from and written to.
-# channels are usually installed by a successfully connected client
+# endpoints are usually installed by a successfully connected client
 # or a by a newly accepted server connection.
 #
 # Note that even though UDP is a connection-less protocol its
@@ -32,10 +32,10 @@
 # caveats.
 # 1) Reading a Datagram with a buffer not large enough to hold
 # all data will lead to the rest of the datagram being dropped.
-# 2) writing to a channel installed by `server.accept` will result in an error.
-# 3) reading from a channel installed by `client ...` will block indefinitely.
+# 2) writing to a endpoint installed by `server.accept` will result in an error.
+# 3) reading from a endpoint installed by `client ...` will block indefinitely.
 #
-module:public channel(desc i32) : effect
+module:public endpoint(desc i32) : effect
 is
 
 

--- a/tests/sockets/sockets_test.fz
+++ b/tests/sockets/sockets_test.fz
@@ -45,11 +45,11 @@ sockets_test is
     accept =>
       (net.server.env.accept.bind c->
         c.with unit lm ()->
-          chan => net.endpoint.env
+          endp => net.endpoint.env
 
           say_silent "$protocol/$family-server, accepted connection"
-          say_silent chan.get_peer_address
-          say_silent chan.get_peer_port
+          say_silent endp.get_peer_address
+          say_silent endp.get_peer_port
 
           rr := (io.buffered lm).read_line_while (s -> !s.is_empty)
 
@@ -100,8 +100,6 @@ sockets_test is
       c net.connection =>
 
         res := c.with String lm ()->
-
-            chan => net.endpoint.env
 
             req := ("GET / HTTP\n"
               + "Host: $host\n"

--- a/tests/sockets/sockets_test.fz
+++ b/tests/sockets/sockets_test.fz
@@ -45,7 +45,7 @@ sockets_test is
     accept =>
       (net.server.env.accept.bind c->
         c.with unit lm ()->
-          chan => net.channel.env
+          chan => net.endpoint.env
 
           say_silent "$protocol/$family-server, accepted connection"
           say_silent chan.get_peer_address
@@ -101,7 +101,7 @@ sockets_test is
 
         res := c.with String lm ()->
 
-            chan => net.channel.env
+            chan => net.endpoint.env
 
             req := ("GET / HTTP\n"
               + "Host: $host\n"

--- a/tests/sockets_thread_pool/sockets_test.fz
+++ b/tests/sockets_thread_pool/sockets_test.fz
@@ -45,7 +45,7 @@ sockets_thread_pool_test is
     accept =>
       (net.server.env.accept.bind c->
         sc := c.in_thread_pool unit concur.thread_pool mutate ()->
-          chan => net.channel.env
+          chan => net.endpoint.env
 
           say_silent "$protocol/$family-server, accepted connection"
           say_silent chan.get_peer_address
@@ -103,7 +103,7 @@ sockets_thread_pool_test is
 
         res := c.in_thread_pool String concur.thread_pool mutate ()->
 
-            chan => net.channel.env
+            chan => net.endpoint.env
 
             req := ("GET / HTTP\n"
               + "Host: $host\n"

--- a/tests/sockets_thread_pool/sockets_test.fz
+++ b/tests/sockets_thread_pool/sockets_test.fz
@@ -45,11 +45,11 @@ sockets_thread_pool_test is
     accept =>
       (net.server.env.accept.bind c->
         sc := c.in_thread_pool unit concur.thread_pool mutate ()->
-          chan => net.endpoint.env
+          endp => net.endpoint.env
 
           say_silent "$protocol/$family-server, accepted connection"
-          say_silent chan.get_peer_address
-          say_silent chan.get_peer_port
+          say_silent endp.get_peer_address
+          say_silent endp.get_peer_port
 
           rr := (io.buffered mutate).read_line_while (s -> !s.is_empty)
 
@@ -102,8 +102,6 @@ sockets_thread_pool_test is
       c net.connection =>
 
         res := c.in_thread_pool String concur.thread_pool mutate ()->
-
-            chan => net.endpoint.env
 
             req := ("GET / HTTP\n"
               + "Host: $host\n"


### PR DESCRIPTION
fix #7443