### PR TITLE
fe: raise error if visibility is specified for type parameter

### DIFF
--- a/modules/base/src/Binary.fz
+++ b/modules/base/src/Binary.fz
@@ -25,4 +25,4 @@
 #
 # T is the result type of the function, U1 and U2 are the argument types of the function
 #
-public Binary(public T, U1 type, U2 type) ref : Function T U1 U2 is
+public Binary(T, U1 type, U2 type) ref : Function T U1 U2 is

--- a/modules/base/src/Cons.fz
+++ b/modules/base/src/Cons.fz
@@ -27,7 +27,7 @@
 #
 # A Cons is a ref to a cell that contains a head and a tail
 #
-public Cons(public A, B type) ref is
+public Cons(A, B type) ref is
 
   public head A => abstract
 

--- a/modules/base/src/Function.fz
+++ b/modules/base/src/Function.fz
@@ -27,8 +27,8 @@
 #
 # R is the result type of the function, A are the argument types of the function
 #
-public Function(public R type,
-                public A type...) ref is
+public Function(R type,
+                A type...) ref is
 
   # call this function on given arguments a...
   #

--- a/modules/base/src/Lazy.fz
+++ b/modules/base/src/Lazy.fz
@@ -31,7 +31,7 @@
 # `4+5>10` will never be executed:
 #     true || 4+5>10
 #
-public Lazy(public T type) ref : Nullary T,
+public Lazy(T type) ref : Nullary T,
 # Read here how lazy compuations form a monad: https://blog.ploeh.dk/2022/05/30/the-lazy-monad/
 # NYI: UNDER DEVELOPMENT: add example where monad is useful #5057
                                  monad T is

--- a/modules/base/src/Monoid.fz
+++ b/modules/base/src/Monoid.fz
@@ -30,7 +30,7 @@
 # (string/concat/""), etc.
 #
 #
-public Monoid(public T type /* : property.equatable */) ref
+public Monoid(T type /* : property.equatable */) ref
 
 /* NYI: quantor intrinsics not supported yet:
 

--- a/modules/base/src/Nullary.fz
+++ b/modules/base/src/Nullary.fz
@@ -25,7 +25,7 @@
 #
 # T is the result type of the function
 #
-public Nullary(public T type) ref : Function T,
+public Nullary(T type) ref : Function T,
                                     auto_unwrap T is
 
   public redef unwrap T => call

--- a/modules/base/src/Sequence.fz
+++ b/modules/base/src/Sequence.fz
@@ -33,7 +33,7 @@
 #
 # Heirs of Sequence must implement 'as_list'.
 #
-public Sequence(public T type) ref
+public Sequence(T type) ref
   : property.countable,
     property.orderable,
     property.hashable

--- a/modules/base/src/Typed_Function.fz
+++ b/modules/base/src/Typed_Function.fz
@@ -30,8 +30,8 @@
 #
 # This is used, e.g., as an argument to `Any.dynamic_apply`.
 #
-public Typed_Function(public R type,
-                      public A type...) ref is
+public Typed_Function(R type,
+                      A type...) ref is
 
 
   # call this function for type `T` on arguments `a...` and `v`.

--- a/modules/base/src/Unary.fz
+++ b/modules/base/src/Unary.fz
@@ -28,7 +28,7 @@
 # For unary functions, function composition is possible if the result type of
 # the first function matches the argument type of the second function.
 #
-public Unary(public T, U type) ref : Function T U is
+public Unary(T, U type) ref : Function T U is
 
 
   # function composition

--- a/modules/base/src/abort.fz
+++ b/modules/base/src/abort.fz
@@ -28,5 +28,5 @@
 # contains the final value of a computation.
 # used e.g. in Sequence.reduce
 #
-public abort(public T type,
+public abort(T type,
              public val T) is

--- a/modules/base/src/array.fz
+++ b/modules/base/src/array.fz
@@ -32,7 +32,7 @@
 # name clash with routine array(T,length,init).
 #
 module:public array(
-      public T type,
+      T type,
       module internal_array fuzion.sys.internal_array T,
       _ unit,
       _ unit,

--- a/modules/base/src/array2.fz
+++ b/modules/base/src/array2.fz
@@ -31,7 +31,7 @@
 # two index parameters.
 #
 private:public array2(
-       public T type,
+       T type,
        public length0, length1 i64,
        module redef internal_array fuzion.sys.internal_array T,
        _ unit,

--- a/modules/base/src/array3.fz
+++ b/modules/base/src/array3.fz
@@ -31,7 +31,7 @@
 # three index parameters.
 #
 private:public array3(
-       public T type,
+       T type,
        public length0, length1, length2 i64,
        module redef internal_array fuzion.sys.internal_array T,
        _ unit,

--- a/modules/base/src/choice.fz
+++ b/modules/base/src/choice.fz
@@ -103,4 +103,4 @@
 # A choice type with no actual generic arguments is isomorphic to 'void', i.e, it
 # is a type that has an empty set of possible values.
 #
-public choice(public CHOICE_ELEMENT_TYPE type...) is
+public choice(CHOICE_ELEMENT_TYPE type...) is

--- a/modules/base/src/concur/Channel.fz
+++ b/modules/base/src/concur/Channel.fz
@@ -36,7 +36,7 @@
 # channel will return `nil`.
 #
 # NYI: UNDER DEVELOPMENT: max buf size
-public Channel(public T type/*, buf_size i32*/) ref : Iterator T, Sending_Channel T, Receiving_Channel T is
+public Channel(T type/*, buf_size i32*/) ref : Iterator T, Sending_Channel T, Receiving_Channel T is
 
   bq := Blocking_Queue T
 
@@ -182,11 +182,11 @@ public Unbuffered_Channel(# the mutate environment to be used for this channel.
                           # A multi-thread variant like `concur.blocking_mutate` is
                           # required.
                           #
-                          public M type : mutate,
+                          M type : mutate,
 
                           # The type of the elements sent through this channel.
                           #
-                          public T type
+                          T type
                           ) : Channel T
 is
 

--- a/modules/base/src/container/Binary_Heap_Queue.fz
+++ b/modules/base/src/container/Binary_Heap_Queue.fz
@@ -34,11 +34,11 @@
 module:public Binary_Heap_Queue(
   # the mutate effect
   #
-  public LM type : mutate,
+  LM type : mutate,
 
   # type of the elements in the queue
   #
-  public T type,
+  T type,
 
   # comparator to determine priority of the elements
   #

--- a/modules/base/src/container/Dynamic_Array.fz
+++ b/modules/base/src/container/Dynamic_Array.fz
@@ -30,11 +30,11 @@ module:public Dynamic_Array (
 
   # the mutate effect
   #
-  public LM type : mutate,
+  LM type : mutate,
 
   # element type
   #
-  public T type,
+  T type,
 
   # contents of the array
   #

--- a/modules/base/src/container/Fixed_Capacity_Array.fz
+++ b/modules/base/src/container/Fixed_Capacity_Array.fz
@@ -32,11 +32,11 @@ module:public Fixed_Capacity_Array(
 
   # the mutate effect
   #
-  public LM type : mutate,
+  LM type : mutate,
 
   # element type
   #
-  public T type,
+  T type,
 
   # contents of the array
   #

--- a/modules/base/src/container/Linked_List.fz
+++ b/modules/base/src/container/Linked_List.fz
@@ -23,7 +23,7 @@
 
 # abstract type for 'Linked_List'
 #
-public Linked_List(public T type) ref : Sequence T is
+public Linked_List(T type) ref : Sequence T is
 
 
   # the next element in the linked list, or nil if this is the last element

--- a/modules/base/src/container/Map.fz
+++ b/modules/base/src/container/Map.fz
@@ -25,7 +25,7 @@
 
 # Map -- an abstract map from keys K to values V
 #
-public Map(public K type : property.equatable, public V type) ref is
+public Map(K type : property.equatable, V type) ref is
 
   # number of entries in this map
   #

--- a/modules/base/src/container/Mutable_Hash_Map.fz
+++ b/modules/base/src/container/Mutable_Hash_Map.fz
@@ -33,15 +33,15 @@
 module:public Mutable_Hash_Map(
         # the mutate effect
         #
-        public LM type : mutate,
+        LM type : mutate,
 
         # type of the keys
         #
-        public HK type : property.hashable,
+        HK type : property.hashable,
 
         # type of the values
         #
-        public V  type,
+        V  type,
 
         # initial size, also the size of the hash map will not decrease below this
         #

--- a/modules/base/src/container/Mutable_Map.fz
+++ b/modules/base/src/container/Mutable_Map.fz
@@ -23,7 +23,7 @@
 
 # Mutable_Map -- an abstract mutable map from keys K to values V
 #
-public Mutable_Map(public K type : property.equatable, public V type) ref is
+public Mutable_Map(K type : property.equatable, V type) ref is
 
   # number of entries in this map
   #

--- a/modules/base/src/container/Mutable_Priority_Queue.fz
+++ b/modules/base/src/container/Mutable_Priority_Queue.fz
@@ -23,7 +23,7 @@
 
 # An abstract mutable priority queue, returning the element with the highest priority first
 #
-public Mutable_Priority_Queue(public T type) ref is
+public Mutable_Priority_Queue(T type) ref is
 
   # add an element to the queue
   #

--- a/modules/base/src/container/Persistent_Map.fz
+++ b/modules/base/src/container/Persistent_Map.fz
@@ -23,7 +23,7 @@
 
 # Persistent_Map -- an abstract persistent map from keys K to values V
 #
-public Persistent_Map(public K type : property.equatable, public V type) ref : container.Map K V is
+public Persistent_Map(K type : property.equatable, V type) ref : container.Map K V is
 
   # returns a new Persistent_Map
   # which contains all entries of the

--- a/modules/base/src/container/Ring_Buffer.fz
+++ b/modules/base/src/container/Ring_Buffer.fz
@@ -30,7 +30,7 @@
 #
 public Ring_Buffer(
   # the type of elements stored in this buffer
-  public T type,
+  T type,
 
   # effect used to modify this buffer
   #

--- a/modules/base/src/container/Set.fz
+++ b/modules/base/src/container/Set.fz
@@ -25,7 +25,7 @@
 
 # Set -- an abstract set of values
 #
-public Set(public E type : property.equatable) ref : Sequence E,
+public Set(E type : property.equatable) ref : Sequence E,
                                                      property.equatable
 is
 

--- a/modules/base/src/container/abstract_array.fz
+++ b/modules/base/src/container/abstract_array.fz
@@ -31,7 +31,7 @@
 public abstract_array
   (
    # element type
-   public T type
+   T type
   ) : Sequence T is
 
 

--- a/modules/base/src/container/expanding_array.fz
+++ b/modules/base/src/container/expanding_array.fz
@@ -42,7 +42,7 @@
 private:public expanding_array
   (
    # element type
-   public T type,
+   T type,
 
    # the array containing the actual data
    data fuzion.sys.internal_array (container.slot T),

--- a/modules/base/src/container/hash_map.fz
+++ b/modules/base/src/container/hash_map.fz
@@ -26,8 +26,8 @@
 # hash_map -- an immutable hash map from keys HK to values V
 #
 public hash_map(
-        public HK type : property.hashable,
-        public V  type,
+        HK type : property.hashable,
+        V  type,
         ks Sequence HK,
         vs Sequence V) : container.Map HK V
   pre

--- a/modules/base/src/container/mutable_tree_map.fz
+++ b/modules/base/src/container/mutable_tree_map.fz
@@ -24,9 +24,9 @@
 
 # mutable_tree_map -- a mutable map using an AVL tree
 #
-private:public mutable_tree_map(public LM  type : mutate,
-                                public KEY type : property.orderable,
-                                public VAL type                      ) : container.Mutable_Map KEY VAL
+private:public mutable_tree_map(LM  type : mutate,
+                                KEY type : property.orderable,
+                                VAL type                      ) : container.Mutable_Map KEY VAL
 is
 
 

--- a/modules/base/src/container/ordered_map.fz
+++ b/modules/base/src/container/ordered_map.fz
@@ -33,8 +33,8 @@
 # keys.length.
 #
 public ordered_map(
-           public OK type : property.orderable,
-           public V  type,
+           OK type : property.orderable,
+           V  type,
            k0 Sequence OK,
            v0 Sequence V) : container.Map OK V
 pre

--- a/modules/base/src/flow/exception.fz
+++ b/modules/base/src/flow/exception.fz
@@ -34,7 +34,7 @@ public exception (# type parameter used only to distinguish different
                   # errors raised by the reader from those raised
                   # by the writer.
                   #
-                  public T type,
+                  T type,
 
                   h error->void
                   ) : flow.fallible error h

--- a/modules/base/src/fuzion/java.fz
+++ b/modules/base/src/fuzion/java.fz
@@ -44,7 +44,7 @@ public java is
 
   # A Java array
   #
-  public Array(public T type,
+  public Array(T type,
                public redef java_ref Java_Ref) ref : Sequence T, fuzion.java.Java_Object java_ref
   is
     public length i32 ! fuzion.jvm =>

--- a/modules/base/src/io/buffered.fz
+++ b/modules/base/src/io/buffered.fz
@@ -36,6 +36,6 @@
 public buffered (# the type of the (local) mutate instance
                  # to be used for this buffered i/o
                  #
-                 module LM type : mutate
+                 LM type : mutate
                 )
 is

--- a/modules/base/src/list.fz
+++ b/modules/base/src/list.fz
@@ -42,7 +42,7 @@
 #
 #
 #
-public list(public A type)
+public list(A type)
   : choice nil (Cons A (list A)),
     Sequence A
 is

--- a/modules/base/src/monad.fz
+++ b/modules/base/src/monad.fz
@@ -34,7 +34,7 @@
 # applied to generic types.
 #
 #
-public monad (public A type) is
+public monad (A type) is
 
 
   # monadic operator within the same monad

--- a/modules/base/src/mutate.fz
+++ b/modules/base/src/mutate.fz
@@ -157,7 +157,7 @@ public mutate : linear_effect is
   # 'mutate' effect in the current environment
   #
   public new (
-    public T type,
+    T type,
 
     # initial value, will be updated by 'put' or 'infix <-'.
     mutable_value T

--- a/modules/base/src/mutate/array.fz
+++ b/modules/base/src/mutate/array.fz
@@ -25,7 +25,7 @@
 #
 module:public array (
        # element type
-       public T type,
+       T type,
 
        # contents of the array
        module data fuzion.sys.internal_array T

--- a/modules/base/src/mutate/array2.fz
+++ b/modules/base/src/mutate/array2.fz
@@ -25,7 +25,7 @@
 #
 module:public array2 (
        # element type
-       public T type,
+       T type,
 
        # length of the array to create
        public redef length0 i64,

--- a/modules/base/src/mutate/array3.fz
+++ b/modules/base/src/mutate/array3.fz
@@ -25,7 +25,7 @@
 #
 module:public array3 (
        # element type
-       public T type,
+       T type,
 
        # length of each dimension
        public redef length0 i64,

--- a/modules/base/src/num/complex.fz
+++ b/modules/base/src/num/complex.fz
@@ -29,7 +29,7 @@
 # A complex number consists of a real and an imaginary part.
 #
 public complex (
-         public C type : numeric,
+         C type : numeric,
          public real,    # real part
                 imag C   # imaginary part
          ) : numeric

--- a/modules/base/src/num/fraction.fz
+++ b/modules/base/src/num/fraction.fz
@@ -36,7 +36,7 @@
 # or the denominator.
 #
 public fraction(
-         public B type : integer,
+         B type : integer,
          public numerator,
                 denominator B
         ) : numeric

--- a/modules/base/src/num/matrix.fz
+++ b/modules/base/src/num/matrix.fz
@@ -27,7 +27,7 @@
 #
 # matrix provides matrix operations based on an arbitrary numeric type
 #
-public matrix(public M type : numeric,
+public matrix(M type : numeric,
               e array2 M) : property.equatable
 is
 

--- a/modules/base/src/num/ryu.fz
+++ b/modules/base/src/num/ryu.fz
@@ -31,7 +31,7 @@
 #
 # NYI: UNDER DEVELOPMENT: lacks documentation
 #
-public ryū(public T type : float) is
+public ryū(T type : float) is
 
   five := T.from_u32 5
 

--- a/modules/base/src/option.fz
+++ b/modules/base/src/option.fz
@@ -27,7 +27,7 @@
 #
 # option represents an optional value of type T
 #
-public option(public T type)
+public option(T type)
   : switch T nil,
     property.orderable,
     property.hashable

--- a/modules/base/src/outcome.fz
+++ b/modules/base/src/outcome.fz
@@ -49,7 +49,7 @@
 # compatible to  'outcome data IO_Error Permission_Error', so everything
 # is fine.
 #
-public outcome(public T type)
+public outcome(T type)
   : switch T error,
     property.equatable
 is

--- a/modules/base/src/property/orderable.fz
+++ b/modules/base/src/property/orderable.fz
@@ -80,7 +80,7 @@ is
 # This allows to reverse the sorting order, e.g.,
 #     [1,5,3,4,2].sort_by property.reverse_order
 #
-public reverse_order(public O type : property.orderable,
+public reverse_order(O type : property.orderable,
                      public val O
                      ) : property.orderable
 is

--- a/modules/base/src/state.fz
+++ b/modules/base/src/state.fz
@@ -62,7 +62,7 @@
 public state(
 
   # types of contained and the state value
-  public T, S type,
+  T, S type,
 
   # the contained value
   public val T,

--- a/modules/base/src/transducer.fz
+++ b/modules/base/src/transducer.fz
@@ -44,7 +44,7 @@
 # B    input      type
 # C    transduced type
 #
-public transducer(public TA, B, C type,
+public transducer(TA, B, C type,
                   td ((TA,B) -> TA) ->  (TA,C) -> TA) is
 
   # use the transducer with reducing function `rf`.

--- a/modules/base/src/tuple.fz
+++ b/modules/base/src/tuple.fz
@@ -105,7 +105,7 @@
 #     a, b := (b, a)
 #     o, t, a, n := (n, a, t, o)
 #
-public tuple(public A type...,
+public tuple(A type...,
              public values A...
              ) : property.orderable,
                  property.hashable

--- a/modules/lock_free/src/lock_free/Map.fz
+++ b/modules/lock_free/src/lock_free/Map.fz
@@ -272,8 +272,8 @@ root_node(CTK type : property.hashable, CTV type) : choice (Indirection_Node CTK
 
 
 # the ctrie
-private:public Map(public CTK type : property.hashable,
-                   public CTV type,
+private:public Map(CTK type : property.hashable,
+                   CTV type,
                    root concur.atomic (root_node CTK CTV),
                    public read_only bool) ref : container.Mutable_Map CTK CTV
 is

--- a/src/dev/flang/ast/AstErrors.java
+++ b/src/dev/flang/ast/AstErrors.java
@@ -2679,7 +2679,16 @@ public class AstErrors extends ANY
   {
     error(range, "A result of type " + st("unit") + " must not be ignored explicitly.",
       "Remove " + ss("_ :=") + " to fix this error.");
-    }
+  }
+
+  public static void typeParameterMustNotDefineTypeVisibility(Feature f)
+  {
+    error(
+      f.pos(),
+      "Setting the visibility is not allowed for a type parameter.",
+      "A type parameters visibility is always public. To fix this, remove the visibility modifier."
+    );
+  }
 
 }
 

--- a/src/dev/flang/ast/Feature.java
+++ b/src/dev/flang/ast/Feature.java
@@ -33,7 +33,6 @@ import java.util.LinkedList;
 import java.util.ListIterator;
 import java.util.Optional;
 import java.util.Set;
-import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
 
@@ -108,7 +107,7 @@ public class Feature extends AbstractFeature
   public Visi visibility()
   {
     return _visibility == Visi.UNSPECIFIED
-      ? Visi.PRIV
+      ? (isTypeParameter() ? Visi.PUB : Visi.PRIV)
       : _visibility;
   }
 
@@ -792,15 +791,15 @@ public class Feature extends AbstractFeature
    * @param p the implementation (feature body etc).
    */
   Feature(SourcePosition pos,
-                 Visi v,
-                 int m,
-                 ReturnType r,
-                 List<String> qname,
-                 List<AbstractFeature> a,
-                 List<AbstractCall> i,
-                 Contract c,
-                 Impl p,
-                 List<AbstractType> effects) // NYI: UNDER DEVELOPMENT: effects
+          Visi v,
+          int m,
+          ReturnType r,
+          List<String> qname,
+          List<AbstractFeature> a,
+          List<AbstractCall> i,
+          Contract c,
+          Impl p,
+          List<AbstractType> effects) // NYI: UNDER DEVELOPMENT: effects
   {
     if (PRECONDITIONS) require
       (pos != null,
@@ -853,6 +852,10 @@ public class Feature extends AbstractFeature
               .collect(Collectors.toSet());
         // NYI: UNDER DEVELOPMENT: report pos of arguments not pos of feature
         AstErrors.argumentNamesNotDistinct(this, duplicateNames);
+      }
+    if (isVisibilitySpecified() && isTypeParameter())
+      {
+        AstErrors.typeParameterMustNotDefineTypeVisibility(this);
       }
   }
 
@@ -2899,7 +2902,7 @@ A pre-condition of a feature that does not redefine an inherited feature must st
     this._returnType = new FunctionReturnType(frt);
   };
 
-  
+
   /**
    * is this feature a field that is nameless i.e. declared using {@code _ :=}
    */

--- a/src/dev/flang/ast/Function.java
+++ b/src/dev/flang/ast/Function.java
@@ -349,7 +349,7 @@ public class Function extends AbstractLambda
                   {
                     var n = _names.get(i);
                     var arg = new Feature(n._pos,
-                                          Visi.PRIV,
+                                          i < cl.typeArguments().size() ? Visi.UNSPECIFIED : Visi.PRIV,
                                           0,
                                           at,
                                           n._name,

--- a/src/dev/flang/ast/Resolution.java
+++ b/src/dev/flang/ast/Resolution.java
@@ -620,7 +620,7 @@ public class Resolution extends ANY
             var p = af.pos();
             var inh = cotypeInherits(af);
             var typeArg = new Feature(p,
-                                      Visi.PRIV,
+                                      Visi.UNSPECIFIED,
                                       0,
                                       af.selfType(),
                                       FuzionConstants.COTYPE_RELAY_TYPE,
@@ -641,9 +641,14 @@ public class Resolution extends ANY
                 var constraint0 = (t instanceof Feature tf ? tf.returnType().functionReturnType() : t.resultType())
                   .resolve(this, af.context());
                 var constraint = af.rebaseTypeForCotype(constraint0);
-                var ta = new Feature(p, t.visibility(), t.modifiers() & FuzionConstants.MODIFIER_REDEFINE, constraint, t.baseName(),
-                                     Contract.EMPTY_CONTRACT,
-                                     i);
+                var ta = new Feature(
+                    p,
+                    Visi.UNSPECIFIED,
+                    t.modifiers() & FuzionConstants.MODIFIER_REDEFINE,
+                    constraint,
+                    t.baseName(),
+                    Contract.EMPTY_CONTRACT,
+                    i);
                 typeArgs.add(ta);
               }
 

--- a/src/dev/flang/ast/UnresolvedType.java
+++ b/src/dev/flang/ast/UnresolvedType.java
@@ -875,7 +875,7 @@ public abstract class UnresolvedType extends AbstractType implements HasSourcePo
       (outer.isValueArgument());
 
     var tp = new Feature(pos(),
-                         outer.visibility(),
+                         Visi.UNSPECIFIED,
                          0,
                          freeTypeConstraint().resolve(res, context),
                          _name,

--- a/src/dev/flang/parser/Parser.java
+++ b/src/dev/flang/parser/Parser.java
@@ -867,7 +867,8 @@ argType     : type
                                     var n = argNames();
                                     AbstractType t;
                                     Impl i;
-                                    if (current() == Token.t_type)
+                                    var isTypePar = current() == Token.t_type;
+                                    if (isTypePar)
                                       {
                                         i = typeType();
                                         t = skipColon() ? type()
@@ -890,9 +891,17 @@ argType     : type
                                       }
                                     for (var s : n)
                                       {
-                                        result.add(new Feature(s._pos, forPreOrPostCondition ? Visi.PRIV : v, m, t, s._name, Contract.EMPTY_CONTRACT,
-                                                               i == null ? new Impl(s._pos, null, Impl.Kind.FieldActual)
-                                                                         : i));
+                                        result.add(
+                                          new Feature(
+                                            s._pos,
+                                            forPreOrPostCondition && !isTypePar ? Visi.PRIV : v,
+                                            m,
+                                            t,
+                                            s._name,
+                                            Contract.EMPTY_CONTRACT,
+                                            i == null ? new Impl(s._pos, null, Impl.Kind.FieldActual): i
+                                          )
+                                        );
                                       }
                                   }
                                 while (skipComma());

--- a/tests/reg_issue5433/reg_issue5433.fz
+++ b/tests/reg_issue5433/reg_issue5433.fz
@@ -25,8 +25,8 @@
 #
 reg_issue5433 =>
 
-  a(public R type,
-           public A type...) is
+  a(R type,
+    A type...) is
 
     b is
       c(arg A...) unit => abstract

--- a/tests/reg_issue5583/reg_issue5583.fz.expected_err
+++ b/tests/reg_issue5583/reg_issue5583.fz.expected_err
@@ -1,8 +1,8 @@
 
 error 1: IMPLEMENTATION RESTRICTION: illegal inheritance and usage of fixed feature:
 q.type.b.type.me
-private type.q(private fixed RELAY#TYPE Type (type parameter)) q.type : a q.this.type is
-private type.a(private fixed RELAY#TYPE Type (type parameter)) a.type : has_me a.this.type is
+private type.q(public fixed RELAY#TYPE Type (type parameter)) q.type : a q.this.type is
+private type.a(public fixed RELAY#TYPE Type (type parameter)) a.type : has_me a.this.type is
 
 *** fatal errors encountered, stopping.
 one error.

--- a/tests/reg_issue6957/reg_issue6957.fz.expected_err
+++ b/tests/reg_issue6957/reg_issue6957.fz.expected_err
@@ -1,8 +1,8 @@
 
 error 1: IMPLEMENTATION RESTRICTION: illegal inheritance and usage of fixed feature:
 f.type.Stat.type.default_value
-private type.f(private fixed RELAY#TYPE Type (type parameter)) f.type : (io f.this.type).file f.this.type is
-public type.file(private fixed RELAY#TYPE Type (type parameter)) io.type.file.type : Any io.file.this.type is
+private type.f(public fixed RELAY#TYPE Type (type parameter)) f.type : (io f.this.type).file f.this.type is
+public type.file(public fixed RELAY#TYPE Type (type parameter)) io.type.file.type : Any io.file.this.type is
 
 *** fatal errors encountered, stopping.
 one error.

--- a/tests/reg_issue7256/reg_issue7256.fz
+++ b/tests/reg_issue7256/reg_issue7256.fz
@@ -23,9 +23,9 @@
 
 public my_mut : mutate is
 
-  public abstract_a (public T type) ref is
+  public abstract_a (T type) ref is
 
-  public arr (public T type) ref : abstract_a T is
+  public arr (T type) ref : abstract_a T is
     public type.empty abstract_a T =>
       my_mut.this.env.arr T
 


### PR DESCRIPTION
This PR as a suggestion, since i currently don't see the point of controlling the visibility of type parameters. They can IMHO always be public since they are also marked as fixed and are never inherited.