### PR TITLE
ir: fix boxing if ref to be boxed to is in nested choice

### DIFF
--- a/src/dev/flang/ast/Expr.java
+++ b/src/dev/flang/ast/Expr.java
@@ -845,21 +845,40 @@ public abstract class Expr extends ANY implements HasSourcePosition
         if (frmlT.isChoice() &&
             frmlT.isAssignableFromWithoutBoxing(t).no() &&
             frmlT.isAssignableFrom(t).yes())
-          { // we do both, box and then tag:
-            for (var cg : frmlT.choiceGenerics())
-              {
-                if (cg.isAssignableFrom(t).yes())
-                  {
-                    return cg;
-                  }
-              }
-            throw new Error("Expr.needsBoxing confused for choice type "+frmlT+" which is assignable from "+t.asRef()+" but not from "+t);
+          {
+            // we do both, box and then tag:
+            return findAssignableChoiceGeneric(frmlT, t);
           }
         else
           {
             return null;
           }
       }
+  }
+
+
+  /**
+   * In a potentially nested choice find the choice generic
+   * that t is assignable to
+   *
+   * @param ct
+   * @param t
+   * @return
+   */
+  private AbstractType findAssignableChoiceGeneric(AbstractType ct, AbstractType t)
+  {
+    for (var cg : ct.choiceGenerics())
+      {
+        if (cg.isChoice() && cg.isAssignableFrom(t).yes())
+          {
+            return findAssignableChoiceGeneric(cg, t);
+          }
+        if (cg.isAssignableFromWithoutTagging(t).yes())
+          {
+            return cg;
+          }
+      }
+    throw new Error("Expr.needsBoxing confused for choice type "+ct+" which is assignable from "+t.asRef()+" but not from "+t);
   }
 
 

--- a/src/dev/flang/ir/Box.java
+++ b/src/dev/flang/ir/Box.java
@@ -73,7 +73,8 @@ public class Box extends Expr
     if (PRECONDITIONS) require
       (value != null,
        !frmlT.containsUndefined(),
-       frmlT.isParametricType() || frmlT.isThisType() || !value.type().isRef(),
+       frmlT.isParametricType() || frmlT.isThisType() || frmlT.isRef(),
+       !value.type().isRef(),
        !(value instanceof Box));
 
     this._value = value;


### PR DESCRIPTION
We have the case box, tag, tag again, the PR where this problem shows up #7714

the value type: `container.ps_map String nom.parsers.this.json_value`
the type we want to assign to is: `outcome nom.parsers.this.json_value`

the json value is a choice defined as:

`json_value : choice String f64 bool nil (Sequence json_value) (container.Map String json_value)`

so what needs to happen is:

box ps_map to become a Map, than tag this to become a json_value, then tag it to become an outcome.

For the boxing case needsBoxing wrongly returned `json_value` instead of `Map`.
