### PR TITLE
rt: add `fzE_process_close`

### DIFF
--- a/include/fz.h
+++ b/include/fz.h
@@ -484,7 +484,15 @@ int fzE_process_create(char * args[], size_t argsLen, char * env[], size_t envLe
 int64_t fzE_process_poll(int64_t p);
 
 /**
+ * close process handle, free memory
+ *
+ * @return -1 error, 0 success
+ */
+int fzE_process_close(int64_t p);
+
+/**
  * get the hostname
+ *
  * @return -1 on error, length of hostname on success
  */
 int fzE_hostname(char *buf, size_t nbytes);

--- a/include/posix.c
+++ b/include/posix.c
@@ -789,6 +789,15 @@ int fzE_process_create(char * args[], size_t argsLen, char * env[], size_t envLe
   return ret;
 }
 
+/**
+ * close process handle, free memory
+ */
+int fzE_process_close(int64_t p)
+{
+  // nothing to be done
+  return 0;
+}
+
 
 // check the status of process p, does not wait for process to finish
 //

--- a/include/win.c
+++ b/include/win.c
@@ -967,9 +967,17 @@ int64_t fzE_process_poll(int64_t p){
         return -1;
     }
 
-    // Process has exited.
-    CloseHandle((HANDLE)p);
     return (int64_t)status;
+}
+
+/**
+ * close process handle, free memory
+ */
+int fzE_process_close(int64_t p)
+{
+  return CloseHandle((HANDLE)p)
+    ? 0
+    : 1;
 }
 
 

--- a/modules/base/src/native.fz
+++ b/modules/base/src/native.fz
@@ -261,6 +261,14 @@ module fzE_process_create(
 module fzE_process_poll(process i64) i64 => native
 
 
+#
+# close process handle, free memory
+#
+# return: -1 error, 0 success
+#
+module fzE_process_close(process i64) i32 => native
+
+
 # returns -1 on error or length of the hostname otherwise
 #
 module fzE_hostname(
@@ -269,7 +277,7 @@ module fzE_hostname(
   # the length of the array
   length i32) i64 => native
 
-  
+
 # returns error code on error or zero on success
 #
 module fzE_pipe_create(pipefd Array i64) i32 => native

--- a/modules/base/src/os/Process_effect.fz
+++ b/modules/base/src/os/Process_effect.fz
@@ -154,5 +154,7 @@ public Process ref : effect is
           _ := fzE_pipe_close p.std_in
           _ := fzE_pipe_close p.std_out
           _ := fzE_pipe_close p.std_err
+          if fzE_process_close p.pid != 0
+            Runtime_Failure.env.register_failure (error "process could not be close successfully: $p")
 
     universe.P_ref


### PR DESCRIPTION
On windows the process HANDLE needs to be freed.
We need to do this independently from `fzE_process_poll`


