### PR TITLE
base: rename `mutate.new` as `mutate.var`

### DIFF
--- a/examples/jitter/jitter_threaded.fz
+++ b/examples/jitter/jitter_threaded.fz
@@ -292,7 +292,7 @@ jitter_threaded =>
         error_cell := concur.atomic (option String) .new nil
 
         # Mutable cell for expected release time
-        cell := bm.env.new start
+        cell := bm.env.var start
 
         # Sleep until the first release time to align the scheduler's start.
         now := time.Nano.env.read

--- a/modules/base/src/auto_unwrap.fz
+++ b/modules/base/src/auto_unwrap.fz
@@ -23,7 +23,7 @@
 
 # auto_unwrap adds compiler support for automatic unwrapping.
 #
-# this is used by e.g. concur.atomic, mutate.new
+# this is used by e.g. concur.atomic, mutate.var
 #
 # example:
 #

--- a/modules/base/src/concur/Channel.fz
+++ b/modules/base/src/concur/Channel.fz
@@ -307,7 +307,7 @@ is
 
   # current value in the channel, nil if none.
   #
-  state := M.env.new (unbuffered_channel_state T) ready
+  state := M.env.var (unbuffered_channel_state T) ready
 
 
   # send a value to this Channel.

--- a/modules/base/src/concur/atomic.fz
+++ b/modules/base/src/concur/atomic.fz
@@ -39,7 +39,7 @@ is
 
   # the underlying mutable value
   #
-  value := (AAA_builtin_atomic_mutate atomic.this).env.new initial_value
+  value := (AAA_builtin_atomic_mutate atomic.this).env.var initial_value
 
 
   # Does the current system permit racy accesses to the value of type T

--- a/modules/base/src/concur/racy_access.fz
+++ b/modules/base/src/concur/racy_access.fz
@@ -24,7 +24,7 @@
 # -----------------------------------------------------------------------
 
 # racy_access -- an effect that permits reading and writing values in instances
-# of `concur.atomic_mutate.new` using the racy access functions `get_racy` and
+# of `concur.atomic_mutate.var` using the racy access functions `get_racy` and
 # `put_racy`.
 #
 private:module racy_access(M type : mutate) : effect is

--- a/modules/base/src/concur/task_pool.fz
+++ b/modules/base/src/concur/task_pool.fz
@@ -30,7 +30,7 @@ public task_pool (
 ) : realtime.Scheduler
 is
 
-  thrds := M.env.new (list concur.Thread) nil
+  thrds := M.env.var (list concur.Thread) nil
 
 
   # submit a task to the thread pool

--- a/modules/base/src/container/Doubly_Linked_List.fz
+++ b/modules/base/src/container/Doubly_Linked_List.fz
@@ -35,11 +35,11 @@ L_Node(
 
   # the previous list node
   #
-  prev := LM.env.new (L_Node LM T) L_Node.this
+  prev := LM.env.var (L_Node LM T) L_Node.this
 
   # the next list node
   #
-  next := LM.env.new (L_Node LM T) L_Node.this
+  next := LM.env.var (L_Node LM T) L_Node.this
 
   # the element stored in this list node
   #
@@ -114,7 +114,7 @@ private:public Doubly_Linked_List(
 
   # number of elements currently in the list (does not include the sentinel)
   #
-  len := LM.env.new i64 0
+  len := LM.env.var i64 0
 
 
   # is this list empty?

--- a/modules/base/src/container/Dynamic_Array.fz
+++ b/modules/base/src/container/Dynamic_Array.fz
@@ -38,11 +38,11 @@ module:public Dynamic_Array (
 
   # contents of the array
   #
-  data LM.new (LM.array T),
+  data LM.var (LM.array T),
 
   # length -- number of elements in data that are in use,
   #           i.e. store actual elements
-  len LM.new i64
+  len LM.var i64
 
 ) ref : Buffer T LM
   pre
@@ -179,7 +179,7 @@ is
   =>
     init_len := s.is_array_backed ? s.count.as_i64 : min_length
 
-    d := container.Dynamic_Array LM T (LM.env.new (LM.array T .empty init_len)) (LM.env.new i64 0)
+    d := container.Dynamic_Array LM T (LM.env.var (LM.array T .empty init_len)) (LM.env.var i64 0)
 
     for e in s do d.add e
 
@@ -189,7 +189,7 @@ is
   # initialize an empty Dynamic_Array of type T
   #
   public type.empty container.Dynamic_Array LM T =>
-    container.Dynamic_Array LM T (LM.env.new (LM.array T .empty min_length)) (LM.env.new i64 0)
+    container.Dynamic_Array LM T (LM.env.var (LM.array T .empty min_length)) (LM.env.var i64 0)
 
 
   # initialize an empty Dynamic_Array of type T, allocates the internal array with the given initial length
@@ -199,7 +199,7 @@ is
   # resulting in a reallocation of the internal array
   #
   module type.empty(initial_internal_length i64) container.Dynamic_Array LM T =>
-    container.Dynamic_Array LM T (LM.env.new (LM.array T .empty initial_internal_length)) (LM.env.new i64 0)
+    container.Dynamic_Array LM T (LM.env.var (LM.array T .empty initial_internal_length)) (LM.env.var i64 0)
 
 
   # the length below which the internal array won't shrink

--- a/modules/base/src/container/Fixed_Capacity_Array.fz
+++ b/modules/base/src/container/Fixed_Capacity_Array.fz
@@ -40,11 +40,11 @@ module:public Fixed_Capacity_Array(
 
   # contents of the array
   #
-  data LM.new (LM.array T),
+  data LM.var (LM.array T),
 
   # length -- number of elements in data that are in use,
   #           i.e. store actual elements
-  len LM.new i64
+  len LM.var i64
 
 ) ref : Dynamic_Array LM T data len
 is
@@ -79,7 +79,7 @@ is
   public redef type.from_sequence(s Sequence T) container.Dynamic_Array LM T =>
     arr := s.as_array_backed
 
-    d := container.Fixed_Capacity_Array LM T (LM.env.new (LM.array T .empty arr.count.as_i64)) (LM.env.new i64 0)
+    d := container.Fixed_Capacity_Array LM T (LM.env.var (LM.array T .empty arr.count.as_i64)) (LM.env.var i64 0)
 
     for e in arr do d.add e
 
@@ -89,10 +89,10 @@ is
   # initialize an empty Fixed_Capacity_Array of type T with default capacity of `min_length`
   #
   public redef type.empty container.Dynamic_Array LM T =>
-    container.Fixed_Capacity_Array LM T (LM.env.new (LM.array T .empty min_length)) (LM.env.new i64 0)
+    container.Fixed_Capacity_Array LM T (LM.env.var (LM.array T .empty min_length)) (LM.env.var i64 0)
 
 
   # initialize an empty Fixed_Capacity_Array of type T with the given capacity
   #
   public redef type.empty(capacity i64) container.Dynamic_Array LM T =>
-    container.Fixed_Capacity_Array LM T (LM.env.new (LM.array T .empty capacity)) (LM.env.new i64 0)
+    container.Fixed_Capacity_Array LM T (LM.env.var (LM.array T .empty capacity)) (LM.env.var i64 0)

--- a/modules/base/src/container/LRU_Cache.fz
+++ b/modules/base/src/container/LRU_Cache.fz
@@ -70,11 +70,11 @@ private:public LRU_Cache(
 
   # the most recently used element
   #
-  mru  := LM.env.new i64 -1
+  mru  := LM.env.var i64 -1
 
   # the least recently used element
   #
-  lru  := LM.env.new i64 -1
+  lru  := LM.env.var i64 -1
 
   # the number of elements currently in the cache
   #
@@ -82,13 +82,13 @@ private:public LRU_Cache(
   # * increased iff a free index is obtained without evicting an element
   # * decreased iff an element is explicitly removed (by the user)
   #
-  _size := LM.env.new i64  0
+  _size := LM.env.var i64  0
 
   # the head of the list of free elements
   #
   # free elements are stored using the elements next pointers
   #
-  free := LM.env.new i64  0
+  free := LM.env.var i64  0
 
 
   # the capacity of the cache,

--- a/modules/base/src/container/Mutable_Hash_Map.fz
+++ b/modules/base/src/container/Mutable_Hash_Map.fz
@@ -73,7 +73,7 @@ is
 
   # number of entries currently in this map
   #
-  load := LM.env.new 0
+  load := LM.env.var 0
 
   # maximum number of pairs before size is increased
   #
@@ -85,11 +85,11 @@ is
 
   # size of allocated contents array, allows for some empty slots
   #
-  allocated_size := LM.env.new ((num.fraction min_size 1) / upper_load_factor).ceil
+  allocated_size := LM.env.var ((num.fraction min_size 1) / upper_load_factor).ceil
 
   # the contents
   #
-  contents := LM.env.new (LM.env.new_array (choice nil del (tuple HK V)) _ allocated_size.get _->(id (choice nil del (tuple HK V)) nil))
+  contents := LM.env.var (LM.env.new_array (choice nil del (tuple HK V)) _ allocated_size.get _->(id (choice nil del (tuple HK V)) nil))
 
 
   # calculate the index of k within contents array in case of no conflict

--- a/modules/base/src/container/Mutable_Linked_List.fz
+++ b/modules/base/src/container/Mutable_Linked_List.fz
@@ -40,7 +40,7 @@ private:public Mutable_Linked_List(# mutate effect to be used to create mutable 
   # mutable references to next. Initializes to refer to nil to form
   # a list with a single element.
   #
-  n := LM.env.new (option (Mutable_Linked_List LM T)) nil
+  n := LM.env.var (option (Mutable_Linked_List LM T)) nil
 
 
   # shorthand features to get the mutable references from `n`

--- a/modules/base/src/container/Ring_Buffer.fz
+++ b/modules/base/src/container/Ring_Buffer.fz
@@ -58,7 +58,7 @@ is
   #
   # This may be in the range `0..(size-1)`.
   #
-  first := M.env.new (i64 0)
+  first := M.env.var (i64 0)
 
   # number of elements that are currently stored in this `Ring_Buffer`.
   #
@@ -66,7 +66,7 @@ is
   # `first..(first + used).map (%size)` contains the elements stored in
   # this buffer.
   #
-  used  := M.env.new (i64 0)
+  used  := M.env.var (i64 0)
 
 
   # is this buffer full?

--- a/modules/base/src/container/mutable_tree_map.fz
+++ b/modules/base/src/container/mutable_tree_map.fz
@@ -37,7 +37,7 @@ is
   #
   # if this map is empty, this is nil
   #
-  root := LM.env.new (option Entry) nil
+  root := LM.env.var (option Entry) nil
 
 
   # returns the size of the map, i.e. the number of elements it contains

--- a/modules/base/src/container/mutable_tree_map/Entry.fz
+++ b/modules/base/src/container/mutable_tree_map/Entry.fz
@@ -29,17 +29,17 @@ module Entry(module key KEY, module val VAL) ref is
 
   # reference to the left subtree at this entry, or, if it is empty, nil
   #
-  module left := LM.env.new (option Entry) nil
+  module left := LM.env.var (option Entry) nil
 
 
   # reference to the right subtree at this entry, or if it is empty, nil
   #
-  module right := LM.env.new (option Entry) nil
+  module right := LM.env.var (option Entry) nil
 
 
   # height of the subtree whose root is this entry
   #
-  module height := LM.env.new i32 0
+  module height := LM.env.var i32 0
 
 
   # get the value stored in this submap at key k, nil if k is not a key

--- a/modules/base/src/container/sorted_array.fz
+++ b/modules/base/src/container/sorted_array.fz
@@ -90,7 +90,7 @@ is
         # h1 is the mutable index within the current first heap, this is updated
         # by the function passed to the array constructor.
         #
-        h1 := m.env.new 0
+        h1 := m.env.var 0
 
         na := array a.length i->
           # index in current pair of heaps

--- a/modules/base/src/container/stack0.fz
+++ b/modules/base/src/container/stack0.fz
@@ -30,7 +30,7 @@ public stack(LM type : mutate, T type) : container.Stack T is
       data : (next.bind (.as_sequence.as_list) .or_else nil)
 
 
-  top := LM.env.new (option Element) nil
+  top := LM.env.var (option Element) nil
 
 
   # push an element to the stack

--- a/modules/base/src/flow/try.fz
+++ b/modules/base/src/flow/try.fz
@@ -56,7 +56,7 @@ public try(ERROR type, F type : flow.fallible ERROR, T type, code_try ()->T) is
   # an `invalid mutate` error.
   #
   catch0(code_catch ERROR->T) T ! lm =>
-    m := lm.env.new (option ERROR nil)
+    m := lm.env.var (option ERROR nil)
     v := F.new e->
               m <- e
               F.abort

--- a/modules/base/src/io/buffered/Reader.fz
+++ b/modules/base/src/io/buffered/Reader.fz
@@ -38,7 +38,7 @@ public Reader ref : effect is
 
   # buffer backing this reader
   #
-  buffer := LM.env.new (Sequence u8) []
+  buffer := LM.env.var (Sequence u8) []
 
 
 
@@ -64,7 +64,7 @@ public Reader ref : effect is
 
     # the current position in the array
     #
-    pos := LM.env.new 0
+    pos := LM.env.var 0
 
     max_count ->
       p := pos.get

--- a/modules/base/src/mutate.fz
+++ b/modules/base/src/mutate.fz
@@ -28,7 +28,7 @@
 # This effect is typically used to work with mutable values. You can create
 # a mutable value as follows
 #
-#     v := mutate.env.new i32 42
+#     v := mutate.env.var i32 42
 #
 # and then modify it using
 #
@@ -223,10 +223,10 @@ public mutate : effect is
     intrinsic
 
 
-  # create a new mutable value with the given initial value and update the
+  # create a var mutable value with the given initial value and update the
   # 'mutate' effect in the current environment
   #
-  public new (
+  public var (
     T type,
 
     # initial value, will be updated by 'put' or 'infix <-'.
@@ -532,8 +532,8 @@ public mutate : effect is
 
     # creates a copy of the mutable field
     #
-    public copy new T =>
-      new get
+    public copy var T =>
+      var get
 
 
     # unwrap this mutable value
@@ -644,6 +644,6 @@ public mutate : effect is
 
 # create a new mutable value of type T with initial value v
 #
-public mut(T type, v T) mutate.new T ! mutate
+public mut(T type, v T) mutate.var T ! mutate
 =>
-  mutate.env.new v
+  mutate.env.var v

--- a/modules/base/src/once.fz
+++ b/modules/base/src/once.fz
@@ -35,7 +35,7 @@ once_mutate : racy_mutate is
 #
 public once(T type, f Lazy T) : auto_unwrap T once_mutate is
 
-  cache := once_mutate.env.new (option T) nil
+  cache := once_mutate.env.var (option T) nil
 
   # get the result of `f`
   #

--- a/modules/base/src/time/calendar_duration.fz
+++ b/modules/base/src/time/calendar_duration.fz
@@ -94,9 +94,9 @@ is
   public redef as_string String =>
     lm : mutate is
     lm ! ()->
-      is_positive := lm.env.new bool false
-      time_prefix := lm.env.new bool false
-      s := lm.env.new String "P"
+      is_positive := lm.env.var bool false
+      time_prefix := lm.env.var bool false
+      s := lm.env.var String "P"
 
       with_time_prefix (x String) =>
         if !time_prefix.get

--- a/modules/base/src/time/histogram.fz
+++ b/modules/base/src/time/histogram.fz
@@ -83,7 +83,7 @@ is
 
   # total number of measurements, including ignored ones.
   #
-  total_number := time.histogram_mutate.env.new (u64 0)
+  total_number := time.histogram_mutate.env.var (u64 0)
 
 
   # buffer of measurements at the end that should be ignored.
@@ -93,7 +93,7 @@ is
 
   # current index to add new data to ignore_last_buffer
   #
-  ignore_last_buffer_index := histogram_mutate.env.new (i64 0)
+  ignore_last_buffer_index := histogram_mutate.env.var (i64 0)
 
 
   # Number of distinct buckets that are recorded
@@ -105,28 +105,28 @@ is
   # the counts for different value ranges corresponding to buckets are
   # stored in buckets.
   #
-  size := histogram_mutate.env.new (u64 0)
+  size := histogram_mutate.env.var (u64 0)
 
 
   # min and max recorded durations
   #
-  min_ := histogram_mutate.env.new (option time.duration) nil
-  max_ := histogram_mutate.env.new (option time.duration) nil
+  min_ := histogram_mutate.env.var (option time.duration) nil
+  max_ := histogram_mutate.env.var (option time.duration) nil
 
 
   # sum of recorded durations
   #
-  sum := histogram_mutate.env.new time.duration.zero
+  sum := histogram_mutate.env.var time.duration.zero
 
 
   # sum of squares of recorded ns values
   #
-  squares := histogram_mutate.env.new 0.0
+  squares := histogram_mutate.env.var 0.0
 
 
   # time of first sample
   #
-  start_time := histogram_mutate.env.new (option time.instant) nil
+  start_time := histogram_mutate.env.var (option time.instant) nil
 
 
   # table of durations in each bucket, each entry gives the maximum duration for that index

--- a/modules/clang/src/clang.fz
+++ b/modules/clang/src/clang.fz
@@ -141,7 +141,7 @@ public clang is
   # get the fields of a struct/union
   #
   get_fields(crsr CXCursor) =>
-    childs := lm.env.new (container.expanding_array clang.arg .empty)
+    childs := lm.env.var (container.expanding_array clang.arg .empty)
 
     visitor : Function i32 CXCursor Native_Ref Native_Ref is
       public redef call(cxc CXCursor, parent Native_Ref, client_data Native_Ref) i32 =>

--- a/modules/http/src/http/body_readers.fz
+++ b/modules/http/src/http/body_readers.fz
@@ -42,7 +42,7 @@ module body_reader(LM type : mutate) i64 -> choice (Sequence u8) io.end_of_file 
 module body_reader(LM type : mutate, reader_size i64, _ unit) i64 -> choice (Sequence u8) io.end_of_file error =>
 
 
-  remaining := LM.env.new reader_size
+  remaining := LM.env.var reader_size
 
   max_count ->
     if remaining <= 0
@@ -111,9 +111,9 @@ module body_reader_chunked(LM type : mutate) i64 -> choice (Sequence u8) io.end_
 
   extension_limit := (u64 1024) * 64 # arbitrary value, see below
 
-  position := LM.env.new chunk_enum chunk_start
-  current_chunk_size := LM.env.new u64 0
-  extension_size := LM.env.new u64 0
+  position := LM.env.var chunk_enum chunk_start
+  current_chunk_size := LM.env.var u64 0
+  extension_size := LM.env.var u64 0
 
   update_current_chunk_size (new option u64) choice (Sequence u8) io.end_of_file error =>
     match new

--- a/src/dev/flang/ast/Types.java
+++ b/src/dev/flang/ast/Types.java
@@ -174,8 +174,8 @@ public class Types extends ANY
     public final AbstractFeature f_array;
     public final AbstractFeature f_mutate;
     public final AbstractFeature f_mutate_array;
-    public final AbstractFeature f_mutate_new;
-    public final AbstractFeature f_mutate_new_mutable_value;
+    public final AbstractFeature f_mutate_var;
+    public final AbstractFeature f_mutate_var_mutable_value;
     public final AbstractFeature f_effect;
     public final AbstractFeature f_effect_finally;
     public final AbstractFeature f_effect_static_finally;
@@ -252,8 +252,8 @@ public class Types extends ANY
       f_array                   = universe.get(mod, FuzionConstants.ARRAY_NAME, 6);
       f_mutate                  = universe.get(mod, "mutate", 0);
       f_mutate_array            = f_mutate.get(mod, FuzionConstants.ARRAY_NAME, 2);
-      f_mutate_new              = f_mutate.get(mod, "new", 2);
-      f_mutate_new_mutable_value= f_mutate_new.get(mod, "mutable_value");
+      f_mutate_var              = f_mutate.get(mod, "var", 2);
+      f_mutate_var_mutable_value= f_mutate_var.get(mod, "mutable_value");
       f_effect                  = universe.get(mod, "effect", 0);
       f_effect_finally          = f_effect.get(mod, "finally", 0);
       f_effect_static_finally   = f_effect.get(mod, "static_finally", 0);

--- a/src/dev/flang/be/c/C.java
+++ b/src/dev/flang/be/c/C.java
@@ -956,10 +956,10 @@ public class C extends ANY
     return Stream.of("fuzion.sys.thread.spawn0",
                      "fuzion.sys.thread.join0",
                      "mutate.atomic_access_supported",
-                     "mutate.new.compare_and_swap0",
-                     "mutate.new.compare_and_set0",
-                     "mutate.new.atomic_read0",
-                     "mutate.new.atomic_write0")
+                     "mutate.var.compare_and_swap0",
+                     "mutate.var.compare_and_set0",
+                     "mutate.var.atomic_read0",
+                     "mutate.var.atomic_write0")
       .anyMatch(_intrinsics._usedIntrinsics::contains);
   }
 

--- a/src/dev/flang/be/c/Intrinsics.java
+++ b/src/dev/flang/be/c/Intrinsics.java
@@ -96,7 +96,7 @@ public class Intrinsics extends ANY
         c.boxedConstString(c._fuir.clazzTypeName(c._fuir.clazzOuterClazz(cl)))
          .ret());
 
-    put("mutate.new.compare_and_swap0",  (c,cl,outer,in) ->
+    put("mutate.var.compare_and_swap0",  (c,cl,outer,in) ->
         {
           var nc = c._fuir.clazzOuterClazz(cl);
           var v = c._fuir.lookupMutableValue(nc);
@@ -133,7 +133,7 @@ public class Intrinsics extends ANY
           return code;
         });
 
-    put("mutate.new.compare_and_set0",  (c,cl,outer,in) ->
+    put("mutate.var.compare_and_set0",  (c,cl,outer,in) ->
         {
           var nc = c._fuir.clazzOuterClazz(cl);
           var v = c._fuir.lookupMutableValue(nc);
@@ -183,7 +183,7 @@ public class Intrinsics extends ANY
           return (r ? c._names.FZ_TRUE : c._names.FZ_FALSE).ret();
         });
 
-    put("mutate.new.atomic_read0",  (c,cl,outer,in) ->
+    put("mutate.var.atomic_read0",  (c,cl,outer,in) ->
         {
           var ac = c._fuir.clazzOuterClazz(cl);
           var v = c._fuir.lookupMutableValue(ac);
@@ -219,7 +219,7 @@ public class Intrinsics extends ANY
           return code;
         });
 
-    put("mutate.new.atomic_write0", (c,cl,outer,in) ->
+    put("mutate.var.atomic_write0", (c,cl,outer,in) ->
         {
           var ac = c._fuir.clazzOuterClazz(cl);
           var v = c._fuir.lookupMutableValue(ac);

--- a/src/dev/flang/be/interpreter/Intrinsics.java
+++ b/src/dev/flang/be/interpreter/Intrinsics.java
@@ -192,7 +192,7 @@ public class Intrinsics extends ANY
     put("Type.name"            , (executor, innerClazz) -> args ->
       Interpreter.boxedConstString(executor.fuir().clazzTypeName(executor.fuir().clazzOuterClazz(innerClazz))));
 
-    put("mutate.new.compare_and_swap0",  (executor, innerClazz) -> args ->
+    put("mutate.var.compare_and_swap0",  (executor, innerClazz) -> args ->
         {
           var nc = executor.fuir().clazzOuterClazz(innerClazz);
           var f = executor.fuir().lookupMutableValue(nc);
@@ -211,7 +211,7 @@ public class Intrinsics extends ANY
             }
         });
 
-    put("mutate.new.compare_and_set0",  (executor, innerClazz) -> args ->
+    put("mutate.var.compare_and_set0",  (executor, innerClazz) -> args ->
         {
           var nc = executor.fuir().clazzOuterClazz(innerClazz);
           var f = executor.fuir().lookupMutableValue(nc);
@@ -247,7 +247,7 @@ public class Intrinsics extends ANY
              (t == executor.fuir().clazz(SpecialClazzes.c_bool)));
         });
 
-    put("mutate.new.atomic_read0",  (executor, innerClazz) -> args ->
+    put("mutate.var.atomic_read0",  (executor, innerClazz) -> args ->
         {
           var a = executor.fuir().clazzOuterClazz(innerClazz);
           var f = executor.fuir().lookupMutableValue(a);
@@ -258,7 +258,7 @@ public class Intrinsics extends ANY
             }
         });
 
-    put("mutate.new.atomic_write0",  (executor, innerClazz) -> args ->
+    put("mutate.var.atomic_write0",  (executor, innerClazz) -> args ->
         {
           var a = executor.fuir().clazzOuterClazz(innerClazz);
           var f = executor.fuir().lookupMutableValue(a);

--- a/src/dev/flang/be/jvm/Intrinsix.java
+++ b/src/dev/flang/be/jvm/Intrinsix.java
@@ -154,7 +154,7 @@ public class Intrinsix extends ANY implements ClassFileConstants
                             locked(Expr.UNIT));
         });
 
-    put("mutate.new.atomic_read0",
+    put("mutate.var.atomic_read0",
         (jvm, si, cc, tvalue, args) ->
         {
           var ac = jvm._fuir.clazzOuterClazz(cc);
@@ -164,7 +164,7 @@ public class Intrinsix extends ANY implements ClassFileConstants
           return new Pair<>(val, Expr.UNIT);
         });
 
-    put("mutate.new.atomic_write0",
+    put("mutate.var.atomic_write0",
         (jvm, si, cc, tvalue, args) ->
         {
           var ac = jvm._fuir.clazzOuterClazz(cc);
@@ -175,8 +175,8 @@ public class Intrinsix extends ANY implements ClassFileConstants
           return new Pair<>(Expr.UNIT, code);
         });
 
-    put("mutate.new.compare_and_set0",
-        "mutate.new.compare_and_swap0",
+    put("mutate.var.compare_and_set0",
+        "mutate.var.compare_and_swap0",
         (jvm, si, cc, tvalue, args) ->
         {
           var nc = jvm._fuir.clazzOuterClazz(cc);
@@ -189,7 +189,7 @@ public class Intrinsix extends ANY implements ClassFileConstants
           int vslot  = jvm.allocLocal(si, jt.stackSlots());    // local var slot for old value, not casted.
 
           Expr pos, neg, oldv;
-          if (jvm._fuir.clazzOriginalName(cc).equals("mutate.new.compare_and_set0"))
+          if (jvm._fuir.clazzOriginalName(cc).equals("mutate.var.compare_and_set0"))
             { // compare_and_set: return true or false
               pos = Expr.iconst(1);            // 1
               neg = Expr.iconst(0);            // 0

--- a/src/dev/flang/be/jvm/JVM.java
+++ b/src/dev/flang/be/jvm/JVM.java
@@ -254,7 +254,7 @@ There are basically two approaches to pass such value fields
 
       class G extends FuzionInstance
       {
-        int x_mutable_value;   // inlined field mutate.new.mutable_value
+        int x_mutable_value;   // inlined field mutate.var.mutable_value
       }
 
       static Access_F access_G_x = new Access_f() {
@@ -277,7 +277,7 @@ There are basically two approaches to pass such value fields
 +
 This might turn out difficult since if we would not inline the calls made in
 `f.inc` we need to wrap the access wrapper into another access wrapper for
-calling `mutate.new.get` and `mutate.new.infix <-`.
+calling `mutate.var.get` and `mutate.var.infix <-`.
 
 . Since mutating value fields should happen only for the target of a call, we
   could specialize the call for the location of the value in the surrounding
@@ -285,7 +285,7 @@ calling `mutate.new.get` and `mutate.new.infix <-`.
 
       class G extends FuzionInstance
       {
-        int x_mutable_value;   // inlined field mutate.new.mutable_value
+        int x_mutable_value;   // inlined field mutate.var.mutable_value
       }
 
       static void g()

--- a/src/dev/flang/fuir/FUIR.java
+++ b/src/dev/flang/fuir/FUIR.java
@@ -620,12 +620,12 @@ public abstract class FUIR extends IR
 
 
   /**
-   * For a clazz inheriting from {@code mutate.new}, lookup the inner clazz of
+   * For a clazz inheriting from {@code mutate.var}, lookup the inner clazz of
    * the {@code mutable_value} field.
    *
    * @param cl index of a clazz representing cl's {@code mutable_value} field
    *
-   * @return the index of the requested {@code mutate.new.mutable_value} field's clazz.
+   * @return the index of the requested {@code mutate.var.mutable_value} field's clazz.
    */
   public abstract int lookupMutableValue(int cl);
 

--- a/src/dev/flang/fuir/GeneratingFUIR.java
+++ b/src/dev/flang/fuir/GeneratingFUIR.java
@@ -1886,12 +1886,12 @@ public class GeneratingFUIR extends FUIR
 
 
   /**
-   * For a clazz inheriting from {@code mutate.new}, lookup the inner clazz of
+   * For a clazz inheriting from {@code mutate.var}, lookup the inner clazz of
    * the {@code mutable_value} field.
    *
    * @param cl index of a clazz representing cl's {@code mutable_value} field
    *
-   * @return the index of the requested {@code mutate.new.mutable_value} field's clazz.
+   * @return the index of the requested {@code mutate.var.mutable_value} field's clazz.
    */
   public int lookupMutableValue(int cl)
   {
@@ -1899,7 +1899,7 @@ public class GeneratingFUIR extends FUIR
       (cl >= CLAZZ_BASE,
        cl < CLAZZ_BASE + _clazzes.size());
 
-    return id2clazz(cl).lookupNeeded(Types.resolved.f_mutate_new_mutable_value)._id;
+    return id2clazz(cl).lookupNeeded(Types.resolved.f_mutate_var_mutable_value)._id;
   }
 
 

--- a/src/dev/flang/fuir/analysis/dfa/DFA.java
+++ b/src/dev/flang/fuir/analysis/dfa/DFA.java
@@ -1837,7 +1837,7 @@ public class DFA extends ANY
   {
     put("Type.name"                      , cl -> cl._dfa.newConstString(fuir(cl).clazzTypeName(fuir(cl).clazzOuterClazz(cl.calledClazz())), cl) );
 
-    put("mutate.new.compare_and_swap0",  cl ->
+    put("mutate.var.compare_and_swap0",  cl ->
         {
           var v = fuir(cl).lookupMutableValue(fuir(cl).clazzOuterClazz(cl.calledClazz()));
 
@@ -1856,7 +1856,7 @@ public class DFA extends ANY
           return res;
         });
 
-    put("mutate.new.compare_and_set0",  cl ->
+    put("mutate.var.compare_and_set0",  cl ->
         {
           var v = fuir(cl).lookupMutableValue(fuir(cl).clazzOuterClazz(cl.calledClazz()));
 
@@ -1881,7 +1881,7 @@ public class DFA extends ANY
           return cl._dfa.bool();
         });
 
-    put("mutate.new.atomic_read0",  cl ->
+    put("mutate.var.atomic_read0",  cl ->
         {
           var v = fuir(cl).lookupMutableValue(fuir(cl).clazzOuterClazz(cl.calledClazz()));
 
@@ -1892,7 +1892,7 @@ public class DFA extends ANY
           return atomic.callField(cl._dfa, v, cl.site(), cl);
         });
 
-    put("mutate.new.atomic_write0",  cl ->
+    put("mutate.var.atomic_write0",  cl ->
         {
           var v = fuir(cl).lookupMutableValue(fuir(cl).clazzOuterClazz(cl.calledClazz()));
 

--- a/src/dev/flang/fuir/cfg/CFG.java
+++ b/src/dev/flang/fuir/cfg/CFG.java
@@ -209,10 +209,10 @@ public class CFG extends ANY
     put("Type.name"                      , (cfg, cl) -> { } );
 
     put("mutate.atomic_access_supported" , (cfg, cl) -> { } );
-    put("mutate.new.compare_and_set0"    , (cfg, cl) -> { } );
-    put("mutate.new.compare_and_swap0"   , (cfg, cl) -> { } );
-    put("mutate.new.atomic_read0"        , (cfg, cl) -> { } );
-    put("mutate.new.atomic_write0"       , (cfg, cl) -> { } );
+    put("mutate.var.compare_and_set0"    , (cfg, cl) -> { } );
+    put("mutate.var.compare_and_swap0"   , (cfg, cl) -> { } );
+    put("mutate.var.atomic_read0"        , (cfg, cl) -> { } );
+    put("mutate.var.atomic_write0"       , (cfg, cl) -> { } );
     put("mutate.read_fence"              , (cfg, cl) -> { } );
     put("mutate.write_fence"             , (cfg, cl) -> { } );
 

--- a/src/dev/flang/lsp/shared/records/TokenInfo.java
+++ b/src/dev/flang/lsp/shared/records/TokenInfo.java
@@ -305,7 +305,7 @@ public class TokenInfo extends ANY
           // NYI: UNDER DEVELOPMENT: check if all cases are considered
           .orElse(Optional.of(TokenType.Type));
       case t_const, t_leaf, t_infix, t_infix_right, t_prefix, t_postfix, t_private, t_module, t_public -> Optional.of(TokenType.Modifier);
-      case t_abstract,  t_check, t_do, t_else, t_env, t_fixed, t_for, t_if, t_in, t_index, t_intrinsic, t_invariant, t_is, t_loop, t_match, t_native, t_period, t_post, t_pre, t_redef, t_ref, t_set, t_ternary, t_then, t_this, t_type, t_universe, t_until, t_var, t_variant, t_while -> Optional.of(TokenType.Keyword);
+      case t_abstract,  t_check, t_do, t_else, t_env, t_fixed, t_for, t_if, t_in, t_index, t_intrinsic, t_invariant, t_is, t_loop, t_match, t_native, t_period, t_post, t_pre, t_redef, t_ref, t_set, t_ternary, t_then, t_this, t_type, t_universe, t_until, t_variant, t_while -> Optional.of(TokenType.Keyword);
       default -> Optional.empty();
       };
   }

--- a/src/dev/flang/parser/Lexer.java
+++ b/src/dev/flang/parser/Lexer.java
@@ -193,7 +193,6 @@ public class Lexer extends SourceFile
     t_pre("pre"),
     t_post("post"),
     t_invariant("invariant"),
-    t_var("var"),                     // unused
     t_match("match"),
     t_ref("ref"),
     t_redef("redef"),

--- a/tests/atomic_mutate/atomic_mutate_test.fz
+++ b/tests/atomic_mutate/atomic_mutate_test.fz
@@ -41,7 +41,7 @@ atomic_mutate_test =>
 
   count(M type : mutate, max u64)
   =>
-   c := M.env.new u64 0
+   c := M.env.var u64 0
    do
      n := c.update (+1) .1
    until n>=max
@@ -79,10 +79,10 @@ atomic_mutate_test =>
 
     tm ! ()->
 
-      started := tm.env.new 0
-      error   := tm.env.new (option String) nil
+      started := tm.env.var 0
+      error   := tm.env.var (option String) nil
       N := 3
-      c := M.env.new u64 0
+      c := M.env.var u64 0
 
       count_threaded(max u64)
       =>
@@ -137,10 +137,10 @@ atomic_mutate_test =>
 
     tm ! ()->
 
-      started := tm.env.new 0
-      error   := tm.env.new (option String) nil
+      started := tm.env.var 0
+      error   := tm.env.var (option String) nil
       N := 3
-      c := M.env.new u64 0
+      c := M.env.var u64 0
 
       count_threaded(max u64)
       =>

--- a/tests/blocking_mutate_timeout/blocking_mutate_timeout.fz
+++ b/tests/blocking_mutate_timeout/blocking_mutate_timeout.fz
@@ -38,8 +38,8 @@ blocking_mutate_timeout =>
 
   test_relative(BM type : concur.blocking_mutate_using_clock C, C type : time.Clock, name String)
   =>
-    running := BM.env.new "init"
-    counter := BM.env.new u64 0
+    running := BM.env.var "init"
+    counter := BM.env.var u64 0
 
     t_start := C.env.read
 
@@ -76,8 +76,8 @@ blocking_mutate_timeout =>
 
   test_absolute(BM type : concur.blocking_mutate_using_clock C, C type : time.Clock, name String)
   =>
-    running := BM.env.new "init"
-    counter := BM.env.new u64 0
+    running := BM.env.var "init"
+    counter := BM.env.var u64 0
 
     t1 := concur.Threads.env.spawn ()->
       BM.env.exclusive_when ()->running="start" ()->

--- a/tests/calls_on_ref_and_val_target/calls.fz
+++ b/tests/calls_on_ref_and_val_target/calls.fz
@@ -209,7 +209,7 @@ calls is
 
     ron ref is
       f String => abstract
-      cnt mutate.new i64 => abstract
+      cnt mutate.var i64 => abstract
 
     on : ron is
       redef cnt := mut 0

--- a/tests/catch_postcondition/catch_postcondition.fz
+++ b/tests/catch_postcondition/catch_postcondition.fz
@@ -103,7 +103,7 @@ catch_postcondition is
     lm : mutate is
 
     res := lm ! ()->
-        m := lm.env.new (option String nil)
+        m := lm.env.var (option String nil)
         (fuzion.runtime.post_fault.instate
           T
           (rt.post_fault msg->

--- a/tests/catch_postcondition/catch_postcondition.fz.expected_err_int
+++ b/tests/catch_postcondition/catch_postcondition.fz.expected_err_int
@@ -271,7 +271,7 @@ catch_postcondition.loop: --CURDIR--/catch_postcondition.fz:256:10:
 -----------^^^^^^^^^^^^^^^^^^^^^^^^
            nil
 -----------^^^
-(catch_postcondition.try_post (option String)).catch#1.h.(λ()-> m := lm.env.new (option String ni...).call.(λtry).call: --CURDIR--/catch_postcondition.fz:253:3:
+(catch_postcondition.try_post (option String)).catch#1.h.(λ()-> m := lm.env.var (option String ni...).call.(λtry).call: --CURDIR--/catch_postcondition.fz:253:3:
   for
 --^^^
     c in tries.indices
@@ -304,7 +304,7 @@ instate_helper (option String) fuzion.runtime.post_fault: <source position not a
 fuzion.type.runtime.type.post_fault.type.instate#4 (option String): {base.fum}/effect.fz:170:10:
     x := instate_helper R effect.this e code def
 ---------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-(catch_postcondition.try_post (option String)).catch#1.h.(λ()-> m := lm.env.new (option String ni...).call: --CURDIR--/catch_postcondition.fz:107:9:
+(catch_postcondition.try_post (option String)).catch#1.h.(λ()-> m := lm.env.var (option String ni...).call: --CURDIR--/catch_postcondition.fz:107:9:
         (fuzion.runtime.post_fault.instate
 --------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
           T
@@ -339,7 +339,7 @@ instate_helper (option String) (catch_postcondition.try_post (option String)).ca
 (catch_postcondition.try_post (option String)).catch#1.h: --CURDIR--/catch_postcondition.fz:105:12:
     res := lm ! ()->
 -----------^^^^^^^^^
-        m := lm.env.new (option String nil)
+        m := lm.env.var (option String nil)
 --------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
         (fuzion.runtime.post_fault.instate
 --------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -369,7 +369,7 @@ instate_helper (option String) (catch_postcondition.try_post (option String)).ca
 -----------^^^^^^^^^^^^^^^^^^^^^^^^
            nil
 -----------^^^
-(catch_postcondition.try_post (option String)).catch#1.h.(λ()-> m := lm.env.new (option String ni...).call.(λtry).call: --CURDIR--/catch_postcondition.fz:112:11:
+(catch_postcondition.try_post (option String)).catch#1.h.(λ()-> m := lm.env.var (option String ni...).call.(λtry).call: --CURDIR--/catch_postcondition.fz:112:11:
           try
 ----------^^^
 (instate_helper (option String) fuzion.runtime.post_fault).call_code.call: {base.fum}/effect.fz:405:18:
@@ -380,7 +380,7 @@ instate_helper (option String) fuzion.runtime.post_fault: <source position not a
 fuzion.type.runtime.type.post_fault.type.instate#4 (option String): {base.fum}/effect.fz:170:10:
     x := instate_helper R effect.this e code def
 ---------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-(catch_postcondition.try_post (option String)).catch#1.h.(λ()-> m := lm.env.new (option String ni...).call: --CURDIR--/catch_postcondition.fz:107:9:
+(catch_postcondition.try_post (option String)).catch#1.h.(λ()-> m := lm.env.var (option String ni...).call: --CURDIR--/catch_postcondition.fz:107:9:
         (fuzion.runtime.post_fault.instate
 --------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
           T
@@ -415,7 +415,7 @@ instate_helper (option String) (catch_postcondition.try_post (option String)).ca
 (catch_postcondition.try_post (option String)).catch#1.h: --CURDIR--/catch_postcondition.fz:105:12:
     res := lm ! ()->
 -----------^^^^^^^^^
-        m := lm.env.new (option String nil)
+        m := lm.env.var (option String nil)
 --------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
         (fuzion.runtime.post_fault.instate
 --------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -473,7 +473,7 @@ instate_helper String fuzion.runtime.post_fault: --CURDIR--/catch_postcondition.
 fuzion.type.runtime.type.post_fault.type.instate#4 String: {base.fum}/effect.fz:170:10:
     x := instate_helper R effect.this e code def
 ---------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-(catch_postcondition.try_post String).catch#1.h.(λ()-> m := lm.env.new (option String ni...).call: --CURDIR--/catch_postcondition.fz:107:9:
+(catch_postcondition.try_post String).catch#1.h.(λ()-> m := lm.env.var (option String ni...).call: --CURDIR--/catch_postcondition.fz:107:9:
         (fuzion.runtime.post_fault.instate
 --------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
           T
@@ -508,7 +508,7 @@ instate_helper String (catch_postcondition.try_post String).catch#1.h.lm: <sourc
 (catch_postcondition.try_post String).catch#1.h: --CURDIR--/catch_postcondition.fz:105:12:
     res := lm ! ()->
 -----------^^^^^^^^^
-        m := lm.env.new (option String nil)
+        m := lm.env.var (option String nil)
 --------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
         (fuzion.runtime.post_fault.instate
 --------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -541,7 +541,7 @@ instate_helper String fuzion.runtime.post_fault: <source position not available>
 fuzion.type.runtime.type.post_fault.type.instate#4 String: {base.fum}/effect.fz:170:10:
     x := instate_helper R effect.this e code def
 ---------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-(catch_postcondition.try_post String).catch#1.h.(λ()-> m := lm.env.new (option String ni...).call: --CURDIR--/catch_postcondition.fz:107:9:
+(catch_postcondition.try_post String).catch#1.h.(λ()-> m := lm.env.var (option String ni...).call: --CURDIR--/catch_postcondition.fz:107:9:
         (fuzion.runtime.post_fault.instate
 --------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
           T
@@ -576,7 +576,7 @@ instate_helper String (catch_postcondition.try_post String).catch#1.h.lm: <sourc
 (catch_postcondition.try_post String).catch#1.h: --CURDIR--/catch_postcondition.fz:105:12:
     res := lm ! ()->
 -----------^^^^^^^^^
-        m := lm.env.new (option String nil)
+        m := lm.env.var (option String nil)
 --------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
         (fuzion.runtime.post_fault.instate
 --------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -606,7 +606,7 @@ catch_postcondition.res: --CURDIR--/catch_postcondition.fz:212:10:
 -----------^^^^^^^^^^^^^^^^^^^^^^^^
            test u64
 -----------^^^^^^^^
-catch_postcondition.loop.h.(λ()-> m := lm.env.new (option String ni...).call.(λtry).call: --CURDIR--/catch_postcondition.fz:217:7:
+catch_postcondition.loop.h.(λ()-> m := lm.env.var (option String ni...).call.(λtry).call: --CURDIR--/catch_postcondition.fz:217:7:
   say res
 ------^^^
 (instate_helper (option String) fuzion.runtime.post_fault).call_code.call: {base.fum}/effect.fz:405:18:
@@ -617,7 +617,7 @@ instate_helper (option String) fuzion.runtime.post_fault: <source position not a
 fuzion.type.runtime.type.post_fault.type.instate#4 (option String): {base.fum}/effect.fz:170:10:
     x := instate_helper R effect.this e code def
 ---------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-catch_postcondition.loop.h.(λ()-> m := lm.env.new (option String ni...).call: --CURDIR--/catch_postcondition.fz:107:9:
+catch_postcondition.loop.h.(λ()-> m := lm.env.var (option String ni...).call: --CURDIR--/catch_postcondition.fz:107:9:
         (fuzion.runtime.post_fault.instate
 --------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
           T
@@ -652,7 +652,7 @@ catch_postcondition.loop.h.lm.infix !#2 (option String): {base.fum}/effect.fz:22
 catch_postcondition.loop.h: --CURDIR--/catch_postcondition.fz:105:12:
     res := lm ! ()->
 -----------^^^^^^^^^
-        m := lm.env.new (option String nil)
+        m := lm.env.var (option String nil)
 --------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
         (fuzion.runtime.post_fault.instate
 --------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -671,7 +671,7 @@ catch_postcondition.loop.h: --CURDIR--/catch_postcondition.fz:105:12:
 catch_postcondition.loop.h.try: --CURDIR--/catch_postcondition.fz:166:10:
     r := h.res
 ---------^
-catch_postcondition.loop.h.(λ()-> m := lm.env.new (option String ni...).call.(λtry).call: --CURDIR--/catch_postcondition.fz:112:11:
+catch_postcondition.loop.h.(λ()-> m := lm.env.var (option String ni...).call.(λtry).call: --CURDIR--/catch_postcondition.fz:112:11:
           try
 ----------^^^
 (instate_helper (option String) fuzion.runtime.post_fault).call_code.call: {base.fum}/effect.fz:405:18:
@@ -682,7 +682,7 @@ instate_helper (option String) fuzion.runtime.post_fault: <source position not a
 fuzion.type.runtime.type.post_fault.type.instate#4 (option String): {base.fum}/effect.fz:170:10:
     x := instate_helper R effect.this e code def
 ---------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-catch_postcondition.loop.h.(λ()-> m := lm.env.new (option String ni...).call: --CURDIR--/catch_postcondition.fz:107:9:
+catch_postcondition.loop.h.(λ()-> m := lm.env.var (option String ni...).call: --CURDIR--/catch_postcondition.fz:107:9:
         (fuzion.runtime.post_fault.instate
 --------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
           T
@@ -717,7 +717,7 @@ catch_postcondition.loop.h.lm.infix !#2 (option String): {base.fum}/effect.fz:22
 catch_postcondition.loop.h: --CURDIR--/catch_postcondition.fz:105:12:
     res := lm ! ()->
 -----------^^^^^^^^^
-        m := lm.env.new (option String nil)
+        m := lm.env.var (option String nil)
 --------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
         (fuzion.runtime.post_fault.instate
 --------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -755,7 +755,7 @@ catch_postcondition.z.catch#1: --CURDIR--/catch_postcondition.fz:162:3:
 --^^^^
     say "*** all failed ***"
 ----^^^^^^^^^^^^^^^^^^^^^^^^
-catch_postcondition.z.(λ()-> m := lm.env.new (option String ni...).call.(λ(_ -> catch m.get.or_panic)).call#1: --CURDIR--/catch_postcondition.fz:113:17:
+catch_postcondition.z.(λ()-> m := lm.env.var (option String ni...).call.(λ(_ -> catch m.get.or_panic)).call#1: --CURDIR--/catch_postcondition.fz:113:17:
           (_ -> catch m.get.or_panic))
 ----------------^^^^^^^^^^^^^^^^^^^^
 (instate_helper (option String) fuzion.runtime.post_fault).call_def.call#1: {base.fum}/effect.fz:410:18:
@@ -770,7 +770,7 @@ fuzion.type.runtime.type.post_fault.type.precall abort: {base.fum}/effect.fz:326
 ----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     safety: effect.this.env.abortable
 ----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-catch_postcondition.z.(λ()-> m := lm.env.new (option String ni...).call.(λmsg-> m <- msg fuzion.runtime.post_fau...).call#1: --CURDIR--/catch_postcondition.fz:111:13:
+catch_postcondition.z.(λ()-> m := lm.env.var (option String ni...).call.(λmsg-> m <- msg fuzion.runtime.post_fau...).call#1: --CURDIR--/catch_postcondition.fz:111:13:
             fuzion.runtime.post_fault.abort)
 ------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 fuzion.runtime.post_fault.cause#1: {base.fum}/flow/fallible.fz:40:6:
@@ -805,7 +805,7 @@ catch_postcondition.(λ(() -> test i32)).call: --CURDIR--/catch_postcondition.fz
 catch_postcondition.z.try: --CURDIR--/catch_postcondition.fz:151:33:
     redef try option String  => tries[c0.get].call
 --------------------------------^^^^^^^^^^^^^^^^^^
-catch_postcondition.z.(λ()-> m := lm.env.new (option String ni...).call.(λtry).call: --CURDIR--/catch_postcondition.fz:112:11:
+catch_postcondition.z.(λ()-> m := lm.env.var (option String ni...).call.(λtry).call: --CURDIR--/catch_postcondition.fz:112:11:
           try
 ----------^^^
 (instate_helper (option String) fuzion.runtime.post_fault).call_code.call: {base.fum}/effect.fz:405:18:
@@ -816,7 +816,7 @@ instate_helper (option String) fuzion.runtime.post_fault: <source position not a
 fuzion.type.runtime.type.post_fault.type.instate#4 (option String): {base.fum}/effect.fz:170:10:
     x := instate_helper R effect.this e code def
 ---------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-catch_postcondition.z.(λ()-> m := lm.env.new (option String ni...).call: --CURDIR--/catch_postcondition.fz:107:9:
+catch_postcondition.z.(λ()-> m := lm.env.var (option String ni...).call: --CURDIR--/catch_postcondition.fz:107:9:
         (fuzion.runtime.post_fault.instate
 --------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
           T
@@ -851,7 +851,7 @@ catch_postcondition.z.lm.infix !#2 (option String): {base.fum}/effect.fz:229:5:
 catch_postcondition.z: --CURDIR--/catch_postcondition.fz:105:12:
     res := lm ! ()->
 -----------^^^^^^^^^
-        m := lm.env.new (option String nil)
+        m := lm.env.var (option String nil)
 --------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
         (fuzion.runtime.post_fault.instate
 --------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -867,7 +867,7 @@ catch_postcondition.z: --CURDIR--/catch_postcondition.fz:105:12:
 ----------^^^
           (_ -> catch m.get.or_panic))
 ----------^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-(catch_postcondition.ref handle_post String).(λ()-> m := lm.env.new (option String ni...).call.(λtry).call: --CURDIR--/catch_postcondition.fz:154:7:
+(catch_postcondition.ref handle_post String).(λ()-> m := lm.env.var (option String ni...).call.(λtry).call: --CURDIR--/catch_postcondition.fz:154:7:
   say z.res
 ------^
 (instate_helper String fuzion.runtime.post_fault).call_code.call: {base.fum}/effect.fz:405:18:
@@ -878,7 +878,7 @@ instate_helper String fuzion.runtime.post_fault: <source position not available>
 fuzion.type.runtime.type.post_fault.type.instate#4 String: {base.fum}/effect.fz:170:10:
     x := instate_helper R effect.this e code def
 ---------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-(catch_postcondition.ref handle_post String).(λ()-> m := lm.env.new (option String ni...).call: --CURDIR--/catch_postcondition.fz:107:9:
+(catch_postcondition.ref handle_post String).(λ()-> m := lm.env.var (option String ni...).call: --CURDIR--/catch_postcondition.fz:107:9:
         (fuzion.runtime.post_fault.instate
 --------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
           T
@@ -913,7 +913,7 @@ instate_helper String (catch_postcondition.ref handle_post String).lm: <source p
 catch_postcondition.anonymous: --CURDIR--/catch_postcondition.fz:105:12:
     res := lm ! ()->
 -----------^^^^^^^^^
-        m := lm.env.new (option String nil)
+        m := lm.env.var (option String nil)
 --------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
         (fuzion.runtime.post_fault.instate
 --------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -929,7 +929,7 @@ catch_postcondition.anonymous: --CURDIR--/catch_postcondition.fz:105:12:
 ----------^^^
           (_ -> catch m.get.or_panic))
 ----------^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-catch_postcondition.y.(λ()-> m := lm.env.new (option String ni...).call.(λtry).call: --CURDIR--/catch_postcondition.fz:132:8:
+catch_postcondition.y.(λ()-> m := lm.env.var (option String ni...).call.(λtry).call: --CURDIR--/catch_postcondition.fz:132:8:
   say (_ : handle_post String is
 -------^^^^^^^^^^^^^^^^^^^^^^^^^
         redef try =>
@@ -950,7 +950,7 @@ instate_helper String fuzion.runtime.post_fault: <source position not available>
 fuzion.type.runtime.type.post_fault.type.instate#4 String: {base.fum}/effect.fz:170:10:
     x := instate_helper R effect.this e code def
 ---------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-catch_postcondition.y.(λ()-> m := lm.env.new (option String ni...).call: --CURDIR--/catch_postcondition.fz:107:9:
+catch_postcondition.y.(λ()-> m := lm.env.var (option String ni...).call: --CURDIR--/catch_postcondition.fz:107:9:
         (fuzion.runtime.post_fault.instate
 --------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
           T
@@ -985,7 +985,7 @@ catch_postcondition.y.lm.infix !#2 String: {base.fum}/effect.fz:229:5:
 catch_postcondition.y: --CURDIR--/catch_postcondition.fz:105:12:
     res := lm ! ()->
 -----------^^^^^^^^^
-        m := lm.env.new (option String nil)
+        m := lm.env.var (option String nil)
 --------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
         (fuzion.runtime.post_fault.instate
 --------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/effect_installed/test_effect.fz
+++ b/tests/effect_installed/test_effect.fz
@@ -32,9 +32,9 @@ test_effect is
   b : mutate is
   c : mutate is
   d : mutate is
-  use_a => v := {a.env.new   42}; v <- 1+v; say v
-  use_b => v := {b.env.new 4711}; v <- 1+v; say v
-  use_c => v := {c.env.new 0815}; v <- 1+v; say v
+  use_a => v := {a.env.var   42}; v <- 1+v; say v
+  use_b => v := {b.env.var 4711}; v <- 1+v; say v
+  use_c => v := {c.env.var 0815}; v <- 1+v; say v
   use_a_err1 => _ := a.env       # 1. should flag an error: effect not installed
   use_b_err2 => _ := b.env       # 2. should flag an error: effect not installed
   use_c_err3 => _ := c.env       # 3. should flag an error: effect not installed

--- a/tests/effect_wormholes/effect_wormholes.fz
+++ b/tests/effect_wormholes/effect_wormholes.fz
@@ -46,8 +46,8 @@ effect_wormholes =>
   lm ! ()->
 
     wh0 := effect_wormhole
-    whAm := lm.env.new (option effect_wormhole nil)
-    whBm := lm.env.new (option effect_wormhole nil)
+    whAm := lm.env.var (option effect_wormhole nil)
+    whBm := lm.env.var (option effect_wormhole nil)
 
     io.Out.env.println "01 - using                    default io.Out in main    thread!"
     io.Out.instate out_A ()->

--- a/tests/lib_mutate_array3/lib_mutate_array3.fz
+++ b/tests/lib_mutate_array3/lib_mutate_array3.fz
@@ -23,7 +23,7 @@
 
 lib_mutate_array3 =>
 
-  a := mutate.new_array3 i32 2 3 4 0
+  a := mutate.var_array3 i32 2 3 4 0
 
   a[0,1,1] := 7
   a[1,0,0] := 3

--- a/tests/lib_try_or_try/lib_try_or_try.fz
+++ b/tests/lib_try_or_try/lib_try_or_try.fz
@@ -32,7 +32,7 @@
 # ```
 # catch(code_catch ERROR->T) T =>
 #     lm ! ()->
-#           m := lm.env.new (option ERROR nil)
+#           m := lm.env.var (option ERROR nil)
 #           v := F.new e->
 #               m <- e
 #               F.abort

--- a/tests/local_mutate/test_local_mutate.fz
+++ b/tests/local_mutate/test_local_mutate.fz
@@ -47,7 +47,7 @@ test_local_mutate is
       count =>
 
         # create mutable variable s:
-        s := m.env.new 0
+        s := m.env.var 0
 
         for e in l do
 
@@ -60,7 +60,7 @@ test_local_mutate is
       # run code within an instance of m
       #
       m ! ()->
-        s := m.env.new 0
+        s := m.env.var 0
 
         for e in l do
           _ := s.update a->a+e
@@ -71,7 +71,7 @@ test_local_mutate is
       say "using m.instate_self and count: $(m ! ()->count)"
 
       count2 =>
-        s := m.env.new 0
+        s := m.env.var 0
         for e in l do
           _ := s.update a->a+e
         option s
@@ -178,8 +178,8 @@ test_local_mutate is
   test_ring1 =>
 
     Cell(T type, LM type : mutate, data T) ref is
-      n := LM.env.new (Cell T LM) Cell.this
-      p := LM.env.new (Cell T LM) Cell.this
+      n := LM.env.var (Cell T LM) Cell.this
+      p := LM.env.var (Cell T LM) Cell.this
       link(ne, pr Cell T LM) =>
         n <- ne
         p <- pr
@@ -274,8 +274,8 @@ test_local_mutate is
       # mutable references to next and previous. Initializes to refer to
       # Mut_Ring.this to form a minimal ring
       #
-      private n := LM.env.new (Mut_Ring LM T) Mut_Ring.this
-      private p := LM.env.new (Mut_Ring LM T) Mut_Ring.this
+      private n := LM.env.var (Mut_Ring LM T) Mut_Ring.this
+      private p := LM.env.var (Mut_Ring LM T) Mut_Ring.this
 
 
       # shorthand features to get the mutable references from `n` and `p`

--- a/tests/local_mutate_negative/test_local_mutate_neg.fz
+++ b/tests/local_mutate_negative/test_local_mutate_neg.fz
@@ -47,7 +47,7 @@ test_local_mutate_neg is
       count =>
 
         # create mutable variable s:
-        s := m.env.new 0
+        s := m.env.var 0
 
         for e in l do
 
@@ -60,7 +60,7 @@ test_local_mutate_neg is
       # run code within an instance of m
       #
       m ! ()->
-        s := m.env.new 0
+        s := m.env.var 0
 
         for e in l do
           _ := s.update a->a+e
@@ -71,7 +71,7 @@ test_local_mutate_neg is
       say "using m.instate_self and count: $(m ! ()->count)"
 
       count2 =>
-        s := m.env.new 0
+        s := m.env.var 0
         for e in l do
           _ := s.update a->a+e
         option s

--- a/tests/local_mutate_negative/test_local_mutate_neg.fz.expected_err
+++ b/tests/local_mutate_negative/test_local_mutate_neg.fz.expected_err
@@ -1,11 +1,11 @@
 
 --CURDIR--/test_local_mutate_neg.fz:50:14: error 1: Failed to verify that effect 'test_local_mutate_neg.test_sum.sum#1.m' is installed in current environment.
-        s := m.env.new 0
+        s := m.env.var 0
 -------------^^^^^
 Callchain that lead to this point:
 
 effect environment '--empty--' for call to 'test_local_mutate_neg.type.test_sum.type.sum#1.type.m.type.from_env' at --CURDIR--/test_local_mutate_neg.fz:50:14:
-        s := m.env.new 0
+        s := m.env.var 0
 -------------^^^^^
 effect environment '--empty--' for call to 'test_local_mutate_neg.test_sum.sum#1.count' at --CURDIR--/test_local_mutate_neg.fz:79:11:
       say count    # *** will cause compile-time an error, requires m to be installed

--- a/tests/lru_cache/lru_cache_test.fz
+++ b/tests/lru_cache/lru_cache_test.fz
@@ -160,7 +160,7 @@ lru_cache_test =>
         # expected key value pairs
         exp_map := container.mutable_tree_map m i64 i64 .empty
         # expected order from mru to lru
-        exp_ord := m.env.new (Sequence i64) []
+        exp_ord := m.env.var (Sequence i64) []
         cache := container.LRU_Cache m i64 i64 .new capacity
 
         remove_exp(k i64) unit =>

--- a/tests/reg_issue1943_type_parameter_as_outer_type/issue1943.fz
+++ b/tests/reg_issue1943_type_parameter_as_outer_type/issue1943.fz
@@ -42,7 +42,7 @@ test_outer_as_type_parameter is
   test z z.y
 
   # here the code in an example from the Fuzion presentation at TyDe'23
-  count(n (M : mutate).new i64,
+  count(n (M : mutate).var i64,
         l Sequence T) ! M =>
     l.for_each x->
       n <- n.get + 1

--- a/tests/reg_issue1943_type_parameter_as_outer_type/issue1943.fz
+++ b/tests/reg_issue1943_type_parameter_as_outer_type/issue1943.fz
@@ -51,7 +51,7 @@ test_outer_as_type_parameter is
   mm : mutate is
   mm ! ()->
     {
-      cnt := mm.env.new 100
+      cnt := mm.env.var 100
       cnt1 := count mm i64 cnt [1,2,3]
       say cnt1
     }

--- a/tests/reg_issue3352/reg_issue3352.fz
+++ b/tests/reg_issue3352/reg_issue3352.fz
@@ -22,6 +22,6 @@
 # -----------------------------------------------------------------------
 
 m : mutate is
-s := m.instate_self (() -> m.env.new 0)
+s := m.instate_self (() -> m.env.var 0)
 _ := s.get
 say "*** failed, should have panicked ***"

--- a/tests/reg_issue3352/reg_issue3352.fz.expected_err_int
+++ b/tests/reg_issue3352/reg_issue3352.fz.expected_err_int
@@ -22,10 +22,10 @@ fuzion.runtime.pre_fault.cause#1: {base.fum}/flow/fallible.fz:40:6:
 fuzion.runtime.precondition_fault#1: {base.fum}/fuzion/runtime/pre_fault.fz:56:3:
   fuzion.runtime.pre_fault.env.cause msg
 --^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-(m.new i64).pre get: {base.fum}/mutate.fz:207:9:
+(m.var i64).pre get: {base.fum}/mutate.fz:246:9:
         safety: !open || is_atomic || is_exclusive
 --------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-(m.new i64).precall get: {base.fum}/mutate.fz:206:7:
+(m.var i64).precall get: {base.fum}/mutate.fz:245:7:
       pre
 ------^^^
         safety: !open || is_atomic || is_exclusive

--- a/tests/reg_issue3352/reg_issue3352.fz.expected_err_jvm
+++ b/tests/reg_issue3352/reg_issue3352.fz.expected_err_jvm
@@ -4,8 +4,8 @@ Call stack:
 fuzion.sys.fatal_fault#2 at {base.fum}/fuzion/sys.fz:55
 [..]
 fuzion.runtime.precondition_fault#1 at {base.fum}/fuzion/runtime/pre_fault.fz:56
-(m.new i64).pre get at {base.fum}/mutate.fz:207
-(m.new i64).precall get at {base.fum}/mutate.fz:206
+(m.var i64).pre get at {base.fum}/mutate.fz:246
+(m.var i64).precall get at {base.fum}/mutate.fz:245
 universe at --builtin--:26
 
 *** fatal errors encountered, stopping.

--- a/tests/reg_issue4119/reg_issue4119.fz
+++ b/tests/reg_issue4119/reg_issue4119.fz
@@ -24,4 +24,4 @@
 reg_issue4119 =>
 
   lm : racy_mutate is
-  x := lm.new 0
+  x := lm.var 0

--- a/tests/reg_issue4119/reg_issue4119.fz.expected_err
+++ b/tests/reg_issue4119/reg_issue4119.fz.expected_err
@@ -1,6 +1,6 @@
 
 --CURDIR--/reg_issue4119.fz:27:11: error 1: Effect features must be called via 'env'.
-  x := lm.new 0
+  x := lm.var 0
 ----------^^^
 To solve this, insert 'env' before the call to retrieve the current value of the effect from the environment.
 

--- a/tests/reg_issue4220/reg_issue4220.fz
+++ b/tests/reg_issue4220/reg_issue4220.fz
@@ -28,7 +28,7 @@ reg_issue4220 =>
 
   v := m1.instate_self ()->
     say "start"
-    r := m.env.new 42
+    r := m.env.var 42
     say "r = $r"
     r
 

--- a/tests/reg_issue5302/reg_issue5302.fz
+++ b/tests/reg_issue5302/reg_issue5302.fz
@@ -24,7 +24,7 @@
 reg_issue5302 =>
 
   a(LM type: mutate) is
-    x := LM.env.new 2
+    x := LM.env.var 2
     say x
 
   some is

--- a/tests/reg_issue5968/reg_issue5968.fz
+++ b/tests/reg_issue5968/reg_issue5968.fz
@@ -27,7 +27,7 @@ reg_issue5968 =>
 
   a : effect is
 
-    b := lm.env.new 3
+    b := lm.env.var 3
 
 
     incr =>

--- a/tests/reg_issue6263/reg_issue6263.fz
+++ b/tests/reg_issue6263/reg_issue6263.fz
@@ -43,7 +43,7 @@ reg_issue6263 =>
 
   part1 =>
     lm.instate_self i64 ()->
-      cell(n lm.new String) ref is
+      cell(n lm.var String) ref is
       area := array2 1000 1000 _,_->(cell (lm.env.var $"."))
       say "start: "
       for px := 500, nx

--- a/tests/reg_issue6263/reg_issue6263.fz
+++ b/tests/reg_issue6263/reg_issue6263.fz
@@ -44,7 +44,7 @@ reg_issue6263 =>
   part1 =>
     lm.instate_self i64 ()->
       cell(n lm.new String) ref is
-      area := array2 1000 1000 _,_->(cell (lm.env.new $"."))
+      area := array2 1000 1000 _,_->(cell (lm.env.var $"."))
       say "start: "
       for px := 500, nx
           py := 500, ny
@@ -79,7 +79,7 @@ reg_issue6263 =>
         fill min_x min_y
         say "filled: "
         show
-        res := lm.env.new 0 # (max_x-min_x+1)*(max_y-min_y+1)
+        res := lm.env.var 0 # (max_x-min_x+1)*(max_y-min_y+1)
         for y in min_y..max_y do
           for x in min_x..max_x do
             c := area[_,x,y].n.get

--- a/tests/reg_issue6266/reg_issue6266.fz.expected_err
+++ b/tests/reg_issue6266/reg_issue6266.fz.expected_err
@@ -14,11 +14,11 @@ To solve this, you could try to use a value type as the target type of the call,
     value.get
 ----^^^^^^^^^
 The result type of this call depends on the target type.  Since the target type is a 'ref' type that may represent a number of different actual dynamic types, the result type is not clearly defined.
-Called feature: 'mutate.new.precall get'
+Called feature: 'mutate.var.precall get'
 Original result type: 'option Stack.this.node'
 Type depending on target: 'Stack.this'
 Target type: 'Stack'
-To solve this, you could try to use a value type as the target type of the call, e,g., 'mutate.new T', or change the result type of 'mutate.new.precall get' to no longer depend on 'Stack.this'.
+To solve this, you could try to use a value type as the target type of the call, e,g., 'mutate.var T', or change the result type of 'mutate.var.precall get' to no longer depend on 'Stack.this'.
 
 
 {base.fum}/mutate.fz:235:7: error 3: Call has an ambiguous result type since target of the call is a 'ref' type.
@@ -27,10 +27,10 @@ To solve this, you could try to use a value type as the target type of the call,
         safety: !open || is_atomic || is_exclusive
 --------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 The result type of this call depends on the target type.  Since the target type is a 'ref' type that may represent a number of different actual dynamic types, the result type is not clearly defined.
-Called feature: 'mutate.new.get'
+Called feature: 'mutate.var.get'
 Original result type: 'option Stack.this.node'
 Type depending on target: 'Stack.this'
 Target type: 'Stack'
-To solve this, you could try to use a value type as the target type of the call, e,g., 'mutate.new T', or change the result type of 'mutate.new.get' to no longer depend on 'Stack.this'.
+To solve this, you could try to use a value type as the target type of the call, e,g., 'mutate.var T', or change the result type of 'mutate.var.get' to no longer depend on 'Stack.this'.
 
 3 errors.

--- a/tests/reg_issue6709_unbalanced_infix/reg_issue6709_unbalanced_infix.fz
+++ b/tests/reg_issue6709_unbalanced_infix/reg_issue6709_unbalanced_infix.fz
@@ -93,7 +93,7 @@ reg_6709_unbalanced_infix =>
   # from modules/base/src/time/histogram.fz
   from_base_time_histogram =>
     ignore_last_buffer => [1,2,3]
-    ignore_last_buffer_index := mutate.env.new 42
+    ignore_last_buffer_index := mutate.env.var 42
     ignore_last_buffer_index <- (ignore_last_buffer_index.get = 0 ? ignore_last_buffer.length
                                                                   : ignore_last_buffer_index.get)- 1     # 16. should flag an error: unbalanced infix `-`
 

--- a/tests/reg_issue7166/reg_issue7166.fz
+++ b/tests/reg_issue7166/reg_issue7166.fz
@@ -47,7 +47,7 @@ reg_issue7166 =>
 
     # first, create mutable field and array:
 
-    v1 := LM.env.new 13
+    v1 := LM.env.var 13
     a1 := LM.env.new_array 32 _->"bla"
 
     # ------------------------------------

--- a/tests/unwrap/test_unwrap.fz
+++ b/tests/unwrap/test_unwrap.fz
@@ -23,7 +23,7 @@
 
 test_unwrap =>
 
-  a := mutate.env.new 3
+  a := mutate.env.var 3
   b := concur.atomic i64 .new 5
 
   say2(v i64) => say v


### PR DESCRIPTION
fixes #7702

Had to change the Lexer for this since `var` was a reserved word.