### PR TITLE
mail: workaround for call to compile_time_panic via switch

### DIFF
--- a/modules/mail/src/mail.fz
+++ b/modules/mail/src/mail.fz
@@ -186,7 +186,11 @@ public mail is
                   _ := (io.buffered net_lm).read_line_while (s -> s != "250 STARTTLS")
                   write_or_cause net_lm "STARTTLS\r\n"
                   ok := (io.buffered net_lm).read_line
-                  if ok != "220 OK"
-                    (flow.exception unit).env.cause (error "Expected 220 OK, got $(ok)")
+                  match ok
+                    s String =>
+                      if s != "220 OK"
+                        (flow.exception unit).env.cause (error "Expected 220 OK, got $(ok)")
+                    eof io.end_of_file =>
+                      (flow.exception unit).env.cause (error "Expected 220 OK, got $(eof)")
 
                 wolfssl _ net_lm ssl_lm host write_request


### PR DESCRIPTION
Previously, switch required only the first type parameter to be equatable, this recently changed and therefore now this call to equals fails. As a workaround, we only compare if there is a String.