### PR TITLE
ast: warn for unused fields that get placed in internal features by syntax sugar 

### DIFF
--- a/modules/base/src/io/buffered/Reader.fz
+++ b/modules/base/src/io/buffered/Reader.fz
@@ -134,7 +134,7 @@ public type.read_bytes(n i64) outcome (Sequence u8) ! Reader
   for res Sequence u8 := container.Finger_Tree u8 .empty,
             {
               match r
-                o outcome => res
+                outcome => res
                 s Sequence =>
                   a := s.take n-res.count
                   check debug: a.is_array_backed

--- a/src/dev/flang/ast/Feature.java
+++ b/src/dev/flang/ast/Feature.java
@@ -2836,7 +2836,6 @@ A pre-condition of a feature that does not redefine an inherited feature must st
     return kind() == AbstractFeature.Kind.Field
           && visibility().eraseTypeVisibility() != Visi.PUB  // public fields may be unused
           && !featureName().isInternal()                     // don't warn for internal features
-          && !this.outer().featureName().isInternal()        // don't warn for inner features of internal features
           && !featureName().isNameless()                     // don't warn for nameless features
           && !isArgument()                                   // don't warn for arguments
           && redefines().isEmpty();                          // don't warn for unused redefinitions

--- a/tests/inherit_postcondition/inherit_postcondition.fz
+++ b/tests/inherit_postcondition/inherit_postcondition.fz
@@ -198,7 +198,7 @@ test_postcondition is
       post
         ok "original $result"
         { io.Out.env.println "hi"; true }
-        { v := post_accessing_result.this; true }
+        { _ := post_accessing_result.this; true }
         { [1,result,2].fold i64.sum > 3 }
         { fn i64->i64 := *result; fn 3 > 120 }
         result > 23

--- a/tests/inherit_postcondition/module_src/mod.fz
+++ b/tests/inherit_postcondition/module_src/mod.fz
@@ -39,7 +39,7 @@ public mod is
         m * 2 = r
         ok "original $result $m $r"
         { io.Out.env.println "hi"; true }
-        { v := post_accessing_result.this; true }
+        { _ := post_accessing_result.this; true }
         { [1,result,2].fold i64.sum > 3 }
         { fn i64->i64 := *result; fn 3 > 120 }
         result > 23

--- a/tests/loop/looptest.fz
+++ b/tests/loop/looptest.fz
@@ -175,7 +175,7 @@ looptest is
   testLoop7(data array i64, isWhatWeWant (i64) -> bool) i64 =>
     for ix := 0, ix + 1
     while ix < data.length
-      element := data[ix]
+      _ := data[ix]
     until isWhatWeWant data[ix]
       3333
     else
@@ -187,7 +187,7 @@ looptest is
   testLoop8(data array i64, isWhatWeWant (i64) -> bool) i64 =>
     for ix := 0, ix + 1
     while ix < data.length
-      element := data[ix]
+      _ := data[ix]
     until isWhatWeWant data[ix]
       ix
     else
@@ -199,7 +199,7 @@ looptest is
   testLoop9(data array i64, isWhatWeWant (i64) -> bool) i64 =>
     for ix := 0, ix + 1
     while ix < data.length
-      element := data[ix]
+      _ := data[ix]
     until isWhatWeWant data[ix]
       3333
     else
@@ -211,7 +211,7 @@ looptest is
   testLoop10(data array i64, isWhatWeWant (i64) -> bool) i64 =>
     for ix := 0, ix + 1
     while ix < data.length
-      element := data[ix]
+      _ := data[ix]
     else
       4444
   chck (testLoop10(a, (i -> i >    100)) = 4444) "testLoop10 returns 4444 in else branch"

--- a/tests/lru_cache/lru_cache_test.fz
+++ b/tests/lru_cache/lru_cache_test.fz
@@ -140,6 +140,7 @@ lru_cache_test =>
       for i in elems do
         exp := i%%2 ?  "~$(i**2)~" : "_$(i)_"
         act := test c get i nil .or_panic
+        check exp = act
 
   update_value 7
 

--- a/tests/reg_issue2367/reg_issue2367.fz
+++ b/tests/reg_issue2367/reg_issue2367.fz
@@ -31,13 +31,13 @@ else
 for s := 1230, s+3
     j in 0..
 while j < 4
-   sm := 3
+   _ := 3
 else
    say s
 
 for s := 1230, s+3
     j := 0, j+1
 while j < 4
-   sm := 3
+   _ := 3
 else
    say s

--- a/tests/visibility/visibility.fz
+++ b/tests/visibility/visibility.fz
@@ -305,11 +305,11 @@ visibility is
       ix3 := a + ix1 + ix2 + it1 + it2   # can make unqualified call to a, ix1, ix2, it1, it2 ..
     while a + ix1 + ix2 + it1 + it2 + ix3 < 10000
       b => 6
-      q := a + ix1 + ix2 + it1 + it2 + ix3 + b
+      _ := a + ix1 + ix2 + it1 + it2 + ix3 + b
     until a * (ix1 + ix2 + it1 + it2 + ix3 + b) > 1000000
-      r := a + ix1 + ix2 + it1 + it2 + ix3 + b
+      _ := a + ix1 + ix2 + it1 + it2 + ix3 + b
     else
-      s := a + ix1 + ix2
+      _ := a + ix1 + ix2
     _ := a
   visi9
 


### PR DESCRIPTION
So, for a feature that is not internal, i.e., one written directly in the code, it should not matter whether syntax sugar places it in an internal feature when checking for its usage.

Seems a bit to simple though...

fix #7590
