### PR TITLE
fix crash in `Function.propagateTypeAndInferResult`

### DIFF
--- a/modules/lock_free/src/lock_free/Map.fz
+++ b/modules/lock_free/src/lock_free/Map.fz
@@ -118,7 +118,7 @@ is
   public redef as_string String => "container_node[gen=$gen]($(array.as_string ", "))"
 
   as_list(f Indirection_Node CTK CTV -> Main_Node CTK CTV) =>
-    array.flat_map /* NYI: BUG: type inference */ (tuple CTK CTV) (.as_list f)
+    array.flat_map (tuple CTK CTV) (.as_list f)
          .as_list
 
 

--- a/src/dev/flang/ast/Function.java
+++ b/src/dev/flang/ast/Function.java
@@ -410,13 +410,20 @@ public class Function extends AbstractLambda
                   {
                     _expr.propagateExpectedType(res, context, rt0, from);
                   }
-                result = refineResultType(res, context, rt0, _feature.resultType());
-                var g = t.lambdaTargetResultTypeParameter(res);
-                if (g != null && !_inheritsCall.isDefunct())
+                if (_feature.resultTypeIfPresentUrgent(res, true) == Types.t_FORWARD_CYCLIC)
                   {
-                    int idx = g.typeParameterIndex();
-                    _inheritsCall._generics = _inheritsCall._generics.setOrClone(idx, result);
-                    _inheritsCall.notifyInferred();
+                    AstErrors.forwardTypeInference(pos(), _feature);
+                  }
+                else
+                  {
+                    result = refineResultType(res, context, rt0, _feature.resultType());
+                    var g = t.lambdaTargetResultTypeParameter(res);
+                    if (g != null && !_inheritsCall.isDefunct())
+                      {
+                        int idx = g.typeParameterIndex();
+                        _inheritsCall._generics = _inheritsCall._generics.setOrClone(idx, result);
+                        _inheritsCall.notifyInferred();
+                      }
                   }
               }
 


### PR DESCRIPTION
fixes #7456

but type inference does not work nonetheless:

```
build/modules/lock_free/src/lock_free/Map.fz:121:20: error 1: Illegal forward or cyclic type inference
    array.flat_map (.as_list f)

The definition of a field using ':=', or of a feature or function
using '=>' must not create cyclic type dependencies.
Referenced feature: 'lock_free.container_node.as_list.(λ(.as_list f)).call' at build/modules/lock_free/src/lock_free/Map.fz:121:20:
    array.flat_map (.as_list f)
```
