### PR TITLE
fe: robuster code for #7747 when infering type pars and their count is wrong

### DIFF
--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -2247,9 +2247,9 @@ public class Call extends AbstractCall
     else if (formalType.isParametricType())
       {
         var g = formalType.typeParameter();
-        if (g.outer() == _calledFeature)
+        var i = g.typeParameterIndex();
+        if (g.outer() == _calledFeature && i < _generics.size())
           { // we found a use of a generic type, so record it:
-            var i = g.typeParameterIndex();
             var gt = _generics.get(i);
             if (!conflict[i] && gt != Types.t_ERROR && changingGenericAllowed(i))
               {

--- a/src/dev/flang/ast/Call.java
+++ b/src/dev/flang/ast/Call.java
@@ -2248,7 +2248,9 @@ public class Call extends AbstractCall
       {
         var g = formalType.typeParameter();
         var i = g.typeParameterIndex();
-        if (g.outer() == _calledFeature && i < _generics.size())
+        if (g.outer() == _calledFeature &&
+            i < _generics.size() // the index may be out-of-range if the input is fully broken, see #7747 for an example
+           )
           { // we found a use of a generic type, so record it:
             var gt = _generics.get(i);
             if (!conflict[i] && gt != Types.t_ERROR && changingGenericAllowed(i))

--- a/src/dev/flang/ast/Contract.java
+++ b/src/dev/flang/ast/Contract.java
@@ -318,6 +318,61 @@ public class Contract extends ANY
 
 
   /**
+   * Helper for call*Condition to create the actual call, unless the type
+   * parameters do not match (see #7747 for an example).
+   *
+   * @param res resolution instance
+   *
+   * @param pos the source position of the call
+   *
+   * @param target the target of the call
+   *
+   * @param typepars the type parameters
+   *
+   * @param args the actual arguments
+   *
+   * @param pf the called feature (pre/preBool/postFeature)
+   *
+   * @param context the environment we are creating the call in
+   */
+  private static Call callCondition(Resolution res,
+                                    SourcePosition pos,
+                                    Expr target,
+                                    List<AbstractType> typepars,
+                                    List<Expr> args,
+                                    AbstractFeature pf,
+                                    Context context)
+  {
+    return pf.generics().sizeMatches(typepars) ? new Call(pos,
+                                                          target,
+                                                          typepars,
+                                                          args,
+                                                          pf).resolveTypes(res, context)
+                                               : Call.ERROR;
+  }
+
+
+  /**
+   * Helper for call*Condition to create the actual args from the args of feature `f`.
+   *
+   * @param res resolution instance
+   *
+   * @param pos the source position of the call
+   *
+   * @param f the feature to copy arguments from
+   */
+  private static List<Expr> argsAsActuals(Resolution res,
+                                          SourcePosition pos,
+                                          AbstractFeature f)
+  {
+    return f.valueArguments().map2(a -> new Call(pos,
+                                                 new Current(pos, f),
+                                                 a
+                                                ).resolveTypes(res, f.context()));
+  }
+
+
+  /**
    * Create call to outer's precondition feature
    *
    * @param res resolution instance
@@ -337,15 +392,7 @@ public class Contract extends ANY
     if (PRECONDITIONS) require(outer == context.outerFeature());
     var oc = f.contract();
     var p = oc._hasPre != null ? oc._hasPre : f.pos();
-    List<Expr> args = new List<>();
-    for (var a : outer.valueArguments())
-      {
-        var ca = new Call(p,
-                          new Current(p, outer),
-                          a);
-        ca = ca.resolveTypes(res, context);
-        args.add(ca);
-      }
+    var args = argsAsActuals(res, p, outer);
     return callPreCondition(res, f, outer, context, args);
   }
 
@@ -387,41 +434,6 @@ public class Contract extends ANY
 
 
   /**
-   * Helper for call*Condition to create the actual call, unless the type
-   * parameters do not match (see #7747 for an example).
-   *
-   * @param res resolution instance
-   *
-   * @param pos the source position of the call
-   *
-   * @param target the target of the call
-   *
-   * @param typepars the type parameters
-   *
-   * @param args the actual arguments
-   *
-   * @param pf the called feature (pre/preBool/postFeature)
-   *
-   * @param context the environment we are creating the call in
-   */
-  static Call callCondition(Resolution res,
-                            SourcePosition pos,
-                            Expr target,
-                            List<AbstractType> typepars,
-                            List<Expr> args,
-                            AbstractFeature pf,
-                            Context context)
-  {
-    return pf.generics().sizeMatches(typepars) ? new Call(pos,
-                                                          target,
-                                                          typepars,
-                                                          args,
-                                                          pf).resolveTypes(res, context)
-                                               : Call.ERROR;
-  }
-
-
-  /**
    * Create call to f's pre bool feature
    *
    * @param res resolution instance
@@ -437,16 +449,8 @@ public class Contract extends ANY
     var outer = context.outerFeature();
     var oc = f.contract();
     var p = oc._hasPre != null ? oc._hasPre : f.pos();
-    List<Expr> args = new List<>();
-    for (var a : outer.valueArguments())
-      {
-        var ca = new Call(p,
-                          new Current(p, outer),
-                          a);
-        ca = ca.resolveTypes(res, context);
-        args.add(ca);
-      }
 
+    var args = argsAsActuals(res, p, outer);
     var t = outer.outerRef() != null ? This.thiz(res, p, context, outer.outer())
                                      : Universe.instance;
     addContractFeatures(res, f, context);  // if f is currently being compiled, make sure its contract features are created first
@@ -474,15 +478,7 @@ public class Contract extends ANY
     var preAndCallOuter = f.preAndCallFeature();
     var oc = f.contract();
     var p = oc._hasPre != null ? oc._hasPre : f.pos();
-    List<Expr> args = new List<>();
-    for (var a : preAndCallOuter.valueArguments())
-      {
-        var ca = new Call(p,
-                          new Current(p, preAndCallOuter),
-                          a);
-        ca = ca.resolveTypes(res, preAndCallOuter.context());
-        args.add(ca);
-      }
+    var args = argsAsActuals(res, p, preAndCallOuter);
     var t = This.thiz(res, p, preAndCallOuter.context(), preAndCallOuter.outer());
     return new Call(p,
                     t,
@@ -518,14 +514,7 @@ public class Contract extends ANY
       }
     else
       {
-        for (var a : outer.valueArguments())
-          {
-            var ca = new Call(p,
-                              new Current(p, outer),
-                              a);
-            ca = ca.resolveTypes(res, context);
-            args.add(ca);
-          }
+        args = argsAsActuals(res, p, outer);
         if (outer.hasResultField())
           {
             var c2 = new Call(p,
@@ -756,7 +745,7 @@ public class Contract extends ANY
    *
    * @param res Resolution instance
    *
-   * @param f the feature that requires a pre or pre bool feature
+   * @param of the feature that requires a pre or pre bool or post feature
    */
   static void addContractFeatures(Resolution res, AbstractFeature of, Context context)
   {
@@ -1115,18 +1104,7 @@ The conditions of a post-condition are checked at run-time in sequential source-
           {
             if (hasPostConditionsFeature(inh))
               {
-                List<Expr> args2 = new List<>();
-                for (var a : args)
-                  {
-                    var ca = new Call(pos,
-                                      new Current(pos, pF),
-                                      a);
-                    ca = ca.resolveTypes(res, pF.context());
-                    if (!ca.calledFeature().isTypeParameter())
-                      {
-                        args2.add(ca);
-                      }
-                  }
+                var args2 = argsAsActuals(res, pos, pF);
                 var inhpost = callPostCondition(res, inh, pF.context(), args2);
                 if (inhpost != Call.ERROR)
                   {

--- a/src/dev/flang/ast/Contract.java
+++ b/src/dev/flang/ast/Contract.java
@@ -343,12 +343,14 @@ public class Contract extends ANY
                                     AbstractFeature pf,
                                     Context context)
   {
-    return pf.generics().sizeMatches(typepars) ? new Call(pos,
-                                                          target,
-                                                          typepars,
-                                                          args,
-                                                          pf).resolveTypes(res, context)
-                                               : Call.ERROR;
+    return
+      pf.generics().sizeMatches(typepars)  // check generics match to avoid fz crash in case of broken input as in #7747
+      ? new Call(pos,
+                 target,
+                 typepars,
+                 args,
+                 pf).resolveTypes(res, context)
+      : Call.ERROR;
   }
 
 

--- a/src/dev/flang/ast/Contract.java
+++ b/src/dev/flang/ast/Contract.java
@@ -379,12 +379,14 @@ public class Contract extends ANY
       {
         addContractFeatures(res, ff, context);
       }
-    return new Call(p,
-                    t,
-                    outer.genericsAsActuals(),
-                    args,
-                    f.preFeature())
-      .resolveTypes(res, context);
+    var typepars = outer.genericsAsActuals();
+    var pf = f.preFeature();
+    return pf.generics().sizeMatches(typepars) ? new Call(p,
+                                                          t,
+                                                          typepars,
+                                                          args,
+                                                          pf).resolveTypes(res, context)
+                                               : Call.ERROR;
   }
 
 
@@ -420,12 +422,14 @@ public class Contract extends ANY
       {
         addContractFeatures(res, ff, context);
       }
-    return new Call(p,
-                    t,
-                    outer.genericsAsActuals(),
-                    args,
-                    f.preBoolFeature())
-      .resolveTypes(res, context);
+    var typepars = outer.genericsAsActuals();
+    var pf = f.preBoolFeature();
+    return pf.generics().sizeMatches(typepars) ? new Call(p,
+                                                          t,
+                                                          typepars,
+                                                          args,
+                                                          pf).resolveTypes(res, context)
+                                               : Call.ERROR;
   }
 
 
@@ -534,13 +538,14 @@ public class Contract extends ANY
       {
         addContractFeatures(res, of, context);
       }
-    var callPostCondition = new Call(p,
-                                     t,
-                                     origouter.isConstructor() ? new List<>() : in.genericsAsActuals(),
-                                     args,
-                                     origouter.postFeature());
-    callPostCondition = callPostCondition.resolveTypes(res, in.context());
-    return callPostCondition;
+    var typepars = origouter.isConstructor() ? new List<AbstractType>() : in.genericsAsActuals();
+    var pf = origouter.postFeature();
+    return pf.generics().sizeMatches(typepars) ? new Call(p,
+                                                          t,
+                                                          typepars,
+                                                          args,
+                                                          pf).resolveTypes(res, in.context())
+                                               : Call.ERROR;
   }
 
 
@@ -1101,12 +1106,14 @@ The conditions of a post-condition are checked at run-time in sequential source-
                       }
                   }
                 var inhpost = callPostCondition(res, inh, pF.context(), args2);
-                inhpost = inhpost.resolveTypes(res, pF.context());
-                if (l2 == null)
+                if (inhpost != Call.ERROR)
                   {
-                    l2 = new List<>();
+                    if (l2 == null)
+                      {
+                        l2 = new List<>();
+                      }
+                    l2.add(inhpost);
                   }
-                l2.add(inhpost);
               }
           }
         if (l2 != null)

--- a/src/dev/flang/ast/Contract.java
+++ b/src/dev/flang/ast/Contract.java
@@ -375,14 +375,45 @@ public class Contract extends ANY
 
     var t = outer.outerRef() != null ? This.thiz(res, p, context, outer.outer())
                                      : Universe.instance;
-    if (f instanceof Feature ff)  // if f is currently being compiled, make sure its contract features are created first
-      {
-        addContractFeatures(res, ff, context);
-      }
-    var typepars = outer.genericsAsActuals();
-    var pf = f.preFeature();
-    return pf.generics().sizeMatches(typepars) ? new Call(p,
-                                                          t,
+    addContractFeatures(res, f, context);  // if f is currently being compiled, make sure its contract features are created first
+    return callCondition(res,
+                         p,
+                         t,
+                         outer.genericsAsActuals(),
+                         args,
+                         f.preFeature(),
+                         context);
+  }
+
+
+  /**
+   * Helper for call*Condition to create the actual call, unless the type
+   * parameters do not match (see #7747 for an example).
+   *
+   * @param res resolution instance
+   *
+   * @param pos the source position of the call
+   *
+   * @param target the target of the call
+   *
+   * @param typepars the type parameters
+   *
+   * @param args the actual arguments
+   *
+   * @param pf the called feature (pre/preBool/postFeature)
+   *
+   * @param context the environment we are creating the call in
+   */
+  static Call callCondition(Resolution res,
+                            SourcePosition pos,
+                            Expr target,
+                            List<AbstractType> typepars,
+                            List<Expr> args,
+                            AbstractFeature pf,
+                            Context context)
+  {
+    return pf.generics().sizeMatches(typepars) ? new Call(pos,
+                                                          target,
                                                           typepars,
                                                           args,
                                                           pf).resolveTypes(res, context)
@@ -418,18 +449,14 @@ public class Contract extends ANY
 
     var t = outer.outerRef() != null ? This.thiz(res, p, context, outer.outer())
                                      : Universe.instance;
-    if (f instanceof Feature ff)  // if f is currently being compiled, make sure its post feature is added first
-      {
-        addContractFeatures(res, ff, context);
-      }
-    var typepars = outer.genericsAsActuals();
-    var pf = f.preBoolFeature();
-    return pf.generics().sizeMatches(typepars) ? new Call(p,
-                                                          t,
-                                                          typepars,
-                                                          args,
-                                                          pf).resolveTypes(res, context)
-                                               : Call.ERROR;
+    addContractFeatures(res, f, context);  // if f is currently being compiled, make sure its contract features are created first
+    return callCondition(res,
+                         p,
+                         t,
+                         outer.genericsAsActuals(),
+                         args,
+                         f.preBoolFeature(),
+                         context);
   }
 
 
@@ -517,13 +544,13 @@ public class Contract extends ANY
    *
    * @param res resolution instance
    *
-   * @param origouter a feature with a postcondition
+   * @param f a feature with a postcondition
    *
    * @param args actual arguments to be passed to the call
    *
    * @return a call to outer.postFeature() to be added to code of in.
    */
-  private static Call callPostCondition(Resolution res, AbstractFeature origouter, Context context, List<Expr> args)
+  private static Call callPostCondition(Resolution res, AbstractFeature f, Context context, List<Expr> args)
   {
     var in = context.outerFeature();
     var p = in.contract()._hasPost != null
@@ -534,18 +561,14 @@ public class Contract extends ANY
                                : (in.outerRef() != null)
                                   ? This.thiz(res, p, in.context(), in.outer())
                                   : Universe.instance;
-    if (origouter instanceof Feature of)  // if origouter is currently being compiled, make sure its post feature is added first
-      {
-        addContractFeatures(res, of, context);
-      }
-    var typepars = origouter.isConstructor() ? new List<AbstractType>() : in.genericsAsActuals();
-    var pf = origouter.postFeature();
-    return pf.generics().sizeMatches(typepars) ? new Call(p,
-                                                          t,
-                                                          typepars,
-                                                          args,
-                                                          pf).resolveTypes(res, in.context())
-                                               : Call.ERROR;
+    addContractFeatures(res, f, context);  // if f is currently being compiled, make sure its contract features are created first
+    return callCondition(res,
+                         p,
+                         t,
+                         f.isConstructor() ? new List<AbstractType>() : in.genericsAsActuals(),
+                         args,
+                         f.postFeature(),
+                         in.context());
   }
 
 
@@ -726,9 +749,8 @@ public class Contract extends ANY
   }
 
 
-
   /**
-   * Part of the syntax sugar phase: For f's contract, create artificial
+   * Part of the syntax sugar phase: For of's contract, create artificial
    * features that check that contract: pre feature, pre bool feature, pre and
    * call feature and post feature as needed.
    *
@@ -736,18 +758,18 @@ public class Contract extends ANY
    *
    * @param f the feature that requires a pre or pre bool feature
    */
-  static void addContractFeatures(Resolution res, Feature f, Context context)
+  static void addContractFeatures(Resolution res, AbstractFeature of, Context context)
   {
     if (PRECONDITIONS) require
-      (f != null,
+      (of != null,
        res != null,
-       Errors.any() || !f.isUniverse() || (f.contract()._declared_preconditions.isEmpty () &&
-                                           f.contract()._declared_postconditions.isEmpty()   ));
+       Errors.any() || !of.isUniverse() || (of.contract()._declared_preconditions.isEmpty () &&
+                                            of.contract()._declared_postconditions.isEmpty()   ));
 
-    var fc = f.contract();
+    var fc = of.contract();
 
     // add precondition feature
-    if (requiresPreConditionsFeature(f) && f._preBoolFeature == null)
+    if (of instanceof Feature f && requiresPreConditionsFeature(f) && f._preBoolFeature == null)
       {
         // NYI: UNDER DEVELOPMENT:
         if (!f.isRoutine() && f.kind() != Kind.Intrinsic && f.kind() != Kind.Abstract)
@@ -1015,7 +1037,7 @@ all of their redefinition to `true`. +
       }
 
     // add postcondition feature
-    if (requiresPostConditionsFeature(f) && f._postFeature == null)
+    if (of instanceof Feature f && requiresPostConditionsFeature(f) && f._postFeature == null)
       {
         // NYI: UNDER DEVELOPMENT:
         if (!f.isRoutine() && f.kind() != Kind.Abstract)

--- a/src/dev/flang/ast/Contract.java
+++ b/src/dev/flang/ast/Contract.java
@@ -373,7 +373,7 @@ public class Contract extends ANY
 
 
   /**
-   * Create call to outer's precondition feature
+   * Create call to context.outerFeature()'s precondition feature
    *
    * @param res resolution instance
    *
@@ -385,41 +385,14 @@ public class Contract extends ANY
    */
   static Call callPreCondition(Resolution res, AbstractFeature f, Context context)
   {
-    return callPreCondition(res, f, (Feature) context.outerFeature(), context);
-  }
-  static Call callPreCondition(Resolution res, AbstractFeature f, Feature outer, Context context)
-  {
-    if (PRECONDITIONS) require(outer == context.outerFeature());
-    var oc = f.contract();
-    var p = oc._hasPre != null ? oc._hasPre : f.pos();
+    if (PRECONDITIONS)
+      require(context.outerFeature() instanceof Feature /* used on newly compiled code only */);
+
+    var outer = (Feature) context.outerFeature();
+    var fc = f.contract();
+    var p = fc._hasPre != null ? fc._hasPre  // use `pre` position if `outer` is of the form `f pre cc is ...`
+                               : f.pos();    // `outer` does not have `pre` clause, only inherits preconditions. So use the feature position instead
     var args = argsAsActuals(res, p, outer);
-    return callPreCondition(res, f, outer, context, args);
-  }
-
-
-  /**
-   * Create call to outer's precondition feature to be added to code of feature {@code outer}.
-   *
-   * @param res resolution instance
-   *
-   * @param f a feature with a precondition that should be called.
-   *
-   * @param outer The call to f's precondition is to be added to outer's code.
-   *
-   * @param args actual arguments to be passed to the call
-   *
-   * @return a call to f.preFeature() to be added to code of outer.
-   */
-  private static Call callPreCondition(Resolution res,
-                                       AbstractFeature f,
-                                       Feature outer,
-                                       Context context,
-                                       List<Expr> args)
-  {
-    var p = outer.contract()._hasPre != null
-          ? outer.contract()._hasPre    // use `pre` position if `outer` is of the form `f pre cc is ...`
-          : outer.pos();                // `outer` does not have `pre` clause, only inherits preconditions. So use the feature position instead
-
     var t = outer.outerRef() != null ? This.thiz(res, p, context, outer.outer())
                                      : Universe.instance;
     addContractFeatures(res, f, context);  // if f is currently being compiled, make sure its contract features are created first

--- a/tests/reg_issue7747/Makefile
+++ b/tests/reg_issue7747/Makefile
@@ -1,0 +1,25 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test Makefile
+#
+# -----------------------------------------------------------------------
+
+override NAME = reg_issue7747
+include ../simple.mk

--- a/tests/reg_issue7747/reg_issue7747.fz
+++ b/tests/reg_issue7747/reg_issue7747.fz
@@ -1,0 +1,53 @@
+# This file is part of the Fuzion language implementation.
+#
+# The Fuzion language implementation is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, version 3 of the License.
+#
+# The Fuzion language implementation is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License along with The
+# Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion test reg_issue7747
+#
+# -----------------------------------------------------------------------
+
+# regression test for issue #7747: redefinition with non-matching arg count results in fz crash
+#
+# The problem here is that `a.f` and `b.f` have different argument counts, so `b.f` does
+# not redefine `a.f`, but the code for checking the inherited pre- and post-conditions expected
+# these to be the same.
+#
+reg_issue7747 =>
+
+case_pre is
+
+  a is
+    f (p Q)
+      pre
+        0=1
+    =>
+
+  b : a is
+    redef f(p i64) =>  # *** error ***: Wrong number of arguments in redefined feature
+
+
+case_post is
+
+  a is
+    f (p Q)
+      post
+        0=1
+    =>
+
+  b : a is
+    redef f(p i64) =>  # *** error ***: Wrong number of arguments in redefined feature

--- a/tests/reg_issue7747/reg_issue7747.fz.expected_err
+++ b/tests/reg_issue7747/reg_issue7747.fz.expected_err
@@ -1,0 +1,19 @@
+
+--CURDIR--/reg_issue7747.fz:35:11: error 1: Wrong number of arguments in redefined feature
+    redef f(p i64) =>  # *** error ***: Wrong number of arguments in redefined feature
+----------^
+In 'case_pre.b.f' that redefines 'case_pre.a.f' argument count is 1, argument count should be 2: one (free) type parameter 'Q' and one value argument 'p'.
+Original feature declared at --CURDIR--/reg_issue7747.fz:29:5:
+    f (p Q)
+----^
+
+
+--CURDIR--/reg_issue7747.fz:47:11: error 2: Wrong number of arguments in redefined feature
+    redef f(p i64) =>  # *** error ***: Wrong number of arguments in redefined feature
+----------^
+In 'case_post.b.f' that redefines 'case_post.a.f' argument count is 1, argument count should be 2: one (free) type parameter 'Q' and one value argument 'p'.
+Original feature declared at --CURDIR--/reg_issue7747.fz:41:5:
+    f (p Q)
+----^
+
+2 errors.


### PR DESCRIPTION
This bug fix for #7747 turned into a cleanup patch. 

The bug fix is to make the code for type inference for type parameters in `Call` robust to a mismatch in the type parameter indices and a check to not generate code for calling redefined pre-/post-conditions in case the type parameter count does not match. 

Then, the cleanup part simplifies the code to generate pre-/postconditions by moving repeated code into helper methods, removing methods that were called only once, etc. 