### PR TITLE
base: allow index operations on `array2`/`3` without type parameter

### DIFF
--- a/modules/base/src/array2.fz
+++ b/modules/base/src/array2.fz
@@ -33,7 +33,7 @@
 private:public array2(
        T type,
        public length0, length1 i64,
-       public base array T,
+       module base array T,
        _ unit,
        _ unit) : property.hashable
   pre

--- a/modules/base/src/array2.fz
+++ b/modules/base/src/array2.fz
@@ -33,17 +33,14 @@
 private:public array2(
        T type,
        public length0, length1 i64,
-       module redef internal_array fuzion.sys.internal_array T,
+       public base array T,
        _ unit,
-       _ unit)
- : array T internal_array unit unit unit unit
+       _ unit) : property.hashable
   pre
     safety: length0 ≥ 0
     safety: length1 ≥ 0
     safety: length0 *? length1 >=? 0
 is
-
-  internal_array.freeze
 
 
   # equality of two arrays2 is true iff `a` and `b` have the same dimensions and for all
@@ -59,8 +56,8 @@ is
     if T : property.equatable then
       (a.length0 = b.length0 &&
        a.length1 = b.length1 &&
-       (for ae in a
-            be in b
+       (for ae in a.base
+            be in b.base
         until ae != be
           false
         else
@@ -73,7 +70,7 @@ is
   #
   # There is no natural total ordering for two-dimensional arrays
   #
-  public redef fixed type.lteq(a, b array2 T) bool =>
+  public fixed type.lteq(a, b array2 T) bool =>
     compile_time_panic # no natural total ordering for two-dimensional arrays
 
 
@@ -102,7 +99,7 @@ is
               # include dimensions so reshaped arrays with identical elements hash differently
               # e.g. [[1,2,3],[4,5,6]] != [[1,2],[3,4],[5,6]]
               (a.length0.as_u64 << 32 | a.length1.as_u64)
-      a.map (T.hash_code)
+      a.base.map (T.hash_code)
        .foldf h0 xxh_next
     else
       compile_time_panic  # array is not hashable since element type is not
@@ -129,7 +126,7 @@ is
       safety: i64.zero ≤ i1.as_i64 < length0
       safety: i64.zero ≤ i2.as_i64 < length1
   =>
-    array2.this[i1.as_i64 * length1 + i2.as_i64]
+    array2.this.base[i1.as_i64 * length1 + i2.as_i64]
 
 
   # create a string representation of this array including all the string
@@ -139,7 +136,7 @@ is
   public redef as_string  String : encodings =>
     c =>
       indices0
-        .map (i -> "  " + (slice i*length1 (i+1)*length1))
+        .map (i -> "  " + (base.slice i*length1 (i+1)*length1))
         .fold (String.concat ","+ascii.lf_str)
     "[$(ascii.lf_str)$c$(ascii.lf_str)]"
 
@@ -148,7 +145,7 @@ is
   # get a list of tuples indices and elements in this array
   #
   public enumerate2 list (i64, i64, T) =>
-    if length = 0 then nil else enumerate_cons 0 0
+    if base.length = 0 then nil else enumerate_cons 0 0
 
 
   # create a cons cell for a list of tuples of this array's indices and elements
@@ -201,14 +198,9 @@ is
       debug : length1.fits_in_i64
   =>
 
-    internal_array := fuzion.sys.internal_array_init T length0.as_i32*length1.as_i32
-    for i1 := I.zero, i1+1
-    while i1 < length0
-      for i2 := I.zero, i2+1
-      while i2 < length1
-        internal_array[i1.as_i32 * length1.as_i32 + i2.as_i32] := init i1 i2
+    base := array T I length0*length1 (i->init (i/length1) (i%length1))
 
-    array2 T length0.as_i64 length1.as_i64 internal_array unit unit
+    array2 T length0.as_i64 length1.as_i64 base unit unit
 
 
 

--- a/modules/base/src/array3.fz
+++ b/modules/base/src/array3.fz
@@ -33,18 +33,16 @@
 private:public array3(
        T type,
        public length0, length1, length2 i64,
-       module redef internal_array fuzion.sys.internal_array T,
+       module base array T,
        _ unit,
        _ unit)
- : array T internal_array unit unit unit unit
+ : property.hashable
   pre
     safety: length0 ≥ 0
     safety: length1 ≥ 0
     safety: length2 ≥ 0
     safety: length0 *? length1 *? length2 >=? 0
 is
-
-  internal_array.freeze
 
 
   # equality of two array3s is true iff `a` and `b` have the same dimensions and for all
@@ -61,8 +59,8 @@ is
       (a.length0 = b.length0 &&
        a.length1 = b.length1 &&
        a.length2 = b.length2 &&
-       (for ae in a
-            be in b
+       (for ae in a.base
+            be in b.base
         until ae != be
           false
         else
@@ -75,7 +73,7 @@ is
   #
   # There is no natural total ordering for three-dimensional arrays
   #
-  public redef fixed type.lteq(a, b array3 T) bool =>
+  public fixed type.lteq(a, b array3 T) bool =>
     compile_time_panic # no natural total ordering for three-dimensional arrays
 
 
@@ -105,7 +103,7 @@ is
                 # include dimensions so reshaped arrays with identical elements hash differently
                 (a.length0.as_u64 << 32 | a.length1.as_u64))
               a.length2.as_u64
-      a.map (T.hash_code)
+      a.base.map (T.hash_code)
        .foldf h0 xxh_next
     else
       compile_time_panic  # array is not hashable since element type is not
@@ -132,7 +130,7 @@ is
       safety: i64.zero ≤ i1.as_i64 < length1
       safety: i64.zero ≤ i2.as_i64 < length2
   =>
-    array3.this[(i0.as_i64 * length1 + i1.as_i64) * length2 + i2.as_i64]
+    array3.this.base[(i0.as_i64 * length1 + i1.as_i64) * length2 + i2.as_i64]
 
 
   # create a string representation of this array including all the string
@@ -150,7 +148,7 @@ is
     dim_2(i i64, j i64) =>
       from := (i * length1 + j) * length2
       to := from + length2
-      "    " + slice from to
+      "    " + base.slice from to
 
     ("[" + ascii.lf_str
       + indices0
@@ -162,7 +160,7 @@ is
   # get a list of tuples indices and elements in this array
   #
   public enumerate3 list (i64, i64, i64, T) =>
-    if length = 0 then nil else enumerate_cons 0 0 0
+    if base.length = 0 then nil else enumerate_cons 0 0 0
 
 
   # create a cons cell for a list of tuples of this array's indices and elements
@@ -203,14 +201,9 @@ is
       debug : length2.fits_in_i64
   =>
 
-    internal_array := fuzion.sys.internal_array_init T length0.as_i32*length1.as_i32*length2.as_i32
-    for i1 := I.zero, i1+1 while i1 < length0
-      for i2 := I.zero, i2+1 while i2 < length1
-        for i3 := I.zero, i3+1 while i3 < length2
-          internal_array[(i1.as_i32 * length1.as_i32 + i2.as_i32) * length2.as_i32 + i3.as_i32] := init i1 i2 i3
+    base := array T I length0*length1*length2 (i->init (i/(length1*length2)) ((i/length2) % length1) (i%length2))
 
-
-    array3 T length0.as_i64 length1.as_i64 length2.as_i64 internal_array unit unit
+    array3 T length0.as_i64 length1.as_i64 length2.as_i64 base unit unit
 
 
 

--- a/modules/base/src/num/matrix.fz
+++ b/modules/base/src/num/matrix.fz
@@ -67,8 +67,8 @@ is
   #
   public fixed redef type.equality(a, b num.matrix M) bool =>
     for
-      x in a.e
-      y in b.e
+      x in a.e.base
+      y in b.e.base
     until x != y
       false
     else

--- a/tests/reg_issue2380/reg_issue2380.fz
+++ b/tests/reg_issue2380/reg_issue2380.fz
@@ -35,7 +35,7 @@ reg_issue2380 is
   part1 =>
     lm : mutate is
     lm ! ()->
-      visited := lm.array i32 .new _ area.length.as_i64 (_->0)
+      visited := lm.array i32 .new _ area.base.length.as_i64 (_->0)
       r => 1
       l => 2
       u => 4
@@ -46,7 +46,7 @@ reg_issue2380 is
             (y.as_i64 ∈ area.indices1) &&
             (visited[ix x y] & d) = 0) then
           visited[ix x y] := visited[ix x y] | d
-          c := area[_,y,x]
+          c := area[y,x]
           if  w = r  &&  c = "."              then trace x+1 y   w
           if  w = l  &&  c = "."              then trace x-1 y   w
           if  w = u  &&  c = "."              then trace x   y-1 w

--- a/tests/reg_issue2380/reg_issue2380.fz
+++ b/tests/reg_issue2380/reg_issue2380.fz
@@ -35,7 +35,7 @@ reg_issue2380 is
   part1 =>
     lm : mutate is
     lm ! ()->
-      visited := lm.array i32 .new _ area.base.length.as_i64 (_->0)
+      visited := lm.array i32 .new _ area.length0*area.length1 (_->0)
       r => 1
       l => 2
       u => 4

--- a/tests/reg_issue2381/reg_issue2381.fz
+++ b/tests/reg_issue2381/reg_issue2381.fz
@@ -35,7 +35,7 @@ reg_issue2381 is
   part1 =>
     lm : mutate is
     lm ! ()->
-      visited := lm.array i32 .new _ area.length.as_i64 (_->0)
+      visited := lm.array i32 .new _ area.base.length.as_i64 (_->0)
       r => 1
       l => 2
       u => 4

--- a/tests/reg_issue2381/reg_issue2381.fz
+++ b/tests/reg_issue2381/reg_issue2381.fz
@@ -35,7 +35,7 @@ reg_issue2381 is
   part1 =>
     lm : mutate is
     lm ! ()->
-      visited := lm.array i32 .new _ area.base.length.as_i64 (_->0)
+      visited := lm.array i32 .new _ area.length0*area.length1 (_->0)
       r => 1
       l => 2
       u => 4

--- a/tests/reg_issue6882/reg_issue6882.fz.expected_err_jvm
+++ b/tests/reg_issue6882/reg_issue6882.fz.expected_err_jvm
@@ -1,15 +1,15 @@
 
 error 1: java.lang.Error: No effect of reg_issue6882.lm instated.
-	at fzC__L5623_reg_issue6__all__INTERN_fun1__call__INTERN_fun2__call.fzRoutine(--CURDIR--/reg_issue6882.fz)
+	at fzC__L5626_reg_issue6__all__INTERN_fun1__call__INTERN_fun2__call.fzRoutine(--CURDIR--/reg_issue6882.fz)
 	at fzC_3instate_helper_unit_panic__call_code__call.fzRoutine({base.fum}/effect.fz:405)
 	at fzC_3instate_helper_unit_panic.fzRoutine({base.fum}/effect.fz:400)
 	at fzC_panic_INTERN_type_panic__3instate_unit.fzRoutine({base.fum}/effect.fz:170)
 	at fzC_flow__1try_String_panic_unit__1catch0.fzRoutine({base.fum}/flow/try.fz:63)
-	at fzC_flow__1try_String_panic_unit__1catch__INTERN_fun56__call.fzRoutine({base.fum}/flow/try.fz:50)
-	at fzC__L5036_3instate_h__try_String_panic_unit_lm__call_code__call.fzRoutine({base.fum}/effect.fz:405)
+	at fzC_flow__1try_String_panic_unit__1catch__INTERN_fun23__call.fzRoutine({base.fum}/flow/try.fz:50)
+	at fzC__L5035_3instate_h__try_String_panic_unit_lm__call_code__call.fzRoutine({base.fum}/effect.fz:405)
 	at fzC_3instate_helper__unit__flow_try_String_panic_unit_lm.fzRoutine({base.fum}/effect.fz:400)
-	at fzC__L5011_flow_INTER__w_try_String_panic_unit_lm__3instate_unit.fzRoutine({base.fum}/effect.fz:170)
-	at fzC__L5000_flow_INTER__w_try_String_panic_unit_lm__2instate_unit.fzRoutine({base.fum}/effect.fz:191)
+	at fzC__L5010_flow_INTER__w_try_String_panic_unit_lm__3instate_unit.fzRoutine({base.fum}/effect.fz:170)
+	at fzC__L4999_flow_INTER__w_try_String_panic_unit_lm__2instate_unit.fzRoutine({base.fum}/effect.fz:191)
 	at fzC_flow__1try_String_panic_unit__lm__1instate_self_unit.fzRoutine({base.fum}/effect.fz:212)
 	at fzC_flow__1try_String_panic_unit__lm__1infix_not_unit.fzRoutine({base.fum}/effect.fz:229)
 	at fzC_flow__1try_String_panic_unit__1catch.fzRoutine({base.fum}/flow/try.fz:49)
@@ -20,7 +20,7 @@ error 1: java.lang.Error: No effect of reg_issue6882.lm instated.
 	at dev.flang.be.jvm.runtime.FuzionThread.lambda$new$0(FuzionThread.java:100)
 	at dev.flang.util.Errors.runAndExit(Errors.java:930)
 	at dev.flang.be.jvm.runtime.FuzionThread.lambda$new$2(FuzionThread.java:132)
-	at java.base/java.lang.Thread.run(Thread.java:1474)
+	at java.base/java.lang.Thread.run(Thread.java:1516)
 
 *** fatal errors encountered, stopping.
 one error.


### PR DESCRIPTION
Change `array2`/`3` to not inherit from `array`, instead define an inner field `base` of type `array`.

fix #7543