### PR TITLE
module: replace `racy_mutate` by `mutate`

### DIFF
--- a/modules/clang/src/clang.fz
+++ b/modules/clang/src/clang.fz
@@ -86,7 +86,7 @@ cx_string_to_string(cx_str CXString) =>
   res
 
 
-lm : racy_mutate is
+lm : mutate is
 
 
 # clang -- unit feature to group clang related features
@@ -141,7 +141,7 @@ public clang is
   # get the fields of a struct/union
   #
   get_fields(crsr CXCursor) =>
-    childs := lm.new (container.expanding_array clang.arg .empty)
+    childs := lm.env.new (container.expanding_array clang.arg .empty)
 
     visitor : Function i32 CXCursor Native_Ref Native_Ref is
       public redef call(cxc CXCursor, parent Native_Ref, client_data Native_Ref) i32 =>


### PR DESCRIPTION
The actual problem why racy_mutate seemed necessary was that `new` was not called via  `env`.