### PR TITLE
win: fix `non-void function does not return a value in all control paths`

### DIFF
--- a/include/win.c
+++ b/include/win.c
@@ -745,6 +745,7 @@ int fzE_thread_join(void * thrd) {
         }
       default:
         assert(false);
+        return -1;
     }
 }
 


### PR DESCRIPTION
[ci skip]

