### PR TITLE
base: rename `time.precision` to `time.units`

### DIFF
--- a/modules/base/src/time/date_time.fz
+++ b/modules/base/src/time/date_time.fz
@@ -82,21 +82,21 @@ is
   # ISO 8601 string for this datetime
   # example: 2018-09-14T23:59:59.079
   #
-  public as_string(p time.precision.val) String =>
-    match p
-      time.precision.year         =>  "$year_as_string"
-      time.precision.month        =>  "$year_as_string-$month_as_string"
-      time.precision.day          =>  "$year_as_string-$month_as_string-$day_as_string"
-      time.precision.hour         => ("$year_as_string-$month_as_string-$day_as_string" +
-                              "T$hour_as_string")
-      time.precision.minute       => ("$year_as_string-$month_as_string-$day_as_string" +
-                              "T$hour_as_string:$minute_as_string")
-      time.precision.second       => ("$year_as_string-$month_as_string-$day_as_string" +
-                              "T$hour_as_string:$minute_as_string:$second_as_string")
-      time.precision.milli_second => ("$year_as_string-$month_as_string-$day_as_string" +
-                              "T$hour_as_string:$minute_as_string:$second_as_string.$milli_second_as_string")
-      time.precision.nano_second  => ("$year_as_string-$month_as_string-$day_as_string" +
-                              "T$hour_as_string:$minute_as_string:$second_as_string.$milli_second_as_string$nano_second_as_string")
+  public as_string(u time.units.val) String =>
+    match u
+      time.units.year             =>  "$year_as_string"
+      time.units.month            =>  "$year_as_string-$month_as_string"
+      time.units.day              =>  "$year_as_string-$month_as_string-$day_as_string"
+      time.units.hour             => ("$year_as_string-$month_as_string-$day_as_string" +
+                                  "T$hour_as_string")
+      time.units.minute           => ("$year_as_string-$month_as_string-$day_as_string" +
+                                  "T$hour_as_string:$minute_as_string")
+      time.units.second           => ("$year_as_string-$month_as_string-$day_as_string" +
+                                  "T$hour_as_string:$minute_as_string:$second_as_string")
+      time.units.milli_second     => ("$year_as_string-$month_as_string-$day_as_string" +
+                                  "T$hour_as_string:$minute_as_string:$second_as_string.$milli_second_as_string")
+      time.units.nano_second      => ("$year_as_string-$month_as_string-$day_as_string" +
+                                  "T$hour_as_string:$minute_as_string:$second_as_string.$milli_second_as_string$nano_second_as_string")
 
 
   # internal helper: total nanoseconds since unix epoch

--- a/modules/base/src/time/units.fz
+++ b/modules/base/src/time/units.fz
@@ -17,47 +17,48 @@
 #
 #  Tokiwa Software GmbH, Germany
 #
-#  Source code of Fuzion standard library feature time.precision
+#  Source code of Fuzion standard library feature time.units
 #
 # -----------------------------------------------------------------------
 
-# precision -- unit feature to group time precision related features
-#
-public precision is
 
-  # unit feature denoting precision to the year
+# units -- unit feature to group time unit related features
+#
+public units is
+
+  # unit feature denoting the time unit year
   #
   public year is
 
-  # unit feature denoting precision to the month
+  # unit feature denoting the time unit month
   #
   public month is
 
-  # unit feature denoting precision to the day
+  # unit feature denoting the time unit day
   #
   public day is
 
-  # unit feature denoting precision to the hour
+  # unit feature denoting the time unit hour
   #
   public hour is
 
-  # unit feature denoting precision to the minute
+  # unit feature denoting the time unit minute
   #
   public minute is
 
-  # unit feature denoting precision to the second
+  # unit feature denoting the time unit second
   #
   public second is
 
-  # unit feature denoting precision to the millisecond
+  # unit feature denoting the time unit millisecond
   #
   public milli_second is
 
-  # unit feature denoting precision to the nanosecond
+  # unit feature denoting the time unit nanosecond
   #
   public nano_second is
 
 
-  # precision level
+  # time unit
   #
   public val : choice year month day hour minute second milli_second nano_second is

--- a/tests/lib_time_date_time/lib_time_date_time.fz
+++ b/tests/lib_time_date_time/lib_time_date_time.fz
@@ -82,12 +82,12 @@ lib_time_date_time =>
       .from_seconds i
 
 
-  say <| a.as_string time.precision.year
-  say <| a.as_string time.precision.month
-  say <| a.as_string time.precision.day
-  say <| a.as_string time.precision.hour
-  say <| a.as_string time.precision.minute
-  say <| a.as_string time.precision.second
-  say <| a.as_string time.precision.milli_second
-  say <| a.as_string time.precision.nano_second
+  say <| a.as_string time.units.year
+  say <| a.as_string time.units.month
+  say <| a.as_string time.units.day
+  say <| a.as_string time.units.hour
+  say <| a.as_string time.units.minute
+  say <| a.as_string time.units.second
+  say <| a.as_string time.units.milli_second
+  say <| a.as_string time.units.nano_second
   check time.date_time.from_seconds 1762961342 .unix_time_stamp = 1762961342


### PR DESCRIPTION
[fixes #7675]
