### PR TITLE
base: simply use `or_panic` for operations that are expected to never fail

### DIFF
--- a/modules/base/src/concur/Thread.fz
+++ b/modules/base/src/concur/Thread.fz
@@ -271,7 +271,7 @@ is
 #
 # NYI: CLEANUP: This could be just a field in thread as follows
 #
-#    mtx := concur.sync.mtx_init.or_else (panic "failed to create mutex")
+#    mtx := concur.sync.mtx_init.or_panic
 #
 # but there is currently no easy way to access this field while `concur.Threads.env.current`
 # cannot be used becuse `concur.Threads` is not yet instated.
@@ -281,7 +281,7 @@ is
 #
 module A0_park_mutex : thread_local_effect is
 
-  mtx_var := concur.sync.mtx_init.or_else (panic "failed to create mutex")
+  mtx_var := concur.sync.mtx_init.or_panic
   mtx =>
     mtx_var
 
@@ -301,7 +301,7 @@ module A0_park_mutex : thread_local_effect is
 #
 module A1_park_condition(C type : time.Clock) ref : thread_local_effect is
 
-  cond_var := (concur.sync.condition.new C A0_park_mutex.mtx).or_else (panic "failed to create condition variable")
+  cond_var := concur.sync.condition.new C A0_park_mutex.mtx .or_panic
   cond =>
     cond_var
 

--- a/modules/base/src/concur/blocking_mutate.fz
+++ b/modules/base/src/concur/blocking_mutate.fz
@@ -39,8 +39,7 @@ public blocking_mutate_using_clock(C type : time.Clock) : mutate is
 
   # mutex to be used for synchronization
   #
-  mtx := concur.sync.mutex.new.or_else
-            (panic "`concur.sync.mutex.new` failed to create mutex for `$(concur.blocking_mutate_using_clock.this.type)`")
+  mtx := concur.sync.mutex.new.or_panic
 
 
   # Threads that are currently blocked in `wait`


### PR DESCRIPTION
In the future `or_panic` will include a stacktrace when in debug mode.

