### PR TITLE
fe: fix require-condition in `isLambdaTarget`

### DIFF
--- a/src/dev/flang/ast/AbstractType.java
+++ b/src/dev/flang/ast/AbstractType.java
@@ -2808,7 +2808,7 @@ there is no common super type of the two types (Types.t_ERROR)
    */
   public AbstractType selfOrConstraint()
   {
-    return (isParametricType() ? typeParameter().constraint(Context.NONE) : this);
+    return selfOrConstraint(Context.NONE);
   }
 
 
@@ -2819,7 +2819,10 @@ there is no common super type of the two types (Types.t_ERROR)
    */
   AbstractType selfOrConstraint(Context context)
   {
-    return (isParametricType() ? typeParameter().constraint(context) : this);
+    var result = isParametricType() ? typeParameter().constraint(context) : this;
+    return result.isParametricType()
+      ? result.selfOrConstraint(context)
+      : result;
   }
 
 
@@ -2831,7 +2834,10 @@ there is no common super type of the two types (Types.t_ERROR)
    */
   AbstractType selfOrConstraint(Resolution res, Context context)
   {
-    return (isParametricType() ? typeParameter().constraint(res, context) : this);
+    var result = isParametricType() ? typeParameter().constraint(res, context) : this;
+    return result.isParametricType()
+      ? result.selfOrConstraint(res, context)
+      : result;
   }
 
 


### PR DESCRIPTION
If the constraint is a parametric type again this will lead to problems. Changed selfOrConstraint to recurse in this case.
```
error 1: java.lang.Error: require-condition2 failed: AbstractType.java:237 "(!(this instanceof UnresolvedType), !isParametricType());"
        at dev.flang.util.ANY.require(ANY.java:156)
        at dev.flang.ast.AbstractType.feature(AbstractType.java:237)
        at dev.flang.ast.AbstractType.isLambdaTarget(AbstractType.java:1551)
        at dev.flang.ast.AbstractType.isLambdaTargetButNotLazy(AbstractType.java:1537)
```


