### PR TITLE
build: remove `.SILENT` modifier from `run_tests*` rules in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -599,30 +599,30 @@ run_tests: run_tests_fuir run_tests_jvm run_tests_c run_tests_effect run_tests_j
 TEST_DEPENDENCIES = $(FZ_MODULES) $(MOD_JAVA_BASE) $(MOD_FZ_CMD) $(BUILD_DIR)/tests $(BUILD_DIR)/bin/run_tests $(BUILD_DIR)/fuzion.jar
 
 # phony target to run Fuzion tests using effects and report number of failures
-.PHONY .SILENT: run_tests_effect
+.PHONY: run_tests_effect
 run_tests_effect: $(FZ) $(TEST_DEPENDENCIES)
 	$(BUILD_DIR)/bin/run_tests $(BUILD_DIR) effect
 
 # phony target to run Fuzion tests using interpreter and report number of failures
-.PHONY .SILENT: run_tests_int
+.PHONY: run_tests_int
 run_tests_int: $(FZ_INT) $(TEST_DEPENDENCIES)
 	$(BUILD_DIR)/bin/run_tests $(BUILD_DIR) int
 
 # phony target to run Fuzion tests using c backend and report number of failures
-.PHONY .SILENT: run_tests_c
+.PHONY: run_tests_c
 run_tests_c: $(FZ_C) $(TEST_DEPENDENCIES)
 	$(BUILD_DIR)/bin/run_tests $(BUILD_DIR) c
 
 # phony target to run Fuzion tests using jvm backend and report number of failures
-.PHONY .SILENT: run_tests_jvm
+.PHONY: run_tests_jvm
 run_tests_jvm: $(FZ_JVM) $(TEST_DEPENDENCIES)
 	$(BUILD_DIR)/bin/run_tests $(BUILD_DIR) jvm
 
-.PHONY .SILENT: run_tests_fuir
+.PHONY: run_tests_fuir
 run_tests_fuir: $(TEST_DEPENDENCIES)
 	$(BUILD_DIR)/bin/run_tests $(BUILD_DIR) fuir
 
-.PHONY .SILENT: run_tests_jar_build
+.PHONY: run_tests_jar_build
 run_tests_jar_build: $(FZ_JVM) $(BUILD_DIR)/tests
 	$(FZ) -jar $(BUILD_DIR)/tests/hello/HelloWorld.fz
 	LD_LIBRARY_PATH="$(LD_LIBRARY_PATH):$(BUILD_DIR)/lib" \
@@ -630,7 +630,7 @@ run_tests_jar_build: $(FZ_JVM) $(BUILD_DIR)/tests
 	DYLD_FALLBACK_LIBRARY_PATH="$(DYLD_FALLBACK_LIBRARY_PATH):$(BUILD_DIR)/lib" \
 		$(JAVA) -jar HelloWorld.jar > /dev/null
 
-.PHONY .SILENT: run_tests_jar
+.PHONY: run_tests_jar
 run_tests_jar: run_tests_jar_build
 	output1="Hello World!"; \
 	output2=$$(./HelloWorld); \


### PR DESCRIPTION
I had a bug in the `run_tests` binary and these silent rules made it unnecessarily hard for me to understand where the problem was.
