### PR TITLE
lsp|parser: align string interpolation token names and comments with new `$()` syntax

### DIFF
--- a/src/dev/flang/lsp/feature/Completion.java
+++ b/src/dev/flang/lsp/feature/Completion.java
@@ -112,7 +112,7 @@ public class Completion
           .left()
           .token();
         // NYI: UNDER DEVELOPMENT: do not offer completion for number
-        if (tokenBeforeDot == Token.t_StringDQ ||
+        if (tokenBeforeDot == Token.t_stringDQ ||
             tokenBeforeDot == Token.t_stringPQ ||
             tokenBeforeDot == Token.t_stringQQ ||
             tokenBeforeDot == Token.t_numliteral)
@@ -153,7 +153,7 @@ public class Completion
               Token.t_rbracket,
               Token.t_rparen,
               Token.t_stringQQ,
-              Token.t_StringDQ,
+              Token.t_stringDQ,
               Token.t_stringPQ
           };
         var set = Util.arrayToSet(validTokens);

--- a/src/dev/flang/lsp/feature/SemanticToken.java
+++ b/src/dev/flang/lsp/feature/SemanticToken.java
@@ -69,7 +69,7 @@ public class SemanticToken extends ANY
       .flatMap(t -> {
         switch (t.token())
           {
-          case t_stringPQ :    // ')+-*"' in "abc$(x)+-*"
+          case t_stringPQ :    //      ')+-*"'  in  "abc$(x)+-*"
             return Stream.of(
               new TokenInfo(t.start(),
                 LexerTool.goRight(t.start()),
@@ -77,10 +77,10 @@ public class SemanticToken extends ANY
               new TokenInfo(LexerTool.goRight(t.start()),
                 t.end(),
                 t.text().substring(1), Token.t_stringQQ));
-          case t_stringQD :    // '"x is $' in "x is $x.".
-          case t_stringDD :    // '+-*$' in "abc$x+-*$x.".
-          case t_stringQP :    // '"a+b is $(' in "a+b is $(a+b)."
-          case t_stringDP :    // '+-*$(' in "abc$x+-*$(a+b)."
+          case t_stringQD :    //    '"x is $'  in  "x is $x.".
+          case t_stringDD :    //       '+-*$'  in  "abc$x+-*$x.".
+          case t_stringQP :    // '"a+b is $('  in  "a+b is $(a+b)."
+          case t_stringDP :    //      '+-*$('  in  "abc$x+-*$(a+b)."
             return Stream.of(
               new TokenInfo(t.start(),
                 SourcePositionTool.byLineColumn(t.end()._sourceFile, t.end().line(),
@@ -91,8 +91,8 @@ public class SemanticToken extends ANY
                   t.end().column() - 1),
                 t.end(),
                 t.text().substring(Util.charCount(t.text()) - 1, Util.charCount(t.text())), Token.t_op));
-          case t_stringPD :    // ')+-*$' in "abc$(x)+-*$x.".
-          case t_stringPP :    // ')+-*$(' in "abc$(x)+-*$(a+b)."
+          case t_stringPD :    //      ')+-*$'  in  "abc$(x)+-*$x.".
+          case t_stringPP :    //     ')+-*$('  in  "abc$(x)+-*$(a+b)."
             return Stream.of(
               new TokenInfo(t.start(), LexerTool.goRight(t.start()), ")",
                 Token.t_op),

--- a/src/dev/flang/lsp/feature/SemanticToken.java
+++ b/src/dev/flang/lsp/feature/SemanticToken.java
@@ -78,9 +78,9 @@ public class SemanticToken extends ANY
                 t.end(),
                 t.text().substring(1), Token.t_stringQQ));
           case t_stringQD :    // '"x is $' in "x is $x.".
-          case t_StringDD :    // '+-*$' in "abc$x+-*$x.".
+          case t_stringDD :    // '+-*$' in "abc$x+-*$x.".
           case t_stringQP :    // '"a+b is $(' in "a+b is $(a+b)."
-          case t_StringDP :    // '+-*$(' in "abc$x+-*$(a+b)."
+          case t_stringDP :    // '+-*$(' in "abc$x+-*$(a+b)."
             return Stream.of(
               new TokenInfo(t.start(),
                 SourcePositionTool.byLineColumn(t.end()._sourceFile, t.end().line(),

--- a/src/dev/flang/lsp/feature/SemanticToken.java
+++ b/src/dev/flang/lsp/feature/SemanticToken.java
@@ -79,8 +79,8 @@ public class SemanticToken extends ANY
                 t.text().substring(1), Token.t_stringQQ));
           case t_stringQD :    // '"x is $' in "x is $x.".
           case t_StringDD :    // '+-*$' in "abc$x+-*$x.".
-          case t_stringQB :    // '"a+b is $(' in "a+b is $(a+b)."
-          case t_StringDB :    // '+-*$(' in "abc$x+-*$(a+b)."
+          case t_stringQP :    // '"a+b is $(' in "a+b is $(a+b)."
+          case t_StringDP :    // '+-*$(' in "abc$x+-*$(a+b)."
             return Stream.of(
               new TokenInfo(t.start(),
                 SourcePositionTool.byLineColumn(t.end()._sourceFile, t.end().line(),
@@ -92,7 +92,7 @@ public class SemanticToken extends ANY
                 t.end(),
                 t.text().substring(Util.charCount(t.text()) - 1, Util.charCount(t.text())), Token.t_op));
           case t_stringPD :    // ')+-*$' in "abc$(x)+-*$x.".
-          case t_stringPB :    // ')+-*$(' in "abc$(x)+-*$(a+b)."
+          case t_stringPP :    // ')+-*$(' in "abc$(x)+-*$(a+b)."
             return Stream.of(
               new TokenInfo(t.start(), LexerTool.goRight(t.start()), ")",
                 Token.t_op),

--- a/src/dev/flang/lsp/feature/SemanticToken.java
+++ b/src/dev/flang/lsp/feature/SemanticToken.java
@@ -69,7 +69,7 @@ public class SemanticToken extends ANY
       .flatMap(t -> {
         switch (t.token())
           {
-          case t_stringPQ :    // '}+-*"' in "abc{x}+-*"
+          case t_stringPQ :    // ')+-*"' in "abc$(x)+-*"
             return Stream.of(
               new TokenInfo(t.start(),
                 LexerTool.goRight(t.start()),
@@ -79,8 +79,8 @@ public class SemanticToken extends ANY
                 t.text().substring(1), Token.t_stringQQ));
           case t_stringQD :    // '"x is $' in "x is $x.".
           case t_StringDD :    // '+-*$' in "abc$x+-*$x.".
-          case t_stringQB :    // '"a+b is {' in "a+b is {a+b}."
-          case t_StringDB :    // '+-*{' in "abc$x+-*{a+b}."
+          case t_stringQB :    // '"a+b is $(' in "a+b is $(a+b)."
+          case t_StringDB :    // '+-*$(' in "abc$x+-*$(a+b)."
             return Stream.of(
               new TokenInfo(t.start(),
                 SourcePositionTool.byLineColumn(t.end()._sourceFile, t.end().line(),
@@ -91,10 +91,10 @@ public class SemanticToken extends ANY
                   t.end().column() - 1),
                 t.end(),
                 t.text().substring(Util.charCount(t.text()) - 1, Util.charCount(t.text())), Token.t_op));
-          case t_stringPD :    // '}+-*$' in "abc{x}+-*$x.".
-          case t_stringPB :    // '}+-*{' in "abc{x}+-*{a+b}."
+          case t_stringPD :    // ')+-*$' in "abc$(x)+-*$x.".
+          case t_stringPB :    // ')+-*$(' in "abc$(x)+-*$(a+b)."
             return Stream.of(
-              new TokenInfo(t.start(), LexerTool.goRight(t.start()), "}",
+              new TokenInfo(t.start(), LexerTool.goRight(t.start()), ")",
                 Token.t_op),
               new TokenInfo(LexerTool.goRight(t.start()),
                 SourcePositionTool.byLineColumn(t.start()._sourceFile, t.start().line(),

--- a/src/dev/flang/lsp/shared/records/TokenInfo.java
+++ b/src/dev/flang/lsp/shared/records/TokenInfo.java
@@ -291,7 +291,7 @@ public class TokenInfo extends ANY
       case t_comment -> Optional.of(TokenType.Comment);
       case t_numliteral -> Optional.of(TokenType.Number);
       case t_stringQQ, t_StringDQ -> Optional.of(TokenType.String);
-      case t_stringQD, t_stringQB, t_StringDD, t_StringDB, t_stringPQ, t_stringPD, t_stringPB -> Optional.empty();
+      case t_stringQD, t_stringQP, t_StringDD, t_StringDP, t_stringPQ, t_stringPD, t_stringPP -> Optional.empty();
       case t_question -> Optional.of(TokenType.Keyword);
       case t_op ->
            (_text.equals("=>")

--- a/src/dev/flang/lsp/shared/records/TokenInfo.java
+++ b/src/dev/flang/lsp/shared/records/TokenInfo.java
@@ -290,8 +290,8 @@ public class TokenInfo extends ANY
       {
       case t_comment -> Optional.of(TokenType.Comment);
       case t_numliteral -> Optional.of(TokenType.Number);
-      case t_stringQQ, t_StringDQ -> Optional.of(TokenType.String);
-      case t_stringQD, t_stringQP, t_StringDD, t_StringDP, t_stringPQ, t_stringPD, t_stringPP -> Optional.empty();
+      case t_stringQQ, t_stringDQ -> Optional.of(TokenType.String);
+      case t_stringQD, t_stringQP, t_stringDD, t_stringDP, t_stringPQ, t_stringPD, t_stringPP -> Optional.empty();
       case t_question -> Optional.of(TokenType.Keyword);
       case t_op ->
            (_text.equals("=>")

--- a/src/dev/flang/parser/Lexer.java
+++ b/src/dev/flang/parser/Lexer.java
@@ -162,11 +162,11 @@ public class Lexer extends SourceFile
                    //   a+b is $(' in
                    // '"""
                    //   a+b is $(a+b)."""'
-    t_StringDQ,    // '+-*"'      in "abc$x+-*"
+    t_stringDQ,    // '+-*"'      in "abc$x+-*"
                    //     ^--- fat quotations (""") instead of single
                    //          quotation if part of multiline string
-    t_StringDD,    // '+-*$'      in "abc$x+-*$x.".
-    t_StringDP,    // '+-*$('     in "abc$x+-*$(a+b)."
+    t_stringDD,    // '+-*$'      in "abc$x+-*$x.".
+    t_stringDP,    // '+-*$('     in "abc$x+-*$(a+b)."
     t_stringPQ,    // ')+-*"'     in "abc$(x)+-*"
                    //      ^--- fat quotations (""") instead of single
                    //           quotation if part of multiline string
@@ -325,9 +325,9 @@ public class Lexer extends SourceFile
               case t_stringQQ   -> "string constant";
               case t_stringQD   -> "string constant ending in $";
               case t_stringQP   -> "string constant ending in $(";
-              case t_StringDQ   -> "string constant after $<id>";
-              case t_StringDD   -> "string constant after $<id> ending in $";
-              case t_StringDP   -> "string constant after $<id> ending in $(";
+              case t_stringDQ   -> "string constant after $<id>";
+              case t_stringDD   -> "string constant after $<id> ending in $";
+              case t_stringDP   -> "string constant after $<id> ending in $(";
               case t_stringPQ   -> "string constant after $(<expr>)";
               case t_stringPD   -> "string constant after $(<expr>) ending in $";
               case t_stringPP   -> "string constant after $(<expr>) ending in $(";
@@ -2971,9 +2971,9 @@ PIPE        : "|"
       if      (this == StringEnd.QUOTE  && end == StringEnd.QUOTE ) { return Token.t_stringQQ; }
       else if (this == StringEnd.QUOTE  && end == StringEnd.DOLLAR) { return Token.t_stringQD; }
       else if (this == StringEnd.QUOTE  && end == StringEnd.PAREN ) { return Token.t_stringQP; }
-      else if (this == StringEnd.DOLLAR && end == StringEnd.QUOTE ) { return Token.t_StringDQ; }
-      else if (this == StringEnd.DOLLAR && end == StringEnd.DOLLAR) { return Token.t_StringDD; }
-      else if (this == StringEnd.DOLLAR && end == StringEnd.PAREN ) { return Token.t_StringDP; }
+      else if (this == StringEnd.DOLLAR && end == StringEnd.QUOTE ) { return Token.t_stringDQ; }
+      else if (this == StringEnd.DOLLAR && end == StringEnd.DOLLAR) { return Token.t_stringDD; }
+      else if (this == StringEnd.DOLLAR && end == StringEnd.PAREN ) { return Token.t_stringDP; }
       else if (this == StringEnd.PAREN  && end == StringEnd.QUOTE ) { return Token.t_stringPQ; }
       else if (this == StringEnd.PAREN  && end == StringEnd.DOLLAR) { return Token.t_stringPD; }
       else if (this == StringEnd.PAREN  && end == StringEnd.PAREN ) { return Token.t_stringPP; }
@@ -2996,9 +2996,9 @@ PIPE        : "|"
       case t_stringQQ:
       case t_stringQD:
       case t_stringQP: return StringEnd.QUOTE;
-      case t_StringDQ:
-      case t_StringDD:
-      case t_StringDP: return StringEnd.DOLLAR;
+      case t_stringDQ:
+      case t_stringDD:
+      case t_stringDP: return StringEnd.DOLLAR;
       case t_stringPQ:
       case t_stringPD:
       case t_stringPP: return StringEnd.PAREN;
@@ -3020,13 +3020,13 @@ PIPE        : "|"
     switch (t)
       {
       case t_stringQQ:
-      case t_StringDQ:
+      case t_stringDQ:
       case t_stringPQ: return StringEnd.QUOTE;
       case t_stringQD:
-      case t_StringDD:
+      case t_stringDD:
       case t_stringPD: return StringEnd.DOLLAR;
       case t_stringQP:
-      case t_StringDP:
+      case t_stringDP:
       case t_stringPP: return StringEnd.PAREN;
       default        : throw new Error();
 
@@ -3528,9 +3528,9 @@ PIPE        : "|"
       case t_stringQQ:
       case t_stringQD:
       case t_stringQP:
-      case t_StringDQ:
-      case t_StringDD:
-      case t_StringDP:
+      case t_stringDQ:
+      case t_stringDD:
+      case t_stringDP:
       case t_stringPQ:
       case t_stringPD:
       case t_stringPP: return true;

--- a/src/dev/flang/parser/Lexer.java
+++ b/src/dev/flang/parser/Lexer.java
@@ -156,7 +156,7 @@ public class Lexer extends SourceFile
                    //   x is $'   in
                    // '"""
                    //   x is $x."""'
-    t_stringQB,    // '"a+b is $(' in "a+b is $(a+b)."
+    t_stringQP,    // '"a+b is $(' in "a+b is $(a+b)."
                    // OR multiline string
                    // '"""
                    //   a+b is $(' in
@@ -166,12 +166,12 @@ public class Lexer extends SourceFile
                    //     ^--- fat quotations (""") instead of single
                    //          quotation if part of multiline string
     t_StringDD,    // '+-*$'      in "abc$x+-*$x.".
-    t_StringDB,    // '+-*$('     in "abc$x+-*$(a+b)."
+    t_StringDP,    // '+-*$('     in "abc$x+-*$(a+b)."
     t_stringPQ,    // ')+-*"'     in "abc$(x)+-*"
                    //      ^--- fat quotations (""") instead of single
                    //           quotation if part of multiline string
     t_stringPD,    // ')+-*$'     in "abc$(x)+-*$x.".
-    t_stringPB,    // ')+-*$('    in "abc$(x)+-*$(a+b)."
+    t_stringPP,    // ')+-*$('    in "abc$(x)+-*$(a+b)."
     t_this("this"),
     t_env("env"),
     t_check("check"),
@@ -324,13 +324,13 @@ public class Lexer extends SourceFile
               case t_ident      -> "identifier";
               case t_stringQQ   -> "string constant";
               case t_stringQD   -> "string constant ending in $";
-              case t_stringQB   -> "string constant ending in $(";
+              case t_stringQP   -> "string constant ending in $(";
               case t_StringDQ   -> "string constant after $<id>";
               case t_StringDD   -> "string constant after $<id> ending in $";
-              case t_StringDB   -> "string constant after $<id> ending in $(";
+              case t_StringDP   -> "string constant after $<id> ending in $(";
               case t_stringPQ   -> "string constant after $(<expr>)";
               case t_stringPD   -> "string constant after $(<expr>) ending in $";
-              case t_stringPB   -> "string constant after $(<expr>) ending in $(";
+              case t_stringPP   -> "string constant after $(<expr>) ending in $(";
               case t_eof        -> "end-of-file";
               default           -> super.toString();
           };
@@ -2970,13 +2970,13 @@ PIPE        : "|"
     {
       if      (this == StringEnd.QUOTE  && end == StringEnd.QUOTE ) { return Token.t_stringQQ; }
       else if (this == StringEnd.QUOTE  && end == StringEnd.DOLLAR) { return Token.t_stringQD; }
-      else if (this == StringEnd.QUOTE  && end == StringEnd.PAREN ) { return Token.t_stringQB; }
+      else if (this == StringEnd.QUOTE  && end == StringEnd.PAREN ) { return Token.t_stringQP; }
       else if (this == StringEnd.DOLLAR && end == StringEnd.QUOTE ) { return Token.t_StringDQ; }
       else if (this == StringEnd.DOLLAR && end == StringEnd.DOLLAR) { return Token.t_StringDD; }
-      else if (this == StringEnd.DOLLAR && end == StringEnd.PAREN ) { return Token.t_StringDB; }
+      else if (this == StringEnd.DOLLAR && end == StringEnd.PAREN ) { return Token.t_StringDP; }
       else if (this == StringEnd.PAREN  && end == StringEnd.QUOTE ) { return Token.t_stringPQ; }
       else if (this == StringEnd.PAREN  && end == StringEnd.DOLLAR) { return Token.t_stringPD; }
-      else if (this == StringEnd.PAREN  && end == StringEnd.PAREN ) { return Token.t_stringPB; }
+      else if (this == StringEnd.PAREN  && end == StringEnd.PAREN ) { return Token.t_stringPP; }
       throw new Error("impossible StringEnd.token combination "+this+" and "+end);
     }
   }
@@ -2995,13 +2995,13 @@ PIPE        : "|"
       {
       case t_stringQQ:
       case t_stringQD:
-      case t_stringQB: return StringEnd.QUOTE;
+      case t_stringQP: return StringEnd.QUOTE;
       case t_StringDQ:
       case t_StringDD:
-      case t_StringDB: return StringEnd.DOLLAR;
+      case t_StringDP: return StringEnd.DOLLAR;
       case t_stringPQ:
       case t_stringPD:
-      case t_stringPB: return StringEnd.PAREN;
+      case t_stringPP: return StringEnd.PAREN;
       default        : throw new Error();
 
       }
@@ -3025,9 +3025,9 @@ PIPE        : "|"
       case t_stringQD:
       case t_StringDD:
       case t_stringPD: return StringEnd.DOLLAR;
-      case t_stringQB:
-      case t_StringDB:
-      case t_stringPB: return StringEnd.PAREN;
+      case t_stringQP:
+      case t_StringDP:
+      case t_stringPP: return StringEnd.PAREN;
       default        : throw new Error();
 
       }
@@ -3527,13 +3527,13 @@ PIPE        : "|"
       {
       case t_stringQQ:
       case t_stringQD:
-      case t_stringQB:
+      case t_stringQP:
       case t_StringDQ:
       case t_StringDD:
-      case t_StringDB:
+      case t_StringDP:
       case t_stringPQ:
       case t_stringPD:
-      case t_stringPB: return true;
+      case t_stringPP: return true;
       default        : return false;
       }
   }

--- a/src/dev/flang/parser/Parser.java
+++ b/src/dev/flang/parser/Parser.java
@@ -1640,7 +1640,7 @@ actualArgs  : actualSpaces
            t_until           ,
            t_stringPD        ,
            t_stringPQ        ,
-           t_stringPB        ,
+           t_stringPP        ,
            t_question        ,
            t_eof             -> true;
 


### PR DESCRIPTION
fix #7226