### PR TITLE
base: update `tuple` comment to reflect current destructuring syntax

### DIFF
--- a/modules/base/src/tuple.fz
+++ b/modules/base/src/tuple.fz
@@ -47,12 +47,11 @@
 # Similarly, syntactic sugar for the destructuring of tuples can be used
 # to access the values as in
 #
-#     (a, b, c, ...) := t
+#     a, b, c, ... := t
 #
-# In destructurings, we can denote values we are not interested in using
-# '_' as in
+# When destructuring, '_' denotes a value that is to be ignored, as in
 #
-#  (_, b) := ("first", "second")
+#  _, b := ("first", "second")
 #
 # which will set 'b' to '"second"' and drop the first element of the tuple.
 #
@@ -65,58 +64,46 @@
 #
 # Then, we could extract Bob's age using
 #
-#     (_, age) := b
+#     _, age := b
 #
 # or Claire's name using
 #
-#     (name, _) := c
+#     name, _ := c
 #
 # Destructuring also works for general features, e.g.
 #
 #     point (x,y i32) is {}
 #
-#     p := point 3, 4
-#     (px, py) := p       # will set px to 3 and py to 4
+#     p := point 3 4
+#     px, py := p          # will set px to 3 and py to 4
 #
 # and the destructured value can then be used to create a tuple
 #
-#     t := (px, py)       # will create tuple<i32,i32> instance
+#     t := (px, py)        # will create an instance of tuple i32 i32
 #
 # however, tuples are not assignment compatible with general features even
 # if they would destructure into the same types, i.e.,
 #
 #     u tuple i32 i32 = p  # will cause compile time error
-#     q point = (7, 12)      # will cause compile time error
+#     q point = (7, 12)    # will cause compile time error
 #
-# The unit tuple '()' can be used as a shorthand to create the empty tuple
-# 'tuple'.  The empty tuple can be destructured like any other tuple
-# using
+# The 0-tuple '()' can be used as a shorthand to create the empty tuple
+# 'tuple'.  The 0-tuple can not be destructured.
+# A tuple type with no actual generic arguments is isomorphic to 'unit', i.e, it
+# is a type that has only one single value: '()'.
 #
-#     () := ()
-#
-# even though this has no effect.
-#
-# An instance of the single tuple 'tuple A' with sole element 'a' can not
+# An instance of the 1-tuple 'tuple A' with sole element 'a' can not
 # be created using syntactic sugar '(a)', this will produce the plain
-# value of 'a' instead. However, destructuring of a single tuple is possible:
+# value of 'a' instead. Destructuring of a 1-tuple is not possible.
 #
-#     (a0) := tuple a
-#
-# which is equivalent to
-#
-#     a0 := a
-#
-# NYI: A single tuple 'tuple A' is currently not assignment compatible with
+# NYI: A 1-tuple 'tuple A' is currently not assignment compatible with
 # type 'A', which would make handling of general tuples easier.
 #
 # tuples and destructuring can be used to swap two elements or create a
 # permutation as in
 #
-#     (a, b) := (b, a)
-#     (o, t, a, n) := (n, a, t, o)
-#
-# A tuple type with no actual generic arguments is isomorphic to 'unit', i.e, it
-# is a type that has only one single value: '()'.
+#     a, b := (b, a)
+#     o, t, a, n := (n, a, t, o)
 #
 public tuple(public A type...,
              public values A...


### PR DESCRIPTION
fix #7498
