### PR TITLE
parser: do not add `ERROR_NAME` to formal args

### DIFF
--- a/src/dev/flang/parser/Parser.java
+++ b/src/dev/flang/parser/Parser.java
@@ -891,17 +891,20 @@ argType     : type
                                       }
                                     for (var s : n)
                                       {
-                                        result.add(
-                                          new Feature(
-                                            s._pos,
-                                            forPreOrPostCondition && !isTypePar ? Visi.PRIV : v,
-                                            m,
-                                            t,
-                                            s._name,
-                                            Contract.EMPTY_CONTRACT,
-                                            i == null ? new Impl(s._pos, null, Impl.Kind.FieldActual): i
-                                          )
-                                        );
+                                        if (s != ParsedName.ERROR_NAME)
+                                          {
+                                            result.add(
+                                              new Feature(
+                                                  s._pos,
+                                                  forPreOrPostCondition && !isTypePar ? Visi.PRIV : v,
+                                                  m,
+                                                  t,
+                                                  s._name,
+                                                  Contract.EMPTY_CONTRACT,
+                                                  i == null ? new Impl(s._pos, null, Impl.Kind.FieldActual): i
+                                              )
+                                            );
+                                          }
                                       }
                                   }
                                 while (skipComma());

--- a/tests/reg_issue7599/Makefile
+++ b/tests/reg_issue7599/Makefile
@@ -1,0 +1,25 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test Makefile
+#
+# -----------------------------------------------------------------------
+
+override NAME = reg_issue7599
+include ../simple.mk

--- a/tests/reg_issue7599/reg_issue7599.fz
+++ b/tests/reg_issue7599/reg_issue7599.fz
@@ -1,0 +1,36 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test reg_issue7599
+#
+# -----------------------------------------------------------------------
+
+public my_mut : mutate is
+
+  public abstract_a (
+        T type
+        ) ref
+  is
+
+  public arr (
+        T type, # the comma here causes a NullPointerException
+        ) ref : abstract_a T
+  is
+    public type.empty abstract_a T =>
+      my_mut.this.env.arr T

--- a/tests/reg_issue7599/reg_issue7599.fz.expected_err
+++ b/tests/reg_issue7599/reg_issue7599.fz.expected_err
@@ -1,0 +1,7 @@
+
+--CURDIR--/reg_issue7599.fz:33:9: error 1: Syntax error: expected identifier name, infix/prefix/postfix operator, 'ternary ? :', 'index' or 'set' name, found right parenthesis ')'
+        ) ref : abstract_a T
+--------^
+While parsing: name, parse stack: name (twice), argNames, formArgs, formArgsOpt, routOrField, feature, expr, exprs, block (twice), implRout, routOrField, feature, expr, exprs, block (twice), unit
+
+one error.


### PR DESCRIPTION
fixes #7599
