### PR TITLE
lsp: fix "Unimplemented method 'outer'"

### DIFF
--- a/src/dev/flang/lsp/feature/Commands.java
+++ b/src/dev/flang/lsp/feature/Commands.java
@@ -142,7 +142,7 @@ public enum Commands
               .choiceGenerics()
               .stream()
               .filter(cg -> !m.cases().stream().anyMatch(c -> c.field() == null || c.field().resultType().isAssignableFromDirectly(cg).yes()))
-              .map(t -> indent + CaseConverter.toSnakeCase(TypeTool.baseName(t)) + " " + TypeTool.label(t) + " =>")
+              .map(t -> indent + CaseConverter.toSnakeCase(TypeTool.baseName(t)) + " " + t.toString(true) + " =>")
               .collect(Collectors.joining(System.lineSeparator()));
 
           var endOfSubPos = Bridge.toPosition(ExprTool.endOfExpr(m.subject()));

--- a/src/dev/flang/lsp/shared/FeatureTool.java
+++ b/src/dev/flang/lsp/shared/FeatureTool.java
@@ -283,7 +283,7 @@ public class FeatureTool extends ANY
           + feature.arguments()
             .stream()
             .map(a -> {
-              var type = a.isTypeParameter() ? "type": TypeTool.label(a.resultType());
+              var type = a.isTypeParameter() ? "type": a.resultType().toString(true);
               type = useMarkup ? MarkdownTool.italic(type) : type;
               if (isInternal(a))
                 {
@@ -294,10 +294,10 @@ public class FeatureTool extends ANY
             .collect(Collectors.joining(", "))
           + (feature.arguments().isEmpty() ? "" : ")");
         return feature.baseName() + arguments
-          + (feature.isConstructor() ? "" : " " + (useMarkup ? MarkdownTool.italic(TypeTool.label(feature.resultType())) : TypeTool.label(feature.resultType())))
+          + (feature.isConstructor() ? "" : " " + (useMarkup ? MarkdownTool.italic(feature.resultType().toString(true)) : feature.resultType().toString(true)))
           + labelInherited(feature);
       }
-    return feature.baseName() + " " + TypeTool.label(feature.resultType()) + labelInherited(feature);
+    return feature.baseName() + " " + feature.resultType().toString(true) + labelInherited(feature);
   }
 
 

--- a/src/dev/flang/lsp/shared/TypeTool.java
+++ b/src/dev/flang/lsp/shared/TypeTool.java
@@ -27,70 +27,17 @@ Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
 
 package dev.flang.lsp.shared;
 
-import java.util.stream.Collectors;
-
 import dev.flang.ast.AbstractType;
-import dev.flang.ast.Types;
-import dev.flang.ast.UnresolvedType;
 import dev.flang.util.ANY;
 
 public class TypeTool extends ANY
 {
-  /**
-   * human readable label for type
-   * @param type
-   * @return
-   */
-  public static String label(AbstractType type)
-  {
-
-    if (containsError(type)
-      || type.containsUndefined())
-      {
-        return baseName(type);
-      }
-    if (type.isNormalType() && type.generics() != UnresolvedType.NONE)
-      {
-        return labelNoErrorOrUndefined(type) + " "
-          + type.generics().stream().map(g -> Util.addParens(label(g))).collect(Collectors.joining(" "));
-      }
-    return labelNoErrorOrUndefined(type);
-  }
 
   // NYI: UNDER DEVELOPMENT: DUCKTAPE! ensure condition sometimes fails on containsError()
   // unable to reproduce unfortunately
   public static boolean containsError(AbstractType type)
   {
     return ErrorHandling.resultOrDefault(() -> type.containsError(), true);
-  }
-
-
-  private static String labelNoErrorOrUndefined(AbstractType type)
-  {
-    if (PRECONDITIONS)
-      require(!containsError(type), !type.containsUndefined());
-
-    if (type.isParametricType())
-      {
-        return baseName(type) + (type.isRef() ? " (boxed)": "");
-      }
-    else if (type.outer() != null)
-      {
-        return (type.isRef() && (type.feature() == null || !type.feature().isRef()) ? "ref "
-                    : !type.isRef() && type.feature() != null && type.feature().isRef() ? "value "
-                    : "")
-          + (type.feature() == null
-                                          ? baseName(type)
-                                          : type.feature().baseName());
-      }
-    else if (type.feature() == null || type.feature() == Types.f_ERROR)
-      {
-        return baseName(type);
-      }
-    else
-      {
-        return type.feature().baseName();
-      }
   }
 
 


### PR DESCRIPTION
```
dev.flang.ast.ThisType.outer(ThisType.java:97)
dev.flang.lsp.shared.TypeTool.labelNoErrorOrUndefined(TypeTool.java:77)
dev.flang.lsp.shared.TypeTool.label(TypeTool.java:57)
dev.flang.lsp.shared.FeatureTool.label(FeatureTool.java:297)
dev.flang.lsp.util.Bridge.toDocumentSymbol(Bridge.java:97)
dev.flang.lsp.feature.DocumentSymbols.documentSymbolTree(DocumentSymbols.java:54)
dev.flang.lsp.feature.DocumentSymbols.lambda$documentSymbolTree$0(DocumentSymbols.java:57)
java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:214)
java.base/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:197)
java.base/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:197)
java.base/java.util.TreeMap$ValueSpliterator.forEachRemaining(TreeMap.java:3258)
java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:570)
```
