### PR TITLE
build: improve output of run_test by separating backends more clearly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -601,30 +601,25 @@ TEST_DEPENDENCIES = $(FZ_MODULES) $(MOD_JAVA_BASE) $(MOD_FZ_CMD) $(BUILD_DIR)/te
 # phony target to run Fuzion tests using effects and report number of failures
 .PHONY .SILENT: run_tests_effect
 run_tests_effect: $(FZ) $(TEST_DEPENDENCIES)
-	printf "testing effects: "
 	$(BUILD_DIR)/bin/run_tests $(BUILD_DIR) effect
 
 # phony target to run Fuzion tests using interpreter and report number of failures
 .PHONY .SILENT: run_tests_int
 run_tests_int: $(FZ_INT) $(TEST_DEPENDENCIES)
-	printf "testing interpreter: "
 	$(BUILD_DIR)/bin/run_tests $(BUILD_DIR) int
 
 # phony target to run Fuzion tests using c backend and report number of failures
 .PHONY .SILENT: run_tests_c
 run_tests_c: $(FZ_C) $(TEST_DEPENDENCIES)
-	printf "testing C backend: "; \
 	$(BUILD_DIR)/bin/run_tests $(BUILD_DIR) c
 
 # phony target to run Fuzion tests using jvm backend and report number of failures
 .PHONY .SILENT: run_tests_jvm
 run_tests_jvm: $(FZ_JVM) $(TEST_DEPENDENCIES)
-	printf "testing JVM backend: "; \
 	$(BUILD_DIR)/bin/run_tests $(BUILD_DIR) jvm
 
 .PHONY .SILENT: run_tests_fuir
 run_tests_fuir: $(TEST_DEPENDENCIES)
-	printf "testing FUIR backend: "; \
 	$(BUILD_DIR)/bin/run_tests $(BUILD_DIR) fuir
 
 .PHONY .SILENT: run_tests_jar_build

--- a/bin/run_tests.fz
+++ b/bin/run_tests.fz
@@ -95,6 +95,8 @@ main =>
   build_dir := io.path.of envir.Args.env[1]
   target := envir.Args.env[2]
 
+  say ""
+  say_section "start testing $target"
 
   # source: https://stackoverflow.com/questions/45181115/portable-way-to-find-the-number-of-processors-cpus-in-a-shell-script
   # first, try third arg then try a few executables, if everything fails use default value
@@ -187,7 +189,7 @@ main =>
   say h
 
   if failed + produced_error > 0
-    say_section "Failed tests"
+    say_section "Failed tests using $target backend"
 
     failed_tests := results_content.filter (.ends_with "failed")
 
@@ -231,7 +233,7 @@ main =>
     .take num_slowest
     .for_each (td -> say "$(td.1.as_string_pad) $(td.0)")
 
-  say_section "$target done"
+  say ""
 
   match envir.Vars.env.get "INFLUXDB_TOKEN"
     nil => say "INFLUXDB_TOKEN not set, not sending to influxdb."


### PR DESCRIPTION
Output now looks like this
```
⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ Slowest 10 tests using fuir backend ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯

5058ms build/tests/assignments
4053ms build/tests/asParsedType
1048ms build/tests/atomic
 531ms build/tests/anonymous_features_must_not_inherit_multiple
  22ms build/tests/assignment_negative
  19ms build/tests/argumentcount_negative
  16ms build/tests/asParsedType_negative
  15ms build/tests/abstractfeatures_negative

INFLUXDB_TOKEN not set, not sending to influxdb.


⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ start testing jvm ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯

8 tests, running 8 tests in parallel.
#.......
```

instead of this
```
⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ Slowest 10 tests using fuir backend ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯

  85s build/tests/mod_webserver
  50s build/tests/blocking_mutate_timeout
  43s build/tests/mod_http_message
  42s build/tests/ring_buf
  40s build/tests/process
  39s build/tests/mod_nom_parser_xml
  39s build/tests/lib_io_file
  38s build/tests/lib_io_utf8
  38s build/tests/sockets
  37s build/tests/nom

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ fuir done ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯

INFLUXDB_TOKEN is blank, not sending to influxdb.
testing JVM backend: 777 tests, running 4 tests in parallel.
..............
```