### PR TITLE
clang: fix `FATAL FAULT precondition: safety: !open || is_exclusive`

### DIFF
--- a/modules/clang/src/clang.fz
+++ b/modules/clang/src/clang.fz
@@ -86,7 +86,7 @@ cx_string_to_string(cx_str CXString) =>
   res
 
 
-lm : mutate is
+lm : racy_mutate is
 
 
 # clang -- unit feature to group clang related features
@@ -219,20 +219,20 @@ public clang is
 
         CXChildVisit_Continue
 
+    lm.instate_self (outcome unit) ()->
 
-    ci := clang_createIndex 0 0
+      ci := clang_createIndex 0 0
 
-    check !(ffi.is_null ci)
+      check !(ffi.is_null ci)
 
-    tu := lm ! ()->
-      clang_parseTranslationUnit ci (header_file.as_c_string lm) ((lm.array Native_Ref).from_Sequence (Sequence Native_Ref .empty)) 0 ffi.null 0 0
+      tu := clang_parseTranslationUnit ci (header_file.as_c_string lm) ((lm.array Native_Ref).from_Sequence (Sequence Native_Ref .empty)) 0 ffi.null 0 0
 
-    if ffi.is_null tu
-      error "failed to open header file: $header_file"
-    else
-      cursor := clang_getTranslationUnitCursor tu
+      if ffi.is_null tu
+        error "failed to open header file: $header_file"
+      else
+        cursor := clang_getTranslationUnitCursor tu
 
-      _ := clang_visitChildren cursor visitor ffi.null
+        _ := clang_visitChildren cursor visitor ffi.null
 
-      clang_disposeTranslationUnit tu
-      clang_disposeIndex ci
+        clang_disposeTranslationUnit tu
+        clang_disposeIndex ci

--- a/src/dev/flang/be/jvm/runtime/FuzionThread.java
+++ b/src/dev/flang/be/jvm/runtime/FuzionThread.java
@@ -59,7 +59,7 @@ public class FuzionThread extends Thread
    * Runtime.effect_pop will remove the last element in this list and install it
    * back as the effect instance.
    *
-   * Unitle _installedEffects, this list does not regard effect types or
+   * Unlike _installedEffects, this list does not regard effect types or
    * effectIds, but mixes effects of different types. This is possible since
    * effect_push/effect_pop is guaranteed to be perfectly nested even for
    * different effect types.


### PR DESCRIPTION
This seems to have broken a while ago...