### PR TITLE
net/ip_address: implement `property.orderable`

### DIFF
--- a/modules/base/src/net/ip_address.fz
+++ b/modules/base/src/net/ip_address.fz
@@ -27,7 +27,7 @@
 # in the case of an IPv4 address, this is the canonical mapping of that
 # address to an IPv6 address.
 #
-public ip_address (val u128) : property.equatable, property.orderable is
+public ip_address (val u128) : property.orderable is
 
   # is the stored IP address an IPv4 or IPv6 address?
   #

--- a/modules/base/src/net/ip_address.fz
+++ b/modules/base/src/net/ip_address.fz
@@ -27,7 +27,7 @@
 # in the case of an IPv4 address, this is the canonical mapping of that
 # address to an IPv6 address.
 #
-public ip_address (val u128) : property.equatable is
+public ip_address (val u128) : property.equatable, property.orderable is
 
   # is the stored IP address an IPv4 or IPv6 address?
   #
@@ -54,6 +54,12 @@ public ip_address (val u128) : property.equatable is
   #
   public redef type.equality (a, b ip_address.this) bool =>
     a.val = b.val
+
+
+  # dummy orderable implementation
+  #
+  public redef type.lteq (a, b ip_address.this) bool =>
+    a.val <= b.val
 
 
   # creates an ip_address from a Sequence of u8 like returned by the


### PR DESCRIPTION
This is necessary for use in a `container.Set`.