### PR TITLE
tokiwa: close_out/err to fix jenkins error of too many open files

### DIFF
--- a/modules/base/src/os/Process_effect.fz
+++ b/modules/base/src/os/Process_effect.fz
@@ -117,6 +117,7 @@ public Process ref : effect is
             time.Nano.env.sleep (min timeout-elapsed_time polling_time)
           else
             if r >= 0
+              # NYI: UNDER DEVELOPMENT: it is kind of arbitrary to remove process from running processes in this case...
               _ := running_processes.update (container.Set os.process)->(container.Set os.process) rp->
                 rp ∖ (container.set_of_ordered [p])
               outcome r.as_u32
@@ -150,6 +151,7 @@ public Process ref : effect is
         running_processes.for_each p->
           # NYI: UNDER DEVELOPMENT: register failures
           _ := p.wait
+          _ := fzE_pipe_close p.std_in
           _ := fzE_pipe_close p.std_out
           _ := fzE_pipe_close p.std_err
 

--- a/modules/base/src/os/process.fz
+++ b/modules/base/src/os/process.fz
@@ -164,12 +164,16 @@ module:public process(public pid i64, module std_in, std_out, std_err i64, name 
 
   # close standard output of this process
   #
+  # NYI: CLEANUP: should this better be done automatically by runtime?
+  #
   public close_out outcome unit =>
     if fzE_pipe_close std_out != 0
       error "closing $(desc_name std_out) of process $(pid)" fzE_last_error
 
 
   # close standard error of this process
+  #
+  # NYI: CLEANUP: should this better be done automatically by runtime?
   #
   public close_err outcome unit =>
     if fzE_pipe_close std_err != 0

--- a/modules/tokiwa/src/tokiwa.fz
+++ b/modules/tokiwa/src/tokiwa.fz
@@ -156,5 +156,10 @@ public tokiwa is
             p.close_err.or_panic
             p.kill     .or_else (say "sending kill signal to $p failed")
             process_result "" "failed waiting for $cmd, error is: $e" 1
-          ec u32 => process_result fout.get ferr.get ec)
+          ec u32 =>
+            o := fout.get
+            e := ferr.get
+            p.close_out.or_panic
+            p.close_err.or_panic
+            process_result o e ec)
       .or_panic


### PR DESCRIPTION
This is the second time I "fix" this, I forgot this happens.
In the long run, I think it is more reasonable to have std_out/std_err be closed automatically when process has been waited on.