### PR TITLE
base: remove NYI comment

### DIFF
--- a/modules/base/src/net/ip_address.fz
+++ b/modules/base/src/net/ip_address.fz
@@ -127,7 +127,6 @@ public ip_address (val u128) : property.orderable is
   # parse an ip_address from a String
   #
   public type.from_string (s String) outcome net.ip_address =>
-    # NYI: PERFORMANCE: search for . and : in parallel
     if s.contains "."
       sv4 := s.split "."
       check sv4.count = 4

--- a/modules/base/src/os/pipe.fz
+++ b/modules/base/src/os/pipe.fz
@@ -71,7 +71,7 @@ private:public pipe : effect is
 
       match (io.buffered LM).Reader.instate (pipe_reader LM read_desc "reading in $(pipe.this.type.name)") r
         unit =>
-          # NYI: UDNER DEVELOPMENT: this explicit closing
+          # NYI: UNDER DEVELOPMENT: this explicit closing
           # should probably be removed
           _ := fzE_pipe_close read_desc
           w write_desc


### PR DESCRIPTION
I don't think it is sensible to "search for . and : in parallel"

