### PR TITLE
base: process, more detailed error message

### DIFF
--- a/modules/base/src/os/process.fz
+++ b/modules/base/src/os/process.fz
@@ -29,19 +29,19 @@ module:public process(public pid i64, module std_in, std_out, std_err i64, name 
   # predefined read handler for reading from
   # standard out of the process
   #
-  std_out_reader(LM type : mutate) => pipe_reader LM std_out "reading from stdout(desc=$std_out) of process $(pid)"
+  std_out_reader(LM type : mutate) => pipe_reader LM std_out "reading from stdout(desc=$std_out) of process $(description)"
 
 
   # predefined read handler for reading from
   # standard err of the process
   #
-  std_err_reader(LM type : mutate) => pipe_reader LM std_err "reading from stderr(desc=$std_err) of process $(pid)"
+  std_err_reader(LM type : mutate) => pipe_reader LM std_err "reading from stderr(desc=$std_err) of process $(description)"
 
 
   # predefined write handler for writing to
   # standard in of the process
   #
-  std_in_writer(LM type : mutate) => pipe_writer LM std_in "writing to stdin(desc=$std_in) of process $(pid)"
+  std_in_writer(LM type : mutate) => pipe_writer LM std_in "writing to stdin(desc=$std_in) of process $(description)"
 
 
   # read bytes from standard out
@@ -52,7 +52,7 @@ module:public process(public pid i64, module std_in, std_out, std_err i64, name 
       arr := array u8 _ io.buffer_size.as_i32 _->0
       res := fzE_pipe_read desc arr.internal_array.data arr.count
       if res = -1
-        error "reading from stdout of process $(pid)" fzE_last_error
+        error "reading from stdout of process $(description)" fzE_last_error
       else if res = 0
         io.end_of_file
       else
@@ -115,7 +115,7 @@ module:public process(public pid i64, module std_in, std_out, std_err i64, name 
   #
   public close_in outcome unit =>
     if fzE_pipe_close std_in != 0
-      error "closing stdin of process $(pid)" fzE_last_error
+      error "closing stdin of process $(description)" fzE_last_error
 
 
   # close standard output of this process
@@ -124,7 +124,7 @@ module:public process(public pid i64, module std_in, std_out, std_err i64, name 
   #
   public close_out outcome unit =>
     if fzE_pipe_close std_out != 0
-      error "closing stdout of process $(pid)" fzE_last_error
+      error "closing stdout of process $(description)" fzE_last_error
 
 
   # close standard error of this process
@@ -133,7 +133,7 @@ module:public process(public pid i64, module std_in, std_out, std_err i64, name 
   #
   public close_err outcome unit =>
     if fzE_pipe_close std_err != 0
-      error "closing stderr of process $(pid)" fzE_last_error
+      error "closing stderr of process $(description)" fzE_last_error
 
 
   # wait for this process
@@ -201,6 +201,12 @@ module:public process(public pid i64, module std_in, std_out, std_err i64, name 
   #
   public fixed redef type.lteq(a, b process.this) bool =>
     a.pid <= b.pid
+
+
+  # used in error messages
+  #
+  description =>
+    "$name $(String.join args " ") (PID: $pid)"
 
 
   # this process as a human readable String


### PR DESCRIPTION
example:
`error(code=9): reading from stdout(desc=7) of process make int --environment-overrides --directory=build/tests/reg_issue7341 (PID: 39388).`