### PR TITLE
rt, posix:  `fzE_file_write` handle `EWOULDBLOCK`/`EAGAIN`

### DIFF
--- a/include/posix.c
+++ b/include/posix.c
@@ -1105,10 +1105,12 @@ void fzE_date_time(int32_t * result)
 
 int32_t fzE_file_write(void * file, void * buf, int32_t size)
 {
+  errno = 0;
   size_t result = fwrite(buf, 1, size, (FILE*)file);
-  return ferror((FILE*)file)!=0
-    ? -1
-    : result;
+
+  return result >= 0
+    ? (int32_t)result
+    : (errno == EAGAIN || errno == EWOULDBLOCK ? 0 : -1);
 }
 
 int32_t fzE_file_move(const char *oldpath, const char *newpath)


### PR DESCRIPTION
We don't want to return error on EWOULDBLOCK/EAGAIN, we instead just return 0 bytes written.

fixes #7627
