### PR TITLE
win, tests: native outerref pass through, remove skip file

### DIFF
--- a/tests/native_outerref_pass_through/skip_win
+++ b/tests/native_outerref_pass_through/skip_win
@@ -1,1 +1,0 @@
-segfaults currently


### PR DESCRIPTION
This should now work as well due to #7598

[ci skip]

