### PR TITLE
base: in error `incompatible type parameter`, add positive list of types `actual` is assignable to

### DIFF
--- a/src/dev/flang/ast/AbstractType.java
+++ b/src/dev/flang/ast/AbstractType.java
@@ -712,13 +712,23 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
    * @param context the source code context where this Type is used
    *
    * @param actual the actual type.
+   *
+   * @param assignableTo if non-null, this will collect all constraint types
+   * that `actual` is assignable to. Use for error messages.
    */
-  private boolean constraintAssignableFrom(Context context, AbstractType actual)
+  private boolean constraintAssignableFrom(Context context,
+                                           AbstractType actual,
+                                           Set<AbstractType> assignableTo)
   {
     if (PRECONDITIONS) require
       (this  .isParametricType() || this  .feature() != null || Errors.any(),
        actual.isParametricType() || actual.feature() != null || Errors.any(),
        Errors.any() || this != Types.t_ERROR && actual != Types.t_ERROR);
+
+    if (assignableTo != null)
+      {
+        assignableTo.add(actual);
+      }
 
     var result = containsError()                   ||
       actual.containsError()                       ||
@@ -736,7 +746,7 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
              * this: 'T : property.orderable'
              * actual: 'I : integer'
              */
-            case ParametricType -> !isThisType() && constraintAssignableFrom(context, actual.typeParameter().constraint(context));
+          case ParametricType -> !isThisType() && constraintAssignableFrom(context, actual.typeParameter().constraint(context), assignableTo);
             /**
              * e.g.:
              *
@@ -746,7 +756,7 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
             case ThisType -> {
               yield actual.feature() == feature()
               ||
-                constraintAssignableViaInherits(context, actual);
+                constraintAssignableViaInherits(context, actual, assignableTo);
             }
             /**
              * e.g.:
@@ -760,7 +770,7 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
                 // NYI: BUG: isThisType logic certainly wrong...
                 (isThisType() || outer() == null && actual.outer() == null || outer().isAssignableFromDirectly(actual.outer()).yes())
               ||
-                constraintAssignableViaInherits(context, actual);
+                constraintAssignableViaInherits(context, actual, assignableTo);
             }
           };
       }
@@ -775,13 +785,18 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
    * @param context the source code context where this Type is used
    *
    * @param actual the actual type.
+   *
+   * @param assignableTo if non-null, this will collect all constraint types
+   * that `actual` is assignable to. Use for error messages.
    */
-  private boolean constraintAssignableViaInherits(Context context, AbstractType actual)
+  private boolean constraintAssignableViaInherits(Context context,
+                                                  AbstractType actual,
+                                                  Set<AbstractType> assignableTo)
   {
     return actual.feature().inherits().stream().anyMatch(p ->
       {
         var pa = actual.actualType(p.type());
-        return pa!=actual && constraintAssignableFrom(context, pa);
+        return pa!=actual && constraintAssignableFrom(context, pa, assignableTo);
       }
     );
   }
@@ -795,7 +810,7 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
    */
   public boolean constraintAssignableFrom(AbstractType actual)
   {
-    return constraintAssignableFrom(Context.NONE, actual);
+    return constraintAssignableFrom(Context.NONE, actual, null);
   }
 
 
@@ -839,7 +854,7 @@ public abstract class AbstractType extends ANY implements Comparable<AbstractTyp
                                       // for now just prevent infinite recursion
                                       gt.compareTo(this) != 0
                                       &&
-                                      !gt.constraintAssignableFrom(context, og);
+                                      !gt.constraintAssignableFrom(context, og, null);
               case ValueType, RefType, ThisType -> g.compareTo(og) != 0;
             }
           )
@@ -2664,7 +2679,7 @@ there is no common super type of the two types (Types.t_ERROR)
             a.checkChoice(p, context);
             if (!c.isParametricType() && // See AstErrors.constraintMustNotBeParametricType,
                                           // will be checked in SourceModule.checkTypes(Feature)
-                !c.constraintAssignableFrom(context, a) &&
+                !c.constraintAssignableFrom(context, a, null) &&
                 // NYI: CLEANUP: probably not a good place for this logic, move to constraintAssignableFrom?
                 (!a.isParametricType() ||
                  f != a.typeParameter())
@@ -2672,7 +2687,9 @@ there is no common super type of the two types (Types.t_ERROR)
               {
                 if (!f.isCoTypesRelayTypeParameter())
                   {
-                    AstErrors.incompatibleActualGeneric(p, f, c, a);
+                    var assignableTo = new TreeSet<AbstractType>();
+                    var ignore = c.constraintAssignableFrom(context, a, assignableTo);
+                    AstErrors.incompatibleActualGeneric(p, f, c, a, assignableTo);
                     result = false;
                   }
               }

--- a/src/dev/flang/ast/AstErrors.java
+++ b/src/dev/flang/ast/AstErrors.java
@@ -1930,16 +1930,32 @@ public class AstErrors extends ANY
           "Declared at " + cf.pos().show());
   }
 
-  static void incompatibleActualGeneric(SourcePosition pos, AbstractFeature f, AbstractType constraint, AbstractType g)
+  static void incompatibleActualGeneric(SourcePosition pos,
+                                        AbstractFeature f,
+                                        AbstractType constraint,
+                                        AbstractType g,
+                                        Set<AbstractType> assignableTo)
   {
-    if (g != Types.t_UNDEFINED || !any())
+    var errorOrUndefinedFound = g.containsUndefined();
+    var assignableToSB = new StringBuilder();
+    for (var ts : assignableTo)
+      {
+        errorOrUndefinedFound |= ts.containsUndefined();
+        assignableToSB
+          .append(assignableToSB.length() == 0
+                  ?    "assignable to constraint: "
+                  : ",\n                          ")
+          .append(st(ts.toString(true)));
+      }
+    if (!any() || !errorOrUndefinedFound)
       {
         error(pos,
               "Incompatible type parameter",
               "formal type parameter " + sc(f)
                 + (f.constraint().compareTo(constraint)==0 ? "" : " with constraint " + s(constraint))
                 + "\n" +
-              "actual type parameter " + s(g) + "\n");
+              "actual type parameter " + s(g) + "\n" +
+              assignableToSB + (assignableToSB.length() > 0 ? "\n" : ""));
       }
   }
 

--- a/tests/compile_time_type_casts_negative/compile_time_type_casts_negative.fz.expected_err
+++ b/tests/compile_time_type_casts_negative/compile_time_type_casts_negative.fz.expected_err
@@ -40,6 +40,8 @@ To solve this, you could change the type of the target 'v' to 'compile_time_type
 --^^
 formal type parameter 'T : compile_time_type_casts_negative.this.A'
 actual type parameter 'compile_time_type_casts_negative.this.B'
+assignable to constraint: 'Any',
+                          'compile_time_type_casts_negative.this.B'
 
 
 --CURDIR--/compile_time_type_casts_negative.fz:108:3: error 5: Incompatible type parameter
@@ -47,6 +49,8 @@ actual type parameter 'compile_time_type_casts_negative.this.B'
 --^^
 formal type parameter 'T : compile_time_type_casts_negative.this.A'
 actual type parameter 'compile_time_type_casts_negative.this.C'
+assignable to constraint: 'Any',
+                          'compile_time_type_casts_negative.this.C'
 
 
 --CURDIR--/compile_time_type_casts_negative.fz:109:3: error 6: Incompatible type parameter
@@ -54,6 +58,10 @@ actual type parameter 'compile_time_type_casts_negative.this.C'
 --^^
 formal type parameter 'T : compile_time_type_casts_negative.this.A'
 actual type parameter 'compile_time_type_casts_negative.this.bc'
+assignable to constraint: 'compile_time_type_casts_negative.this.bc',
+                          'Any',
+                          'compile_time_type_casts_negative.this.B',
+                          'compile_time_type_casts_negative.this.C'
 
 
 --CURDIR--/compile_time_type_casts_negative.fz:67:12: error 7: Incompatible types when passing argument in a call
@@ -157,5 +165,7 @@ To solve this, you could change the type of the target 'v' to 'T' or convert the
 ------------------^^
 formal type parameter 'T : compile_time_type_casts_negative.this.A'
 actual type parameter 'U'
+assignable to constraint: 'U',
+                          'Any'
 
 15 errors.

--- a/tests/equals_negative/equals_test_negative.fz.expected_err
+++ b/tests/equals_negative/equals_test_negative.fz.expected_err
@@ -4,6 +4,8 @@
 -------------------------^^^^^^
 formal type parameter 'T : property.equatable'
 actual type parameter 'equals_test_a'
+assignable to constraint: 'equals_test_a',
+                          'Any'
 
 
 --CURDIR--/equals_test_negative.fz:45:27: error 2: Incompatible type parameter
@@ -11,6 +13,8 @@ actual type parameter 'equals_test_a'
 --------------------------^^^^^^^
 formal type parameter 'T : property.equatable'
 actual type parameter 'equals_test_b'
+assignable to constraint: 'equals_test_b',
+                          'Any'
 
 
 --CURDIR--/equals_test_negative.fz:50:21: error 3: Incompatible type parameter
@@ -18,5 +22,7 @@ actual type parameter 'equals_test_b'
 --------------------^^^^^^^
 formal type parameter 'T : property.equatable'
 actual type parameter 'equals_test_c'
+assignable to constraint: 'equals_test_c',
+                          'Any'
 
 3 errors.

--- a/tests/free_types_negative/test_free_types_negative.fz.expected_err
+++ b/tests/free_types_negative/test_free_types_negative.fz.expected_err
@@ -77,6 +77,12 @@ Type inference failed for 2 type parameters 'A', 'B'
 --^^
 formal type parameter 'T : numeric'
 actual type parameter 'String'
+assignable to constraint: 'property.equatable',
+                          'property.hashable',
+                          'property.orderable',
+                          'property.partially_orderable',
+                          'Any',
+                          'String'
 
 
 --CURDIR--/test_free_types_negative.fz:76:5: error 9: Incompatible types when passing argument in a call
@@ -96,6 +102,12 @@ To solve this, you could change the type of the target 'v' to 'f64' or convert t
 --^
 formal type parameter 'B : numeric'
 actual type parameter 'String'
+assignable to constraint: 'property.equatable',
+                          'property.hashable',
+                          'property.orderable',
+                          'property.partially_orderable',
+                          'Any',
+                          'String'
 
 
 --CURDIR--/test_free_types_negative.fz:74:5: error 11: Type inference from actual arguments failed due to incompatible types of actual arguments

--- a/tests/reg_issue1054_incompatible_contraint_generics/issue1054.fz.expected_err
+++ b/tests/reg_issue1054_incompatible_contraint_generics/issue1054.fz.expected_err
@@ -4,5 +4,7 @@
 -------^
 formal type parameter 'T : issue1054.this.floaty f64'
 actual type parameter 'issue1054.this.floaty f32'
+assignable to constraint: 'issue1054.this.floaty f32',
+                          'Any'
 
 one error.

--- a/tests/reg_issue1771/reg_issue1771.fz.expected_err
+++ b/tests/reg_issue1771/reg_issue1771.fz.expected_err
@@ -4,5 +4,16 @@ f(_ type : String) => { }; f i32
 ---------------------------^
 formal type parameter '_ : String'
 actual type parameter 'i32'
+assignable to constraint: 'i32',
+                          'integer',
+                          'java_primitive',
+                          'num.wrap_around',
+                          'numeric',
+                          'property.interval',
+                          'property.equatable',
+                          'property.hashable',
+                          'property.orderable',
+                          'property.partially_orderable',
+                          'Any'
 
 one error.

--- a/tests/reg_issue2111/reg_issue2111.fz.expected_err
+++ b/tests/reg_issue2111/reg_issue2111.fz.expected_err
@@ -4,5 +4,9 @@
 --^^^^
 formal type parameter 'T : property.equatable'
 actual type parameter 'test.this.my_switch'
+assignable to constraint: 'choice',
+                          'void',
+                          'test.this.my_switch',
+                          'Any'
 
 one error.

--- a/tests/reg_issue309_check_constraints_of_types/issue309.fz.expected_err
+++ b/tests/reg_issue309_check_constraints_of_types/issue309.fz.expected_err
@@ -4,6 +4,8 @@
 ------------------^
 formal type parameter 'E : property.equatable'
 actual type parameter 'issue309.this.a'
+assignable to constraint: 'issue309.this.a',
+                          'Any'
 
 
 --CURDIR--/issue309.fz:31:27: error 2: Incompatible type parameter
@@ -11,6 +13,8 @@ actual type parameter 'issue309.this.a'
 --------------------------^
 formal type parameter 'E : property.equatable'
 actual type parameter 'T'
+assignable to constraint: 'T',
+                          'Any'
 
 
 --CURDIR--/issue309.fz:34:7: error 3: Incompatible type parameter
@@ -18,5 +22,7 @@ actual type parameter 'T'
 ------^
 formal type parameter 'T : property.equatable'
 actual type parameter 'issue309.this.a'
+assignable to constraint: 'issue309.this.a',
+                          'Any'
 
 3 errors.

--- a/tests/reg_issue3362/reg_issue3362.fz.expected_err
+++ b/tests/reg_issue3362/reg_issue3362.fz.expected_err
@@ -4,6 +4,10 @@
 -------^^^^^
 formal type parameter 'T : property.equatable'
 actual type parameter 'reg_issue3362.this.c'
+assignable to constraint: 'choice',
+                          'void',
+                          'reg_issue3362.this.c',
+                          'Any'
 
 
 --CURDIR--/reg_issue3362.fz:49:16: error 2: Incompatible type parameter
@@ -11,5 +15,9 @@ actual type parameter 'reg_issue3362.this.c'
 ---------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 formal type parameter 'T : property.equatable'
 actual type parameter 'reg_issue3362.this.my_c'
+assignable to constraint: 'choice',
+                          'void',
+                          'reg_issue3362.this.my_c',
+                          'Any'
 
 2 errors.

--- a/tests/reg_issue3649/reg_issue3649.fz.expected_err
+++ b/tests/reg_issue3649/reg_issue3649.fz.expected_err
@@ -4,5 +4,8 @@
 --^^
 formal type parameter 'F : scenario1.this.a F' with constraint 'scenario1.this.a scenario1.this.b'
 actual type parameter 'scenario1.this.b'
+assignable to constraint: 'scenario1.this.a bool',
+                          'scenario1.this.b',
+                          'Any'
 
 one error.

--- a/tests/reg_issue3773/reg_issue3773.fz.expected_err
+++ b/tests/reg_issue3773/reg_issue3773.fz.expected_err
@@ -4,5 +4,12 @@ say (a bool (Sequence i32) [42])
 -----^
 formal type parameter 'S : Sequence U' with constraint 'Sequence bool'
 actual type parameter 'Sequence i32'
+assignable to constraint: 'property.countable',
+                          'property.equatable',
+                          'property.hashable',
+                          'property.orderable',
+                          'property.partially_orderable',
+                          'Any',
+                          'Sequence i32'
 
 one error.

--- a/tests/reg_issue4480/reg_issue4480.fz.expected_err
+++ b/tests/reg_issue4480/reg_issue4480.fz.expected_err
@@ -4,5 +4,8 @@ _ := [3].map count |> sum
 ----------------------^^^
 formal type parameter 'T : numeric'
 actual type parameter 'void'
+assignable to constraint: 'choice',
+                          'void',
+                          'Any'
 
 one error.

--- a/tests/reg_issue5003/reg_issue5003.fz.expected_err
+++ b/tests/reg_issue5003/reg_issue5003.fz.expected_err
@@ -4,5 +4,7 @@
 ------^
 formal type parameter 'T : reg_issue5003.this.A'
 actual type parameter 'reg_issue5003.this.C'
+assignable to constraint: 'reg_issue5003.this.C',
+                          'Any'
 
 one error.

--- a/tests/reg_issue5714_1/reg_issue5714_1.fz.expected_err
+++ b/tests/reg_issue5714_1/reg_issue5714_1.fz.expected_err
@@ -4,5 +4,7 @@ p.f o.i
 --^
 formal type parameter 'A : p.this.i' with constraint 'p.i'
 actual type parameter 'o.i'
+assignable to constraint: 'o.i',
+                          'Any'
 
 one error.

--- a/tests/reg_issue5714_2/reg_issue5714_2.fz.expected_err
+++ b/tests/reg_issue5714_2/reg_issue5714_2.fz.expected_err
@@ -4,5 +4,7 @@ p.f o.i
 --^
 formal type parameter 'A : p.this.i' with constraint 'p.i'
 actual type parameter 'o.i'
+assignable to constraint: 'o.i',
+                          'Any'
 
 one error.

--- a/tests/reg_issue5714_3/reg_issue5714_3.fz.expected_err
+++ b/tests/reg_issue5714_3/reg_issue5714_3.fz.expected_err
@@ -4,5 +4,7 @@ p.f o.i
 --^
 formal type parameter 'A : p.this.i' with constraint 'p.i'
 actual type parameter 'o.i'
+assignable to constraint: 'o.i',
+                          'Any'
 
 one error.

--- a/tests/reg_issue6830/reg_issue6830.fz.expected_err
+++ b/tests/reg_issue6830/reg_issue6830.fz.expected_err
@@ -34,5 +34,7 @@ To solve this, change constraint of type parameter to 'reg_issue6830.part2.this.
 --------^
 formal type parameter '_ : reg_issue6830.part2.this.storage String' with constraint '_.storage String'
 actual type parameter 'reg_issue6830.part2.this.storage String'
+assignable to constraint: 'reg_issue6830.part2.this.storage String',
+                          'Any'
 
 3 errors.

--- a/tests/reg_issue7025/reg_issue7025.fz.expected_err
+++ b/tests/reg_issue7025/reg_issue7025.fz.expected_err
@@ -4,5 +4,7 @@ v t2.e
 ^
 formal type parameter 'E : t.e'
 actual type parameter 't2.e'
+assignable to constraint: 't2.e',
+                          'Any'
 
 one error.

--- a/tests/reg_issue7421/reg_issue7421.fz.expected_err
+++ b/tests/reg_issue7421/reg_issue7421.fz.expected_err
@@ -4,5 +4,6 @@
 ----^
 formal type parameter 'E : e.this'
 actual type parameter 'E'
+assignable to constraint: 'E'
 
 one error.

--- a/tests/reg_issue7_genericConstraint/checkGenericConstraint.fz.expected_err
+++ b/tests/reg_issue7_genericConstraint/checkGenericConstraint.fz.expected_err
@@ -4,5 +4,7 @@
 -------^^
 formal type parameter 'T : checkGenericConstraint.this.H'
 actual type parameter 'checkGenericConstraint.this.m32'
+assignable to constraint: 'checkGenericConstraint.this.m32',
+                          'Any'
 
 one error.

--- a/tests/reg_issues4992_5001_negative/reg_issues4992_5001_negative.fz.expected_err
+++ b/tests/reg_issues4992_5001_negative/reg_issues4992_5001_negative.fz.expected_err
@@ -12,6 +12,12 @@ To solve this, change the type provided, e.g. to the unconstrained 'type'.
 --------^
 formal type parameter 'U : tuple i32'
 actual type parameter 'tuple i32 bool'
+assignable to constraint: 'property.equatable',
+                          'property.hashable',
+                          'property.orderable',
+                          'property.partially_orderable',
+                          'tuple i32 bool',
+                          'Any'
 
 
 --CURDIR--/reg_issues4992_5001_negative.fz:97:9: error 3: Incompatible type parameter
@@ -19,6 +25,12 @@ actual type parameter 'tuple i32 bool'
 --------^
 formal type parameter 'U : tuple unit reg_issues4992_5000.case5.x.this.type' with constraint 'tuple unit X'
 actual type parameter 'tuple unit true_'
+assignable to constraint: 'property.equatable',
+                          'property.hashable',
+                          'property.orderable',
+                          'property.partially_orderable',
+                          'tuple unit true_',
+                          'Any'
 
 
 --CURDIR--/reg_issues4992_5001_negative.fz:150:9: error 4: Incompatible type parameter
@@ -26,6 +38,12 @@ actual type parameter 'tuple unit true_'
 --------^
 formal type parameter 'U : tuple reg_issues4992_5000.case6.x.type.A reg_issues4992_5000.case6.x.type.B reg_issues4992_5000.case6.x.type.C' with constraint 'tuple Any unit f32'
 actual type parameter 'tuple i32 i32 i32'
+assignable to constraint: 'property.equatable',
+                          'property.hashable',
+                          'property.orderable',
+                          'property.partially_orderable',
+                          'tuple i32 i32 i32',
+                          'Any'
 
 
 --CURDIR--/reg_issues4992_5001_negative.fz:162:13: error 5: Incompatible type parameter
@@ -33,5 +51,7 @@ actual type parameter 'tuple i32 i32 i32'
 ------------^
 formal type parameter 'U : reg_issues4992_5000.case7.this.box reg_issues4992_5000.case7.x.type.A' with constraint 'reg_issues4992_5000.case7.this.box f32'
 actual type parameter 'reg_issues4992_5000.case7.this.box i32'
+assignable to constraint: 'reg_issues4992_5000.case7.this.box i32',
+                          'Any'
 
 5 errors.


### PR DESCRIPTION
Listing what constraints a type parameter is actually assignable to may help to understand where the problem is and how it could be solved.

Found this while working on #7415 to improve the second error produced by the example given in that issue. 