### PR TITLE
fe: fix replacing this-type in choice generics

### DIFF
--- a/modules/base/src/Sequence/equatable.fz
+++ b/modules/base/src/Sequence/equatable.fz
@@ -112,12 +112,6 @@ public find(pattern Sequence T) option i32
   fold_until init 0
 
 
-# NYI: BUG: Node could be in Sequence?
-# but currently gives confusing error in a few places:
-#
-# Case matches type 'Sequence.this.Node'.
-# Subject type is one of '(option Sequence.this.Node).Node' or 'nil'.
-
 # helper features for knuth morris pratt algorithm
 #
 universe.Node(T type, top Sequence T, next once (option (Node T)), rest option (Node T)) ref is

--- a/src/dev/flang/ast/AbstractType.java
+++ b/src/dev/flang/ast/AbstractType.java
@@ -377,7 +377,7 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
     return
       isThisType()
       ? g
-      : replaceGenerics(g).map(t -> t.replace_this_type_by_actual_outer(this, context));
+      : replaceGenerics(g).map(t -> t.replace_this_type_by_actual_outer(outer(), context));
   }
 
 


### PR DESCRIPTION
for a choice `option Sequence.this.Node` the code replaced Sequence.this by the choice itself. For choice generic `Sequence.this.Node` this resulted in `(option Sequence.this.Node).Node` which is obviously wrong.

Moving Node to `Sequence` is still not possible, since this would be a ref in a ref and will give errors like: "Call has an ambiguous result type since target of the call is a 'ref' type."
