### PR TITLE
fix #7626: use position of value expression for loop index var actuals

### DIFF
--- a/src/dev/flang/ast/Loop.java
+++ b/src/dev/flang/ast/Loop.java
@@ -610,6 +610,39 @@ public class Loop extends ANY
   }
 
 
+   /**
+   * Create an actual argument that passes the value of an index var to the tail
+   * recursive loop feature.
+   *
+   * The source position and range are taken from the expression that defines
+   * the value such that error messages, e.g., for failed type inference, refer
+   * to that expression and not to the index variable's name.
+   *
+   * @param f an index var (for the initial value) or the corresponding feature
+   * from _nextValues (for the value used in the next iteration)
+   *
+   * @param prefix ITER_ARG_PREFIX_INIT or ITER_ARG_PREFIX_NEXT
+   *
+   * @param name the base name of the index var
+   *
+   * @param fallback the position to be used in case the value of f does not
+   * correspond to an expression in the source code, e.g., for an iterating
+   * index var ('for x in s') whose Impl was replaced in addIterators.
+   */
+  private Call iterArgActual(Feature f, String prefix, String name, SourcePosition fallback)
+  {
+    var e = f.impl().expr();
+    var useE = e != null && !e.pos().isBuiltIn();
+    var result = new Call(useE ? e.pos() : fallback, prefix + name);
+    // NYI: CLEANUP: set source range/pos in constructor call
+    if (useE && e.sourceRange() instanceof SourceRange r)
+      {
+        result.setSourceRange(r);
+      }
+    return result;
+  }
+
+
   /**
    * Helper routine to determine the formal and actual arguments to be passed to the tail recursive loop
    *
@@ -636,8 +669,8 @@ public class Loop extends ANY
           (f.impl()._kind != Impl.Kind.FieldIter);
 
         var p = f.pos();
-        var ia = new Call(p, FuzionConstants.ITER_ARG_PREFIX_INIT + f.baseName());
-        var na = new Call(p, FuzionConstants.ITER_ARG_PREFIX_NEXT + f.baseName());
+        var ia = iterArgActual(f                 , FuzionConstants.ITER_ARG_PREFIX_INIT, f.baseName(), p);
+        var na = iterArgActual(_nextValues.get(i), FuzionConstants.ITER_ARG_PREFIX_NEXT, f.baseName(), p);
         var type = (f.impl()._kind == Impl.Kind.FieldDef)
           ? null        // index var with type inference from initial actual
           : _indexVars.get(i).returnType().functionReturnType();

--- a/tests/reg_issue2347/reg_issue2347.fz.expected_err
+++ b/tests/reg_issue2347/reg_issue2347.fz.expected_err
@@ -7,15 +7,15 @@ Target feature: 'i32'
 In call: 'd.bla'
 
 
---CURDIR--/reg_issue2347.fz:27:5: error 2: Incompatible types when passing argument in a call
+--CURDIR--/reg_issue2347.fz:27:21: error 2: Incompatible types when passing argument in a call
 for s := [1] : nil, s.filter x->d.bla
-----^
+--------------------^^^^^^^^^^^^^^^^^
 Actual type for argument #1 's' does not match expected type.
 In call to          : 'loop'
 expected formal type: 'list (array i32)'
 actual type found   : 'Sequence (array i32)'
 assignable to       : 'Sequence (array i32)'
-for value assigned  : 's'
+for value assigned  : 's.filter x->d.bla'
 To solve this, you could change the type of the target 's' to 'Sequence (array i32)' or convert the type of the assigned value to 'list (array i32)'.
 
 2 errors.

--- a/tests/reg_issue7626/Makefile
+++ b/tests/reg_issue7626/Makefile
@@ -1,0 +1,26 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test Makefile
+#
+# -----------------------------------------------------------------------
+
+override NAME = reg_issue7626
+
+include ../simple.mk

--- a/tests/reg_issue7626/reg_issue7626.fz
+++ b/tests/reg_issue7626/reg_issue7626.fz
@@ -1,0 +1,24 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test reg_issue7626
+#
+# -----------------------------------------------------------------------
+
+for i := 3, true do   # 1. should flag an error: incompatible types of actual arguments

--- a/tests/reg_issue7626/reg_issue7626.fz.expected_err
+++ b/tests/reg_issue7626/reg_issue7626.fz.expected_err
@@ -1,0 +1,13 @@
+
+--CURDIR--/reg_issue7626.fz:24:5: error 1: Type inference from actual arguments failed due to incompatible types of actual arguments
+for i := 3, true do   # 1. should flag an error: incompatible types of actual arguments
+----^
+For the formal argument 'loop.i' the following incompatible actual arguments where found for type inference:
+actual is value of type 'i32' at --CURDIR--/reg_issue7626.fz:24:10:
+for i := 3, true do   # 1. should flag an error: incompatible types of actual arguments
+---------^
+actual is value of type 'bool' at --CURDIR--/reg_issue7626.fz:24:13:
+for i := 3, true do   # 1. should flag an error: incompatible types of actual arguments
+------------^^^^
+
+one error.


### PR DESCRIPTION
Fixes #7626.

Loop index vars are passed to the tail recursive loop feature as actual
arguments. These actuals were built with the index var's position, so
every expression in the error message pointed at the same place. They
now take position and source range from the value expression.

For `for x in s` the value has no position in the source code after
addIterators, so the old position is kept.

reg_issue2347 expected_err updated: error 2 now points at
`s.filter x->d.bla` instead of at `s`.

Developed with the assistance of AI tools. All local tests passed.